### PR TITLE
ci(link-check): fix repo-wide dead links (localhost + frozen docs)

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -9,6 +9,9 @@
     },
     {
       "pattern": "^https://img.shields.io/"
+    },
+    {
+      "pattern": "^https?://localhost"
     }
   ]
 }

--- a/README.legacy.md
+++ b/README.legacy.md
@@ -1,3 +1,8 @@
+<!-- markdown-link-check-disable -->
+<!-- Frozen legacy doc from the monorepo era — links point at packages/ and
+     planning files that no longer exist in this single-package repo. Kept for
+     historical reference only; superseded by README.md. -->
+
 # HotCRM - Enterprise-Level CRM System
 
 [![CI](https://github.com/objectstack-ai/hotcrm/workflows/CI/badge.svg)](https://github.com/objectstack-ai/hotcrm/actions/workflows/ci.yml)

--- a/docs/archive/2026-02/IMPLEMENTATION_SUMMARY.md
+++ b/docs/archive/2026-02/IMPLEMENTATION_SUMMARY.md
@@ -1,3 +1,7 @@
+<!-- markdown-link-check-disable -->
+<!-- Archived 2026-02 snapshot — references planning docs that have since been
+     removed. Frozen for history; not link-checked. -->
+
 # HotCRM Implementation Complete - Summary
 
 > **Date**: February 11, 2026  

--- a/docs/archive/2026-02/SALESFORCE_FEATURE_COMPARISON.md
+++ b/docs/archive/2026-02/SALESFORCE_FEATURE_COMPARISON.md
@@ -1,3 +1,7 @@
+<!-- markdown-link-check-disable -->
+<!-- Archived 2026-02 snapshot — references planning docs that have since been
+     removed. Frozen for history; not link-checked. -->
+
 # HotCRM vs Salesforce: Deep Feature Comparison
 
 > **Version**: 3.0  


### PR DESCRIPTION
## Summary

The repo-wide `Link Check` on `main` was red — **19 dead links**. None were actionable broken links in current content; all were either local dev-server example URLs or stale references inside frozen historical docs.

## Fix

- **markdown-link-check config**: ignore `^https?://localhost` — documentation example URLs for the dev server (`localhost:4001`, `:3000`, `:3001` in README.md, apps/docs/README.md, docs/DEPLOYMENT.md).
- **`README.legacy.md`** (monorepo-era doc, superseded by README.md) and the two **`docs/archive/2026-02/`** snapshots: added `<!-- markdown-link-check-disable -->`. They reference `packages/*/README.md` and planning files (`ROADMAP.md`, `STRATEGIC_DESIGN_REPORT.md`, …) that no longer exist in this single-package repo and are kept only for history.

## Verification

Ran `markdown-link-check` locally with the updated config against all 6 previously-failing files — **0 dead links** (README.md's 18 real links still checked; legacy/archive report 0 links checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)