### PR TITLE
fix(crm): P0 core-correctness — conversion dedupe, real notify recipients, opportunity amount rollup

### DIFF
--- a/src/flows/lead-assignment.flow.ts
+++ b/src/flows/lead-assignment.flow.ts
@@ -8,10 +8,12 @@ type Flow = Automation.Flow;
  *
  * New leads previously sat with no follow-up SLA and no routing, so hot leads
  * could go cold before anyone looked. This flow fires on lead *insert*, sets a
- * rating-based `next_followup_date` SLA, and routes an alert to the
- * sales-manager queue to claim/assign it. (Owner assignment is left to the
- * manager rather than hard-coded, since this app has no territory / round-robin
- * routing table — the flow handles the urgency + hand-off.)
+ * rating-based `next_followup_date` SLA, and alerts the lead's OWNER (the
+ * accountable party) to follow up. The alert originally targeted a
+ * 'sales_manager' position, but positions aren't a messaging audience so it
+ * reached nobody; with no territory / round-robin table modelled, the owner is
+ * the correct recipient. (Swap to a `team:`/`role:` audience once a manager
+ * group is seeded.)
  *
  * Trigger wiring (7.4): the `start` node declares `triggerType:
  * 'record-after-create'` so the record-change trigger provider binds it to the
@@ -49,7 +51,13 @@ export const LeadAssignmentFlow: Flow = {
     {
       id: 'notify_hot', type: 'notify', label: 'Alert — Hot Lead',
       config: {
-        to: ['sales_manager'],
+        // Route to the lead's OWNER (a real user id). A CRM position like
+        // 'sales_manager' is NOT a messaging audience — the messaging service
+        // resolves user:/role:(sys_member)/team:/owner_of:, and a bare
+        // 'sales_manager' was stored verbatim as sys_inbox_message.user_id,
+        // matching no real user, so these alerts reached nobody. owner is set
+        // on insert (defaultValue os.user.id) and is the accountable party.
+        to: ['{record.owner}'],
         channels: ['inbox', 'email'],
         severity: 'warning',
         topic: 'lead_routing',
@@ -67,7 +75,9 @@ export const LeadAssignmentFlow: Flow = {
     {
       id: 'notify_std', type: 'notify', label: 'Alert — New Lead',
       config: {
-        to: ['sales_manager'],
+        // Route to the lead's owner — see notify_hot for why a bare
+        // 'sales_manager' position never reached anyone.
+        to: ['{record.owner}'],
         channels: ['inbox'],
         topic: 'lead_routing',
         title: 'New lead to assign: {record.first_name} {record.last_name}',

--- a/src/flows/lead-conversion.flow.ts
+++ b/src/flows/lead-conversion.flow.ts
@@ -39,6 +39,20 @@ export const LeadConversionFlow: Flow = {
       config: { objectName: 'crm_lead', filter: { id: '{recordId}' }, outputVariable: 'leadRecord' },
     },
     {
+      // Account dedupe: before creating a new account, look for an existing one
+      // with the same company name. Exact-name match (case/whitespace sensitive)
+      // — the standard lightweight dedupe; fuzzy matching is out of scope here.
+      id: 'find_account', type: 'get_record', label: 'Find Existing Account',
+      config: { objectName: 'crm_account', filter: { name: '{leadRecord.company}' }, outputVariable: 'matchedAccount' },
+    },
+    {
+      id: 'decision_account', type: 'decision', label: 'Account Already Exists?',
+      config: { condition: 'vars.matchedAccount != null' },
+    },
+    {
+      // NEW-account branch. outputVariable is `createdAccount`; the assignment
+      // below normalizes both branches onto a single `accountId` id string so
+      // downstream nodes don't need to know which path ran.
       id: 'create_account', type: 'create_record', label: 'Create Account',
       config: {
         objectName: 'crm_account',
@@ -50,17 +64,26 @@ export const LeadConversionFlow: Flow = {
           billing_address: '{leadRecord.address}',
           owner: '{$User.Id}', is_active: true,
         },
-        outputVariable: 'accountId',
+        outputVariable: 'createdAccount',
       },
     },
     {
+      id: 'use_new_account', type: 'assignment', label: 'Use New Account',
+      config: { assignments: { accountId: '{createdAccount.id}' } },
+    },
+    {
+      id: 'use_existing_account', type: 'assignment', label: 'Reuse Existing Account',
+      config: { assignments: { accountId: '{matchedAccount.id}' } },
+    },
+    {
+      // `accountId` is now a bare id string from whichever branch ran.
       id: 'create_contact', type: 'create_record', label: 'Create Contact',
       config: {
         objectName: 'crm_contact',
         fields: {
           first_name: '{leadRecord.first_name}', last_name: '{leadRecord.last_name}',
           email: '{leadRecord.email}', phone: '{leadRecord.phone}',
-          title: '{leadRecord.title}', crm_account: '{accountId.id}',
+          title: '{leadRecord.title}', crm_account: '{accountId}',
           is_primary: true, owner: '{$User.Id}',
         },
         outputVariable: 'contactId',
@@ -75,7 +98,7 @@ export const LeadConversionFlow: Flow = {
       config: {
         objectName: 'crm_opportunity',
         fields: {
-          name: '{opportunityName}', crm_account: '{accountId.id}', primary_contact: '{contactId.id}',
+          name: '{opportunityName}', crm_account: '{accountId}', primary_contact: '{contactId.id}',
           amount: '{opportunityAmount}', stage: 'prospecting', probability: 10,
           lead_source: '{leadRecord.lead_source}', close_date: '{TODAY() + 90}', owner: '{$User.Id}',
         },
@@ -91,7 +114,7 @@ export const LeadConversionFlow: Flow = {
           // conversion flags (the qualified → converted transition is legal
           // per the lead_status_progression state machine).
           is_converted: true, status: 'converted', converted_date: '{NOW()}',
-          converted_account: '{accountId.id}', converted_contact: '{contactId.id}',
+          converted_account: '{accountId}', converted_contact: '{contactId.id}',
           converted_opportunity: '{opportunityId.id}',
         },
       },
@@ -104,9 +127,9 @@ export const LeadConversionFlow: Flow = {
         to: ['{$User.Id}'],
         channels: ['inbox', 'email'],
         topic: 'lead_converted',
-        title: 'Lead converted: {leadRecord.full_name}',
-        body: 'Lead {leadRecord.full_name} was converted into an account and contact.',
-        actionUrl: '/crm_account/{accountId.id}',
+        title: 'Lead converted: {leadRecord.first_name} {leadRecord.last_name}',
+        body: 'Lead {leadRecord.first_name} {leadRecord.last_name} was converted into an account and contact.',
+        actionUrl: '/crm_account/{accountId}',
       },
     },
     { id: 'end', type: 'end', label: 'End' },
@@ -115,13 +138,19 @@ export const LeadConversionFlow: Flow = {
   edges: [
     { id: 'e1', source: 'start', target: 'screen_1', type: 'default' },
     { id: 'e2', source: 'screen_1', target: 'get_lead', type: 'default' },
-    { id: 'e3', source: 'get_lead', target: 'create_account', type: 'default' },
-    { id: 'e4', source: 'create_account', target: 'create_contact', type: 'default' },
-    { id: 'e5', source: 'create_contact', target: 'decision_opportunity', type: 'default' },
-    { id: 'e6', source: 'decision_opportunity', target: 'create_opportunity', type: 'default', condition: 'vars.createOpportunity == true', label: 'Yes' },
-    { id: 'e7', source: 'decision_opportunity', target: 'mark_converted', type: 'default', condition: 'vars.createOpportunity != true', label: 'No' },
-    { id: 'e8', source: 'create_opportunity', target: 'mark_converted', type: 'default' },
-    { id: 'e9', source: 'mark_converted', target: 'send_notification', type: 'default' },
-    { id: 'e10', source: 'send_notification', target: 'end', type: 'default' },
+    { id: 'e3', source: 'get_lead', target: 'find_account', type: 'default' },
+    { id: 'e4', source: 'find_account', target: 'decision_account', type: 'default' },
+    // Existing account → reuse; no account → create. Both converge on create_contact.
+    { id: 'e5', source: 'decision_account', target: 'use_existing_account', type: 'default', condition: 'vars.matchedAccount != null', label: 'Existing' },
+    { id: 'e6', source: 'decision_account', target: 'create_account', type: 'default', condition: 'vars.matchedAccount == null', label: 'New' },
+    { id: 'e7', source: 'create_account', target: 'use_new_account', type: 'default' },
+    { id: 'e8', source: 'use_new_account', target: 'create_contact', type: 'default' },
+    { id: 'e9', source: 'use_existing_account', target: 'create_contact', type: 'default' },
+    { id: 'e10', source: 'create_contact', target: 'decision_opportunity', type: 'default' },
+    { id: 'e11', source: 'decision_opportunity', target: 'create_opportunity', type: 'default', condition: 'vars.createOpportunity == true', label: 'Yes' },
+    { id: 'e12', source: 'decision_opportunity', target: 'mark_converted', type: 'default', condition: 'vars.createOpportunity != true', label: 'No' },
+    { id: 'e13', source: 'create_opportunity', target: 'mark_converted', type: 'default' },
+    { id: 'e14', source: 'mark_converted', target: 'send_notification', type: 'default' },
+    { id: 'e15', source: 'send_notification', target: 'end', type: 'default' },
   ],
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -20,6 +20,7 @@ import forecastHook from '../objects/forecast.hook';
 import knowledgeArticleHook from '../objects/knowledge_article.hook';
 import leadHook from '../objects/lead.hook';
 import opportunityHook from '../objects/opportunity.hook';
+import opportunityLineItemHook from '../objects/opportunity_line_item.hook';
 import productHook from '../objects/product.hook';
 import quoteHook from '../objects/quote.hook';
 import taskHook from '../objects/task.hook';
@@ -34,6 +35,7 @@ const entries: Array<Hook | Hook[]> = [
   knowledgeArticleHook,
   leadHook,
   opportunityHook,
+  opportunityLineItemHook,
   productHook,
   quoteHook,
   taskHook,

--- a/src/objects/opportunity_line_item.hook.ts
+++ b/src/objects/opportunity_line_item.hook.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Hook, HookContext } from '@objectstack/spec/data';
+import type { HookApi } from './_hook-api';
+
+/**
+ * Opportunity amount rollup.
+ *
+ * Keeps `crm_opportunity.amount` in sync with the sum of its line items'
+ * extended price. Fires after a line item is inserted / updated / deleted (the
+ * console surfaces these as the opportunity's "Products" related list) and
+ * recomputes the parent opportunity's amount from the current line set.
+ *
+ * Why this exists: `amount` was a free-typed currency field with no link to
+ * `crm_opportunity_line_item`, so itemising a deal and its headline number
+ * could drift apart. Once a deal is itemised, the line sum is authoritative.
+ *
+ * Design decisions:
+ * - Recomputes from raw `quantity * unit_price * (1 - discount/100)` rather than
+ *   reading the `total_price` FORMULA field, so it doesn't depend on formula
+ *   hydration inside the sandboxed hook body.
+ * - If the opportunity has NO line items (e.g. the last one was just deleted),
+ *   `amount` is left untouched — zeroing it would trip the `amount > 0`
+ *   validation and wipe the manually-entered figure on opportunities that never
+ *   used line items at all.
+ * - `async: true` + `onError: 'log'` — the rollup is a derived convenience; a
+ *   failure must never block the line-item write. Updating the parent does not
+ *   re-trigger this hook (different object), so there's no loop.
+ * - On re-parenting (update that moves a line to another opportunity), BOTH the
+ *   old and new parents are recomputed.
+ */
+const opportunityAmountRollup: Hook = {
+  name: 'opportunity_amount_rollup',
+  object: 'crm_opportunity_line_item',
+  events: ['afterInsert', 'afterUpdate', 'afterDelete'],
+  priority: 300,
+  async: true,
+  onError: 'log',
+  description: 'Recompute parent opportunity.amount from the sum of its line items.',
+  handler: async (ctx: HookContext) => {
+    const api = ctx.api as HookApi | undefined;
+    if (!api) return;
+    const { input } = ctx;
+    const previous = ctx.previous;
+
+    // Every parent opportunity touched by this change (old + new handles the
+    // re-parenting case on update).
+    const oppIds = new Set<string>();
+    for (const v of [input?.crm_opportunity, previous?.crm_opportunity]) {
+      if (typeof v === 'string' && v) oppIds.add(v);
+    }
+    if (oppIds.size === 0) return;
+
+    for (const oppId of oppIds) {
+      // Skip closed deals. The rollup runs in a system context (no ctx.user),
+      // which BYPASSES the opportunity freeze guard — so without this check,
+      // editing a line item would silently rewrite a closed-won deal's recorded
+      // amount. A closed deal's value is settled; leave it.
+      const opp = await api.object('crm_opportunity').findOne({
+        filter: { id: oppId }, fields: ['id', 'stage'],
+      });
+      const stage = opp && typeof opp.stage === 'string' ? opp.stage : undefined;
+      if (stage === 'closed_won' || stage === 'closed_lost') continue;
+
+      const lines = await api.object('crm_opportunity_line_item').find({
+        filter: { crm_opportunity: oppId },
+        fields: ['quantity', 'unit_price', 'discount'],
+        top: 5000,
+      });
+      // No lines left → leave the existing amount as-is (see design note).
+      if (!lines || lines.length === 0) continue;
+
+      let sum = 0;
+      for (const l of lines) {
+        const qty = typeof l.quantity === 'number' ? l.quantity : 0;
+        const price = typeof l.unit_price === 'number' ? l.unit_price : 0;
+        const disc = typeof l.discount === 'number' ? l.discount : 0;
+        sum += qty * price * (1 - disc / 100);
+      }
+      sum = Math.round(sum * 100) / 100;
+      if (sum > 0) {
+        await api.object('crm_opportunity').update(oppId, { amount: sum });
+      }
+    }
+  },
+};
+
+export default opportunityAmountRollup;

--- a/test/actions-flows-integrity.test.ts
+++ b/test/actions-flows-integrity.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import stack from '../objectstack.config';
+
+/**
+ * Action & flow contract guards — the CI net for the class of defect that
+ * `os validate` / `build` can't see.
+ *
+ * Every case below pins a bug that shipped because it lived INSIDE an action's
+ * JS body, a flow node's field map, or a `visible`/recipient string — none of
+ * which static metadata validation inspects, and none of which the unit tests
+ * exercised. These assertions read the compiled stack metadata and fail if a
+ * fix is reverted (by a human or an AI regeneration). They are intentionally
+ * low-tech (structural assertions over the bundle), matching smoke.test.ts.
+ *
+ * NOTE: these are metadata-contract guards, not a running-kernel harness. A
+ * full LiteKernel integration harness that actually executes the flows/hooks
+ * against a driver is a worthwhile follow-up; these guards cover the specific
+ * regressions cheaply in the meantime.
+ */
+
+type AnyRec = Record<string, any>;
+const actions: AnyRec[] = (stack as any).actions ?? [];
+const flows: AnyRec[] = (stack as any).flows ?? [];
+const hooks: AnyRec[] = (stack as any).hooks ?? [];
+const objects: AnyRec[] = (stack as any).objects ?? [];
+
+const action = (name: string) => actions.find((a) => a.name === name);
+const flow = (name: string) => flows.find((f) => f.name === name);
+const nodeOf = (f: AnyRec | undefined, id: string) =>
+  (f?.nodes ?? []).find((n: AnyRec) => n.id === id);
+const fieldNames = (obj: string) => Object.keys(objects.find((o) => o.name === obj)?.fields ?? {});
+
+describe('action body ↔ schema field-name contracts', () => {
+  it('create_campaign inserts REAL crm_campaign_member fields, not the doc-example names', () => {
+    const a = action('create_campaign');
+    expect(a, 'create_campaign action missing').toBeTruthy();
+    const src: string = a!.body?.source ?? '';
+    // The real lookup fields on crm_campaign_member.
+    const cmFields = fieldNames('crm_campaign_member');
+    expect(cmFields).toContain('crm_campaign');
+    expect(cmFields).toContain('crm_lead');
+    // Body must write those, never the generic campaign_id/lead_id (which left
+    // the required crm_campaign null → validation failure on every insert).
+    expect(src).toMatch(/crm_campaign\s*:/);
+    expect(src).toMatch(/crm_lead\s*:/);
+    expect(src, 'body still writes the non-existent campaign_id column').not.toMatch(/campaign_id\s*:/);
+    expect(src, 'body still writes the non-existent lead_id column').not.toMatch(/lead_id\s*:/);
+  });
+
+  it('create_campaign campaign param is field-backed so it renders a picker (not a paste-ID textbox)', () => {
+    const p = (action('create_campaign')?.params ?? [])[0];
+    expect(p, 'campaign param missing').toBeTruthy();
+    // A field-backed param (`field` + `objectOverride`) is what makes the console
+    // resolve the widget to a record picker. A bare { type:'lookup' } falls back
+    // to a plain text input.
+    expect(p.field, 'param must be field-backed').toBeTruthy();
+    expect(p.objectOverride, 'param must name the object to resolve the field on').toBeTruthy();
+    // And the body must read the value under the param's own key.
+    const key = p.name ?? p.field;
+    expect(action('create_campaign')!.body.source).toContain(`input.${key}`);
+  });
+
+  it('clone_opportunity copies the REQUIRED opportunity fields (not just name+stage)', () => {
+    const src: string = action('clone_opportunity')?.body?.source ?? '';
+    expect(src).toBeTruthy();
+    // crm_account / amount / close_date are required on crm_opportunity; a
+    // clone that omits them fails validation and creates nothing.
+    for (const required of ['crm_account', 'amount', 'close_date']) {
+      expect(src, `clone must set ${required}`).toMatch(new RegExp(`${required}\\s*:`));
+    }
+  });
+});
+
+describe('lead_conversion flow contracts', () => {
+  const f = flow('lead_conversion');
+
+  it('dedupes accounts: looks up an existing account before creating one', () => {
+    const find = nodeOf(f, 'find_account');
+    expect(find, 'find_account node missing — conversion would always create a duplicate account').toBeTruthy();
+    expect(find.type).toBe('get_record');
+    expect(find.config?.objectName).toBe('crm_account');
+    expect(nodeOf(f, 'decision_account'), 'decision_account branch missing').toBeTruthy();
+  });
+
+  it('normalizes both account branches onto a bare {accountId} id (no {accountId.id})', () => {
+    const contact = nodeOf(f, 'create_contact');
+    expect(contact?.config?.fields?.crm_account).toBe('{accountId}');
+    // Guard against the earlier full-record vs id confusion resurfacing.
+    const json = JSON.stringify(f);
+    expect(json, 'stale {accountId.id} ref — accountId is now a bare id string').not.toContain('{accountId.id}');
+  });
+});
+
+describe('notify recipients resolve to real audiences', () => {
+  it('no flow notify targets a bare position/role word (which the messaging service stores verbatim → nobody sees it)', () => {
+    const offenders: string[] = [];
+    for (const f of flows) {
+      for (const n of f.nodes ?? []) {
+        if (n.type !== 'notify') continue;
+        const to: string[] = n.config?.to ?? n.config?.recipients ?? [];
+        for (const spec of to) {
+          const s = String(spec);
+          const ok =
+            s.includes('{') ||                       // template → a real user id / email
+            /^(user|role|team|owner_of):/.test(s) ||  // explicit messaging audience selector
+            s.includes('@');                          // email
+          if (!ok) offenders.push(`${f.name}/${n.id}: "${s}"`);
+        }
+      }
+    }
+    expect(offenders, `bare-word notify recipients never reach an inbox:\n${offenders.join('\n')}`).toEqual([]);
+  });
+});
+
+describe('opportunity amount rollup', () => {
+  it('a hook keeps opportunity.amount in sync with its line items', () => {
+    const h = hooks.find((x) => x.object === 'crm_opportunity_line_item');
+    expect(h, 'no rollup hook on crm_opportunity_line_item').toBeTruthy();
+    for (const ev of ['afterInsert', 'afterUpdate', 'afterDelete']) {
+      expect(h.events, `rollup must fire on ${ev}`).toContain(ev);
+    }
+  });
+});
+
+describe('lead conversion is discoverable', () => {
+  it('convert_lead is not gated to qualified-only (it was hidden on most leads)', () => {
+    const vis = action('convert_lead')?.visible;
+    const src = typeof vis === 'string' ? vis : (vis?.source ?? JSON.stringify(vis ?? ''));
+    // The old gate required status=='qualified'. The fix shows Convert on any
+    // open lead, so the predicate must NOT hard-require the qualified status.
+    expect(src).not.toMatch(/status\s*==\s*["']qualified["']/);
+  });
+});


### PR DESCRIPTION
## What & why

The three **P0 (core-correctness)** gaps from the completeness review, plus a CI
net that would have caught this whole class of defect. Branches off `main`
(post #465).

### P0-1 — Lead conversion account dedupe
`lead_conversion` unconditionally created a new account from the lead's company,
so converting a lead whose company **already exists** spawned a duplicate
account. Added a `find_account` (get_record by name) → `decision_account` branch:
reuse the existing account, else create one, converging both paths on a single
`{accountId}` id via `assignment` nodes.

### P0-2 — Role-addressed alerts reach a real inbox
`lead_assignment` notified `to: ['sales_manager']`, but a CRM **position isn't a
messaging audience** — the service resolves `user:` / `role:`(sys_member) /
`team:` / `owner_of:`, so a bare `sales_manager` was stored verbatim as
`sys_inbox_message.user_id` and matched no user. Hot-lead / new-lead alerts
reached **nobody**. Now notifies `{record.owner}` (the accountable party, set on
insert).

### P0-3 — Opportunity amount rollup
`amount` was a free-typed field decoupled from `crm_opportunity_line_item`, so a
deal's headline number and its itemization could drift. New
`opportunity_line_item.hook` recomputes the parent `amount` from the line sum on
insert/update/delete. Guards:
- leaves `amount` untouched when there are **no** lines (never zeros a
  non-itemized deal → no `amount > 0` violation);
- skips `closed_won` / `closed_lost` (the rollup runs system-context and would
  otherwise bypass the freeze guard and rewrite a settled deal's value);
- handles re-parenting (recomputes old + new parent).

Line items already surface via the console's auto **"Products"** related list, so
this makes that list authoritative for the deal amount.

### P0-4 — Contract-test net (`test/actions-flows-integrity.test.ts`, +8)
Pins each fix from the compiled metadata so a revert (human or AI regeneration)
goes red in CI:
- campaign action inserts the real `crm_campaign`/`crm_lead` fields + is
  field-backed (picker, not paste-ID);
- clone sets the required opportunity fields;
- conversion has the dedupe branch and uses bare `{accountId}`;
- **no** flow notify targets a bare position word;
- the rollup hook is registered on the line-item object;
- `convert_lead` isn't qualified-gated.

These are **metadata-contract guards**, deliberately covering the class of bug
`os validate`/`build` can't see — logic inside action JS bodies, flow field maps,
and visibility/recipient strings. A full LiteKernel harness that executes the
flows/hooks against a driver is a noted follow-up.

## Test plan
- [x] `pnpm verify` green — validate + typecheck + build + **25/25** tests
- [x] Clean dev-server boot with the new flow structure + hook (no boot errors)
- [ ] Reviewer: convert a lead whose company matches an existing account → no
  duplicate; add a Product to an open opportunity → amount reflects the line sum;
  create a hot lead → the owner gets the inbox alert

> Note on live UI proof: end-to-end click-through of the line-item add + the
> conversion was limited this round by the preview harness (flaky related-list
> UI, a quirky lookup search, and in-page `fetch` running without the session
> cookie). The behaviours are pinned by the contract tests + clean boot; the
> running server is available for manual click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
