### PR TITLE
fix(security): guest portal keys full object names (web-to-lead/case)

### DIFF
--- a/src/profiles/guest-portal.profile.ts
+++ b/src/profiles/guest-portal.profile.ts
@@ -21,7 +21,7 @@ export const GuestPortalProfile = {
     'Anonymous visitors submitting public Web-to-Lead / Web-to-Case forms. ' +
     'INSERT-only on lead and case; no read/edit/delete on any object.',
   objects: {
-    lead: {
+    crm_lead: {
       allowCreate: true,
       allowRead: false,
       allowEdit: false,
@@ -29,7 +29,7 @@ export const GuestPortalProfile = {
       viewAllRecords: false,
       modifyAllRecords: false,
     },
-    case: {
+    crm_case: {
       allowCreate: true,
       allowRead: false,
       allowEdit: false,


### PR DESCRIPTION
Web-to-Lead/Case guest profile granted INSERT on `lead`/`case`, but the anonymous public-form permission path checks the full `crm_lead`/`crm_case` — so the insert was denied. Use full names.

**Verified end-to-end:** anonymous `POST /api/v1/forms/contact-us/submit` → creates a `crm_lead`; `/forms/support` → `crm_case`; guests still 401 on reads (INSERT-only enforced).

⚠️ Requires framework [#1989](https://github.com/objectstack-ai/framework/pull/1989) (public-form resolution fix) to be released — on published @9.8.0 the form still returns FORM_NOT_FOUND until HotCRM bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)