### PR TITLE
docs(readme): fix drifted counts (17 flows, 6 profiles + 10 positions) and link the business-language tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # HotCRM
 
 > **The reference app for AI-written enterprise software.** A complete CRM —
-> 15 objects, 10 flows, 4 dashboards, 2 AI copilots, 4 languages — written as
+> 15 objects, 17 flows, 4 dashboards, 2 AI copilots, 4 languages — written as
 > ~17,000 lines of typed [ObjectStack](https://github.com/objectstack-ai/objectstack)
 > metadata, so the whole app still fits in a single agent context window.
 > **Install it online in one click, or fork it and build & ask with Claude
@@ -56,7 +56,9 @@ HotCRM is a complete, opinionated CRM built as the **first official application*
 | `crm_product` | | | |
 | `crm_forecast` | | | |
 
-Plus **2 AI agents** (sales-copilot, service-copilot), **4 dashboards**, **10 flows**, **10 actions**, **6 AI skills**, **4 language bundles** (en, zh-CN, es-ES, ja-JP), **10 roles**, and **5 sharing rules**.
+Plus **2 AI agents** (sales-copilot, service-copilot), **4 dashboards**, **17 flows**, **10 actions**, **6 AI skills**, **4 language bundles** (en, zh-CN, es-ES, ja-JP), **6 permission profiles**, **10 positions**, and **5 sharing rules**.
+
+> **Business reader?** The ObjectStack docs tour every one of these capabilities in plain business language — [What Can It Do?](https://objectstack.ai/docs/capabilities) — with HotCRM as the running example on every page.
 
 ---
 


### PR DESCRIPTION
README still advertised **10 flows** — `src/flows` has **17**. And **10 roles** was conflating two different things: there are **6 permission profiles** and **10 positions**; the intro line and the What-you-get summary now state both accurately.

Also adds a one-line pointer for business readers to the ObjectStack docs' new business-language capability tour ([What Can It Do?](https://objectstack.ai/docs/capabilities), added in objectstack-ai/objectstack#3423), which uses HotCRM as the running example on every page — completing the two-way link between the reference app and the docs.

Counts verified against `src/`: 17 `*.flow.ts`, 6 `*.profile.ts`, 10 positions in `sharing/positions.ts`, 5 sharing rule definitions, 10 exported actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)