### PR TITLE
feat(activity): send_email writes ActivityPointer source pointer

### DIFF
--- a/src/actions/contact.actions.ts
+++ b/src/actions/contact.actions.ts
@@ -77,7 +77,12 @@ export const SendEmailAction: Action = {
         object_name: 'crm_contact',
         record_id: recipientId,
         record_label: record.full_name ?? record.name ?? to,
-        metadata: JSON.stringify({ kind: 'email', to, subject, email_id: email?.id ?? null }),
+        // ADR-0052 ActivityPointer: structured pointer to the rich source entity
+        // (the sys_email row) so the timeline renders a "View source →" drill to
+        // the full email — the queryable replacement for stashing the id in metadata.
+        source_object: 'sys_email',
+        source_id: email?.id ?? null,
+        metadata: JSON.stringify({ kind: 'email', to, subject }),
       });
       return { emailId: email?.id, activityId: activity?.id };
     `,


### PR DESCRIPTION
Send Email now sets `sys_activity.source_object='sys_email'` + `source_id` (structured pointer) instead of `metadata.email_id`, so the timeline renders a "View source →" drill to the full email (objectui #1779). Completes the ActivityPointer story end-to-end in HotCRM. verify green; HotCRM 9.8.0 sys_activity confirmed to expose source_object/source_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)