### PR TITLE
ci: drop conflicting pnpm version pin (fixes "Multiple versions of pnpm")

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,9 +26,7 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,7 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

`code-quality.yml` and `release.yml` pinned `pnpm/action-setup@v4` with `version: 9`, which **conflicts** with `packageManager: pnpm@10.33.0` in `package.json`. action-setup v4 aborts at the **Setup pnpm** step:

```
Error: Multiple versions of pnpm specified:
  - version pnpm@10.33.0 in the package.json with the key "packageManager"
  - version 9 in the GitHub Action config with the key "version"
```

So the **Quality Checks** job failed *deterministically* at setup (every real step skipped) — not a flake. `ci.yml` ("Build and Test") passed because it omits the `version:` input.

## Fix

Remove the redundant `version:` input from both workflows so the action reads the `packageManager` field (single source of truth), matching `ci.yml`. Also fixes the wrong major (was `9`, repo uses pnpm `10`) which would have broken `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
