### PR TITLE
docs(crm): add "After the win: contracts & renewals" to crm_sales

### DIFF
--- a/src/docs/crm_admin.md
+++ b/src/docs/crm_admin.md
@@ -13,6 +13,8 @@ sources:
   - flow:case_sla_monitor
   - flow:case_escalation
   - flow:case_csat_followup
+  - flow:contract_renewal
+  - flow:contract_expiration
   - sharing_rule:account_team_sharing
   - sharing_rule:opportunity_sales_sharing
   - sharing_rule:case_escalation_sharing
@@ -68,7 +70,7 @@ revisits:
 |---|---|---|
 | Large-deal approval (manager) | amount **> $100,000** | `opportunity-approval.flow.ts` |
 | Large-deal approval (+ director) | amount **> $500,000** | `opportunity-approval.flow.ts` |
-| Hot-lead follow-up SLA | **1 day** (rating ≥ 4) | `lead-assignment.flow.ts` |
+| Hot-lead follow-up SLA | **1 day** (Lead Score ≥ 4★) | `lead-assignment.flow.ts` |
 | Standard-lead follow-up SLA | **3 days** | `lead-assignment.flow.ts` |
 | Stalled-deal nudge | **> 14 days** in stage, swept daily **07:30** | `opportunity-stagnation.flow.ts` |
 | Won-deal alert | **Closed Won** over **$100,000** | `opportunity-won-alert.flow.ts` |
@@ -77,6 +79,8 @@ revisits:
 | Case SLA breach sweep | **hourly** | `case-sla-monitor.flow.ts` |
 | Critical-case auto-escalation | priority = **Critical** | `case-escalation.flow.ts` |
 | CSAT request delay after close | **1 day** | `case-csat-followup.flow.ts` |
+| Contract renewal reminder | each contract's **Renewal Notice Days**, swept daily **08:00** | `contract-renewal.flow.ts` |
+| Contract auto-expiration | past **end date**, swept daily **00:00** | `contract-expiration.flow.ts` |
 
 > Object names, fields, and relationships are visible directly in **Studio** and
 > on each record's detail page — they are intentionally **not** duplicated here.

--- a/src/docs/crm_sales.md
+++ b/src/docs/crm_sales.md
@@ -12,9 +12,12 @@ sources:
   - flow:quote_generation
   - flow:quote_expiration
   - flow:task_urgent_alert
+  - flow:contract_renewal
+  - flow:contract_expiration
   - object:crm_lead
   - object:crm_opportunity
   - object:crm_quote
+  - object:crm_contract
 ---
 
 # Sales Process & Rules
@@ -105,7 +108,33 @@ discount amount = subtotal × discount %, and **total = amount × (1 − discoun
 A daily **01:00** job marks any still-open quote past its expiration date as
 **Expired**. Re-issue a fresh quote if the deal is still live.
 
-## 6. Tasks
+## 6. After the win: contracts & renewals
+
+Closing a deal isn't the end of the relationship — it's the start of a contract
+you'll eventually renew. Two automatic jobs make sure a contract never lapses
+unnoticed.
+
+### Renewal reminders (automatic)
+Each contract carries its own **Renewal Notice Days** — how far ahead to start
+the renewal conversation. A daily sweep finds **activated** contracts whose
+**end date** has entered that notice window and:
+
+- creates a **high-priority renewal task** for the owner (due on the contract's
+  end date), and
+- notifies the owner to start the renewal conversation.
+
+### Auto-renewal → a deal already in your pipeline (automatic)
+If a contract has **Auto-Renewal** switched on, the same sweep also opens a
+renewal **opportunity** (type *Existing Customer — Renewal*), pre-filled from
+the contract value — so the renewal is already sitting in your pipeline to work,
+not something you have to remember to create.
+
+### Expiration (automatic)
+A contract that passes its **end date** without being renewed is automatically
+marked **Expired**, and the owner is notified. Renew before the end date to
+avoid the lapse.
+
+## 7. Tasks
 
 Creating a task with **Urgent** priority immediately notifies its owner. Routine
 follow-up tasks (e.g. from the stalled-deal nudge) are created as **High**

--- a/test/docs-drift.test.ts
+++ b/test/docs-drift.test.ts
@@ -30,6 +30,8 @@ const CRON_LABEL: Record<string, string> = {
   '30 7 * * *': '07:30',
   '0 1 * * *': '01:00',
   '0 * * * *': 'hourly',
+  '0 8 * * *': '08:00',
+  '0 0 * * *': '00:00',
 };
 
 type Rule = {
@@ -109,6 +111,18 @@ const RULES: Rule[] = [
     extract: () => cap('case-sla-monitor.flow.ts', /schedule: '([^']+)'/),
     display: cronDisplay,
     docs: ['crm_service.md', 'crm_admin.md'],
+  },
+  {
+    label: 'contract renewal sweep schedule',
+    extract: () => cap('contract-renewal.flow.ts', /schedule: '([^']+)'/),
+    display: cronDisplay,
+    docs: ['crm_admin.md'],
+  },
+  {
+    label: 'contract expiration sweep schedule',
+    extract: () => cap('contract-expiration.flow.ts', /schedule: '([^']+)'/),
+    display: cronDisplay,
+    docs: ['crm_admin.md'],
   },
 ];
 


### PR DESCRIPTION
## What

Closes the narrative gap where `crm_sales` stopped at **Closed Won**. Adds **§6 "After the win: contracts & renewals"** documenting the post-sale automation — all values extracted from the flow source, not invented.

- **Renewal reminders** (`contract_renewal`, daily sweep): each contract's own **Renewal Notice Days** window → high-priority renewal task + owner notice.
- **Auto-renewal** → when a contract's **Auto-Renewal** is on, the sweep also opens a renewal **opportunity** (*Existing Customer — Renewal*) pre-filled from the contract value, so the renewal is already in the pipeline.
- **Expiration** (`contract_expiration`): contracts past their **end date** auto-flip to **Expired** with an owner notice.

## Consistency (kept the guardrails honest)

- `crm_admin`'s "automation knobs" table gains the two contract rows (sweeps at **08:00** / **00:00**), so the table's "every threshold" promise stays true.
- `test/docs-drift.test.ts` guards both new schedules (now 11 rules). Change either contract cron without updating the doc → red at PR time.
- Both docs' `sources:` frontmatter gains `flow:contract_renewal`, `flow:contract_expiration`, `object:crm_contract`.
- Aligned the admin hot-lead row to the **Lead Score ≥ 4★** wording used in `crm_sales`.

## Verification

- `pnpm build` → `docs: 4`; `pnpm validate && pnpm typecheck` green; `pnpm test` **17/17** (incl. 11 drift rules).
- Doc viewer renders §6 with Tasks renumbered to §7 (confirmed via DOM probe; sections ordered 1–7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)