### PR TITLE
fix(reports): split matrix reports to rows × columns (ADR-0021 D2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@objectstack/runtime": "^9.0.0",
     "@objectstack/service-analytics": "^9.0.0",
     "@objectstack/service-automation": "^9.0.0",
-    "@objectstack/spec": "^9.0.0"
+    "@objectstack/spec": "^9.2.0"
   },
   "optionalDependencies": {
     "better-sqlite3": "^12.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0(ai@6.0.201(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^9.0.0
-        version: 9.0.0(ai@6.0.201(zod@4.4.3))
+        specifier: ^9.2.0
+        version: 9.2.0(ai@6.0.201(zod@4.4.3))
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -934,6 +934,15 @@ packages:
 
   '@objectstack/spec@9.0.0':
     resolution: {integrity: sha512-02/NF7c/oAFr4pfpyBgsly9Tv1LFZFaX5rXVtjLCJOMYBVBqAXctOUuhUsv7G7RGOYubNuuig0PsNlK+EtX1DA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      ai: ^6.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
+
+  '@objectstack/spec@9.2.0':
+    resolution: {integrity: sha512-nM0yCg1ya3CHIgF4zI9ENrhHaiwkEEEOu1mtAIwywxcJfl2eZ7DZAUbKvqy6t+U64BbslQthpQz/ktY0/tNbJQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       ai: ^6.0.0
@@ -4721,6 +4730,12 @@ snapshots:
       - ai
 
   '@objectstack/spec@9.0.0(ai@6.0.201(zod@4.4.3))':
+    dependencies:
+      zod: 4.4.3
+    optionalDependencies:
+      ai: 6.0.201(zod@4.4.3)
+
+  '@objectstack/spec@9.2.0(ai@6.0.201(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:

--- a/src/reports/account.report.ts
+++ b/src/reports/account.report.ts
@@ -6,7 +6,7 @@ export const AccountsByIndustryTypeReport: ReportInput = {
   name: 'accounts_by_industry_type',
   label: 'Accounts by Industry and Type',
   description: 'Matrix report showing accounts by industry and type',
-  dataset: 'account_metrics', rows: ['industry', 'type'], values: ['account_count', 'annual_revenue_sum'],
+  dataset: 'account_metrics', rows: ['industry'], columns: ['type'], values: ['account_count', 'annual_revenue_sum'],
   type: 'matrix',
   runtimeFilter: { is_active: true },
 };

--- a/src/reports/case.report.ts
+++ b/src/reports/case.report.ts
@@ -31,6 +31,6 @@ export const CasesOpenedByDayPriorityReport: ReportInput = {
   name: 'cases_opened_by_day_priority',
   label: 'Cases Opened by Priority × Day',
   description: 'Daily case inflow split by priority',
-  dataset: 'case_metrics', rows: ['priority', 'created_date'], values: ['case_count'],
+  dataset: 'case_metrics', rows: ['priority'], columns: ['created_date'], values: ['case_count'],
   type: 'matrix',
 };

--- a/src/reports/lead.report.ts
+++ b/src/reports/lead.report.ts
@@ -13,6 +13,6 @@ export const LeadInflowByMonthSourceReport: ReportInput = {
   name: 'lead_inflow_by_month_source',
   label: 'Lead Engagement by Month × Source',
   description: 'Contacted-lead volume per month, broken down by acquisition channel',
-  dataset: 'lead_metrics', rows: ['lead_source', 'last_contacted_date'], values: ['lead_count'],
+  dataset: 'lead_metrics', rows: ['lead_source'], columns: ['last_contacted_date'], values: ['lead_count'],
   type: 'matrix',
 };

--- a/src/reports/opportunity.report.ts
+++ b/src/reports/opportunity.report.ts
@@ -30,23 +30,23 @@ export const WonOpportunitiesByOwnerReport: ReportInput = {
 /**
  * Quarterly pipeline coverage — the matrix view that powers the classic
  * sales-ops "pipeline coverage" conversation: each forecast category against
- * the quarter the deal is expected to close in. Uses the spec's
- * `dateGranularity` on `groupingsAcross` so the server can bucket close_date
- * into quarters in a single aggregate query.
+ * the quarter the deal is expected to close in. `close_date` is the across
+ * dimension (`columns`); the dataset's `dateGranularity` buckets it into
+ * quarters in a single server-side aggregate query.
  */
 export const PipelineCoverageByQuarterReport: ReportInput = {
   name: 'pipeline_coverage_by_quarter',
   label: 'Pipeline Coverage by Forecast × Quarter',
   description: 'Open pipeline amount by forecast category, bucketed by close quarter',
-  dataset: 'opportunity_metrics', rows: ['forecast_category', 'close_date'], values: ['total_amount', 'opp_count'],
+  dataset: 'opportunity_metrics', rows: ['forecast_category'], columns: ['close_date'], values: ['total_amount', 'opp_count'],
   type: 'matrix',
   runtimeFilter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
 };
 
 /**
  * Sales-rep funnel — two-level summary that mirrors how reps drill into their
- * own book of business. Tests the multi-level `groupingsDown` rendering and
- * the `aggregate`-mixed-with-`detail` column pattern.
+ * own book of business. Exercises multi-level `rows` grouping (owner → stage)
+ * over the dataset's measures.
  */
 export const OpportunityFunnelByOwnerStageReport: ReportInput = {
   name: 'opportunity_funnel_owner_stage',


### PR DESCRIPTION
## Summary

The four `type: 'matrix'` reports flattened their across-dimension into `rows` — the pre-9.1 stopgap convention. With [objectui#1649](https://github.com/objectstack-ai/objectui/pull/1649) the dataset renderer degrades that to a flat grouped table; the true rows × columns cross-tab needs the across-dim in `Report.columns` (added in spec 9.1, [framework#1732](https://github.com/objectstack-ai/framework/pull/1732)).

Move the second dimension into `columns`:

| Report | rows × columns |
|---|---|
| `accounts_by_industry_type` | industry × type |
| `lead_inflow_by_month_source` | lead_source × last_contacted_date |
| `cases_opened_by_day_priority` | priority × created_date |
| `pipeline_coverage_by_quarter` | forecast_category × close_date |

The two **summary** reports (`cases_by_status_priority`, `opportunity_funnel_owner_stage`) keep their multi-level `rows` — legit down-axis nesting, no across dimension.

Also: refresh three doc comments that referenced the retired `groupingsDown` / `groupingsAcross` fields, and bump `@objectstack/spec` to `^9.2.0` (the `columns` field landed in 9.1).

## Test plan
- [x] `pnpm build` — 10 reports compile (matrix with `columns` accepted)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 6 passed
- [x] `pnpm lint` — no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)