### PR TITLE
refactor(agents): drop removed agent visibility field (spec 15 / ADR-0056 D8)

### DIFF
--- a/src/agents/sales-copilot.agent.ts
+++ b/src/agents/sales-copilot.agent.ts
@@ -10,7 +10,6 @@ export const SalesCopilotAgent = defineAgent({
   label: 'Sales Copilot',
   role: 'assistant',
   active: true,
-  visibility: 'organization',
 
   instructions: `You are the Sales Copilot — a single AI surface that
 helps sales reps work an account end-to-end. Use the Active Skills

--- a/src/agents/service-copilot.agent.ts
+++ b/src/agents/service-copilot.agent.ts
@@ -7,7 +7,6 @@ export const ServiceCopilotAgent = defineAgent({
   label: 'Service Copilot',
   role: 'assistant',
   active: true,
-  visibility: 'organization',
 
   instructions: `You are the Service Copilot — a single AI surface
 that helps support reps triage and resolve cases. Be empathetic and


### PR DESCRIPTION
The upcoming `@objectstack/spec` release removes the unenforced agent `visibility` field (objectstack-ai/framework#3216, ADR-0056 D8). hotcrm's two copilot agents still author it, which keeps framework's pre-publish downstream-compat smoke red and stalls the release train.

This drops the two `visibility: 'organization'` lines. Omitting the optional field typechecks against both the currently published spec (14.7) and the upcoming release.

Verified locally by replicating framework's `downstream-smoke.sh`: installed published deps, overlaid the freshly built unreleased spec dist, then `pnpm run typecheck` and `pnpm run validate` both pass (15 objects / 2 agents parse clean).

After merge this ships as **v2.1.0** (package.json is already 2.1.0), and framework bumps its smoke pin `HOTCRM_REF` to v2.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)