### PR TITLE
chore: upgrade @objectstack 7.7.0 → 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
   },
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
-    "@objectstack/account": "^7.7.0",
-    "@objectstack/cli": "^7.7.0",
-    "@objectstack/driver-memory": "^7.7.0",
-    "@objectstack/driver-sql": "^7.7.0",
-    "@objectstack/driver-sqlite-wasm": "^7.7.0",
-    "@objectstack/metadata": "^7.7.0",
-    "@objectstack/objectql": "^7.7.0",
-    "@objectstack/runtime": "^7.7.0",
-    "@objectstack/service-analytics": "^7.7.0",
-    "@objectstack/service-automation": "^7.7.0",
-    "@objectstack/spec": "^7.7.0"
+    "@objectstack/account": "^8.0.1",
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/driver-sqlite-wasm": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/service-analytics": "^8.0.1",
+    "@objectstack/service-automation": "^8.0.1",
+    "@objectstack/spec": "^8.0.1"
   },
   "optionalDependencies": {
     "better-sqlite3": "^12.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,38 +9,38 @@ importers:
   .:
     dependencies:
       '@objectstack/account':
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^8.0.1
+        version: 8.0.1
       '@objectstack/cli':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@objectstack/driver-memory':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
       '@objectstack/driver-sqlite-wasm':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
       '@objectstack/metadata':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@objectstack/objectql':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@objectstack/runtime':
-        specifier: ^7.7.0
-        version: 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@objectstack/service-analytics':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
       '@objectstack/service-automation':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^7.7.0
-        version: 7.7.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -698,35 +698,35 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
-  '@objectstack/account@7.7.0':
-    resolution: {integrity: sha512-zbTAOeP22s6AyTph/FxyEZyU3RNHCJVq6Rb6Fr3R4wtLi0fWFgdLIL1DsODpwQKt3fjbaH49/8HfJDR7Ss20vw==}
+  '@objectstack/account@8.0.1':
+    resolution: {integrity: sha512-hio0SB54+dZJDVkpjU1OZ6Sft3Y1/6gBw0XLZmTqpKxRD6L5Upc/WJ9iL0o55hLvlFKB1d+PotaAtPFK9V6YWg==}
 
-  '@objectstack/cli@7.7.0':
-    resolution: {integrity: sha512-5A7j7z9JRyWl6OZUB5N3cmINI/8DtOvW3MtL9rTa/+4Hq2nYvC4GuKyXG641xTNQPJDraVVYcEhFHn+etry8rA==}
+  '@objectstack/cli@8.0.1':
+    resolution: {integrity: sha512-aMuZHCcLQ3ZB19utH8Rf5lMch9q1LfqMbpBwAawhl79P7QcDR+bX/xMprASM81m2kYhTT+La0dMadM6gkwgjnA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@objectstack/client@7.7.0':
-    resolution: {integrity: sha512-QxFIq99kuAXkkefzlnTM7g3btc4Rj/hzYbaf5PIqfitaoLJNswsa6LJuKoNaMQIdetUWsD3QfyM4iK5gdeJrFQ==}
+  '@objectstack/client@8.0.1':
+    resolution: {integrity: sha512-fLObUYXfa6XmoutgLK5SRthROKM16PTbMyOntiIoGI76zOHbsbZNa8FyDnSV7kEnjWERjBlEedjgT9201Pvnyg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/console@7.7.0':
-    resolution: {integrity: sha512-bG4FZe6mJSpenHAsBYqtQBCDcQcbTTRB66TMdoqVm1fM0546X07OD5cc85CUpt9fRDo7coTSjJpSv4XCKsHg7w==}
+  '@objectstack/console@8.0.1':
+    resolution: {integrity: sha512-d4I0hLRgJKV45MZanPWsCEyXxj7zzZMcjxdIBAc/g+CYWxS8i/dMgi5cuGnQxxPyopmElyadxoFav2tA3kScaA==}
 
-  '@objectstack/core@7.7.0':
-    resolution: {integrity: sha512-HwgkV2QInlT2q5QJQP11DM7/k/WSKvz2T1k78kQKFWB1zp2hhSNVy0C0f0pOPgNcLkShiIEPsFMPY5qV4zq1eA==}
+  '@objectstack/core@8.0.1':
+    resolution: {integrity: sha512-222khmv9KMBCI1dfjy2jknK9kpv/+RD9kcmNCrRApEzRQ5/TbE75UCM+T245yse61K7ez8CV0py/Yr5KJNj6FA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-memory@7.7.0':
-    resolution: {integrity: sha512-xUWXBIs6cTKlFzxSPLw3rpPF+VZ/b7huewWgrImaW27c7sZ39gWtiISlxI+4PdyJIlZFZq+V/rX0/XCn1UYpow==}
+  '@objectstack/driver-memory@8.0.1':
+    resolution: {integrity: sha512-rl3arNAOPotnlRi3PIkcN+597PBUXFdizfijjDOIMbi18KCCaMnFJY+rbk9ASfJv+kfN6L18S2EKSF6CnYoA6w==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-mongodb@7.7.0':
-    resolution: {integrity: sha512-8A31jNpRLahzWlassIi77y/6tQdO0k6ktU7qz2/T7cXnk1uWin/3sH4zvG5p/bb3m9VEhq3vF4AeQOpNnTEXXQ==}
+  '@objectstack/driver-mongodb@8.0.1':
+    resolution: {integrity: sha512-+qdeMt2gYT2NUO7WzoFYbZMvOLjy6n9N7Cs0QRGHFyNOAR9HRlGe/V97dpsmzDAiRDRXDsqdM3Z/shrEJykxZg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-sql@7.7.0':
-    resolution: {integrity: sha512-UPe0YgfYQyKe9wM9eugCmKFx3J3BDJxQLq/NLqsW+aoJeBtpQ4eG926uMm0MlZIq/XAVJtzKBJ6s5IHXSki53g==}
+  '@objectstack/driver-sql@8.0.1':
+    resolution: {integrity: sha512-2kT8VSqDQK1P1hQ2P84FE38fLrD75O9VxZZdLr20IfJI/kUn+klx0KLiu7dGCog7nDic3iSIxamsfxxh3fbSAA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       mysql2: ^3.0.0
@@ -743,15 +743,19 @@ packages:
       tedious:
         optional: true
 
-  '@objectstack/driver-sqlite-wasm@7.7.0':
-    resolution: {integrity: sha512-TOoXwt3mQnRfaBoNywgA5AEijJDb9a1WXxBiWHqFe3ZZ1vC91A9NkbtxWoNnewI2EeOQeNEwHGtm6UjHwYnWiQ==}
+  '@objectstack/driver-sqlite-wasm@8.0.1':
+    resolution: {integrity: sha512-C0bFYRRRyJJB5nJNCoreLWINf4qVEMaZivnioKFkex2Ycb3uwydFedyV7JwAertTjFXXoFaSI54KAXMV+4/Qfg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/formula@7.7.0':
-    resolution: {integrity: sha512-N0ZWFMYmEyz1wgY9FAcsAtYLOSmtvAOn0sxr1hU2SIpK6ZeSr5IZyLn7Pss+mpRLC3lPAiF5SsgutxCEixoy3A==}
+  '@objectstack/formula@8.0.1':
+    resolution: {integrity: sha512-e/CfchRGxnJW4JB1sDAaNKCAj0kbM83fSpzDmn3UMppG89aW9gSyMiB9TvaOnB35iOxsyhTeZ8R9E/rwEEfmfg==}
 
-  '@objectstack/metadata-core@7.7.0':
-    resolution: {integrity: sha512-W4a1Fm98KGPVsCuJtorlAZd7DkXSKh3Gqeb4+2/JdZFuQVQbJ3bJwtI3V3yxqUfGDBu7iwRzPemdgh08R8Mc+g==}
+  '@objectstack/mcp@8.0.1':
+    resolution: {integrity: sha512-KjJftJySVYvC0E4545iCDXgQLAo0FoxEQbXrXNpy1Yp5DtAYsEZESQodkqy0EJppxmtnXAqLD31k1fgjJUESjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@objectstack/metadata-core@8.0.1':
+    resolution: {integrity: sha512-VWrtvYm1pFoYXR2szmFXshNP6LSJ9sXiQPXtoOuKdZ6092Lt1wnSRrKR5RH5TpSaavXEdsidBffGI4NPp2Ej9A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       vitest: ^4.0.0
@@ -759,83 +763,79 @@ packages:
       vitest:
         optional: true
 
-  '@objectstack/metadata-fs@7.7.0':
-    resolution: {integrity: sha512-AbwNa8aiaoy5uOIIEN3EbXaJT2V62dQ4m4fvpGLhXhPEJQo9YF/kb/AC0rc2tEDOgBKOi1RPoB3MVxC5Yy2IjQ==}
+  '@objectstack/metadata-fs@8.0.1':
+    resolution: {integrity: sha512-SdVofg5Bj21U5ZkCwSuHAAMjQqtto5SXZNnSrxzvJfh5Cq3AwG2d3RbWaJ+ev/dZeRJG5yuHiEhpdQJP+eOHGw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/metadata@7.7.0':
-    resolution: {integrity: sha512-mxhia9yLgZV/lzPaqnF4fVU1K2QSXHmYWxaJ+XcGiKgsVMlv9eHsK+pwLTxhyhYGV05YBeQzsPFMCbiHML8l3w==}
+  '@objectstack/metadata@8.0.1':
+    resolution: {integrity: sha512-wR6xSJbpSEDPRNMSBbLUyi+NtWsa0TVttgNJrZHqkb1+yLDGUc4K9NT0Et59nVqvVj5AjuC00Mk5uwzLxcxhPA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/objectql@7.7.0':
-    resolution: {integrity: sha512-k+Lx/iN+pKgYkHNy1hIMXu8ByNBaIUK22TW6HblkvFvBm6SlOiXLlV5SIF3AX7V+Dv3t8VPTTdWMWFXDkL2CZw==}
+  '@objectstack/objectql@8.0.1':
+    resolution: {integrity: sha512-c/n6OLYxC6rfipQjyVXy51u/N7wnWYp9hyllfv6kmujwK56yWKkY8iycAqboyCErgmPahuqW1LLdHjE1gmUiGw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/observability@7.7.0':
-    resolution: {integrity: sha512-WEb1YmQTqUhFlpomKi2Rxf4Eq4kYXrDQomENot86M9A0copywRldUl4A38SKbpNaH4bfjmcUbWuivEJGsUR9PA==}
+  '@objectstack/observability@8.0.1':
+    resolution: {integrity: sha512-XwUu5ZzcbJ+AwQ9Nyw17KfIq+WWsIBgAfqrTaTlqEB4tGHXUHEwGIgYcLS9eGDwS9H92ZhrTOY4kh9n7CdLhDg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/platform-objects@7.7.0':
-    resolution: {integrity: sha512-6nv6teqNVGNp+Tzd3YzLW+oBfK+bFUXGjU/A81qxqVB+HStTn4wqDULenhCNc6BMnw0QB9EEvOX4Ezqnv9xf/w==}
+  '@objectstack/platform-objects@8.0.1':
+    resolution: {integrity: sha512-3qOTeedtN78oyA4Oe/G21Lrf/H8nKa0oGsb8VoscS0nwdKmqRG4vlKplv998voEqro1HwIjvf5KZvQ1HBomVKw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-approvals@7.7.0':
-    resolution: {integrity: sha512-ktrxF+2Plohb+98cQB8WD2YjmtdCpP+ny9aaeqZqU6q6WZFhSj/1psFKfc6p4qWqnTYIhE6Ia3lf8ulZOyK4FA==}
+  '@objectstack/plugin-approvals@8.0.1':
+    resolution: {integrity: sha512-PCrqaTeEgQK+kDfEx4PUsaba9u9Ry/HFPrsx1xWkNS1sglfJG+LFqQEPHxUCDXIlap7hcj6gQtXJl42vVgZnPg==}
 
-  '@objectstack/plugin-audit@7.7.0':
-    resolution: {integrity: sha512-wigjWTNQz0lpK2mEg8ohcMBTJ25EGjOOMnk0BfsBRPRTnXtjPOd6Mhi+XY1IfVa6l20+9/oqJ3PbyBq93Qn2FQ==}
+  '@objectstack/plugin-audit@8.0.1':
+    resolution: {integrity: sha512-VqeC1xnLz1SPVo6+jOnPiWgJaiOPdXipyS6leS/wIVO6h+BcHR4e9XnQefYlB+ikVUeZwl6WM2iVHE48IatNuQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-auth@7.7.0':
-    resolution: {integrity: sha512-6dxO8XpIUuCD3cvu0tRQW5Vj6il72O6VHB1HZW6CG7rG9oALacUFNDlJcqSiZGtORgZbQDt8Np3d8foc6qhqBA==}
+  '@objectstack/plugin-auth@8.0.1':
+    resolution: {integrity: sha512-nLk3/lentF5qZ72X0c/fC5b8Ne/COg6dgwgUUscN8QQIR3EvHPsSWAeLOsrBVqb74v/ShxE81GkbxC0pK81fOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-email@7.7.0':
-    resolution: {integrity: sha512-P3mN8T5CeM/pzaXRX1S3eaMIaY+ZcxgtcFtey2xo7i+++Kj+XpG+TNnBEAR0Zv46g5ITyX9rMp/nLD49ED6nsg==}
+  '@objectstack/plugin-email@8.0.1':
+    resolution: {integrity: sha512-psYJmJDp3LCYWCOk8b1ygVbjcYfYw+BVDeXAEl0LvkMPrPa/ugxAIcDINPSmZluTdL1BjionOSb/ohboHr/g+Q==}
 
-  '@objectstack/plugin-hono-server@7.7.0':
-    resolution: {integrity: sha512-pL14ZqDL4WS/MjJrc49PW2ygUsQozk6ccWV//9vgS7kwEbk2aPKWy58JD6lWIBduz0gWnDoT0IDH0TYMidbhMA==}
+  '@objectstack/plugin-hono-server@8.0.1':
+    resolution: {integrity: sha512-l2RKsunYIzxIU9emWxGVDOonoDDItiE/PDEA0qoBwUG2jUH4pkEahIaUKVgri9NZetKtp9ulKnHTHcDlzqpe7g==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-mcp-server@7.7.0':
-    resolution: {integrity: sha512-0lvHrFU/R5hZHd4fTbaVxTjmjtyKZ2tp/AF4MbgxZJAsU2Thf+cBnz3lHBbtpxGUdH2vsvTKqUuJoL95MK/3jQ==}
+  '@objectstack/plugin-org-scoping@8.0.1':
+    resolution: {integrity: sha512-PrrOzZbwW61AiPvDylSsSduR8Fi19l1pRjKk4e4VMSoJUiM9H+mdYxVtiANT+rpdEUxmjCl4tA1uv5WrGbkksA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-org-scoping@7.7.0':
-    resolution: {integrity: sha512-vxopncbwSI1jnmX1Hsde3tHKuL8hsCHbfZjXjILpAQPGdHmddE3CMwaE3yNFq07WmbIFf4o2kEaXphuECgN15A==}
+  '@objectstack/plugin-reports@8.0.1':
+    resolution: {integrity: sha512-500DjcpmmjtmvOUsrfwK+faGshBfoRAaXdfxzEjwHoFZfXTBX1Uc12YoTySoxQyuXoXE3Lw9OBARAyYiELss8Q==}
+
+  '@objectstack/plugin-security@8.0.1':
+    resolution: {integrity: sha512-NaEozXRvGH06UhFz2CVoKq8YoPc5OTTeoMk3IQ+kiUMz1w0Ky4dwTkXJzd9zW9aWL8cMQ9ezpC1oNQBVcaMo4Q==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-reports@7.7.0':
-    resolution: {integrity: sha512-0P33m1jmG3+NMmbIMuk2fJA8+qkNnwYDj3QFKmVvEVO5rApP7wfAUxL8H7qx10jAL9Fkr13I4GMggNfjbblcNg==}
+  '@objectstack/plugin-sharing@8.0.1':
+    resolution: {integrity: sha512-7vpjAG1uV0cgcxhnEB05WyjGhwlYT7ezufo+83ya9kxJdORnyo8wPHsQ5bnuntOdz0aTtn5WTvS4nQVlZoxkaw==}
 
-  '@objectstack/plugin-security@7.7.0':
-    resolution: {integrity: sha512-NnnsFrbxFp8xAECkKjIkUzKHsrjWWIVWTJrn+xAYzk17ToTjU47qBDdfRZdv+36B7WPLt4jwAz2sVg3IzPdpzg==}
+  '@objectstack/plugin-trigger-record-change@8.0.1':
+    resolution: {integrity: sha512-dvedWALQ78q6cqfwVskZmwcml4f7FsifgqYosNkQWVDW4yE+6em4Gro3ert8XmMBQomFl85SttHf6VdiOiZoYg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-sharing@7.7.0':
-    resolution: {integrity: sha512-KNmaWZ/q9c4gFGSRqFAX7A5pdt5jTnc9+LdvJy/ONndCeIJI8dZXX3zlvZlifkqJt2zbRwO1uQ8e+72y7UZKWA==}
-
-  '@objectstack/plugin-trigger-record-change@7.7.0':
-    resolution: {integrity: sha512-Ds8W3z+cLFpKeWXA4jvB8y3KV8yiSRP8K2L22SPNpAanjIDn2LkwblTQDEZwl1kRXAYa3SQ3kWWCeFDqN2WoHQ==}
+  '@objectstack/plugin-trigger-schedule@8.0.1':
+    resolution: {integrity: sha512-xMiICt1+v/afoTZ8hy/e1Wyi2NEYFQkLxtqxMC72AtIYT6caHJFJLAvzn15Y1nQeMs4tQAJh8t23n1+6hZ8cxQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-trigger-schedule@7.7.0':
-    resolution: {integrity: sha512-z+Rrty6FVn+bOSbqW9Es1hEPTr8MzG1yBb6dRyaXqRUaitIurmsVAOfX+IYBSx72pvBG3lmXkzeW7J4nOuv8gQ==}
+  '@objectstack/plugin-webhooks@8.0.1':
+    resolution: {integrity: sha512-UMzvj2UDm2wJcKQ4yCdOnWxQj/rL/rni90ZkDFwJaVqdstRWmNE/gVUssPvPKTNuA2HxC4+rQdIUfXRQMZvmtQ==}
+
+  '@objectstack/rest@8.0.1':
+    resolution: {integrity: sha512-YA05taXQs3Rzz/DHlF5XBb9BKcmevDHhSA+YmXX8gTIwsuxWQgYG1YyrnWAPBNByyTwCHXqaT/bcBOE0IZ2Wlg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-webhooks@7.7.0':
-    resolution: {integrity: sha512-DZCN5PgX6hOb0TCjYKBc4IfrX75/7cBFZG/xXEwxDX0el5pIvkR7IZK27LJwtD8ZXd6DpvXu4lS/qBUAwi8bpw==}
-
-  '@objectstack/rest@7.7.0':
-    resolution: {integrity: sha512-wN5vmXhyPRavDb4LfxUFMU7Lgh1LPuk6rekLnNg7Eds5eVsVKio2eAtxzIErH8BOntlDKEvsVJv73cSFnapZ6g==}
+  '@objectstack/runtime@8.0.1':
+    resolution: {integrity: sha512-fY5DtKCexgM5AjQnd363wamvLPS88SrDeK7mF84YDoVksD7JmCyeoMzeLQAGm3kOj3dX2F5uEE39m64pUeL+4w==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/runtime@7.7.0':
-    resolution: {integrity: sha512-vzcwZoBC+EyXu2n9IU8sAnGrvtjlW9AuhUWZ9yjLz20Og1AZ8oVXv2aPJGwZXkOehz/ct3b28qn/eY/SEbWmwA==}
-    engines: {node: '>=18.0.0'}
-
-  '@objectstack/service-ai@7.7.0':
-    resolution: {integrity: sha512-i44xxXNx9LE7SfyUS3UOnlpyLSj2yKQUwyOY2wnNwNErjapfkQ0SmlGUNTnhFTRDlM0we33lHovdJJb1QnLNuA==}
+  '@objectstack/service-ai@8.0.1':
+    resolution: {integrity: sha512-i1dj3BV8O/C8ENFDmEzEgIQ7iVt7WPetmRUz5JRYFM+ubeErVwaJAm1JAn/HJ6SRQl7i7fO+fgjWSLvlUr6THA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@ai-sdk/anthropic': ^3.0.0
@@ -852,58 +852,58 @@ packages:
       '@ai-sdk/openai':
         optional: true
 
-  '@objectstack/service-analytics@7.7.0':
-    resolution: {integrity: sha512-8vH7T7BuVyRp7QPc9thMlEYfdIMIQpasH5NzBVR079vOOcFoZfHzIKvQONUgEBB3bCM6Zl6+p86kMdEWAfL07Q==}
+  '@objectstack/service-analytics@8.0.1':
+    resolution: {integrity: sha512-3DWT/kmeM/U4wOzrk2yO1vyrlkij8KLhQIuhbDCth+Xwwj94U4YaPs8JbdmfsSEfec+D5YGnfGaagdk0Q87ejw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-automation@7.7.0':
-    resolution: {integrity: sha512-MdW1o2A40UUzZTCG5+XVbTbY7jCViNRPo5lgSYzIVMbfklhQjEYQNIHU2WlP1HgbOlf78NyVUl+lpyscX+tSzg==}
+  '@objectstack/service-automation@8.0.1':
+    resolution: {integrity: sha512-eiZQH/FGh5Mj1I5EYtn8FGRibWTusM9+SbiE90F02BJ4CSC56PlJ5lXJofyktme+EQf+yQsS/Ck30fAkMZpXYg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cache@7.7.0':
-    resolution: {integrity: sha512-0TBJ5yCGBpsWCOOnmJbWoefSJsXWicl4YVxKouC4bolbYJLMWlCH7D3ZoI2f4zQvb/uguIx2p/+rrSsfT6SR/Q==}
+  '@objectstack/service-cache@8.0.1':
+    resolution: {integrity: sha512-ZZzseZzvflsa2NyC1JUvGUVbq/BYBdQpop3jqZ4W7lqquueiHkN3ffbHGnSf7HJL++/fkwMKKZiDahSecCg7kA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cluster@7.7.0':
-    resolution: {integrity: sha512-H9RBrgmnMVHZYZI9KKAQdChEAlTIpZh7IiQN1LydouQibZw1k7FveuMyzwhV384gq/VueE03jEgQVZddiAeqDw==}
+  '@objectstack/service-cluster@8.0.1':
+    resolution: {integrity: sha512-FR8cHaM/45Ez9VICsp8B1KtwBNlyotqmuazgnT7vJ7FySMRyGKjcWw03Ua8pgYQFYwSpKOl73esgljBCeOuAXw==}
 
-  '@objectstack/service-datasource@7.7.0':
-    resolution: {integrity: sha512-oenatd7hSIXH3Zgd/AoZN/916pWjsZkHSdrsMOWCxqEUmueKXPorctn1Y62liXN3zI91bHJBIP4Wkc9BdoA3LA==}
+  '@objectstack/service-datasource@8.0.1':
+    resolution: {integrity: sha512-kKR0m3YlUw9/Kk4YfjLWqixKYLg5an0G/yNIJxBSrTSAz/9c9XNzfyon5QWvhJg5EPoY/01VKvlGxbcqh1guVA==}
 
-  '@objectstack/service-feed@7.7.0':
-    resolution: {integrity: sha512-G9TEwyTscCDY7qS/3HBEXpFqLxEdri4zIwk6gLdpLw7hQsWEMmZBn8CzAo2IEsGukFi/z9MTkXvF3bwT7kx/pw==}
+  '@objectstack/service-feed@8.0.1':
+    resolution: {integrity: sha512-nGIxnV5qXpp9dL7njuTXq/TA2dAZMFddAcRHhdH9q8qyVdO2DcOi8n4MSaaqdALUnNbwTCLImEuhVTxF+Yo15A==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-i18n@7.7.0':
-    resolution: {integrity: sha512-JYa1EEivpkPOCG6ReKDFZeKkzJkgoXayKHnmcjDBtJSRMVWvgdftq4WoKsWiFsTcG4mkkFktzTrmCq22lZEY5w==}
+  '@objectstack/service-i18n@8.0.1':
+    resolution: {integrity: sha512-h1YjPxHURiLyIc3Mf7dOJ1pgVtnkHxh3ppWuW650pXYo4F4Ys5gbsNNxUD1fuJhGQiQaycBPfADw/0BdK+wv+Q==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-job@7.7.0':
-    resolution: {integrity: sha512-tErPzkcawnpzSubp2PB3mQN8MeA3CV5nGIw8Yy/vLl2cQBBkfI9Gq5rQTBMwfEFUhUuy+6QV1ys04M2GutT88A==}
+  '@objectstack/service-job@8.0.1':
+    resolution: {integrity: sha512-KlTBzR/RL8yIMp4qxpkaoZYYsktAedq1GbgNxTDCWL9wbRGL7S0GNvvG1/dPbg71jgDNIzYUdFjfWCwj5upHkg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-messaging@7.7.0':
-    resolution: {integrity: sha512-Zufrs7SdXPQ0DlA8Mhfr3e+T8isy0w4jk4wdyWNoucqCRTXn0hLoKYp5ovfjpcjoZlCiG7pF8aUJ0Ldpr76uMA==}
+  '@objectstack/service-messaging@8.0.1':
+    resolution: {integrity: sha512-k3q4RyxOEy3U0NxYfVCGcQsi2cNXsvqjNrvUMrMh9Fuew6WHOeuUJ3ftChfOR8EzYHdT/OH/8VYzQjxmKVxNwQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-package@7.7.0':
-    resolution: {integrity: sha512-eENxVcH3pGmLFQQgqPYY6DWwwwX1O6BZZOhzlMlSMhc4ka4lUE0W5JOkrXjagIJckKf3ul6f5DguVLT5wn9N8g==}
+  '@objectstack/service-package@8.0.1':
+    resolution: {integrity: sha512-hTxON2MnrFAHDRNKXYudG0qoSOYbTvpYG7qeo19NnT+lWvvMGcL/9v02SQzjIWZEaV+wsubF0bArdaD2qI5vyQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-queue@7.7.0':
-    resolution: {integrity: sha512-Ekf3IX/t0LUz690mMXQufnHazoxeBrqSNkuRvWWtRn3rzhBg1Uxjl9P/CJiP2JwIR4KotmYScJP9mGftw1TDZg==}
+  '@objectstack/service-queue@8.0.1':
+    resolution: {integrity: sha512-WoOvd+3IQODws99OIwIXQ4armhW0N7JiRQG8Vip6y6s+OFQkZgB5/IG7xtxPHQAAgfmdSDKsNvteeZd2MTK5kg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-realtime@7.7.0':
-    resolution: {integrity: sha512-q/wrSVB5NhSZSIToE7TvFqkHPUtwfMSEHS0E475UButbRLRu/EzgfQ7CPFO/APv9zetjQJmF/hNaKrrcQZmkog==}
+  '@objectstack/service-realtime@8.0.1':
+    resolution: {integrity: sha512-btZGq/ap0Gzl7Ftd886XgMbLclqTbIuAi4B1g1mpAQja8fHQahRiYo/5UW6UXiWlSf4mKOidRrWpmQpjACVR4A==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-settings@7.7.0':
-    resolution: {integrity: sha512-9F21JIjEjrK0RbHn3QFSaI9dZbR9fE678HjJHm287d4ARPog0aLT1LoSuH7x3eZLGzEWwMt4xZHoGImaj0MYYg==}
+  '@objectstack/service-settings@8.0.1':
+    resolution: {integrity: sha512-/Kco/IfvdeMzioPP7UrkqTTVHatrtoHDr2R0VTDvC7jMV2HZORqdFgBWGVmLdY9xUF59I1OP/FxgwtfoT6ixAg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-storage@7.7.0':
-    resolution: {integrity: sha512-KCNbp4DmeudFb/eTbnqxmvopfzPwYatRe0pOZqDVnwXjPU3C/UNLu3Si6XNu9f7T8tm6gJztp9ofFCfGYpctPw==}
+  '@objectstack/service-storage@8.0.1':
+    resolution: {integrity: sha512-SOnvpditPPf4AdaqKCXHPxqQXGw0k3UD67RDTHouk2N+JKoa+Sx0osS0TzhkhrVwha4Kxdvu0M+tyWh0DAGbcA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@aws-sdk/client-s3': ^3.0.0
@@ -914,8 +914,8 @@ packages:
       '@aws-sdk/s3-request-presigner':
         optional: true
 
-  '@objectstack/spec@7.7.0':
-    resolution: {integrity: sha512-p9GxtbD8oJFkf9tjNlaOZmBxufskk683IhBL0My8NK0EOH/xG1xbbeAWctpHHIdK91hz9EkZLthtJVbnBNaMPw==}
+  '@objectstack/spec@8.0.1':
+    resolution: {integrity: sha512-ZTHxY0TJIGDGNNd+i5Jzl8KQEA4wxgm46WTICrrYEybdsUnSkuOEKSW3lH0IBB8vI9Dx8/yUtKw77Di9NDfkAw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       ai: ^6.0.0
@@ -923,8 +923,8 @@ packages:
       ai:
         optional: true
 
-  '@objectstack/types@7.7.0':
-    resolution: {integrity: sha512-msQcyAmD1cFB4KQ3EH9brnoqBIXMTwwmSAagtbJqCBj7bFLKmtAXdjWHp+6FQFG5lHDBwldA0aRO5DEvdzOZaA==}
+  '@objectstack/types@8.0.1':
+    resolution: {integrity: sha512-1oA7/z2k9UkdopRCmEHLVj5bpQJxBZt3qBI8TxN81LhDzTBibI4Bl5qBJiUPc7ClNQuCQHrUjRD/NTadSkq7Dw==}
     engines: {node: '>=18.0.0'}
 
   '@oclif/core@4.11.4':
@@ -4081,53 +4081,53 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
-  '@objectstack/account@7.7.0': {}
+  '@objectstack/account@8.0.1': {}
 
-  '@objectstack/cli@7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/cli@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@ai-sdk/gateway': 3.0.121(zod@4.4.3)
-      '@objectstack/account': 7.7.0
-      '@objectstack/client': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/console': 7.7.0
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-memory': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-mongodb': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sql': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 7.7.0(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/objectql': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/observability': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-approvals': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-audit': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-auth': 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-email': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-hono-server': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-mcp-server': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-org-scoping': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-reports': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-security': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-sharing': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-trigger-record-change': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-trigger-schedule': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-webhooks': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/rest': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/runtime': 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/service-ai': 7.7.0(@ai-sdk/gateway@3.0.121(zod@4.4.3))
-      '@objectstack/service-analytics': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-automation': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-cache': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-datasource': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-feed': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-job': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/service-messaging': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-package': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-queue': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/service-realtime': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/service-settings': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/service-storage': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/account': 8.0.1
+      '@objectstack/client': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/console': 8.0.1
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-memory': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-mongodb': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 8.0.1(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/mcp': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/observability': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-approvals': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-audit': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-auth': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-email': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-hono-server': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-org-scoping': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-reports': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-security': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-sharing': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-trigger-record-change': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-trigger-schedule': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-webhooks': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/rest': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/runtime': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/service-ai': 8.0.1(@ai-sdk/gateway@3.0.121(zod@4.4.3))
+      '@objectstack/service-analytics': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-automation': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-cache': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-datasource': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-feed': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-job': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/service-messaging': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-package': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-queue': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/service-realtime': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/service-settings': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/service-storage': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       '@oclif/core': 4.11.4
       bundle-require: 5.1.0(esbuild@0.28.0)
       chalk: 5.6.2
@@ -4187,34 +4187,34 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/client@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/client@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/console@7.7.0': {}
+  '@objectstack/console@8.0.1': {}
 
-  '@objectstack/core@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/core@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-memory@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/driver-memory@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       mingo: 7.2.1
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-mongodb@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/driver-mongodb@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       mongodb: 7.2.0
       nanoid: 5.1.11
     transitivePeerDependencies:
@@ -4227,10 +4227,10 @@ snapshots:
       - snappy
       - socks
 
-  '@objectstack/driver-sql@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/driver-sql@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.0)
       nanoid: 5.1.11
     optionalDependencies:
@@ -4242,11 +4242,11 @@ snapshots:
       - pg-query-stream
       - supports-color
 
-  '@objectstack/driver-sqlite-wasm@7.7.0(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)':
+  '@objectstack/driver-sqlite-wasm@8.0.1(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sql': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.0)
       nanoid: 5.1.11
       sql.js: 1.14.1
@@ -4262,38 +4262,50 @@ snapshots:
       - supports-color
       - tedious
 
-  '@objectstack/formula@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/formula@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
       '@marcbachmann/cel-js': 7.6.1
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-core@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/mcp@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - ai
+      - supports-color
+
+  '@objectstack/metadata-core@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       zod: 4.4.3
     optionalDependencies:
       vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-fs@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/metadata-fs@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       chokidar: 5.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/metadata@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/metadata@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/metadata-fs': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/metadata-fs': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       chokidar: 5.0.0
       glob: 13.0.6
       js-yaml: 4.2.0
@@ -4302,62 +4314,62 @@ snapshots:
       - ai
       - vitest
 
-  '@objectstack/objectql@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/objectql@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       ajv: 8.20.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/observability@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/observability@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/platform-objects@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/platform-objects@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/plugin-approvals@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/metadata-core': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-audit@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/plugin-approvals@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-auth@7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/plugin-audit@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/plugin-auth@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/oauth-provider': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.13(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.2.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-call@1.3.5(zod@4.4.3))
       '@noble/hashes': 2.2.0
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       better-auth: 1.6.13(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.2.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@better-auth/utils'
@@ -4389,127 +4401,115 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/plugin-email@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/plugin-email@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-hono-server@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-hono-server@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
       '@hono/node-server': 2.0.4(hono@4.12.23)
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       hono: 4.12.23
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-mcp-server@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-org-scoping@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.193(zod@4.4.3))
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - ai
-      - supports-color
-
-  '@objectstack/plugin-org-scoping@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-reports@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/plugin-reports@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-security@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/plugin-security@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-sharing@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/plugin-sharing@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/objectql': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-trigger-record-change@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-trigger-record-change@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-trigger-schedule@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-trigger-schedule@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-webhooks@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-webhooks@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-messaging': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-messaging': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/rest@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/rest@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-package': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-package': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/runtime@7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/runtime@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-memory': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sql': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 7.7.0(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/metadata': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/objectql': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/observability': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-auth': 7.7.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-org-scoping': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/plugin-security': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/rest': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-cluster': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-i18n': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-memory': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 8.0.1(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/objectql': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/observability': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-auth': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.28.17)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-org-scoping': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/plugin-security': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/rest': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-cluster': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-i18n': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       quickjs-emscripten: 0.32.0
       zod: 4.4.3
     optionalDependencies:
-      '@objectstack/driver-mongodb': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-mongodb': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -4553,139 +4553,139 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/service-ai@7.7.0(@ai-sdk/gateway@3.0.121(zod@4.4.3))':
+  '@objectstack/service-ai@8.0.1(@ai-sdk/gateway@3.0.121(zod@4.4.3))':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       ai: 6.0.193(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@ai-sdk/gateway': 3.0.121(zod@4.4.3)
 
-  '@objectstack/service-analytics@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-analytics@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-automation@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-automation@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/formula': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cache@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-cache@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cluster@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-cluster@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-datasource@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-datasource@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-feed@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-feed@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-i18n@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-i18n@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-job@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/service-job@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-messaging@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-messaging@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-package@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-package@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-queue@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/service-queue@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/service-realtime@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-settings@7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@objectstack/service-realtime@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/service-settings@8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@noble/ciphers': 2.2.0
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.7.0(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-storage@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-storage@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/observability': 7.7.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/spec@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/spec@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:
       ai: 6.0.193(zod@4.4.3)
 
-  '@objectstack/types@7.7.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/types@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.7.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
@@ -4705,7 +4705,7 @@ snapshots:
       semver: 7.8.1
       string-width: 4.2.3
       supports-color: 8.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
@@ -5252,7 +5252,7 @@ snapshots:
     dependencies:
       minimatch: 10.2.5
       path-browserify: 1.0.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
 
   '@tybys/wasm-util@0.10.2':
     dependencies:

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -4,9 +4,9 @@
  * CRM Seed Data
  *
  * Demo records for all core CRM objects.
- * Uses defineDataset() for type-safe field name checking at compile time.
+ * Uses defineSeed() for type-safe field name checking at compile time.
  */
-import { defineDataset } from '@objectstack/spec/data';
+import { defineSeed } from '@objectstack/spec/data';
 import { cel } from '@objectstack/spec';
 import { Account } from '../objects/account.object';
 import { Contact } from '../objects/contact.object';
@@ -29,7 +29,7 @@ const celDaysAgo = (n: number) => cel`daysAgo(${n})`;
 const celDaysFromNow = (n: number) => cel`daysFromNow(${n})`;
 
 // ─── Accounts ─────────────────────────────────────────────────────────
-const accounts = defineDataset(Account, {
+const accounts = defineSeed(Account, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -130,7 +130,7 @@ three regional teams (NA, EMEA, APAC).
 });
 
 // ─── Contacts ─────────────────────────────────────────────────────────
-const contacts = defineDataset(Contact, {
+const contacts = defineSeed(Contact, {
   mode: 'upsert',
   externalId: 'email',
   records: [
@@ -188,7 +188,7 @@ const contacts = defineDataset(Contact, {
 });
 
 // ─── Leads ────────────────────────────────────────────────────────────
-const leads = defineDataset(Lead, {
+const leads = defineSeed(Lead, {
   mode: 'upsert',
   externalId: 'email',
   records: [
@@ -268,7 +268,7 @@ const leads = defineDataset(Lead, {
 });
 
 // ─── Opportunities ────────────────────────────────────────────────────
-const opportunities = defineDataset(Opportunity, {
+const opportunities = defineSeed(Opportunity, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -449,7 +449,7 @@ analytics seats for the Ops org, (3) priority support SLA.`,
 });
 
 // ─── Products ─────────────────────────────────────────────────────────
-const products = defineDataset(Product, {
+const products = defineSeed(Product, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -485,7 +485,7 @@ const products = defineDataset(Product, {
 });
 
 // ─── Tasks ────────────────────────────────────────────────────────────
-const tasks = defineDataset(Task, {
+const tasks = defineSeed(Task, {
   mode: 'upsert',
   externalId: 'subject',
   records: [
@@ -543,7 +543,7 @@ const tasks = defineDataset(Task, {
 });
 
 // ─── Cases ────────────────────────────────────────────────────────────
-const cases = defineDataset(Case, {
+const cases = defineSeed(Case, {
   mode: 'upsert',
   externalId: 'subject',
   records: [
@@ -729,7 +729,7 @@ const cases = defineDataset(Case, {
 });
 
 // ─── Campaigns ────────────────────────────────────────────────────────
-const campaigns = defineDataset(Campaign, {
+const campaigns = defineSeed(Campaign, {
   mode: 'upsert',
   externalId: 'name',
   records: [
@@ -809,7 +809,7 @@ const campaigns = defineDataset(Campaign, {
 });
 
 // ─── Contracts ────────────────────────────────────────────────────────
-const contracts = defineDataset(Contract, {
+const contracts = defineSeed(Contract, {
   mode: 'upsert',
   externalId: 'contract_number',
   records: [
@@ -887,7 +887,7 @@ const contracts = defineDataset(Contract, {
 });
 
 // ─── Quotes ───────────────────────────────────────────────────────────
-const quotes = defineDataset(Quote, {
+const quotes = defineSeed(Quote, {
   mode: 'upsert',
   externalId: 'quote_number',
   records: [


### PR DESCRIPTION
Upgrade all `@objectstack/*` deps from `^7.7.0` to `^8.0.1`.

## Breaking change adapted
- `defineDataset` → `defineSeed` — the seed helper was renamed in 8.0 (`defineDataset` is now the analytics dataset in `@objectstack/spec/ui`).

## Verification
- `objectstack validate` ✓
- `tsc --noEmit` (typecheck) ✓ 0 errors
- `objectstack build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)