### PR TITLE
feat(analytics): ADR-0021 dataset migration — all dashboards + reports

### DIFF
--- a/objectstack.config.ts
+++ b/objectstack.config.ts
@@ -6,6 +6,7 @@ import * as cubes from './src/cubes/index.js';
 import * as objects from './src/objects/index.js';
 import * as actions from './src/actions/index.js';
 import * as dashboards from './src/dashboards/index.js';
+import * as datasets from './src/datasets/index.js';
 import * as reports from './src/reports/index.js';
 import { allFlows } from './src/flows/index.js';
 import { allAgents } from './src/agents/index.js';
@@ -62,6 +63,7 @@ export default defineStack({
   objects: Object.values(objects),
   actions: Object.values(actions),
   dashboards: Object.values(dashboards),
+  datasets: Object.values(datasets),
   reports: Object.values(reports),
   flows: allFlows,
   agents: allAgents,

--- a/scripts/analytics-reconcile/macros.ts
+++ b/scripts/analytics-reconcile/macros.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// ADR-0021 Phase 2 — date-macro resolver for the reconciliation harness.
+//
+// In production the renderer (@object-ui/core `resolveDateMacros()`) resolves
+// `{today}` / `{current_quarter_start}` / `{30_days_ago}` to concrete dates
+// BEFORE issuing the query — identically for the legacy and dataset forms. This
+// repo has no runtime resolver, so the harness must resolve them itself, or the
+// two paths diverge on the unparseable placeholder (the dataset filter-normalizer
+// drops an unparseable date filter; engine.aggregate keeps it). The resolved
+// VALUE is arbitrary — what matters is that BOTH paths receive the identical
+// concrete filter, so equality holds iff the two query paths agree semantically.
+//
+// Token grammar mirrors packages/spec/src/data/date-macros.zod.ts.
+
+import { DATE_MACRO_WRAPPED_RE, parseDateMacroParam } from '@objectstack/spec/data';
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+/** Monday-based week start (matches the spec's "Monday 00:00 of this week"). */
+function startOfWeek(d: Date): Date {
+  const s = startOfDay(d);
+  const dow = (s.getDay() + 6) % 7; // 0 = Monday
+  s.setDate(s.getDate() - dow);
+  return s;
+}
+function startOfMonth(d: Date): Date { return new Date(d.getFullYear(), d.getMonth(), 1); }
+function startOfQuarter(d: Date): Date { return new Date(d.getFullYear(), Math.floor(d.getMonth() / 3) * 3, 1); }
+function startOfYear(d: Date): Date { return new Date(d.getFullYear(), 0, 1); }
+
+// ObjectStack `date` fields are stored as epoch-millis (the seed loader writes
+// `cel`daysFromNow(n)`` as a timestamp number), so resolve macros to epoch-millis
+// — a number compares correctly against the stored column, where an ISO string
+// would not. The exact value is arbitrary as long as BOTH paths get the same one.
+const iso = (d: Date): number => d.getTime();
+
+type PeriodKind = 'week' | 'month' | 'quarter' | 'year';
+const startOf: Record<PeriodKind, (d: Date) => Date> = {
+  week: startOfWeek, month: startOfMonth, quarter: startOfQuarter, year: startOfYear,
+};
+function addPeriod(kind: PeriodKind, d: Date, n: number): Date {
+  const r = new Date(d);
+  if (kind === 'week') r.setDate(r.getDate() + n * 7);
+  else if (kind === 'month') r.setMonth(r.getMonth() + n);
+  else if (kind === 'quarter') r.setMonth(r.getMonth() + n * 3);
+  else r.setFullYear(r.getFullYear() + n);
+  return r;
+}
+
+/** Resolve a single token name (inside the braces) to an epoch-millis number, or null. */
+function resolveToken(name: string, now: Date): number | null {
+  switch (name) {
+    case 'today': return iso(startOfDay(now));
+    case 'yesterday': { const d = startOfDay(now); d.setDate(d.getDate() - 1); return iso(d); }
+    case 'tomorrow': { const d = startOfDay(now); d.setDate(d.getDate() + 1); return iso(d); }
+    case 'now': return now.getTime();
+  }
+
+  // current/last/next  ×  week/month/quarter/year  ×  start/end (+ bare aliases).
+  const m = name.match(/^(current|last|next)?_?(week|month|quarter|year)_(start|end)$/);
+  if (m) {
+    const rel = (m[1] ?? 'current') as 'current' | 'last' | 'next';
+    const kind = m[2] as PeriodKind;
+    const bound = m[3] as 'start' | 'end';
+    const offset = rel === 'last' ? -1 : rel === 'next' ? 1 : 0;
+    const periodStart = startOf[kind](addPeriod(kind, now, offset));
+    if (bound === 'start') return iso(periodStart);
+    // end = day before the next period's start.
+    const nextStart = addPeriod(kind, periodStart, 1);
+    nextStart.setDate(nextStart.getDate() - 1);
+    return iso(nextStart);
+  }
+
+  // Parameterised: N_<unit>_(ago|from_now).
+  const p = parseDateMacroParam(name);
+  if (p) {
+    const d = new Date(now);
+    const sign = p.direction === 'ago' ? -1 : 1;
+    switch (p.unit) {
+      case 'minute': d.setMinutes(d.getMinutes() + sign * p.n); break;
+      case 'hour': d.setHours(d.getHours() + sign * p.n); break;
+      case 'day': d.setDate(d.getDate() + sign * p.n); break;
+      case 'week': d.setDate(d.getDate() + sign * p.n * 7); break;
+      case 'month': d.setMonth(d.getMonth() + sign * p.n); break;
+      case 'year': d.setFullYear(d.getFullYear() + sign * p.n); break;
+    }
+    return p.unit === 'minute' || p.unit === 'hour' ? d.getTime() : iso(startOfDay(d));
+  }
+  return null;
+}
+
+/** Resolve a placeholder string like `'{today}'` / `'${30_days_ago}'`, else return it unchanged. */
+function resolveValue(value: unknown, now: Date): unknown {
+  if (typeof value !== 'string') return value;
+  const m = value.match(DATE_MACRO_WRAPPED_RE);
+  if (!m) return value;
+  return resolveToken(m[1], now) ?? value;
+}
+
+/**
+ * Deep-clone a FilterCondition, replacing every `{date-macro}` placeholder with
+ * a concrete ISO date. `now` is fixed once per call so all tokens in one filter
+ * resolve against the same instant.
+ */
+export function resolveDateMacros<T>(filter: T, now: Date = new Date()): T {
+  const walk = (node: unknown): unknown => {
+    if (Array.isArray(node)) return node.map(walk);
+    if (node && typeof node === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(node as Record<string, unknown>)) out[k] = walk(v);
+      return out;
+    }
+    return resolveValue(node, now);
+  };
+  return walk(filter) as T;
+}

--- a/scripts/analytics-reconcile/reconcile.ts
+++ b/scripts/analytics-reconcile/reconcile.ts
@@ -202,6 +202,18 @@ export async function reconcileWidget(
   if (dims.length > 1 && w.categoryField) {
     return { widgetId: w.id, status: 'skipped', issues: ['multi-dimension widget cannot reconcile against single categoryField legacy form'] };
   }
+  // Cross-object (relationship-traversal) dimension: a selected dimension whose
+  // dataset field is dotted (e.g. `crm_account.industry`). The legacy inline
+  // `categoryField` had no server-side join (engine.aggregate can't traverse a
+  // lookup) — it was expanded client-side — so there is NO legacy server path to
+  // reconcile against. The dataset binding is the first server-side join (the
+  // ADR's headline win); skip it rather than flag a non-existent baseline.
+  const crossObject =
+    (typeof w.categoryField === 'string' && w.categoryField.includes('.')) ||
+    dims.some((name) => (dataset.dimensions.find((d) => d.name === name)?.field ?? '').includes('.'));
+  if (crossObject) {
+    return { widgetId: w.id, status: 'skipped', issues: ['cross-object relationship dimension — no legacy server-side join to reconcile (dataset enables it)'] };
+  }
 
   // Resolve date macros once, then feed the identical filter to both paths.
   const wResolved = exec.resolveFilter

--- a/scripts/analytics-reconcile/reconcile.ts
+++ b/scripts/analytics-reconcile/reconcile.ts
@@ -1,0 +1,365 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// ADR-0021 Phase 2 — read-only analytics reconciliation (关键兜底 / hard gate).
+//
+// For every dual-form presentation (a report / dashboard widget that carries
+// BOTH the legacy inline query AND the new `dataset` binding), run BOTH paths
+// against the SAME engine and assert they return identical numbers. This is the
+// safety net that catches an AI migration silently dropping a filter, flipping
+// an aggregate口径 (count vs count_distinct), or pointing at the wrong field /
+// relationship. It ONLY verifies — it never rewrites — and is the gate that
+// must be green before the inline form is deleted (single-form convergence).
+//
+// Engine-agnostic on purpose: this module imports TYPES only. The caller injects
+// the two executors (legacy `aggregate()` + dataset `queryDataset()`) bound to a
+// real booted kernel — see app-todo.ts for the wiring.
+
+import type { Dashboard, DashboardWidget, Dataset, Report } from '@objectstack/spec/ui';
+import type { FilterCondition } from '@objectstack/spec/data';
+import type { DatasetSelection } from '@objectstack/spec/contracts';
+
+/** A groupBy item — a plain field, or a date field bucketed by a granularity. */
+export type GroupByItem = string | { field: string; dateGranularity: string };
+
+/** The legacy inline-query path, lowered to an ObjectQL `aggregate()` call. */
+export interface OldAggregateSpec {
+  objectName: string;
+  filter?: FilterCondition;
+  groupBy: GroupByItem[];
+  aggregations: Array<{ field: string; method: string; alias: string }>;
+}
+
+/** The field name a groupBy item groups on (the key the engine returns rows under). */
+function groupByField(g: GroupByItem): string {
+  return typeof g === 'string' ? g : g.field;
+}
+
+/** The executors the caller binds to a booted kernel. */
+export interface ReconcileExecutors {
+  /** Legacy path — `engine.aggregate(object, { where, groupBy, aggregations })`. */
+  runAggregate(spec: OldAggregateSpec): Promise<Record<string, unknown>[]>;
+  /** New path — `analytics.queryDataset(dataset, selection)`. */
+  runDataset(dataset: Dataset, selection: DatasetSelection): Promise<Record<string, unknown>[]>;
+  /**
+   * Resolve `{date-macro}` placeholders in a filter to concrete values BEFORE
+   * both paths run — mirroring the renderer. Applied identically to both forms,
+   * so the resolved value is arbitrary; what matters is the two paths see the
+   * SAME concrete filter (no normalizer-drop artifact on unparseable strings).
+   */
+  resolveFilter?: (filter: FilterCondition | undefined) => FilterCondition | undefined;
+}
+
+export interface WidgetReconcileResult {
+  widgetId: string;
+  /**
+   * - `ok`       — both forms returned identical numbers.
+   * - `mismatch` — numbers diverged (or a path threw). FAILS the gate.
+   * - `skipped`  — dual-form but not numerically reconcilable here (e.g. a
+   *                multi-dimension widget vs a single-categoryField legacy form).
+   * - `pending`  — still inline-only; not yet dataset-bound (coverage gap, not a failure).
+   */
+  status: 'ok' | 'mismatch' | 'skipped' | 'pending';
+  issues: string[];
+  /** Canonical {dimsKey → measureValues[]} maps for both paths (for diagnostics). */
+  oldRows?: Record<string, (number | null)[]>;
+  newRows?: Record<string, (number | null)[]>;
+}
+
+const NO_DIMS = '∅';
+const DIM_SEP = '∥';
+/** Relative tolerance for float measure comparison (counts are exact). */
+const EPSILON = 1e-9;
+
+/**
+ * A widget is reconcilable only when it carries BOTH forms: the legacy inline
+ * `object` query AND the new `dataset` binding with at least one measure name.
+ */
+export function isReconcilableWidget(
+  w: DashboardWidget,
+): w is DashboardWidget & { object: string; dataset: string; values: string[] } {
+  return (
+    typeof w.object === 'string' &&
+    typeof w.dataset === 'string' &&
+    Array.isArray(w.values) &&
+    w.values.length > 0
+  );
+}
+
+/**
+ * Lower a widget's LEGACY inline fields to an aggregate spec — derived purely
+ * from `object` / `categoryField` / `valueField` / `aggregate` / `measures` /
+ * `filter`, NOT from the dataset. That independence is the whole point: if the
+ * dataset was authored to mean something different, the numbers diverge here.
+ */
+export function deriveOldAggregate(w: DashboardWidget): OldAggregateSpec {
+  let groupBy: GroupByItem[] = w.categoryField
+    ? [w.categoryGranularity
+        ? { field: w.categoryField, dateGranularity: w.categoryGranularity }
+        : w.categoryField]
+    : [];
+  // hotcrm pivot widgets encode their grouping in `options.rowField` /
+  // `options.columnField` (not the schema's `categoryField`). Read them so a
+  // pivot reconciles against its dataset `dimensions: [rowField, columnField]`.
+  if (groupBy.length === 0) {
+    const o = w.options as { rowField?: string; columnField?: string } | undefined;
+    if (o && (o.rowField || o.columnField)) {
+      groupBy = [o.rowField, o.columnField].filter((x): x is string => typeof x === 'string');
+    }
+  }
+  const aggregations: OldAggregateSpec['aggregations'] = [];
+  if (w.measures && w.measures.length > 0) {
+    w.measures.forEach((m, i) => {
+      aggregations.push({ method: m.aggregate ?? 'count', field: m.valueField ?? '*', alias: `m${i}` });
+    });
+  } else {
+    aggregations.push({ method: w.aggregate ?? 'count', field: w.valueField ?? '*', alias: 'm0' });
+  }
+  return { objectName: w.object as string, filter: w.filter, groupBy, aggregations };
+}
+
+/** Build the dataset selection from the widget's `dimensions` / `values` / `filter`. */
+export function deriveSelection(w: DashboardWidget): DatasetSelection {
+  const dimensions = w.dimensions ?? [];
+  const selection: DatasetSelection = {
+    dimensions,
+    measures: w.values as string[],
+    runtimeFilter: w.filter,
+  };
+  // Mirror the legacy `categoryGranularity` as a timeDimension so the dataset
+  // path buckets the date dimension identically (ObjectQLStrategy honours it).
+  if (w.categoryGranularity && dimensions.length === 1) {
+    selection.timeDimensions = [{ dimension: dimensions[0], granularity: w.categoryGranularity }];
+  }
+  return selection;
+}
+
+function toNum(v: unknown): number | null {
+  if (v == null) return null;
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Stable key for a row's dimension tuple, ordered by `dimKeys`. */
+function dimsKeyOf(row: Record<string, unknown>, dimKeys: string[]): string {
+  if (dimKeys.length === 0) return NO_DIMS;
+  return dimKeys.map((k) => String(row[k] ?? '∄')).join(DIM_SEP);
+}
+
+/** Canonicalize rows into {dimsKey → [measure values in `measureKeys` order]}. */
+function normalize(
+  rows: Record<string, unknown>[],
+  dimKeys: string[],
+  measureKeys: string[],
+): Record<string, (number | null)[]> {
+  const out: Record<string, (number | null)[]> = {};
+  for (const row of rows) {
+    out[dimsKeyOf(row, dimKeys)] = measureKeys.map((m) => toNum(row[m]));
+  }
+  return out;
+}
+
+function numbersEqual(a: number | null, b: number | null): boolean {
+  if (a === null || b === null) return a === b;
+  if (a === b) return true;
+  const scale = Math.max(Math.abs(a), Math.abs(b), 1);
+  return Math.abs(a - b) <= EPSILON * scale;
+}
+
+/** Diff two canonical maps; returns human-readable issue strings (empty = match). */
+function diff(
+  oldMap: Record<string, (number | null)[]>,
+  newMap: Record<string, (number | null)[]>,
+): string[] {
+  const issues: string[] = [];
+  const keys = new Set([...Object.keys(oldMap), ...Object.keys(newMap)]);
+  for (const key of keys) {
+    const o = oldMap[key];
+    const n = newMap[key];
+    const label = key === NO_DIMS ? '(scalar)' : key;
+    if (!o) { issues.push(`group "${label}": present in dataset path but missing from legacy path (new=${JSON.stringify(n)})`); continue; }
+    if (!n) { issues.push(`group "${label}": present in legacy path but missing from dataset path (old=${JSON.stringify(o)})`); continue; }
+    if (o.length !== n.length) { issues.push(`group "${label}": measure count differs (old=${o.length} new=${n.length})`); continue; }
+    for (let i = 0; i < o.length; i++) {
+      if (!numbersEqual(o[i], n[i])) issues.push(`group "${label}" measure[${i}]: legacy=${o[i]} dataset=${n[i]}`);
+    }
+  }
+  return issues;
+}
+
+/** Reconcile a single dual-form widget against its dataset. */
+export async function reconcileWidget(
+  w: DashboardWidget,
+  dataset: Dataset | undefined,
+  exec: ReconcileExecutors,
+): Promise<WidgetReconcileResult> {
+  if (!isReconcilableWidget(w)) {
+    return { widgetId: w.id, status: 'skipped', issues: ['not dual-form (missing object or dataset/values)'] };
+  }
+  if (!dataset) {
+    return { widgetId: w.id, status: 'mismatch', issues: [`dataset "${w.dataset}" not found in registry`] };
+  }
+  const dims = w.dimensions ?? [];
+  if (dims.length > 1 && w.categoryField) {
+    return { widgetId: w.id, status: 'skipped', issues: ['multi-dimension widget cannot reconcile against single categoryField legacy form'] };
+  }
+
+  // Resolve date macros once, then feed the identical filter to both paths.
+  const wResolved = exec.resolveFilter
+    ? ({ ...w, filter: exec.resolveFilter(w.filter) } as DashboardWidget)
+    : w;
+  const oldSpec = deriveOldAggregate(wResolved);
+  const selection = deriveSelection(wResolved);
+
+  let oldRaw: Record<string, unknown>[];
+  let newRaw: Record<string, unknown>[];
+  try {
+    oldRaw = await exec.runAggregate(oldSpec);
+  } catch (e) {
+    return { widgetId: w.id, status: 'mismatch', issues: [`legacy aggregate threw: ${(e as Error).message}`] };
+  }
+  try {
+    newRaw = await exec.runDataset(dataset, selection);
+  } catch (e) {
+    return { widgetId: w.id, status: 'mismatch', issues: [`dataset query threw: ${(e as Error).message}`] };
+  }
+
+  // Legacy rows key dimensions by the raw field name (categoryField); dataset
+  // rows key them by the dimension NAME. They share the same value domain, so
+  // canonicalize each by its own key set, then compare positionally.
+  const oldMap = normalize(oldRaw, oldSpec.groupBy.map(groupByField), oldSpec.aggregations.map((a) => a.alias));
+  const newMap = normalize(newRaw, dims, w.values as string[]);
+
+  const issues = diff(oldMap, newMap);
+  return {
+    widgetId: w.id,
+    status: issues.length === 0 ? 'ok' : 'mismatch',
+    issues,
+    oldRows: oldMap,
+    newRows: newMap,
+  };
+}
+
+// ───────────────────────── Reports ─────────────────────────
+//
+// Reports have NO server-side executor in this repo (the pivot is computed
+// client-side). We reconcile the NUMBERS only: lower the legacy report's
+// groupings + aggregate columns to the same `aggregate()` call, and compare to
+// the dataset's `rows`/`values`. A matrix (`groupingsAcross`) flattens to a 2D
+// groupBy — the cell values are identical to the rendered pivot. A detail/summary
+// report with no aggregate columns reconciles its group COUNT (count(*)), which
+// is what the legacy report's group headers show.
+
+/** A report is reconcilable when it carries BOTH the inline query and the dataset binding. */
+export function isReconcilableReport(
+  r: Report,
+): r is Report & { objectName: string; dataset: string; values: string[] } {
+  return (
+    typeof r.objectName === 'string' &&
+    typeof r.dataset === 'string' &&
+    Array.isArray(r.values) &&
+    r.values.length > 0
+  );
+}
+
+/** Lower a report's LEGACY inline fields (groupings + aggregate columns) to an aggregate spec. */
+export function deriveReportAggregate(r: Report): OldAggregateSpec {
+  const groupBy = [
+    ...(r.groupingsDown ?? []).map((g) => g.field),
+    ...(r.groupingsAcross ?? []).map((g) => g.field),
+  ];
+  const aggCols = (r.columns ?? []).filter((c) => c.aggregate);
+  const aggregations: OldAggregateSpec['aggregations'] = aggCols.length > 0
+    ? aggCols.map((c, i) => ({ method: c.aggregate as string, field: c.field, alias: `m${i}` }))
+    : [{ method: 'count', field: '*', alias: 'm0' }]; // detail/summary → group count
+  return { objectName: r.objectName as string, filter: r.filter, groupBy, aggregations };
+}
+
+/** Reconcile a single dual-form report against its dataset. */
+export async function reconcileReport(
+  r: Report,
+  dataset: Dataset | undefined,
+  exec: ReconcileExecutors,
+): Promise<WidgetReconcileResult> {
+  if (!isReconcilableReport(r)) {
+    return { widgetId: r.name, status: 'skipped', issues: ['not dual-form (missing objectName or dataset/values)'] };
+  }
+  if (!dataset) {
+    return { widgetId: r.name, status: 'mismatch', issues: [`dataset "${r.dataset}" not found in registry`] };
+  }
+  const rows = r.rows ?? [];
+
+  // Resolve macros on the legacy filter and the dataset runtimeFilter identically.
+  const legacyFilter = exec.resolveFilter ? exec.resolveFilter(r.filter) : r.filter;
+  const runtimeFilter = exec.resolveFilter ? exec.resolveFilter(r.runtimeFilter ?? r.filter) : (r.runtimeFilter ?? r.filter);
+
+  const oldSpec = { ...deriveReportAggregate(r), filter: legacyFilter };
+  const selection: DatasetSelection = { dimensions: rows, measures: r.values as string[], runtimeFilter };
+
+  let oldRaw: Record<string, unknown>[];
+  let newRaw: Record<string, unknown>[];
+  try {
+    oldRaw = await exec.runAggregate(oldSpec);
+  } catch (e) {
+    return { widgetId: r.name, status: 'mismatch', issues: [`legacy aggregate threw: ${(e as Error).message}`] };
+  }
+  try {
+    newRaw = await exec.runDataset(dataset, selection);
+  } catch (e) {
+    return { widgetId: r.name, status: 'mismatch', issues: [`dataset query threw: ${(e as Error).message}`] };
+  }
+
+  const oldMap = normalize(oldRaw, oldSpec.groupBy.map(groupByField), oldSpec.aggregations.map((a) => a.alias));
+  const newMap = normalize(newRaw, rows, r.values as string[]);
+  const issues = diff(oldMap, newMap);
+  return { widgetId: r.name, status: issues.length === 0 ? 'ok' : 'mismatch', issues, oldRows: oldMap, newRows: newMap };
+}
+
+/** Reconcile every dual-form report. */
+export async function reconcileReports(
+  reports: Report[],
+  datasets: Map<string, Dataset>,
+  exec: ReconcileExecutors,
+): Promise<WidgetReconcileResult[]> {
+  const results: WidgetReconcileResult[] = [];
+  for (const r of reports) {
+    // Joined reports have no single data binding — reconcile each block.
+    if (r.type === 'joined' && Array.isArray(r.blocks)) {
+      for (const block of r.blocks) {
+        const id = `${r.name}/${block.name}`;
+        if (typeof block.dataset !== 'string') {
+          results.push({ widgetId: id, status: 'pending', issues: ['joined block inline-only (record-list / embed)'] });
+          continue;
+        }
+        // A block is shaped like a mini-report (objectName/columns/groupings/
+        // filter + dataset/rows/values/runtimeFilter) — reconcile it as one.
+        const asReport = { ...block, name: id } as unknown as Report;
+        results.push(await reconcileReport(asReport, datasets.get(block.dataset), exec));
+      }
+      continue;
+    }
+    if (typeof r.dataset !== 'string') {
+      results.push({ widgetId: r.name, status: 'pending', issues: ['inline-only — not yet dataset-bound'] });
+      continue;
+    }
+    results.push(await reconcileReport(r, datasets.get(r.dataset), exec));
+  }
+  return results;
+}
+
+/** Reconcile every dual-form widget on a dashboard. */
+export async function reconcileDashboard(
+  dashboard: Dashboard,
+  datasets: Map<string, Dataset>,
+  exec: ReconcileExecutors,
+): Promise<WidgetReconcileResult[]> {
+  const results: WidgetReconcileResult[] = [];
+  for (const w of dashboard.widgets) {
+    if (typeof w.dataset !== 'string') {
+      // Inline-only widget — surfaced as `pending` so migration coverage stays honest.
+      results.push({ widgetId: w.id, status: 'pending', issues: ['inline-only — not yet dataset-bound'] });
+      continue;
+    }
+    results.push(await reconcileWidget(w, datasets.get(w.dataset), exec));
+  }
+  return results;
+}

--- a/scripts/analytics-reconcile/run.ts
+++ b/scripts/analytics-reconcile/run.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// ADR-0021 — read-only analytics reconciliation for hotcrm.
+//
+// Boots the hotcrm stack with a real in-memory engine + the analytics service,
+// then for every dual-form dashboard widget / report runs the legacy inline
+// `aggregate()` vs the new dataset `queryDataset()` and asserts identical
+// numbers. Exits non-zero on any mismatch. Read-only.
+//
+//   pnpm tsx scripts/analytics-reconcile/run.ts
+
+import { ObjectKernel, DriverPlugin, AppPlugin } from '@objectstack/runtime';
+import { SqliteWasmDriver } from '@objectstack/driver-sqlite-wasm';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { AnalyticsServicePlugin } from '@objectstack/service-analytics';
+import { DatasetSchema } from '@objectstack/spec/ui';
+import type { Dataset, Dashboard, Report } from '@objectstack/spec/ui';
+import type { IAnalyticsService, DatasetSelection } from '@objectstack/spec/contracts';
+import type { FilterCondition } from '@objectstack/spec/data';
+
+import {
+  reconcileDashboard,
+  reconcileReports,
+  type ReconcileExecutors,
+  type WidgetReconcileResult,
+} from './reconcile.js';
+import { resolveDateMacros } from './macros.js';
+
+import HotCrmApp from '../../objectstack.config.js';
+import * as datasetMod from '../../src/datasets/index.js';
+import * as dashboardMod from '../../src/dashboards/index.js';
+import * as reportMod from '../../src/reports/index.js';
+
+interface DataEngineLike {
+  aggregate(object: string, options: {
+    where?: Record<string, unknown>;
+    groupBy?: Array<string | { field: string; dateGranularity: string }>;
+    aggregations?: Array<{ function: string; field: string; alias: string }>;
+  }): Promise<Record<string, unknown>[]>;
+}
+
+function report(surface: string, results: WidgetReconcileResult[]): number {
+  let mismatches = 0;
+  const icons: Record<WidgetReconcileResult['status'], string> = {
+    ok: '✅', mismatch: '❌', skipped: '⏭️ ', pending: '🕗',
+  };
+  console.log(`\n── Analytics reconciliation · ${surface} ──`);
+  for (const r of results) {
+    console.log(`${icons[r.status]} ${r.widgetId}  [${r.status}]`);
+    if (r.status === 'mismatch') {
+      mismatches++;
+      for (const issue of r.issues) console.log(`     · ${issue}`);
+    } else if ((r.status === 'skipped' || r.status === 'pending') && r.issues.length) {
+      console.log(`     · ${r.issues[0]}`);
+    }
+  }
+  const count = (s: WidgetReconcileResult['status']) => results.filter((r) => r.status === s).length;
+  console.log(
+    `\n${mismatches === 0 ? '🎉' : '🔴'} ${count('ok')} ok · ${count('skipped')} skipped · ` +
+    `${count('pending')} pending · ${mismatches} mismatch`,
+  );
+  return mismatches;
+}
+
+async function main(): Promise<number> {
+  process.env.OS_MULTI_ORG_ENABLED = 'false';
+
+  const kernel = new ObjectKernel();
+  await kernel.use(new ObjectQLPlugin());
+  await kernel.use(new DriverPlugin(new SqliteWasmDriver({ filename: ':memory:' })));
+  await kernel.use(new AppPlugin(HotCrmApp as ConstructorParameters<typeof AppPlugin>[0]));
+  await kernel.use(new AnalyticsServicePlugin({
+    queryCapabilities: () => ({ nativeSql: false, objectqlAggregate: true, inMemory: false }),
+  }));
+  await kernel.bootstrap();
+
+  const engine =
+    (kernel.getService('data') as DataEngineLike | undefined) ??
+    (kernel.getService('objectql') as DataEngineLike | undefined);
+  if (!engine?.aggregate) throw new Error('No IDataEngine with aggregate() found.');
+  const analytics = kernel.getService('analytics') as IAnalyticsService | undefined;
+  if (!analytics?.queryDataset) throw new Error('No analytics service with queryDataset().');
+
+  const datasets = new Map<string, Dataset>();
+  for (const ds of Object.values(datasetMod) as unknown[]) {
+    const parsed = DatasetSchema.parse(ds) as Dataset;
+    datasets.set(parsed.name, parsed);
+  }
+
+  const exec: ReconcileExecutors = {
+    runAggregate: (spec) => engine.aggregate(spec.objectName, {
+      where: spec.filter as Record<string, unknown> | undefined,
+      groupBy: spec.groupBy.length > 0 ? spec.groupBy : undefined,
+      aggregations: spec.aggregations.map((a) => ({ function: a.method, field: a.field, alias: a.alias })),
+    }),
+    runDataset: async (dataset: Dataset, selection: DatasetSelection) =>
+      (await analytics.queryDataset!(dataset, selection)).rows as Record<string, unknown>[],
+    resolveFilter: (f?: FilterCondition) => (f == null ? f : resolveDateMacros(f)),
+  };
+
+  let mismatches = 0;
+  for (const dashboard of Object.values(dashboardMod) as Dashboard[]) {
+    mismatches += report(`hotcrm · ${dashboard.name}`, await reconcileDashboard(dashboard, datasets, exec));
+  }
+  const reports = Object.values(reportMod) as Report[];
+  if (reports.length) mismatches += report('hotcrm · reports', await reconcileReports(reports, datasets, exec));
+  return mismatches;
+}
+
+main()
+  .then((m) => process.exit(m === 0 ? 0 : 1))
+  .catch((err) => { console.error('❌ Reconciliation failed:', err); process.exit(2); });

--- a/src/dashboards/crm.dashboard.ts
+++ b/src/dashboards/crm.dashboard.ts
@@ -65,6 +65,7 @@ export const CrmOverviewDashboard: Dashboard = {
       actionUrl: '/reports/revenue',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'opportunity_metrics', values: ['total_amount'],
       layout: { x: 0, y: 0, w: 3, h: 2 },
       options: {
         icon: 'DollarSign',
@@ -83,6 +84,7 @@ export const CrmOverviewDashboard: Dashboard = {
       actionUrl: '/objects/opportunity?filter=open',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'opportunity_metrics', values: ['opp_count'],
       layout: { x: 3, y: 0, w: 3, h: 2 },
       options: {
         icon: 'Briefcase',
@@ -103,6 +105,7 @@ export const CrmOverviewDashboard: Dashboard = {
       actionUrl: '/reports/win-rate',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'opportunity_metrics', values: ['opp_count'],
       layout: { x: 6, y: 0, w: 3, h: 2 },
       options: {
         icon: 'Trophy',
@@ -123,6 +126,7 @@ export const CrmOverviewDashboard: Dashboard = {
       actionUrl: '/reports/avg-deal-size',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'opportunity_metrics', values: ['avg_amount'],
       layout: { x: 9, y: 0, w: 3, h: 2 },
       options: {
         icon: 'bar-chart',
@@ -142,6 +146,7 @@ export const CrmOverviewDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'success',
+      dataset: 'opportunity_metrics', dimensions: ['close_date'], values: ['total_amount'],
       layout: { x: 0, y: 2, w: 9, h: 4 },
       chartConfig: {
         type: 'area',
@@ -164,6 +169,7 @@ export const CrmOverviewDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'purple',
+      dataset: 'opportunity_metrics', dimensions: ['lead_source'], values: ['total_amount'],
       layout: { x: 9, y: 2, w: 3, h: 4 },
       chartConfig: {
         type: 'donut',
@@ -185,6 +191,7 @@ export const CrmOverviewDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'teal',
+      dataset: 'opportunity_metrics', dimensions: ['stage'], values: ['total_amount'],
       layout: { x: 0, y: 6, w: 6, h: 4 },
       chartConfig: {
         type: 'funnel',
@@ -203,6 +210,7 @@ export const CrmOverviewDashboard: Dashboard = {
       valueField: 'list_price',
       aggregate: 'sum',
       colorVariant: 'blue',
+      dataset: 'product_metrics', dimensions: ['category'], values: ['list_price_sum'],
       layout: { x: 6, y: 6, w: 6, h: 4 },
       chartConfig: {
         type: 'bar',
@@ -223,6 +231,7 @@ export const CrmOverviewDashboard: Dashboard = {
       object: 'crm_opportunity',
       aggregate: 'count',
       colorVariant: 'default',
+      dataset: 'opportunity_metrics', values: ['opp_count'],
       layout: { x: 0, y: 10, w: 12, h: 4 },
       options: {
         columns: [

--- a/src/dashboards/executive.dashboard.ts
+++ b/src/dashboards/executive.dashboard.ts
@@ -75,6 +75,7 @@ export const ExecutiveDashboard: Dashboard = {
       actionUrl: '/reports/revenue-ytd',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'opportunity_metrics', values: ['total_amount'],
       layout: { x: 0, y: 0, w: 3, h: 2 },
       options: {
         icon: 'DollarSign',
@@ -93,6 +94,7 @@ export const ExecutiveDashboard: Dashboard = {
       actionUrl: '/objects/account',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'account_metrics', values: ['account_count'],
       layout: { x: 3, y: 0, w: 3, h: 2 },
       options: {
         icon: 'Building2',
@@ -111,6 +113,7 @@ export const ExecutiveDashboard: Dashboard = {
       actionUrl: '/objects/contact',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'contact_metrics', values: ['contact_count'],
       layout: { x: 6, y: 0, w: 3, h: 2 },
       options: {
         icon: 'Users',
@@ -130,6 +133,7 @@ export const ExecutiveDashboard: Dashboard = {
       actionUrl: '/objects/lead',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'lead_metrics', values: ['lead_count'],
       layout: { x: 9, y: 0, w: 3, h: 2 },
       options: {
         icon: 'Sparkles',
@@ -150,6 +154,7 @@ export const ExecutiveDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'success',
+      dataset: 'opportunity_metrics', dimensions: ['close_date'], values: ['total_amount'],
       layout: { x: 0, y: 2, w: 8, h: 4 },
       chartConfig: {
         type: 'area',
@@ -175,6 +180,7 @@ export const ExecutiveDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'blue',
+      dataset: 'opportunity_metrics', dimensions: ['account_industry'], values: ['total_amount'],
       layout: { x: 8, y: 2, w: 4, h: 4 },
       chartConfig: {
         type: 'donut',
@@ -196,6 +202,7 @@ export const ExecutiveDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'teal',
+      dataset: 'opportunity_metrics', dimensions: ['stage'], values: ['total_amount'],
       layout: { x: 0, y: 6, w: 6, h: 4 },
       chartConfig: {
         type: 'funnel',
@@ -214,6 +221,7 @@ export const ExecutiveDashboard: Dashboard = {
       categoryField: 'created_at',
       aggregate: 'count',
       colorVariant: 'purple',
+      dataset: 'account_metrics', dimensions: ['created_at'], values: ['account_count'],
       layout: { x: 6, y: 6, w: 6, h: 4 },
       chartConfig: {
         type: 'bar',
@@ -235,6 +243,7 @@ export const ExecutiveDashboard: Dashboard = {
       object: 'crm_account',
       aggregate: 'count',
       colorVariant: 'default',
+      dataset: 'account_metrics', values: ['account_count'],
       layout: { x: 0, y: 10, w: 12, h: 4 },
       options: {
         columns: [

--- a/src/dashboards/sales.dashboard.ts
+++ b/src/dashboards/sales.dashboard.ts
@@ -70,6 +70,7 @@ export const SalesDashboard: Dashboard = {
       actionUrl: '/objects/opportunity?filter=open',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'opportunity_metrics', values: ['total_amount'],
       layout: { x: 0, y: 0, w: 3, h: 2 },
       options: {
         icon: 'DollarSign',
@@ -90,6 +91,7 @@ export const SalesDashboard: Dashboard = {
       actionUrl: '/reports/closed-won',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'opportunity_metrics', values: ['total_amount'],
       layout: { x: 3, y: 0, w: 3, h: 2 },
       options: {
         icon: 'Trophy',
@@ -109,6 +111,7 @@ export const SalesDashboard: Dashboard = {
       actionUrl: '/objects/opportunity?filter=open',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'opportunity_metrics', values: ['opp_count'],
       layout: { x: 6, y: 0, w: 3, h: 2 },
       options: {
         icon: 'Briefcase',
@@ -129,6 +132,7 @@ export const SalesDashboard: Dashboard = {
       actionUrl: '/reports/avg-deal-size',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'opportunity_metrics', values: ['avg_amount'],
       layout: { x: 9, y: 0, w: 3, h: 2 },
       options: {
         icon: 'bar-chart',
@@ -149,6 +153,7 @@ export const SalesDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'teal',
+      dataset: 'opportunity_metrics', dimensions: ['stage'], values: ['total_amount'],
       layout: { x: 0, y: 2, w: 6, h: 4 },
       chartConfig: {
         type: 'funnel',
@@ -168,6 +173,7 @@ export const SalesDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'success',
+      dataset: 'opportunity_metrics', dimensions: ['close_date'], values: ['total_amount'],
       layout: { x: 6, y: 2, w: 6, h: 4 },
       chartConfig: {
         type: 'area',
@@ -196,6 +202,7 @@ export const SalesDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'blue',
+      dataset: 'opportunity_metrics', dimensions: ['forecast_category'], values: ['total_amount'],
       layout: { x: 0, y: 6, w: 6, h: 4 },
       chartConfig: {
         type: 'horizontal-bar',
@@ -217,6 +224,7 @@ export const SalesDashboard: Dashboard = {
       valueField: 'amount',
       aggregate: 'sum',
       colorVariant: 'purple',
+      dataset: 'opportunity_metrics', dimensions: ['lead_source'], values: ['total_amount'],
       layout: { x: 6, y: 6, w: 6, h: 4 },
       chartConfig: {
         type: 'donut',
@@ -236,6 +244,7 @@ export const SalesDashboard: Dashboard = {
       filter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
       aggregate: 'count',
       colorVariant: 'default',
+      dataset: 'opportunity_metrics', values: ['opp_count'],
       layout: { x: 0, y: 10, w: 12, h: 4 },
       options: {
         columns: [
@@ -264,6 +273,7 @@ export const SalesDashboard: Dashboard = {
       object: 'crm_opportunity',
       filter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
       colorVariant: 'default',
+      dataset: 'opportunity_metrics', dimensions: ['stage', 'lead_source'], values: ['total_amount'],
       layout: { x: 0, y: 14, w: 12, h: 4 },
       valueField: 'amount',
       aggregate: 'sum',

--- a/src/dashboards/service.dashboard.ts
+++ b/src/dashboards/service.dashboard.ts
@@ -71,6 +71,7 @@ export const ServiceDashboard: Dashboard = {
       actionUrl: '/objects/case?filter=open',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'case_metrics', values: ['case_count'],
       layout: { x: 0, y: 0, w: 3, h: 2 },
       options: {
         icon: 'Inbox',
@@ -90,6 +91,7 @@ export const ServiceDashboard: Dashboard = {
       actionUrl: '/objects/case?priority=critical',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'case_metrics', values: ['case_count'],
       layout: { x: 3, y: 0, w: 3, h: 2 },
       options: {
         icon: 'AlertTriangle',
@@ -110,6 +112,7 @@ export const ServiceDashboard: Dashboard = {
       actionUrl: '/reports/resolution-time',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'case_metrics', values: ['avg_resolution'],
       layout: { x: 6, y: 0, w: 3, h: 2 },
       options: {
         icon: 'Clock',
@@ -130,6 +133,7 @@ export const ServiceDashboard: Dashboard = {
       actionUrl: '/objects/case?filter=sla_violated',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
+      dataset: 'case_metrics', values: ['case_count'],
       layout: { x: 9, y: 0, w: 3, h: 2 },
       options: {
         icon: 'ShieldAlert',
@@ -149,6 +153,7 @@ export const ServiceDashboard: Dashboard = {
       categoryField: 'status',
       aggregate: 'count',
       colorVariant: 'blue',
+      dataset: 'case_metrics', dimensions: ['status'], values: ['case_count'],
       layout: { x: 0, y: 2, w: 4, h: 4 },
       chartConfig: {
         type: 'donut',
@@ -167,6 +172,7 @@ export const ServiceDashboard: Dashboard = {
       categoryField: 'priority',
       aggregate: 'count',
       colorVariant: 'warning',
+      dataset: 'case_metrics', dimensions: ['priority'], values: ['case_count'],
       layout: { x: 4, y: 2, w: 4, h: 4 },
       chartConfig: {
         type: 'pie',
@@ -185,6 +191,7 @@ export const ServiceDashboard: Dashboard = {
       categoryField: 'origin',
       aggregate: 'count',
       colorVariant: 'purple',
+      dataset: 'case_metrics', dimensions: ['origin'], values: ['case_count'],
       layout: { x: 8, y: 2, w: 4, h: 4 },
       chartConfig: {
         type: 'bar',
@@ -207,6 +214,7 @@ export const ServiceDashboard: Dashboard = {
       categoryField: 'created_date',
       aggregate: 'count',
       colorVariant: 'blue',
+      dataset: 'case_metrics', dimensions: ['created_date'], values: ['case_count'],
       layout: { x: 0, y: 6, w: 8, h: 4 },
       chartConfig: {
         type: 'area',
@@ -229,6 +237,7 @@ export const ServiceDashboard: Dashboard = {
       valueField: 'is_sla_violated',
       aggregate: 'avg',
       colorVariant: 'success',
+      dataset: 'case_metrics', values: ['avg_sla_violated'],
       layout: { x: 8, y: 6, w: 4, h: 4 },
       chartConfig: {
         type: 'gauge',
@@ -260,6 +269,7 @@ export const ServiceDashboard: Dashboard = {
       filter: { owner: '{current_user}', is_closed: false },
       aggregate: 'count',
       colorVariant: 'default',
+      dataset: 'case_metrics', values: ['case_count'],
       layout: { x: 0, y: 10, w: 12, h: 4 },
       options: {
         columns: [

--- a/src/datasets/account.dataset.ts
+++ b/src/datasets/account.dataset.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** Account analytics dataset (ADR-0021). */
+export const AccountDataset = defineDataset({
+  name: 'account_metrics',
+  label: 'Account Metrics',
+  description: 'Semantic layer for account counts by industry / type',
+  object: 'crm_account',
+  dimensions: [
+    { name: 'industry', label: 'Industry', field: 'industry', type: 'string' },
+    { name: 'type', label: 'Type', field: 'type', type: 'string' },
+    { name: 'created_at', label: 'Created', field: 'created_at', type: 'date' },
+  ],
+  measures: [
+    { name: 'account_count', label: 'Accounts', aggregate: 'count' },
+  ],
+});

--- a/src/datasets/account.dataset.ts
+++ b/src/datasets/account.dataset.ts
@@ -15,5 +15,6 @@ export const AccountDataset = defineDataset({
   ],
   measures: [
     { name: 'account_count', label: 'Accounts', aggregate: 'count' },
+    { name: 'annual_revenue_sum', label: 'Annual Revenue', aggregate: 'sum', field: 'annual_revenue', format: '$0,0' },
   ],
 });

--- a/src/datasets/case.dataset.ts
+++ b/src/datasets/case.dataset.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/**
+ * Case analytics dataset (ADR-0021) — the semantic source of truth for the
+ * Service dashboard's case counts, resolution time and SLA compliance.
+ */
+export const CaseDataset = defineDataset({
+  name: 'case_metrics',
+  label: 'Case Metrics',
+  description: 'Semantic layer for support-case counts, resolution time and SLA',
+  object: 'crm_case',
+
+  dimensions: [
+    { name: 'status', label: 'Status', field: 'status', type: 'string' },
+    { name: 'priority', label: 'Priority', field: 'priority', type: 'string' },
+    { name: 'origin', label: 'Origin', field: 'origin', type: 'string' },
+    { name: 'type', label: 'Type', field: 'type', type: 'string' },
+    { name: 'created_date', label: 'Created', field: 'created_date', type: 'date' },
+  ],
+
+  measures: [
+    { name: 'case_count', label: 'Cases', aggregate: 'count' },
+    { name: 'avg_resolution', label: 'Avg Resolution (h)', aggregate: 'avg', field: 'resolution_time_hours', format: '0.0' },
+    { name: 'avg_sla_violated', label: 'SLA Violation Rate', aggregate: 'avg', field: 'is_sla_violated', format: '0.0%' },
+  ],
+});

--- a/src/datasets/contact.dataset.ts
+++ b/src/datasets/contact.dataset.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** Contact analytics dataset (ADR-0021). */
+export const ContactDataset = defineDataset({
+  name: 'contact_metrics',
+  label: 'Contact Metrics',
+  description: 'Semantic layer for contact counts',
+  object: 'crm_contact',
+  dimensions: [],
+  measures: [{ name: 'contact_count', label: 'Contacts', aggregate: 'count' }],
+});

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/** Analytics dataset barrel (ADR-0021). */
+export { OpportunityDataset } from './opportunity.dataset';

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -2,3 +2,8 @@
 
 /** Analytics dataset barrel (ADR-0021). */
 export { OpportunityDataset } from './opportunity.dataset';
+export { CaseDataset } from './case.dataset';
+export { ProductDataset } from './product.dataset';
+export { AccountDataset } from './account.dataset';
+export { ContactDataset } from './contact.dataset';
+export { LeadDataset } from './lead.dataset';

--- a/src/datasets/lead.dataset.ts
+++ b/src/datasets/lead.dataset.ts
@@ -12,6 +12,7 @@ export const LeadDataset = defineDataset({
     { name: 'status', label: 'Status', field: 'status', type: 'string' },
     { name: 'lead_source', label: 'Source', field: 'lead_source', type: 'string' },
     { name: 'created_at', label: 'Created', field: 'created_at', type: 'date' },
+    { name: 'last_contacted_date', label: 'Last Contacted', field: 'last_contacted_date', type: 'date' },
   ],
   measures: [{ name: 'lead_count', label: 'Leads', aggregate: 'count' }],
 });

--- a/src/datasets/lead.dataset.ts
+++ b/src/datasets/lead.dataset.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** Lead analytics dataset (ADR-0021). */
+export const LeadDataset = defineDataset({
+  name: 'lead_metrics',
+  label: 'Lead Metrics',
+  description: 'Semantic layer for lead counts',
+  object: 'crm_lead',
+  dimensions: [
+    { name: 'status', label: 'Status', field: 'status', type: 'string' },
+    { name: 'lead_source', label: 'Source', field: 'lead_source', type: 'string' },
+    { name: 'created_at', label: 'Created', field: 'created_at', type: 'date' },
+  ],
+  measures: [{ name: 'lead_count', label: 'Leads', aggregate: 'count' }],
+});

--- a/src/datasets/opportunity.dataset.ts
+++ b/src/datasets/opportunity.dataset.ts
@@ -8,13 +8,17 @@ import { defineDataset } from '@objectstack/spec/ui';
  * The single semantic source of truth for pipeline metrics across the Sales,
  * CRM and Executive dashboards. Widgets bind to this dataset and select
  * measures BY NAME (`total_amount`, `avg_amount`, `opp_count`) so "pipeline
- * revenue" means the same thing everywhere. Single-object dataset (no joins).
+ * revenue" means the same thing everywhere.
  */
 export const OpportunityDataset = defineDataset({
   name: 'opportunity_metrics',
   label: 'Opportunity Metrics',
   description: 'Semantic layer for sales-pipeline counts and amounts',
   object: 'crm_opportunity',
+
+  // Include the account relationship so dimensions can traverse it (the join is
+  // derived from the `crm_account` lookup — no hand-written ON clause).
+  include: ['crm_account'],
 
   dimensions: [
     { name: 'stage', label: 'Stage', field: 'stage', type: 'string' },
@@ -23,6 +27,8 @@ export const OpportunityDataset = defineDataset({
     { name: 'type', label: 'Deal Type', field: 'type', type: 'string' },
     { name: 'owner', label: 'Owner', field: 'owner', type: 'lookup' },
     { name: 'close_date', label: 'Close Date', field: 'close_date', type: 'date' },
+    // Cross-object dimension: account industry via the crm_account relationship.
+    { name: 'account_industry', label: 'Account Industry', field: 'crm_account.industry', type: 'string' },
   ],
 
   measures: [

--- a/src/datasets/opportunity.dataset.ts
+++ b/src/datasets/opportunity.dataset.ts
@@ -35,5 +35,6 @@ export const OpportunityDataset = defineDataset({
     { name: 'opp_count', label: 'Opportunities', aggregate: 'count' },
     { name: 'total_amount', label: 'Total Amount', aggregate: 'sum', field: 'amount', format: '$0,0' },
     { name: 'avg_amount', label: 'Avg Deal Size', aggregate: 'avg', field: 'amount', format: '$0,0' },
+    { name: 'avg_probability', label: 'Avg Probability', aggregate: 'avg', field: 'probability', format: '0%' },
   ],
 });

--- a/src/datasets/opportunity.dataset.ts
+++ b/src/datasets/opportunity.dataset.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/**
+ * Opportunity analytics dataset (ADR-0021).
+ *
+ * The single semantic source of truth for pipeline metrics across the Sales,
+ * CRM and Executive dashboards. Widgets bind to this dataset and select
+ * measures BY NAME (`total_amount`, `avg_amount`, `opp_count`) so "pipeline
+ * revenue" means the same thing everywhere. Single-object dataset (no joins).
+ */
+export const OpportunityDataset = defineDataset({
+  name: 'opportunity_metrics',
+  label: 'Opportunity Metrics',
+  description: 'Semantic layer for sales-pipeline counts and amounts',
+  object: 'crm_opportunity',
+
+  dimensions: [
+    { name: 'stage', label: 'Stage', field: 'stage', type: 'string' },
+    { name: 'lead_source', label: 'Lead Source', field: 'lead_source', type: 'string' },
+    { name: 'forecast_category', label: 'Forecast Category', field: 'forecast_category', type: 'string' },
+    { name: 'type', label: 'Deal Type', field: 'type', type: 'string' },
+    { name: 'owner', label: 'Owner', field: 'owner', type: 'lookup' },
+    { name: 'close_date', label: 'Close Date', field: 'close_date', type: 'date' },
+  ],
+
+  measures: [
+    { name: 'opp_count', label: 'Opportunities', aggregate: 'count' },
+    { name: 'total_amount', label: 'Total Amount', aggregate: 'sum', field: 'amount', format: '$0,0' },
+    { name: 'avg_amount', label: 'Avg Deal Size', aggregate: 'avg', field: 'amount', format: '$0,0' },
+  ],
+});

--- a/src/datasets/product.dataset.ts
+++ b/src/datasets/product.dataset.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/** Product analytics dataset (ADR-0021) — catalog list-price rollups. */
+export const ProductDataset = defineDataset({
+  name: 'product_metrics',
+  label: 'Product Metrics',
+  description: 'Semantic layer for product catalog counts and list price',
+  object: 'crm_product',
+  dimensions: [
+    { name: 'category', label: 'Category', field: 'category', type: 'string' },
+  ],
+  measures: [
+    { name: 'product_count', label: 'Products', aggregate: 'count' },
+    { name: 'list_price_sum', label: 'Total List Price', aggregate: 'sum', field: 'list_price', format: '$0,0' },
+  ],
+});

--- a/src/reports/account.report.ts
+++ b/src/reports/account.report.ts
@@ -7,6 +7,7 @@ export const AccountsByIndustryTypeReport: ReportInput = {
   label: 'Accounts by Industry and Type',
   description: 'Matrix report showing accounts by industry and type',
   objectName: 'crm_account',
+  dataset: 'account_metrics', rows: ['industry', 'type'], values: ['account_count', 'annual_revenue_sum'],
   type: 'matrix',
   columns: [
     { field: 'name', aggregate: 'count' },

--- a/src/reports/case.report.ts
+++ b/src/reports/case.report.ts
@@ -7,6 +7,7 @@ export const CasesByStatusPriorityReport: ReportInput = {
   label: 'Cases by Status and Priority',
   description: 'Summary of cases by status and priority',
   objectName: 'crm_case',
+  dataset: 'case_metrics', rows: ['status', 'priority'], values: ['avg_resolution'],
   type: 'summary',
   columns: [
     { field: 'case_number', label: 'Case Number' },
@@ -27,6 +28,7 @@ export const SlaPerformanceReport: ReportInput = {
   label: 'SLA Performance Report',
   description: 'Analysis of SLA compliance',
   objectName: 'crm_case',
+  dataset: 'case_metrics', rows: ['priority'], values: ['case_count', 'case_count', 'avg_resolution'],
   type: 'summary',
   columns: [
     { field: 'case_number', label: 'Cases', aggregate: 'count' },
@@ -49,6 +51,7 @@ export const CasesOpenedByDayPriorityReport: ReportInput = {
   label: 'Cases Opened by Priority × Day',
   description: 'Daily case inflow split by priority',
   objectName: 'crm_case',
+  dataset: 'case_metrics', rows: ['priority', 'created_date'], values: ['case_count'],
   type: 'matrix',
   columns: [
     { field: 'case_number', label: 'Cases', aggregate: 'count' },

--- a/src/reports/churn.report.ts
+++ b/src/reports/churn.report.ts
@@ -46,6 +46,7 @@ export const CustomerChurnSignalsReport: ReportInput = {
       description: 'Active accounts with no activity in 14+ days, grouped by industry.',
       type: 'summary',
       objectName: 'crm_account',
+      dataset: 'account_metrics', rows: ['industry'], values: ['account_count'],
       columns: [
         { field: 'name', label: 'Account' },
         { field: 'id', label: 'Accounts', aggregate: 'count' },
@@ -62,6 +63,7 @@ export const CustomerChurnSignalsReport: ReportInput = {
       description: 'Active accounts gone quiet for 30+ days, grouped by type.',
       type: 'summary',
       objectName: 'crm_account',
+      dataset: 'account_metrics', rows: ['type'], values: ['account_count'],
       columns: [
         { field: 'id', label: 'Accounts', aggregate: 'count' },
       ],
@@ -77,6 +79,7 @@ export const CustomerChurnSignalsReport: ReportInput = {
       description: 'Opportunities closed-lost in the last 30 days — investigate before the customer fully churns.',
       type: 'summary',
       objectName: 'crm_opportunity',
+      dataset: 'opportunity_metrics', rows: ['owner'], values: ['total_amount', 'opp_count'],
       columns: [
         { field: 'amount', label: 'Lost Revenue', aggregate: 'sum' },
         { field: 'id', label: 'Deals', aggregate: 'count' },

--- a/src/reports/lead.report.ts
+++ b/src/reports/lead.report.ts
@@ -14,6 +14,7 @@ export const LeadInflowByMonthSourceReport: ReportInput = {
   label: 'Lead Engagement by Month × Source',
   description: 'Contacted-lead volume per month, broken down by acquisition channel',
   objectName: 'crm_lead',
+  dataset: 'lead_metrics', rows: ['lead_source', 'last_contacted_date'], values: ['lead_count'],
   type: 'matrix',
   columns: [
     { field: 'id', label: 'Leads Touched', aggregate: 'count' },

--- a/src/reports/opportunity.report.ts
+++ b/src/reports/opportunity.report.ts
@@ -12,6 +12,7 @@ export const OpportunitiesByStageReport: ReportInput = {
   label: 'Opportunities by Stage',
   description: 'Summary of opportunities grouped by stage',
   objectName: 'crm_opportunity',
+  dataset: 'opportunity_metrics', rows: ['stage'], values: ['total_amount', 'avg_probability'],
   type: 'summary',
   columns: [
     { field: 'name', label: 'Opportunity Name' },
@@ -30,6 +31,7 @@ export const WonOpportunitiesByOwnerReport: ReportInput = {
   label: 'Won Opportunities by Owner',
   description: 'Closed won opportunities grouped by owner',
   objectName: 'crm_opportunity',
+  dataset: 'opportunity_metrics', rows: ['owner'], values: ['total_amount'],
   type: 'summary',
   columns: [
     { field: 'name', label: 'Opportunity Name' },
@@ -54,6 +56,7 @@ export const PipelineCoverageByQuarterReport: ReportInput = {
   label: 'Pipeline Coverage by Forecast × Quarter',
   description: 'Open pipeline amount by forecast category, bucketed by close quarter',
   objectName: 'crm_opportunity',
+  dataset: 'opportunity_metrics', rows: ['forecast_category', 'close_date'], values: ['total_amount', 'opp_count'],
   type: 'matrix',
   columns: [
     { field: 'amount', label: 'Pipeline', aggregate: 'sum' },
@@ -76,6 +79,7 @@ export const OpportunityFunnelByOwnerStageReport: ReportInput = {
   label: 'Opportunity Funnel by Owner → Stage',
   description: 'Per-rep stage-by-stage pipeline funnel',
   objectName: 'crm_opportunity',
+  dataset: 'opportunity_metrics', rows: ['owner', 'stage'], values: ['total_amount', 'opp_count', 'avg_probability'],
   type: 'summary',
   columns: [
     { field: 'amount', label: 'Total Amount', aggregate: 'sum' },


### PR DESCRIPTION
Migrate hotcrm's inline analytics to the semantic `dataset` form (dual-form — kept side-by-side with the legacy inline query), verified by a read-only reconciliation harness.

> Based on `chore/upgrade-objectstack-8.0.1` (#378) — merge that first, then this retargets to `main`.

## What
- **6 datasets**: opportunity (incl. an `account_industry` cross-object dimension via the `crm_account` relationship), case, product, account, contact, lead.
- **4 dashboards** (crm / executive / sales / service) and **12 reports** (incl. the joined churn report's blocks) bound to datasets (`dataset` + `dimensions`/`values`).
- **Reconciliation harness** (`scripts/analytics-reconcile/`): boots the stack, runs legacy `aggregate()` vs dataset `queryDataset()`, asserts identical numbers. Reads hotcrm pivot `options.rowField/columnField`; skips cross-object dims (no legacy server-side join to compare).

## Verification
- Reconcile: **49 ok · 1 skipped (cross-object) · 0 mismatch**
- `objectstack validate` ✓ · `tsc --noEmit` ✓ 0 errors · `objectstack build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)