### PR TITLE
fix(metadata): drop hard-coded "$" from money formats so amounts don't force USD

### DIFF
--- a/.changeset/no-hardcoded-currency-format.md
+++ b/.changeset/no-hardcoded-currency-format.md
@@ -1,0 +1,7 @@
+---
+'hotcrm': patch
+---
+
+Drop the hard-coded `$` from money display formats so amounts don't force a USD symbol.
+
+Currency measures and table/axis columns used the numeral format `'$0,0'`, which bakes a literal `$` into every rendered amount regardless of the actual currency. Combined with the platform's (now removed) default currency, the Executive Overview KPI showed `US$2,528,600` even though the `amount` field declares no currency of its own. All money formats are now plain `'0,0'` (grouped number, no symbol) across the opportunity/account/product datasets and the executive/sales/crm dashboards, so amounts render as plain numbers unless a currency is actually configured (a field code or a workspace default).

--- a/src/dashboards/crm.dashboard.ts
+++ b/src/dashboards/crm.dashboard.ts
@@ -139,7 +139,7 @@ export const CrmOverviewDashboard: Dashboard = {
         showDataLabels: false,
         colors: ['#10B981'],
         xAxis: { field: 'close_date', title: 'Month', showGridLines: false, logarithmic: false },
-        yAxis: [{ field: 'total_amount', title: 'Revenue', format: '$0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [{ field: 'total_amount', title: 'Revenue', format: '0,0', showGridLines: true, logarithmic: false }],
         interaction: { tooltips: true, brush: true, zoom: false },
       },
       options: { dateGranularity: 'month' },
@@ -191,7 +191,7 @@ export const CrmOverviewDashboard: Dashboard = {
         showDataLabels: true,
         colors: ['#4F46E5'],
         xAxis: { field: 'category', title: 'Category', showGridLines: false, logarithmic: false },
-        yAxis: [{ field: 'list_price_sum', title: 'Revenue', format: '$0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [{ field: 'list_price_sum', title: 'Revenue', format: '0,0', showGridLines: true, logarithmic: false }],
       },
     },
 
@@ -215,9 +215,9 @@ export const CrmOverviewDashboard: Dashboard = {
       options: {
         columns: [
           { header: 'Owner',         accessorKey: 'owner' },
-          { header: 'Pipeline',      accessorKey: 'total_amount', format: '$0,0' },
+          { header: 'Pipeline',      accessorKey: 'total_amount', format: '0,0' },
           { header: 'Opportunities', accessorKey: 'opp_count' },
-          { header: 'Avg Deal Size', accessorKey: 'avg_amount', format: '$0,0' },
+          { header: 'Avg Deal Size', accessorKey: 'avg_amount', format: '0,0' },
         ],
         sortBy: 'total_amount',
         sortOrder: 'desc',

--- a/src/dashboards/executive.dashboard.ts
+++ b/src/dashboards/executive.dashboard.ts
@@ -151,7 +151,7 @@ export const ExecutiveDashboard: Dashboard = {
         showDataLabels: false,
         colors: ['#10B981'],
         xAxis: { field: 'close_date', title: 'Month', showGridLines: false, logarithmic: false },
-        yAxis: [{ field: 'total_amount', title: 'Revenue', format: '$0,0', showGridLines: true, logarithmic: false }],
+        yAxis: [{ field: 'total_amount', title: 'Revenue', format: '0,0', showGridLines: true, logarithmic: false }],
         interaction: { tooltips: true, zoom: false, brush: true },
       },
       options: { dateGranularity: 'month' },
@@ -228,7 +228,7 @@ export const ExecutiveDashboard: Dashboard = {
       options: {
         columns: [
           { header: 'Industry',        accessorKey: 'industry' },
-          { header: 'Annual Revenue',  accessorKey: 'annual_revenue_sum', format: '$0,0' },
+          { header: 'Annual Revenue',  accessorKey: 'annual_revenue_sum', format: '0,0' },
           { header: 'Accounts',        accessorKey: 'account_count' },
         ],
         sortBy: 'annual_revenue_sum',

--- a/src/dashboards/sales.dashboard.ts
+++ b/src/dashboards/sales.dashboard.ts
@@ -227,7 +227,7 @@ export const SalesDashboard: Dashboard = {
       options: {
         columns: [
           { header: 'Owner',         accessorKey: 'owner' },
-          { header: 'Open Pipeline', accessorKey: 'total_amount', format: '$0,0' },
+          { header: 'Open Pipeline', accessorKey: 'total_amount', format: '0,0' },
           { header: 'Open Deals',    accessorKey: 'opp_count' },
           { header: 'Avg Win Prob.', accessorKey: 'avg_probability', format: '0%' },
         ],

--- a/src/datasets/account.dataset.ts
+++ b/src/datasets/account.dataset.ts
@@ -15,6 +15,6 @@ export const AccountDataset = defineDataset({
   ],
   measures: [
     { name: 'account_count', label: 'Accounts', aggregate: 'count' },
-    { name: 'annual_revenue_sum', label: 'Annual Revenue', aggregate: 'sum', field: 'annual_revenue', format: '$0,0' },
+    { name: 'annual_revenue_sum', label: 'Annual Revenue', aggregate: 'sum', field: 'annual_revenue', format: '0,0' },
   ],
 });

--- a/src/datasets/opportunity.dataset.ts
+++ b/src/datasets/opportunity.dataset.ts
@@ -33,8 +33,8 @@ export const OpportunityDataset = defineDataset({
 
   measures: [
     { name: 'opp_count', label: 'Opportunities', aggregate: 'count' },
-    { name: 'total_amount', label: 'Total Amount', aggregate: 'sum', field: 'amount', format: '$0,0' },
-    { name: 'avg_amount', label: 'Avg Deal Size', aggregate: 'avg', field: 'amount', format: '$0,0' },
+    { name: 'total_amount', label: 'Total Amount', aggregate: 'sum', field: 'amount', format: '0,0' },
+    { name: 'avg_amount', label: 'Avg Deal Size', aggregate: 'avg', field: 'amount', format: '0,0' },
     { name: 'avg_probability', label: 'Avg Probability', aggregate: 'avg', field: 'probability', format: '0%' },
   ],
 });

--- a/src/datasets/product.dataset.ts
+++ b/src/datasets/product.dataset.ts
@@ -13,6 +13,6 @@ export const ProductDataset = defineDataset({
   ],
   measures: [
     { name: 'product_count', label: 'Products', aggregate: 'count' },
-    { name: 'list_price_sum', label: 'Total List Price', aggregate: 'sum', field: 'list_price', format: '$0,0' },
+    { name: 'list_price_sum', label: 'Total List Price', aggregate: 'sum', field: 'list_price', format: '0,0' },
   ],
 });


### PR DESCRIPTION
## Description

Currency measures and table/axis columns used the numeral format `'$0,0'`, which bakes a literal `$` into every rendered amount regardless of the actual currency. Combined with the platform's default workspace currency, the **Executive Overview** `Total Revenue (YTD)` KPI rendered as `US$2,528,600` even though the `amount` field (`Field.currency()`) declares no currency of its own. This switches all money display formats to plain `'0,0'` so amounts render as plain grouped numbers unless a currency is actually configured (a field code or a workspace default).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Companion to the platform-side fix `objectstack-ai/framework#2672` (drop the hard-coded `USD` platform default for the workspace currency). Both are needed for a code-less amount to render fully plain: the framework change removes the inherited `USD` *currency*, and this change removes the literal `$` *format*.

## Changes Made

- `src/datasets/opportunity.dataset.ts` — `total_amount`, `avg_amount`: `'$0,0'` → `'0,0'`.
- `src/datasets/account.dataset.ts` — `annual_revenue_sum`: `'$0,0'` → `'0,0'`.
- `src/datasets/product.dataset.ts` — `list_price_sum`: `'$0,0'` → `'0,0'`.
- `src/dashboards/executive.dashboard.ts` — revenue chart y-axis + Annual Revenue column.
- `src/dashboards/sales.dashboard.ts` — Open Pipeline column.
- `src/dashboards/crm.dashboard.ts` — two chart y-axes + Pipeline / Avg Deal Size columns.

(11 format strings across 6 files; no other `$`-prefixed formats remain.)

## Testing

- [x] `pnpm typecheck` passes.
- [x] `pnpm validate` passes (ObjectStack Protocol + ADR checks — `'0,0'` is an accepted numeral format).

Note: on the currently *published* `@objectstack/*` runtime the framework companion (#2672) isn't released yet, so the backend still stamps `currency: "USD"` on measures — the KPI won't render fully plain until that ships and HotCRM upgrades. This change is the app-side half and is correct to land now.

## Additional Notes

If HotCRM should instead display a specific currency intentionally, the right pattern is to declare it on the `amount` field (or set a workspace Default currency) rather than hard-coding `$` in the format string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWr8Sgey8LY5nbWYPaYH6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWr8Sgey8LY5nbWYPaYH6z)_