### PR TITLE
docs(crm): add ADR-0046 in-product package docs

### DIFF
--- a/src/docs/crm_admin.md
+++ b/src/docs/crm_admin.md
@@ -1,6 +1,22 @@
 ---
 title: Administration — Roles, Sharing & Automation Knobs
 description: The role hierarchy, record-visibility (sharing) rules, profiles, and where every automated threshold is configured.
+# sources: the automation/sharing/role metadata this doc documents. The knobs
+# table is guarded by test/docs-drift.test.ts; build ignores unknown frontmatter keys.
+sources:
+  - flow:opportunity_approval
+  - flow:lead_assignment
+  - flow:opportunity_stagnation
+  - flow:opportunity_won_alert
+  - flow:quote_generation
+  - flow:quote_expiration
+  - flow:case_sla_monitor
+  - flow:case_escalation
+  - flow:case_csat_followup
+  - sharing_rule:account_team_sharing
+  - sharing_rule:opportunity_sales_sharing
+  - sharing_rule:case_escalation_sharing
+  - role:crm_role_hierarchy
 ---
 
 # Administration — Roles, Sharing & Automation

--- a/src/docs/crm_admin.md
+++ b/src/docs/crm_admin.md
@@ -1,0 +1,73 @@
+---
+title: Administration — Roles, Sharing & Automation Knobs
+description: The role hierarchy, record-visibility (sharing) rules, profiles, and where every automated threshold is configured.
+---
+
+# Administration — Roles, Sharing & Automation
+
+For administrators and implementers. This covers the parts of HotCRM that aren't
+visible by clicking around: **who can see whose data**, and **where the automated
+thresholds live** so you can tune them.
+
+## Role hierarchy
+
+Visibility rolls **up** the hierarchy — a manager can see the records owned by
+people below them.
+
+```
+Executive
+├── Sales Director ── Sales Manager ── Sales Representative
+├── Service Director ── Service Manager ── Service Agent
+└── Marketing Director ── Marketing Manager ── Marketing User
+```
+
+These same roles back the approval and escalation automation: large deals route
+to **Sales Manager** / **Sales Director**; critical cases reassign to the owner's
+**manager** (one level up).
+
+## Record visibility (sharing rules)
+
+Ownership-based access is widened by these rules:
+
+| Rule | Object | Access | Purpose |
+|---|---|---|---|
+| Account Team | Account | **Edit** | Named account-team members can edit the account. |
+| Territory — North America / Europe | Account | **Edit** | Regional teams edit accounts in their territory. |
+| Sales Sharing | Opportunity | **Read** | Broader sales visibility into opportunities. |
+| Case Escalation | Case | **Edit** | Escalated cases become editable by the escalation handler. |
+
+## Profiles
+
+Permission sets ship for the standard personas: **System Administrator**,
+**Sales Manager**, **Sales Representative**, **Service Agent**, **Marketing
+User**, and **Guest (Public Forms)** for unauthenticated web-to-lead capture.
+
+## Automation knobs — where every threshold lives
+
+The business rules are defined in the **flows** under `src/flows/`. To change a
+threshold, edit the flow and redeploy. These are the values an admin most often
+revisits:
+
+| Behavior | Current setting | Defined in |
+|---|---|---|
+| Large-deal approval (manager) | amount **> $100,000** | `opportunity-approval.flow.ts` |
+| Large-deal approval (+ director) | amount **> $500,000** | `opportunity-approval.flow.ts` |
+| Hot-lead follow-up SLA | **1 day** (rating ≥ 4) | `lead-assignment.flow.ts` |
+| Standard-lead follow-up SLA | **3 days** | `lead-assignment.flow.ts` |
+| Stalled-deal nudge | **> 14 days** in stage, swept daily **07:30** | `opportunity-stagnation.flow.ts` |
+| Won-deal alert | **Closed Won** over **$100,000** | `opportunity-won-alert.flow.ts` |
+| Quote default validity | **30 days** | `quote-generation.flow.ts` |
+| Quote auto-expiration sweep | daily **01:00** | `quote-expiration.flow.ts` |
+| Case SLA breach sweep | **hourly** | `case-sla-monitor.flow.ts` |
+| Critical-case auto-escalation | priority = **Critical** | `case-escalation.flow.ts` |
+| CSAT request delay after close | **1 day** | `case-csat-followup.flow.ts` |
+
+> Object names, fields, and relationships are visible directly in **Studio** and
+> on each record's detail page — they are intentionally **not** duplicated here.
+> This guide documents only what those screens can't tell you.
+
+## AI copilots
+
+Two assistants ship with HotCRM: the **Sales Copilot** and the **Service
+Copilot**. They operate over live CRM data and the actions exposed to them; the
+end user simply asks the assistant — no agent selection required.

--- a/src/docs/crm_overview.md
+++ b/src/docs/crm_overview.md
@@ -1,0 +1,39 @@
+---
+title: HotCRM Overview
+description: How HotCRM is organized and where the automated business rules live.
+---
+
+# HotCRM Overview
+
+HotCRM runs your customer lifecycle across four areas. The screens are
+self-explanatory — this documentation covers what the screens **don't** show:
+the rules and automation working behind the scenes (who a record routes to, when
+something escalates, what threshold triggers an approval).
+
+Each guide is written for the people who operate that area.
+
+- **[Sales](crm_sales.md)** — for sales reps and managers. Lead routing,
+  conversion, opportunity stages, large-deal approvals, quotes.
+- **[Service](crm_service.md)** — for service agents and managers. Case
+  priority, SLA breaches, escalation, and satisfaction follow-up.
+- **[Administration](crm_admin.md)** — for administrators. Roles, record
+  visibility (sharing), and where to tune every automated threshold.
+
+## The customer lifecycle, end to end
+
+A record flows through the system like this:
+
+```
+Lead ──convert──▶ Account + Contact ──▶ Opportunity ──▶ Quote ──▶ (Closed Won) ──▶ Contract
+                                          │
+                              Case ◀──────┘  (post-sale support)
+```
+
+Most of what makes HotCRM useful is **automatic**: a new lead gets a follow-up
+deadline and lands in a queue without anyone configuring it; a deal over a
+threshold halts for sign-off; a case that misses its SLA escalates on its own.
+The guides above document each of those behaviors and the exact thresholds, so
+nothing the system does is a surprise.
+
+> Tuning any of these rules (approval amounts, SLA timing, stale-deal windows)
+> is an administrator task — see **[Administration](crm_admin.md)**.

--- a/src/docs/crm_overview.md
+++ b/src/docs/crm_overview.md
@@ -1,6 +1,14 @@
 ---
 title: HotCRM Overview
 description: How HotCRM is organized and where the automated business rules live.
+# sources: the metadata this doc describes — kept in sync by the doc-sync agent
+# and the docs-drift test. Build ignores unknown frontmatter keys.
+sources:
+  - object:crm_lead
+  - object:crm_opportunity
+  - object:crm_quote
+  - object:crm_contract
+  - object:crm_case
 ---
 
 # HotCRM Overview

--- a/src/docs/crm_sales.md
+++ b/src/docs/crm_sales.md
@@ -1,0 +1,98 @@
+---
+title: Sales Process & Rules
+description: Lead routing, conversion, opportunity stages, large-deal approvals, and quotes — including every automated rule and threshold.
+---
+
+# Sales Process & Rules
+
+For sales representatives and sales managers. This covers the motion from a raw
+lead to a closed deal, and — more importantly — the rules the system applies
+automatically along the way.
+
+## 1. New leads route themselves
+
+When a lead is created, HotCRM scores its urgency and sets a follow-up deadline
+automatically:
+
+| Lead rating | Follow-up SLA | What happens |
+|---|---|---|
+| **Hot** (rating ≥ 4) | **1 day** | Manager is alerted to *assign within 24h*. |
+| Everything else | **3 days** | Lead is queued for assignment. |
+
+Every new lead lands in the **sales-manager queue**. Ownership is assigned by a
+manager — there is no automatic territory or round-robin assignment, so a lead
+sits in the queue until someone claims or assigns it. **Lead status** moves
+`New → Contacted → Qualified → Unqualified`.
+
+## 2. Converting a qualified lead
+
+Use **Convert** on a qualified lead. A short screen asks whether to create an
+opportunity (and for its name and amount). On confirm, the system creates:
+
+- an **Account** from the lead's company,
+- a **Contact** from the lead's name and details, and
+- optionally an **Opportunity** with the name/amount you entered.
+
+You don't re-key anything — company and contact details carry over from the lead.
+
+## 3. Working an opportunity
+
+Opportunities advance through these stages:
+
+```
+Prospecting → Qualification → Needs Analysis → Proposal → Negotiation → Closed Won / Closed Lost
+```
+
+New opportunities start at **10% probability**. Keep the **amount**, **stage**,
+and **close date** current — the automation below keys off all three.
+
+### Stalled-deal nudge (automatic)
+A daily **07:30** sweep finds any open opportunity that has sat in its current
+stage for **more than 14 days**. The owner and their manager are notified, and a
+**high-priority follow-up task** is created. Advance the stage or re-qualify the
+deal to clear it.
+
+### Won-deal alert (automatic)
+When a deal over **$100,000** is marked **Closed Won**, the owner and manager are
+notified automatically.
+
+## 4. Large-deal approval — when a deal pauses for sign-off
+
+Deals above a threshold **lock and wait** for approval. You can't move them
+forward until each required approver signs off.
+
+| Deal amount | Required approval |
+|---|---|
+| **> $100,000** | Sales Manager review |
+| **> $500,000** | Sales Manager **and** Sales Director sign-off |
+
+While an approval is pending, the opportunity is **locked** and its
+**Approval Status** shows the live state. On full approval it is stamped
+**Approved** (with date) and you're notified. On rejection it is stamped
+**Rejected** — revise and resubmit. Approvers act from their **Approvals → Inbox**.
+
+## 5. Quotes
+
+Generate a quote from an opportunity. The quote screen asks for:
+
+- **Quote name**
+- **Valid for (days)** — default **30**
+- **Discount %** — default **0**
+
+The system computes the math for you: subtotal = the opportunity amount,
+discount amount = subtotal × discount %, and **total = amount × (1 − discount%)**.
+
+### Quote auto-expiration (automatic)
+A daily **01:00** job marks any still-open quote past its expiration date as
+**Expired**. Re-issue a fresh quote if the deal is still live.
+
+## 6. Tasks
+
+Creating a task with **Urgent** priority immediately notifies its owner. Routine
+follow-up tasks (e.g. from the stalled-deal nudge) are created as **High**
+priority.
+
+---
+
+**Related:** record visibility (who can see whose opportunities) and how to
+change any threshold above are covered in **[Administration](crm_admin.md)**.

--- a/src/docs/crm_sales.md
+++ b/src/docs/crm_sales.md
@@ -1,6 +1,20 @@
 ---
 title: Sales Process & Rules
 description: Lead routing, conversion, opportunity stages, large-deal approvals, and quotes — including every automated rule and threshold.
+# sources: flows/objects this doc documents. Thresholds here are guarded by
+# test/docs-drift.test.ts; build ignores unknown frontmatter keys.
+sources:
+  - flow:lead_assignment
+  - flow:lead_conversion
+  - flow:opportunity_approval
+  - flow:opportunity_stagnation
+  - flow:opportunity_won_alert
+  - flow:quote_generation
+  - flow:quote_expiration
+  - flow:task_urgent_alert
+  - object:crm_lead
+  - object:crm_opportunity
+  - object:crm_quote
 ---
 
 # Sales Process & Rules

--- a/src/docs/crm_sales.md
+++ b/src/docs/crm_sales.md
@@ -14,10 +14,13 @@ automatically along the way.
 When a lead is created, HotCRM scores its urgency and sets a follow-up deadline
 automatically:
 
-| Lead rating | Follow-up SLA | What happens |
+| Lead Score | Follow-up SLA | What happens |
 |---|---|---|
-| **Hot** (rating ≥ 4) | **1 day** | Manager is alerted to *assign within 24h*. |
+| **Hot** — 4★ or higher | **1 day** | Manager is alerted to *assign within 24h*. |
 | Everything else | **3 days** | Lead is queued for assignment. |
+
+**Lead Score** is the 1–5 star field on each lead (shown as *Lead Score* in the
+UI). A score of 4★ or more marks the lead "hot" and triggers the 1-day SLA.
 
 Every new lead lands in the **sales-manager queue**. Ownership is assigned by a
 manager — there is no automatic territory or round-robin assignment, so a lead
@@ -58,8 +61,10 @@ notified automatically.
 
 ## 4. Large-deal approval — when a deal pauses for sign-off
 
-Deals above a threshold **lock and wait** for approval. You can't move them
-forward until each required approver signs off.
+Deals above a threshold **lock and wait** for approval. There is no "submit"
+step — the moment a deal's **amount** crosses $100K, it routes for approval
+automatically, and you can't move it forward until each required approver signs
+off.
 
 | Deal amount | Required approval |
 |---|---|

--- a/src/docs/crm_service.md
+++ b/src/docs/crm_service.md
@@ -1,0 +1,62 @@
+---
+title: Service Process & SLA Rules
+description: Case priority, SLA breach handling, automatic escalation, and satisfaction follow-up — the rules behind the Service desk.
+---
+
+# Service Process & SLA Rules
+
+For service agents and service managers. Cases move from intake to resolution,
+and the system enforces SLAs and escalations automatically — this guide explains
+exactly when and how.
+
+## Case priority
+
+Every case carries a **priority** that drives its urgency:
+
+`Low → Medium → High → Critical`
+
+Each case also has an **SLA Due Date**. The automation below watches that clock
+and the priority for you.
+
+## The clock is watched for you — SLA breach handling (automatic)
+
+An **hourly** sweep checks every open case. If a case passes its **SLA Due Date**
+without being resolved, the system automatically:
+
+- marks it **SLA Violated**,
+- **escalates** it (status → *Escalated*), and
+- alerts the owner and their manager.
+
+You never have to manually catch a missed SLA — but you should work cases before
+the due date, because a breach is recorded permanently on the case.
+
+## Critical cases escalate instantly (automatic)
+
+The moment a case is set to **Critical** priority, it escalates without waiting
+for the SLA clock:
+
+- it is **reassigned to the owner's manager**,
+- status moves to **Escalated** with an escalation reason stamped, and
+- a **high-priority follow-up task** is created (due the next day), with the
+  manager notified.
+
+> Two safety nets, two triggers: **priority = Critical** escalates *immediately*;
+> a **missed SLA Due Date** escalates *on breach*. Both reassign and alert.
+
+## After a case closes — satisfaction follow-up (automatic)
+
+When a case is set to **Closed**, the system waits **one day** and then prompts
+the case owner to collect a **satisfaction (CSAT) rating** from the customer.
+This keeps CSAT capture consistent without anyone remembering to chase it.
+
+## Knowledge articles
+
+Use **Knowledge** articles to resolve cases faster and enable self-service.
+Linking a relevant article to a case (and keeping articles current) is the main
+lever for deflection and faster resolution times.
+
+---
+
+**Related:** who can see and edit which cases (escalation sharing), and how to
+change SLA timing or escalation behavior, are covered in
+**[Administration](crm_admin.md)**.

--- a/src/docs/crm_service.md
+++ b/src/docs/crm_service.md
@@ -1,6 +1,14 @@
 ---
 title: Service Process & SLA Rules
 description: Case priority, SLA breach handling, automatic escalation, and satisfaction follow-up — the rules behind the Service desk.
+# sources: flows/objects this doc documents. Schedules/rules here are guarded by
+# test/docs-drift.test.ts; build ignores unknown frontmatter keys.
+sources:
+  - flow:case_sla_monitor
+  - flow:case_escalation
+  - flow:case_csat_followup
+  - object:crm_case
+  - object:crm_knowledge_article
 ---
 
 # Service Process & SLA Rules

--- a/src/docs/crm_service.md
+++ b/src/docs/crm_service.md
@@ -15,8 +15,9 @@ Every case carries a **priority** that drives its urgency:
 
 `Low → Medium → High → Critical`
 
-Each case also has an **SLA Due Date**. The automation below watches that clock
-and the priority for you.
+Each case also carries an **SLA Due Date** — the deadline to resolve it, set
+when the case is logged per your support policy. The automation below watches
+that clock and the priority for you.
 
 ## The clock is watched for you — SLA breach handling (automatic)
 
@@ -51,9 +52,11 @@ This keeps CSAT capture consistent without anyone remembering to chase it.
 
 ## Knowledge articles
 
-Use **Knowledge** articles to resolve cases faster and enable self-service.
-Linking a relevant article to a case (and keeping articles current) is the main
-lever for deflection and faster resolution times.
+**Knowledge** articles are your searchable library of solutions — for agents to
+reference while resolving a case and for customers to self-serve. Keeping
+articles current and well-titled is the main lever for deflection and faster
+resolution times. (Today a case isn't directly linked to an article; agents
+search Knowledge by topic.)
 
 ---
 

--- a/test/docs-drift.test.ts
+++ b/test/docs-drift.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Docs ↔ source drift guard (the AI-era safety net).
+ *
+ * The package docs under `src/docs/*.md` deliberately state the business-rule
+ * thresholds that live in the flows (approval amounts, the stale-deal window,
+ * sweep schedules, …). That is their whole value — and their whole risk: if a
+ * flow changes and the prose doesn't, the doc silently starts lying.
+ *
+ * This test pins both halves. Each rule's value is EXTRACTED from the flow
+ * source (single source of truth), turned into the string the doc is expected
+ * to show, and every listed doc is asserted to contain it. Change a flow value
+ * without updating the doc → this test goes red at PR time. It catches a human
+ * editor AND an AI regeneration that drifted.
+ *
+ * It is intentionally low-tech (regex over source text, substring over the
+ * markdown) so it stays readable and has no runtime/server dependency.
+ */
+
+const FLOWS = (f: string) => readFileSync(join('src/flows', f), 'utf8');
+const DOC = (f: string) => readFileSync(join('src/docs', f), 'utf8');
+
+/** cron → the human label the docs use. Unknown cron ⇒ deliberate failure. */
+const CRON_LABEL: Record<string, string> = {
+  '30 7 * * *': '07:30',
+  '0 1 * * *': '01:00',
+  '0 * * * *': 'hourly',
+};
+
+type Rule = {
+  label: string;
+  /** Pull the raw value out of the flow source (capture group 1). */
+  extract: () => string;
+  /** Strings the doc may use to render that value — at least one must match. */
+  display: (raw: string) => string[];
+  /** Doc files that must each surface the value. */
+  docs: string[];
+};
+
+const cap = (file: string, re: RegExp): string => {
+  const m = FLOWS(file).match(re);
+  if (!m) throw new Error(`drift test out of date: pattern ${re} not found in ${file}`);
+  return m[1];
+};
+
+const money = (raw: string) => [`$${Number(raw).toLocaleString('en-US')}`, Number(raw).toLocaleString('en-US')];
+const cronDisplay = (raw: string) => {
+  const label = CRON_LABEL[raw];
+  if (!label) throw new Error(`schedule '${raw}' changed — add it to CRON_LABEL and update the docs`);
+  return [label];
+};
+
+const RULES: Rule[] = [
+  {
+    label: 'manager approval threshold',
+    extract: () => cap('opportunity-approval.flow.ts', /record\.amount > (\d+) && record\.approval_status/),
+    display: money,
+    docs: ['crm_sales.md', 'crm_admin.md'],
+  },
+  {
+    label: 'director approval threshold',
+    extract: () => cap('opportunity-approval.flow.ts', /oppRecord\.amount > (\d+)/),
+    display: money,
+    docs: ['crm_sales.md', 'crm_admin.md'],
+  },
+  {
+    label: 'won-deal alert threshold',
+    extract: () => cap('opportunity-won-alert.flow.ts', /record\.amount > (\d+)/),
+    display: money,
+    docs: ['crm_sales.md', 'crm_admin.md'],
+  },
+  {
+    label: 'stalled-deal window (days)',
+    extract: () => cap('opportunity-stagnation.flow.ts', /STALE_THRESHOLD_DAYS = (\d+)/),
+    display: (v) => [`${v} days`, `${v}-day`],
+    docs: ['crm_sales.md', 'crm_admin.md'],
+  },
+  {
+    label: 'quote default validity (days)',
+    extract: () => cap('quote-generation.flow.ts', /expirationDays'[\s\S]*?defaultValue: (\d+)/),
+    display: (v) => [`**${v}**`, `${v} days`],
+    docs: ['crm_sales.md', 'crm_admin.md'],
+  },
+  {
+    label: 'hot-lead score threshold',
+    extract: () => cap('lead-assignment.flow.ts', /record\.rating >= (\d+)/),
+    display: (v) => [`${v}★`, `${v} of 5`],
+    docs: ['crm_sales.md'],
+  },
+  {
+    label: 'stalled-deal sweep schedule',
+    extract: () => cap('opportunity-stagnation.flow.ts', /schedule: '([^']+)'/),
+    display: cronDisplay,
+    docs: ['crm_sales.md', 'crm_admin.md'],
+  },
+  {
+    label: 'quote-expiration sweep schedule',
+    extract: () => cap('quote-expiration.flow.ts', /schedule: '([^']+)'/),
+    display: cronDisplay,
+    docs: ['crm_sales.md', 'crm_admin.md'],
+  },
+  {
+    label: 'case SLA sweep schedule',
+    extract: () => cap('case-sla-monitor.flow.ts', /schedule: '([^']+)'/),
+    display: cronDisplay,
+    docs: ['crm_service.md', 'crm_admin.md'],
+  },
+];
+
+describe('package docs do not drift from the flows they document', () => {
+  for (const rule of RULES) {
+    it(`${rule.label}: docs match the flow source`, () => {
+      const raw = rule.extract();
+      const candidates = rule.display(raw);
+      for (const docFile of rule.docs) {
+        const text = DOC(docFile);
+        const hit = candidates.some((c) => text.includes(c));
+        expect(
+          hit,
+          `${docFile} should state the ${rule.label} (one of ${JSON.stringify(candidates)}) ` +
+            `— the flow source now says "${raw}". Update the doc (or run the doc-sync agent).`,
+        ).toBe(true);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## What

Adds the first **ADR-0046 package docs** (`src/docs/*.md`) — in-product documentation that ships with the HotCRM marketplace install and renders in the Console doc viewer (`/_console/docs/<name>`).

| Doc | Audience | Covers (the invisible rules) |
|---|---|---|
| `crm_overview` | everyone | Lean index + end-to-end lifecycle map |
| `crm_sales` | reps & managers | Lead routing/SLA (hot = 1d, std = 3d), conversion mapping, opportunity stages, large-deal approval ($100K → manager, $500K → + director), stalled-deal nudge (14d), quotes |
| `crm_service` | agents & managers | Case priority, hourly SLA-breach sweep, critical-case auto-escalation, 1-day CSAT follow-up |
| `crm_admin` | administrators | Role hierarchy, sharing rules, and an "automation knobs" table mapping every threshold to its flow file |

## Design principle

**Don't document what the UI already shows** (object/field reference, navigation, CRUD live in Studio + the record screens). Document the **invisible business logic** — the rules and thresholds baked into the flows, approvals, and sharing rules that a user can't discover by clicking. All thresholds are **extracted from the actual source**, not invented.

## Keeping docs in sync with the metadata they describe (AI-era approach)

These docs deliberately cite values that live in the flows, so they can drift. Rather than build a heavy live-projection engine into the doc runtime, the approach is:

- **`test/docs-drift.test.ts`** — extracts each threshold/schedule from the flow source and asserts every doc that cites it stays in sync. Change a flow value without updating the doc → **red at PR time**. This is the deterministic guardrail that catches both a human editor and a drifted AI regeneration (9 rules, green).
- **`sources:` frontmatter** on each doc — names the flows/objects it documents. This is the lightweight association a **doc-sync agent** uses to know which doc to regenerate when a given flow changes. Build-safe (collect-docs only reads `title`/`description`; unknown keys are ignored — artifact still `docs: 4`).
- Deferred: promoting thresholds to per-tenant **Settings** (the one case where read-time interpolation beats AI-regen, since a static doc can't show each tenant's tuned value), and wiring the regeneration routine.

The platform-side doc-capability gaps surfaced along the way (a discoverable entry point — the top-bar Help "?" links to the *external* site, not the in-product `/_console/docs` index; doc ordering; per-locale doc content; seeding baseline first-party docs for Setup/Studio) are tracked separately as framework tasks.

## Verification

- `pnpm build` → `Collecting package docs (ADR-0046)`, artifact `docs: 4`.
- `pnpm validate && pnpm typecheck` green; `pnpm test` 15/15 (incl. 9 drift rules).
- `os lint` clean for docs (flat dir, `crm_`-prefixed names, no MDX/images).
- Console doc viewer renders all four — headings, tables, ASCII diagrams, same-package relative links — and the `/_console/docs` index lists them grouped under "CRM".

No config wiring needed — `os build` / `os serve` collect `src/docs/*.md` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)