### PR TITLE
fix(stackblitz): bootstrap pnpm 10 in WebContainer start command

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,6 +1,6 @@
 {
   "installDependencies": false,
-  "startCommand": "pnpm install && pnpm dev",
+  "startCommand": "npm i -g pnpm@10.33.0 && pnpm install && pnpm dev",
   "env": {
     "OS_DATABASE_URL": ".objectstack/data/hotcrm.wasm.db",
     "OS_DATABASE_DRIVER": "sqlite-wasm"


### PR DESCRIPTION
## Problem

The **Open in StackBlitz** flow dies on `pnpm install`:

```
ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
Expected version: >=10.0.0
Got: 8.15.6
```

StackBlitz WebContainers ship a **pinned pnpm 8.15.6**, which:
- fails the repo's `engines.pnpm: ">=10.0.0"` gate under `engine-strict=true` (`.npmrc`), and
- cannot read `pnpm-lock.yaml` (**lockfileVersion 9.0**, which needs pnpm 9+/10).

Relaxing the engine check is the wrong fix — pnpm 8 still can't parse the v9 lockfile. StackBlitz genuinely needs pnpm 10. The error only flags pnpm (not Node), so the WebContainer's Node already satisfies `>=22`.

## Fix

Prepend `npm i -g pnpm@10.33.0` (matching the `packageManager` field) to `.stackblitzrc`'s `startCommand`, so the WebContainer installs a compatible pnpm before install/dev. Also upgrades the global pnpm, so a manual `pnpm install && pnpm dev` in the StackBlitz terminal works too.

```diff
- "startCommand": "pnpm install && pnpm dev",
+ "startCommand": "npm i -g pnpm@10.33.0 && pnpm install && pnpm dev",
```

Keeps `engine-strict` and the Node 22 / pnpm 10 requirements intact for real dev + CI. Config-only — does not touch the publishable `dist/objectstack.json`.

## Verification

- `pnpm verify` green locally (validate ✓, typecheck ✓, build ✓, test 17/17 ✓).
- v9 lockfile resolves cleanly under pnpm 10.33.0 (`Lockfile is up to date`).
- `.stackblitzrc` is valid JSON.

> Maintenance note: the pinned version is coupled to `packageManager` — bump both together on a future pnpm upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)