### PR TITLE
chore(release): 1.1.0 — ObjectStack 9.4 + in-product docs; fix stale specVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to HotCRM are documented in this file. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); HotCRM follows [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] — 2026-06-14
+
+Platform upgrade to ObjectStack 9.4 and in-product documentation. Built and validated against `@objectstack/* ^9.4.0`; the manifest `specVersion` now declares `^9.4.0` (was `^7.7.0`).
+
+### Added
+
+- **In-product documentation** (ADR-0046): four package docs served in the Console doc viewer (`/_console/docs`) — `crm_overview`, `crm_sales`, `crm_service`, `crm_admin`. They document the *invisible* business logic (the rules and thresholds baked into flows, approvals, and sharing) rather than what the UI already shows.
+- **Account Workbench** (ADR-0047): an interface page with quick-filter dropdowns over accounts.
+- **Docs-drift guard**: `test/docs-drift.test.ts` pins every documented threshold/schedule to its flow source, so a flow change that isn't reflected in the docs fails CI.
+- **`AGENTS.md`**: single source of truth for AI-agent guidance (consolidated from `.github/copilot-instructions.md`, which now points to it).
+
+### Changed
+
+- **ObjectStack platform 7.7 → 9.4** across all `@objectstack/*` packages. Includes the ADR-0021 analytics dataset semantic layer (dashboard widgets / reports / charts bind a named `dataset` and select dimensions/measures by name) and ADR-0021 D2 matrix reports (rows × columns + drilldown).
+- `manifest.specVersion`: `^7.7.0` → `^9.4.0`; package + manifest version → `1.1.0`.
+
+### Fixed
+
+- `sales_dashboard › pipeline_by_forecast_category`: chart axes were swapped (`xAxis` bound to a measure, `yAxis` to a dimension); the 9.x ADR-0021 validator now rejects this as a hard error. Corrected so `xAxis` is the dimension and `yAxis` the measure (the renderer handles the horizontal-bar flip).
+
 ## [1.0.0] — 2026-05-23
 
 First marketplace release. HotCRM is now publishable to [cloud.objectos.app](https://cloud.objectos.app) under the manifest id `app.objectstack.hotcrm`.
@@ -37,4 +57,5 @@ First marketplace release. HotCRM is now publishable to [cloud.objectos.app](htt
 
 - All 15 business objects renamed with explicit `crm_` prefix (576 replacements across 85 files). The platform no longer relies on namespace auto-injection — see the ADR in [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
+[1.1.0]: https://github.com/objectstack-ai/hotcrm/releases/tag/v1.1.0
 [1.0.0]: https://github.com/objectstack-ai/hotcrm/releases/tag/v1.0.0

--- a/objectstack.config.ts
+++ b/objectstack.config.ts
@@ -31,7 +31,7 @@ export default defineStack({
   manifest: {
     id: 'app.objectstack.hotcrm',
     namespace: 'crm',
-    version: '1.0.5',
+    version: '1.1.0',
     type: 'app',
     name: 'HotCRM',
     description: 'AI-Native CRM for the ObjectStack marketplace — Accounts, Contacts, Leads, Opportunities, Cases, Knowledge, Forecasts, Campaigns, Contracts.',

--- a/objectstack.manifest.json
+++ b/objectstack.manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schemas.objectstack.dev/template-manifest.json",
   "name": "hotcrm",
-  "specVersion": "^7.7.0",
+  "specVersion": "^9.4.0",
   "manifestId": "app.objectstack.hotcrm",
   "displayName": "HotCRM",
   "description": "AI-Native CRM for the ObjectStack marketplace — Accounts, Contacts, Leads, Opportunities, Cases, Knowledge, Forecasts, Campaigns, and Contracts in one production-grade workspace.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hotcrm",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "HotCRM - Production CRM built on ObjectStack",
   "private": true,
   "main": "./objectstack.config.ts",


### PR DESCRIPTION
## What

Release prep so the 9.4 upgrade + in-product docs can be published to the marketplace.

- **version** `1.0.5` → **`1.1.0`** (`package.json` + manifest in `objectstack.config.ts`)
- **`manifest.specVersion`** `^7.7.0` → **`^9.4.0`** — the bundle is built against 9.4; advertising 7.7 compatibility was stale/misleading to installs
- **CHANGELOG** `[1.1.0]` entry (platform 7.7→9.4 incl. ADR-0021 dataset layer + matrix reports, ADR-0046 in-product docs, ADR-0047 account workbench, docs-drift guard, chart-binding fix)

## Why a bump is required

The publish script treats a duplicate version as a **409 no-op** ("re-running is safe when nothing changed"), so re-pushing `1.0.5` would ship **nothing**. Bumping to `1.1.0` is what actually carries the new content to the marketplace.

## Verification

- `pnpm build` → artifact `manifest.version = 1.1.0`, `docs: 4`
- `pnpm validate && pnpm typecheck` green; `pnpm test` **17/17**
- `DRY_RUN=1 pnpm publish:marketplace:dry-run` → valid payloads, "published version 1.1.0"

## Release flow (after merge)

Manual, staging-first — I do **not** trigger these (outward-facing, per-env secrets):
1. Tag `v1.1.0` on `main` → `release.yml` builds the GitHub Release.
2. Run **publish-staging** workflow → verify in staging (cloud.objectos.app).
3. Run **publish-production** workflow → prod (cloud.objectos.ai).

🤖 Generated with [Claude Code](https://claude.com/claude-code)