### PR TITLE
fix(flows): case_escalation re-fire guard must use status, not the boolean is_escalated

### DIFF
--- a/src/flows/case-escalation.flow.ts
+++ b/src/flows/case-escalation.flow.ts
@@ -18,13 +18,18 @@ export const CaseEscalationFlow: Flow = {
   nodes: [
     {
       // Trigger wiring (7.4): bind to afterUpdate and gate on the critical
-      // transition. `is_escalated != true` guard prevents the flow's own
-      // escalation write from re-triggering it (infinite-loop safe).
+      // transition. The re-fire guard MUST use `status` (a string enum), NOT the
+      // boolean `is_escalated`: this flow's own escalation write re-triggers
+      // record-after-update, and on SQLite/libsql a boolean persists as integer
+      // `1`, so `record.is_escalated != true` is `1 != true` = true — the guard
+      // never trips and the flow loops forever (it wedged a first-boot seed on
+      // 2026-07-06). The same write sets `status: 'escalated'`, so
+      // `status != "escalated"` reliably suppresses the second fire.
       id: 'start', type: 'start', label: 'Start',
       config: {
         objectName: 'crm_case',
         triggerType: 'record-after-update',
-        condition: 'record.priority == "critical" && record.is_escalated != true',
+        condition: 'record.priority == "critical" && record.status != "escalated"',
       },
     },
     {


### PR DESCRIPTION
## Why

`case_escalation` fires on `record-after-update` and its action writes back to the same case (`is_escalated=true, status='escalated', …`), re-triggering record-after-update. The guard `record.is_escalated != true` was meant to stop the second fire, but a `boolean` persists as integer `1` on SQLite/libsql and CEL `1 != true` is `true` — the guard never trips and the flow loops forever. On 2026-07-06 this wedged a new env's first-boot seed and left the workspace unopenable.

## What

Gate on `record.status != "escalated"` — `status` is a string enum set by the same escalation write, so it reliably suppresses the re-fire regardless of how the driver stores booleans. (The platform now also coerces booleans for flow conditions + guards against self-trigger loops — objectstack-ai/framework#2661 — but the template must not depend on that.)

`task_urgent_alert` also guards on a boolean (`is_completed != true`) but fires on record-after-**create** with a notify-only body (no self-write), so it cannot loop; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)