### PR TITLE
feat(activity): surface CRM business events on the unified timeline

### DIFF
--- a/src/actions/contact.actions.ts
+++ b/src/actions/contact.actions.ts
@@ -67,7 +67,19 @@ export const SendEmailAction: Action = {
         related_id: recipientId,
         sent_by: ctx.user?.id ?? null,
       });
-      return { emailId: email?.id };
+      // Surface the email on the contact's unified activity timeline
+      // (the audit writer only logs generic CRUD; this is the semantic event).
+      const activity = await ctx.api.object('sys_activity').insert({
+        type: 'completed',
+        summary: 'Email: ' + subject,
+        actor_id: ctx.user?.id ?? null,
+        actor_name: ctx.user?.name ?? null,
+        object_name: 'crm_contact',
+        record_id: recipientId,
+        record_label: record.full_name ?? record.name ?? to,
+        metadata: JSON.stringify({ kind: 'email', to, subject, email_id: email?.id ?? null }),
+      });
+      return { emailId: email?.id, activityId: activity?.id };
     `,
     capabilities: ['api.write'],
     timeoutMs: 5000,

--- a/src/actions/global.actions.ts
+++ b/src/actions/global.actions.ts
@@ -67,6 +67,77 @@ export const LogCallAction: Action = {
 };
 
 /**
+ * Log a Meeting.
+ *
+ * Modal-typed cross-domain (global) action: companion to `log_call`.
+ * Collects subject / duration / attendees / notes then writes a semantic
+ * `sys_activity` row so the meeting lands on the record's unified timeline.
+ */
+export const LogMeetingAction: Action = {
+  name: 'log_meeting',
+  label: 'Log a Meeting',
+  icon: 'calendar',
+  type: 'modal',
+  target: 'log_meeting',
+  body: {
+    language: 'js',
+    source: `
+      const recordId = ctx.recordId ?? ctx.record?.id ?? null;
+      const objectName = ctx.objectName ?? input.objectName ?? null;
+      const subject = input.subject ? String(input.subject) : 'Untitled Meeting';
+      const duration = input.duration ? Number(input.duration) : 0;
+      const attendees = input.attendees ? String(input.attendees) : '';
+      const notes = input.notes ? String(input.notes) : '';
+      const summary = duration
+        ? subject + ' (' + duration + ' min)'
+        : subject;
+      const activity = await ctx.api.object('sys_activity').insert({
+        type: 'completed',
+        summary: 'Meeting: ' + summary,
+        actor_id: ctx.user?.id ?? null,
+        actor_name: ctx.user?.name ?? null,
+        object_name: objectName,
+        record_id: recordId,
+        record_label: ctx.record?.name ?? null,
+        metadata: JSON.stringify({ kind: 'meeting', duration_minutes: duration, attendees, notes }),
+      });
+      return { activityId: activity?.id };
+    `,
+    capabilities: ['api.write'],
+    timeoutMs: 5000,
+  },
+  locations: ['record_header', 'list_item', 'record_related'],
+  params: [
+    {
+      name: 'subject',
+      label: 'Meeting Subject',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'duration',
+      label: 'Duration (minutes)',
+      type: 'number',
+      required: false,
+    },
+    {
+      name: 'attendees',
+      label: 'Attendees',
+      type: 'text',
+      required: false,
+    },
+    {
+      name: 'notes',
+      label: 'Meeting Notes',
+      type: 'textarea',
+      required: false,
+    }
+  ],
+  successMessage: 'Meeting logged successfully!',
+  refreshAfter: true,
+};
+
+/**
  * Export to CSV.
  *
  * Script-typed cross-domain (global) action: dumps the rows of the

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -13,6 +13,6 @@
  */
 export { EscalateCaseAction, CloseCaseAction } from './case.actions';
 export { MarkPrimaryContactAction, SendEmailAction } from './contact.actions';
-export { LogCallAction, ExportToCsvAction } from './global.actions';
+export { LogCallAction, LogMeetingAction, ExportToCsvAction } from './global.actions';
 export { ConvertLeadAction, CreateCampaignAction } from './lead.actions';
 export { CloneOpportunityAction, MassUpdateStageAction } from './opportunity.actions';

--- a/src/objects/opportunity.hook.ts
+++ b/src/objects/opportunity.hook.ts
@@ -146,4 +146,100 @@ const opportunityWonHook: Hook = {
   },
 };
 
-export default [opportunityValidationHook, opportunityWonHook];
+/**
+ * Opportunity activity-timeline hook.
+ *
+ * On every stage transition, write a *semantic* `sys_activity` row so the
+ * record's unified timeline reads like a sales narrative ("Stage advanced to
+ * Negotiation", "Deal won — Acme Renewal ($250000)") instead of the generic
+ * "updated crm_opportunity" the audit writer emits. Win/loss is mirrored onto
+ * the linked account's timeline too. Side-effect only: `async` + `onError:'log'`
+ * so a timeline write can never block or fail the underlying update.
+ */
+const opportunityActivityHook: Hook = {
+  name: 'opportunity_activity_timeline',
+  object: 'crm_opportunity',
+  events: ['afterUpdate'],
+  priority: 850,
+  async: true,
+  onError: 'log',
+  description: 'Write semantic activity-timeline rows on stage advance and win/loss.',
+  handler: async (ctx: HookContext) => {
+    const STAGE_LABELS: Record<string, string> = {
+      prospecting: 'Prospecting',
+      qualification: 'Qualification',
+      needs_analysis: 'Needs Analysis',
+      proposal: 'Proposal',
+      negotiation: 'Negotiation',
+      closed_won: 'Closed Won',
+      closed_lost: 'Closed Lost',
+    };
+
+    const { input } = ctx;
+    const previous = ctx.previous;
+    const newStage = typeof input.stage === 'string' ? input.stage : undefined;
+    if (!newStage || newStage === previous?.stage) return;
+
+    const api = ctx.api as HookApi | undefined;
+    if (!api) return;
+
+    const oppId =
+      (typeof input.id === 'string' && input.id) ||
+      (typeof previous?.id === 'string' ? (previous.id as string) : undefined);
+    if (!oppId) return;
+
+    const label =
+      (typeof input.name === 'string' && input.name) ||
+      (typeof previous?.name === 'string' ? (previous.name as string) : oppId);
+    const amount =
+      typeof input.amount === 'number'
+        ? input.amount
+        : typeof previous?.amount === 'number'
+          ? (previous.amount as number)
+          : undefined;
+    const accountId =
+      (typeof input.crm_account === 'string' && input.crm_account) ||
+      (typeof previous?.crm_account === 'string' && previous.crm_account) ||
+      undefined;
+
+    let type = 'updated';
+    let kind = 'stage_change';
+    let summary = `Stage advanced to ${STAGE_LABELS[newStage] ?? newStage} — ${label}`;
+    if (newStage === 'closed_won') {
+      type = 'completed';
+      kind = 'deal_won';
+      summary = `Deal won — ${label}${typeof amount === 'number' ? ` ($${amount})` : ''}`;
+    } else if (newStage === 'closed_lost') {
+      type = 'completed';
+      kind = 'deal_lost';
+      const reason = typeof input.loss_reason === 'string' ? input.loss_reason : undefined;
+      summary = `Deal lost — ${label}${reason ? ` (${reason})` : ''}`;
+    }
+
+    const base = {
+      type,
+      summary,
+      actor_id: ctx.user?.id ?? null,
+      actor_name: ctx.user?.name ?? null,
+      record_label: label,
+      metadata: JSON.stringify({ kind, stage: newStage, amount: amount ?? null }),
+    };
+
+    await api.object('sys_activity').insert({
+      ...base,
+      object_name: 'crm_opportunity',
+      record_id: oppId,
+    });
+
+    // Mirror win/loss onto the account timeline so the account narrative shows it.
+    if ((newStage === 'closed_won' || newStage === 'closed_lost') && accountId) {
+      await api.object('sys_activity').insert({
+        ...base,
+        object_name: 'crm_account',
+        record_id: accountId,
+      });
+    }
+  },
+};
+
+export default [opportunityValidationHook, opportunityWonHook, opportunityActivityHook];

--- a/src/pages/action_modals.page.ts
+++ b/src/pages/action_modals.page.ts
@@ -101,6 +101,17 @@ export const LogCallPage = modalPage('log_call', {
     'objections, next steps or commitments in **Notes**.',
 });
 
+export const LogMeetingPage = modalPage('log_meeting', {
+  label: 'Log a Meeting',
+  icon: 'calendar',
+  heading: 'Log a meeting against this record',
+  body:
+    'Captures a meeting as a `sys_activity` entry of type **completed**. ' +
+    'Visible in the record activity timeline alongside calls and emails. ' +
+    'Use **Duration** in whole minutes, list **Attendees**, and record ' +
+    'decisions or next steps in **Notes**.',
+});
+
 export const MassUpdateStagePage = modalPage('mass_update_stage', {
   label: 'Update Stage',
   icon: 'layers',

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -12,6 +12,7 @@ export {
   CloseCasePage,
   CreateCampaignPage,
   LogCallPage,
+  LogMeetingPage,
   MassUpdateStagePage,
   SendEmailPage,
 } from './action_modals.page';


### PR DESCRIPTION
## What

Make the record activity timeline (**讨论 / 全部动态**, backed by the always-on `sys_activity` system object) read like a CRM narrative instead of generic `created/updated/deleted` CRUD rows.

| Event | Where | Timeline row |
|---|---|---|
| Opportunity stage change | `opportunity.hook.ts` (new `opportunityActivityHook`) | "Stage advanced to Negotiation — …" |
| Opportunity won / lost | same hook (mirrored to the account) | "Deal won — … ($500000)" / "Deal lost — … (reason)" |
| Email sent | `contact.actions.ts` `send_email` | "Email: <subject>" |
| Meeting logged | new `log_meeting` action (`global.actions.ts`) | "Meeting: <subject> (30 min)" |

This closes the gap that the unified activity timeline only ever showed generic CRUD, never the communication/sales events a CRM is about.

## Verification

- `pnpm validate && pnpm typecheck && pnpm build && pnpm test` — all green (11 Actions / 14 Pages; 6/6 tests).
- **Opportunity timeline verified end-to-end in the browser**: closing "Globex Manufacturing Suite" won rendered "Stage advanced to Negotiation — …" and "Deal won — … ($500000)" on both the opportunity and account timelines.
- `send_email` / `log_meeting` actions: implemented + validated + typecheck, using the exact `ctx.api.object('sys_activity').insert(...)` pattern of the shipped `log_call` action (whose path is verified). Their end-to-end UI dispatch was not drivable via the synthetic test harness this session — a harness limitation, not a known code defect.

## Follow-ups (not in this PR)

- Service-case side (escalated/resolved → timeline) left out: it surfaced two pre-existing platform bugs — `ctx.api.object(x).update(id, doc)` throws in v9 hooks (silently swallowed by `onError:'log'`; working form is `updateMany({where:{id},doc})`), and a `crm_case` self-update inside its own `afterUpdate` hard-crashes the dev server. Tracked as a follow-up.
- Broader direction (separating audit / activity / collaboration bounded contexts) is captured in draft ADR-0052 in the framework repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
