### PR TITLE
fix: drop removed ObjectSchema detail block (ADR-0085)

### DIFF
--- a/src/objects/product.object.ts
+++ b/src/objects/product.object.ts
@@ -19,13 +19,6 @@ export const Product = ObjectSchema.create({
   nameField: 'display_title',
   compactLayout: ['product_code', 'name', 'category', 'is_active'],
 
-  // Product detail pages are catalog-style — users edit attributes in
-  // place, they don't browse lateral relationships. Suppress the
-  // Reference Rail so the single-column form gets full width.
-  detail: {
-    hideReferenceRail: true,
-  },
-
   fieldGroups: [
     { key: 'basic',    label: 'Product Information', icon: 'info' },
     { key: 'pricing',  label: 'Pricing & Billing',   icon: 'dollar-sign' },

--- a/src/objects/task.object.ts
+++ b/src/objects/task.object.ts
@@ -10,13 +10,6 @@ export const Task = ObjectSchema.create({
   icon: 'check-square',
   description: 'Activities and to-do items',
 
-  // Tasks are atomic action items, not Hub objects. Keep the detail
-  // page single-column so the assignment + due-date + completion flow
-  // dominates instead of being shoulder-bumped by a related-list rail.
-  detail: {
-    hideReferenceRail: true,
-  },
-
   fields: {
     // Task Information
     subject: Field.text({


### PR DESCRIPTION
framework [ADR-0085](https://github.com/objectstack-ai/framework/pull/2521) removed the per-surface `detail` UI-hints block from `ObjectSchema` — presentation intent is now declared as cross-surface semantic roles (`nameField` / `compactLayout`→`highlightFields` / `stageField` / `fieldGroups`).

This repo was the one downstream author of the block (caught by framework's **Downstream backward-compat smoke** — working exactly as designed 👏).

**No behavior change**: `detail.hideReferenceRail` was a proven no-op — the Reference Rail is OFF by default, and the only key that could turn it on (`showReferenceRail`) was never spec-typed, so `product` and `task` detail pages were already single-column without the flag. This PR only removes the dead keys so typecheck passes against the new spec.

Unblocks the framework Release pipeline (currently red on this smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)