### PR TITLE
feat(crm): fix lookup/global search + P1 CPQ & intake capabilities + runtime hook tests

### DIFF
--- a/src/flows/lead-conversion.flow.ts
+++ b/src/flows/lead-conversion.flow.ts
@@ -76,7 +76,23 @@ export const LeadConversionFlow: Flow = {
       config: { assignments: { accountId: '{matchedAccount.id}' } },
     },
     {
-      // `accountId` is now a bare id string from whichever branch ran.
+      // Contact dedupe: within the (possibly reused) account, look for a contact
+      // with the same email before creating one — mirrors the account dedupe so
+      // re-converting a known person doesn't spawn a duplicate contact. Leads
+      // require an email, so the match key is reliable.
+      id: 'find_contact', type: 'get_record', label: 'Find Existing Contact',
+      config: {
+        objectName: 'crm_contact',
+        filter: { email: '{leadRecord.email}', crm_account: '{accountId}' },
+        outputVariable: 'matchedContact',
+      },
+    },
+    {
+      id: 'decision_contact', type: 'decision', label: 'Contact Already Exists?',
+      config: { condition: 'vars.matchedContact != null' },
+    },
+    {
+      // `accountId` is a bare id string from whichever account branch ran.
       id: 'create_contact', type: 'create_record', label: 'Create Contact',
       config: {
         objectName: 'crm_contact',
@@ -86,8 +102,16 @@ export const LeadConversionFlow: Flow = {
           title: '{leadRecord.title}', crm_account: '{accountId}',
           is_primary: true, owner: '{$User.Id}',
         },
-        outputVariable: 'contactId',
+        outputVariable: 'createdContact',
       },
+    },
+    {
+      id: 'use_new_contact', type: 'assignment', label: 'Use New Contact',
+      config: { assignments: { contactId: '{createdContact.id}' } },
+    },
+    {
+      id: 'use_existing_contact', type: 'assignment', label: 'Reuse Existing Contact',
+      config: { assignments: { contactId: '{matchedContact.id}' } },
     },
     {
       id: 'decision_opportunity', type: 'decision', label: 'Create Opportunity?',
@@ -98,7 +122,7 @@ export const LeadConversionFlow: Flow = {
       config: {
         objectName: 'crm_opportunity',
         fields: {
-          name: '{opportunityName}', crm_account: '{accountId}', primary_contact: '{contactId.id}',
+          name: '{opportunityName}', crm_account: '{accountId}', primary_contact: '{contactId}',
           amount: '{opportunityAmount}', stage: 'prospecting', probability: 10,
           lead_source: '{leadRecord.lead_source}', close_date: '{TODAY() + 90}', owner: '{$User.Id}',
         },
@@ -114,7 +138,7 @@ export const LeadConversionFlow: Flow = {
           // conversion flags (the qualified → converted transition is legal
           // per the lead_status_progression state machine).
           is_converted: true, status: 'converted', converted_date: '{NOW()}',
-          converted_account: '{accountId}', converted_contact: '{contactId.id}',
+          converted_account: '{accountId}', converted_contact: '{contactId}',
           converted_opportunity: '{opportunityId.id}',
         },
       },
@@ -144,13 +168,20 @@ export const LeadConversionFlow: Flow = {
     { id: 'e5', source: 'decision_account', target: 'use_existing_account', type: 'default', condition: 'vars.matchedAccount != null', label: 'Existing' },
     { id: 'e6', source: 'decision_account', target: 'create_account', type: 'default', condition: 'vars.matchedAccount == null', label: 'New' },
     { id: 'e7', source: 'create_account', target: 'use_new_account', type: 'default' },
-    { id: 'e8', source: 'use_new_account', target: 'create_contact', type: 'default' },
-    { id: 'e9', source: 'use_existing_account', target: 'create_contact', type: 'default' },
-    { id: 'e10', source: 'create_contact', target: 'decision_opportunity', type: 'default' },
-    { id: 'e11', source: 'decision_opportunity', target: 'create_opportunity', type: 'default', condition: 'vars.createOpportunity == true', label: 'Yes' },
-    { id: 'e12', source: 'decision_opportunity', target: 'mark_converted', type: 'default', condition: 'vars.createOpportunity != true', label: 'No' },
-    { id: 'e13', source: 'create_opportunity', target: 'mark_converted', type: 'default' },
-    { id: 'e14', source: 'mark_converted', target: 'send_notification', type: 'default' },
-    { id: 'e15', source: 'send_notification', target: 'end', type: 'default' },
+    // Both account branches converge on the contact-dedupe lookup.
+    { id: 'e8', source: 'use_new_account', target: 'find_contact', type: 'default' },
+    { id: 'e9', source: 'use_existing_account', target: 'find_contact', type: 'default' },
+    { id: 'e10', source: 'find_contact', target: 'decision_contact', type: 'default' },
+    // Existing contact → reuse; none → create. Both converge on decision_opportunity.
+    { id: 'e11', source: 'decision_contact', target: 'use_existing_contact', type: 'default', condition: 'vars.matchedContact != null', label: 'Existing' },
+    { id: 'e12', source: 'decision_contact', target: 'create_contact', type: 'default', condition: 'vars.matchedContact == null', label: 'New' },
+    { id: 'e13', source: 'create_contact', target: 'use_new_contact', type: 'default' },
+    { id: 'e14', source: 'use_new_contact', target: 'decision_opportunity', type: 'default' },
+    { id: 'e15', source: 'use_existing_contact', target: 'decision_opportunity', type: 'default' },
+    { id: 'e16', source: 'decision_opportunity', target: 'create_opportunity', type: 'default', condition: 'vars.createOpportunity == true', label: 'Yes' },
+    { id: 'e17', source: 'decision_opportunity', target: 'mark_converted', type: 'default', condition: 'vars.createOpportunity != true', label: 'No' },
+    { id: 'e18', source: 'create_opportunity', target: 'mark_converted', type: 'default' },
+    { id: 'e19', source: 'mark_converted', target: 'send_notification', type: 'default' },
+    { id: 'e20', source: 'send_notification', target: 'end', type: 'default' },
   ],
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -23,6 +23,7 @@ import opportunityHook from '../objects/opportunity.hook';
 import opportunityLineItemHook from '../objects/opportunity_line_item.hook';
 import productHook from '../objects/product.hook';
 import quoteHook from '../objects/quote.hook';
+import quoteLineItemHook from '../objects/quote_line_item.hook';
 import taskHook from '../objects/task.hook';
 
 const entries: Array<Hook | Hook[]> = [
@@ -38,6 +39,7 @@ const entries: Array<Hook | Hook[]> = [
   opportunityLineItemHook,
   productHook,
   quoteHook,
+  quoteLineItemHook,
   taskHook,
 ];
 

--- a/src/objects/account.object.ts
+++ b/src/objects/account.object.ts
@@ -16,6 +16,11 @@ export const Account = ObjectSchema.create({
   // which names a real field. The former template composed two local fields, so
   // a `display_title` formula field reproduces it for the record title.
   nameField: 'display_title',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['name', 'account_number'],
   highlightFields: ['account_number', 'name', 'type', 'owner'],
 
   // Field groups organize the form layout. Array order == display order.

--- a/src/objects/campaign.object.ts
+++ b/src/objects/campaign.object.ts
@@ -20,6 +20,11 @@ export const Campaign = ObjectSchema.create({
   // which names a real field. The former template composed two local fields, so
   // a `display_title` formula field reproduces it for the record title.
   nameField: 'display_title',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['name', 'campaign_code'],
   highlightFields: ['campaign_code', 'name', 'type', 'status', 'start_date'],
   
   fields: {

--- a/src/objects/case.object.ts
+++ b/src/objects/case.object.ts
@@ -269,6 +269,11 @@ export const Case = ObjectSchema.create({
   // which names a real field. The former template composed two local fields, so
   // the `display_title` formula field (see fields) reproduces it.
   nameField: 'display_title',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['subject', 'case_number'],
   highlightFields: ['case_number', 'subject', 'crm_account', 'status', 'priority'],
   
   // Removed: list_views and form_views belong in UI configuration, not object definition

--- a/src/objects/contact.object.ts
+++ b/src/objects/contact.object.ts
@@ -196,6 +196,11 @@ export const Contact = ObjectSchema.create({
   // which names the real field holding the record title (here: the `full_name`
   // formula field already defined above).
   nameField: 'full_name',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['first_name', 'last_name', 'email'],
   highlightFields: ['full_name', 'email', 'crm_account', 'phone'],
   
   // Validation Rules

--- a/src/objects/forecast.object.ts
+++ b/src/objects/forecast.object.ts
@@ -35,6 +35,11 @@ export const Forecast = ObjectSchema.create({
   // formula cannot dot-walk a lookup (ADR-0072). The `display_title` formula
   // composes the local fields only: period_label + (period_start).
   nameField: 'display_title',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['period_label'],
   highlightFields: ['owner', 'period', 'period_start', 'commit_amount', 'closed_amount'],
 
   fieldGroups: [

--- a/src/objects/knowledge_article.object.ts
+++ b/src/objects/knowledge_article.object.ts
@@ -25,6 +25,11 @@ export const KnowledgeArticle = ObjectSchema.create({
   // which names a real field. The former template composed two local fields, so
   // a `display_title` formula field reproduces it for the record title.
   nameField: 'display_title',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['title', 'article_number', 'summary'],
   highlightFields: ['article_number', 'title', 'category', 'status', 'audience'],
 
   fieldGroups: [

--- a/src/objects/lead.hook.ts
+++ b/src/objects/lead.hook.ts
@@ -40,6 +40,66 @@ function computeRating(input: Record<string, unknown>): number {
   return Math.round(clamped * 2) / 2;
 }
 
+/**
+ * Lead auto-assignment (load-balanced round-robin).
+ *
+ * A lead created without an owner (CSV import, web-to-lead, API capture) used to
+ * land ownerless and rely on a manager noticing it. This assigns it to the
+ * sales rep with the FEWEST open leads — a self-balancing round-robin that needs
+ * no rotation counter.
+ *
+ * The rep pool is whoever holds the `sales_rep` position (`sys_user_position`).
+ * When that pool is empty (e.g. a fresh org before positions are assigned) the
+ * hook is a NO-OP and the lead keeps whatever owner it had — so it never blocks
+ * lead creation. UI-created leads already carry owner = creator (field default),
+ * so this only kicks in for genuinely ownerless intake.
+ *
+ * Runs beforeInsert so the downstream lead_assignment flow (afterInsert) sees
+ * the assigned owner and routes its SLA alert to that rep. Territory-based
+ * routing is a future extension on top of this pool query.
+ */
+const leadAutoAssignHook: Hook = {
+  name: 'lead_auto_assign',
+  object: 'crm_lead',
+  events: ['beforeInsert'],
+  priority: 150,
+  description: 'Assign ownerless new leads to the least-loaded sales rep.',
+  handler: async (ctx: HookContext) => {
+    const { input } = ctx;
+    // Respect an explicit / creator-assigned owner.
+    if (typeof input.owner === 'string' && input.owner) return;
+    const api = ctx.api as HookApi | undefined;
+    if (!api) return;
+
+    // Rep pool = holders of the sales_rep position.
+    const holders = await api.object('sys_user_position').find({
+      where: { position: 'sales_rep' }, fields: ['user_id'], top: 1000,
+    });
+    const repIds = Array.from(
+      new Set(
+        (holders ?? [])
+          .map((r) => (typeof r.user_id === 'string' ? r.user_id : ''))
+          .filter(Boolean),
+      ),
+    );
+    if (repIds.length === 0) return; // no pool → leave ownerless (no-op)
+
+    // Pick the rep with the fewest OPEN (non-converted) leads.
+    let best: string | undefined;
+    let bestCount = Infinity;
+    for (const repId of repIds) {
+      const openCount = await api.object('crm_lead').count({
+        where: { owner: repId, is_converted: false },
+      });
+      if (openCount < bestCount) {
+        bestCount = openCount;
+        best = repId;
+      }
+    }
+    if (best) input.owner = best;
+  },
+};
+
 const leadHook: Hook = {
   name: 'lead_automation',
   object: 'crm_lead',
@@ -142,4 +202,4 @@ const leadHook: Hook = {
   },
 };
 
-export default leadHook;
+export default [leadAutoAssignHook, leadHook];

--- a/src/objects/lead.object.ts
+++ b/src/objects/lead.object.ts
@@ -303,6 +303,11 @@ export const Lead = ObjectSchema.create({
   // ADR-0079: render-only `titleFormat` retired in favor of `nameField`
   // (the `display_title` formula field defined above).
   nameField: 'display_title',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['first_name', 'last_name', 'company', 'email'],
   highlightFields: ['full_name', 'company', 'email', 'status', 'owner'],
   
   // Removed: list_views and form_views belong in UI configuration, not object definition

--- a/src/objects/opportunity.object.ts
+++ b/src/objects/opportunity.object.ts
@@ -16,6 +16,11 @@ export const Opportunity = ObjectSchema.create({
   // `stage` is a select — the formula references its stored value directly
   // (no label resolution), matching ADR-0079 guidance.
   nameField: 'display_title',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['name'],
   highlightFields: ['name', 'crm_account', 'amount', 'stage', 'owner'],
 
   fieldGroups: [

--- a/src/objects/opportunity_line_item.hook.ts
+++ b/src/objects/opportunity_line_item.hook.ts
@@ -29,6 +29,44 @@ import type { HookApi } from './_hook-api';
  * - On re-parenting (update that moves a line to another opportunity), BOTH the
  *   old and new parents are recomputed.
  */
+/**
+ * Line-item price fill.
+ *
+ * `list_price` was documented as "Auto-populated from product.list_price" but
+ * nothing implemented it. On write, when a product is chosen this stamps the
+ * catalog `list_price`, and on INSERT defaults the negotiated `unit_price` to
+ * the list price when the rep left it blank (they can still override). On update
+ * the negotiated `unit_price` is left alone so a re-synced catalog price never
+ * clobbers a negotiated one.
+ */
+const opportunityLineItemPriceFill: Hook = {
+  name: 'opportunity_line_item_price_fill',
+  object: 'crm_opportunity_line_item',
+  events: ['beforeInsert', 'beforeUpdate'],
+  priority: 100,
+  description: 'Default list_price / unit_price from the chosen product.',
+  handler: async (ctx: HookContext) => {
+    const { event, input } = ctx;
+    const api = ctx.api as HookApi | undefined;
+    if (!api) return;
+    // Only act when a product reference is part of THIS write.
+    const productId = typeof input.crm_product === 'string' ? input.crm_product : undefined;
+    if (!productId) return;
+    const product = await api.object('crm_product').findOne({
+      filter: { id: productId }, fields: ['id', 'list_price'],
+    });
+    const listPrice = product && typeof product.list_price === 'number' ? product.list_price : undefined;
+    if (listPrice === undefined) return;
+    // Catalog reference always tracks the product.
+    input.list_price = listPrice;
+    // Negotiated price defaults to list on create when left blank; never
+    // overwritten on update (respect a rep's negotiated figure).
+    if (event === 'beforeInsert' && input.unit_price == null) {
+      input.unit_price = listPrice;
+    }
+  },
+};
+
 const opportunityAmountRollup: Hook = {
   name: 'opportunity_amount_rollup',
   object: 'crm_opportunity_line_item',
@@ -85,4 +123,4 @@ const opportunityAmountRollup: Hook = {
   },
 };
 
-export default opportunityAmountRollup;
+export default [opportunityLineItemPriceFill, opportunityAmountRollup];

--- a/src/objects/product.object.ts
+++ b/src/objects/product.object.ts
@@ -20,6 +20,11 @@ export const Product = ObjectSchema.create({
   // which names a real field. The former template composed two local fields, so
   // a `display_title` formula field reproduces it for the record title.
   nameField: 'display_title',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['name', 'product_code', 'sku'],
   highlightFields: ['product_code', 'name', 'category', 'is_active'],
 
   fieldGroups: [

--- a/src/objects/quote.object.ts
+++ b/src/objects/quote.object.ts
@@ -20,6 +20,11 @@ export const Quote = ObjectSchema.create({
   // which names a real field. The former template composed two local fields, so
   // a `display_title` formula field reproduces it for the record title.
   nameField: 'display_title',
+  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
+  // FORMULA (display_title/full_name): without this, $search auto-defaults to
+  // the formula field, which isn't a real column, so the lookup picker + global
+  // search silently return zero. These are real, indexed columns.
+  searchableFields: ['name', 'quote_number'],
   highlightFields: ['quote_number', 'name', 'crm_account', 'status', 'total_price'],
 
   fieldGroups: [

--- a/src/objects/quote_line_item.hook.ts
+++ b/src/objects/quote_line_item.hook.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Hook, HookContext } from '@objectstack/spec/data';
+import type { HookApi } from './_hook-api';
+
+/**
+ * Quote total rollup.
+ *
+ * Keeps a quote's pricing (`subtotal` / `discount_amount` / `total_price`) in
+ * sync with the sum of its line items. Fires after a quote line item is
+ * inserted / updated / deleted (the console surfaces these as the quote's
+ * "Line Items" related list).
+ *
+ * Why this exists: `quote_generation` seeds the quote totals from the source
+ * opportunity's amount at create time, but nothing kept them in step once a
+ * rep edited the line items — the quote total and its itemization could drift.
+ *
+ * Total model (mirrors the quote_generation flow):
+ *   subtotal        = Σ line (quantity × unit_price × (1 − line_discount/100))
+ *   discount_amount = subtotal × quote.discount%              (quote-level)
+ *   total_price     = subtotal − discount_amount + tax + shipping_handling
+ * Quote-level `tax` and `shipping_handling` stay manual; only the line-derived
+ * figures are rolled up.
+ *
+ * Design decisions mirror opportunity_line_item.hook:
+ * - recompute from raw `quantity/unit_price/discount` (not the `subtotal`
+ *   FORMULA field) so it doesn't depend on formula hydration in the sandbox;
+ * - leave totals untouched when there are NO lines (never zero a quote whose
+ *   totals came from the opportunity);
+ * - skip accepted / expired quotes — the rollup runs system-context and would
+ *   otherwise bypass the quote freeze guard and rewrite a settled quote;
+ * - async + onError:'log' — a derived convenience, never blocks the line write;
+ * - handles re-parenting (old + new quote).
+ */
+/**
+ * Line-item price fill (see opportunity_line_item.hook for the rationale).
+ * Stamps catalog `list_price` from the chosen product and defaults the
+ * negotiated `unit_price` to it on create when blank.
+ */
+const quoteLineItemPriceFill: Hook = {
+  name: 'quote_line_item_price_fill',
+  object: 'crm_quote_line_item',
+  events: ['beforeInsert', 'beforeUpdate'],
+  priority: 100,
+  description: 'Default list_price / unit_price from the chosen product.',
+  handler: async (ctx: HookContext) => {
+    const { event, input } = ctx;
+    const api = ctx.api as HookApi | undefined;
+    if (!api) return;
+    const productId = typeof input.crm_product === 'string' ? input.crm_product : undefined;
+    if (!productId) return;
+    const product = await api.object('crm_product').findOne({
+      filter: { id: productId }, fields: ['id', 'list_price'],
+    });
+    const listPrice = product && typeof product.list_price === 'number' ? product.list_price : undefined;
+    if (listPrice === undefined) return;
+    input.list_price = listPrice;
+    if (event === 'beforeInsert' && input.unit_price == null) {
+      input.unit_price = listPrice;
+    }
+  },
+};
+
+const quoteTotalRollup: Hook = {
+  name: 'quote_total_rollup',
+  object: 'crm_quote_line_item',
+  events: ['afterInsert', 'afterUpdate', 'afterDelete'],
+  priority: 300,
+  async: true,
+  onError: 'log',
+  description: 'Recompute parent quote subtotal/discount/total from its line items.',
+  handler: async (ctx: HookContext) => {
+    const api = ctx.api as HookApi | undefined;
+    if (!api) return;
+    const { input } = ctx;
+    const previous = ctx.previous;
+
+    const quoteIds = new Set<string>();
+    for (const v of [input?.crm_quote, previous?.crm_quote]) {
+      if (typeof v === 'string' && v) quoteIds.add(v);
+    }
+    if (quoteIds.size === 0) return;
+
+    for (const quoteId of quoteIds) {
+      const quote = await api.object('crm_quote').findOne({
+        filter: { id: quoteId },
+        fields: ['id', 'status', 'discount', 'tax', 'shipping_handling'],
+      });
+      if (!quote) continue;
+      const status = typeof quote.status === 'string' ? quote.status : undefined;
+      if (status === 'accepted' || status === 'expired') continue;
+
+      const lines = await api.object('crm_quote_line_item').find({
+        filter: { crm_quote: quoteId },
+        fields: ['quantity', 'unit_price', 'discount'],
+        top: 5000,
+      });
+      // No lines left → leave the flow-seeded totals as-is (see design note).
+      if (!lines || lines.length === 0) continue;
+
+      let subtotal = 0;
+      for (const l of lines) {
+        const qty = typeof l.quantity === 'number' ? l.quantity : 0;
+        const price = typeof l.unit_price === 'number' ? l.unit_price : 0;
+        const disc = typeof l.discount === 'number' ? l.discount : 0;
+        subtotal += qty * price * (1 - disc / 100);
+      }
+      subtotal = Math.round(subtotal * 100) / 100;
+
+      const quoteDiscountPct = typeof quote.discount === 'number' ? quote.discount : 0;
+      const tax = typeof quote.tax === 'number' ? quote.tax : 0;
+      const shipping = typeof quote.shipping_handling === 'number' ? quote.shipping_handling : 0;
+      const discountAmount = Math.round(subtotal * (quoteDiscountPct / 100) * 100) / 100;
+      const total = Math.round((subtotal - discountAmount + tax + shipping) * 100) / 100;
+
+      await api.object('crm_quote').update(quoteId, {
+        subtotal,
+        discount_amount: discountAmount,
+        total_price: total,
+      });
+    }
+  },
+};
+
+export default [quoteLineItemPriceFill, quoteTotalRollup];

--- a/test/actions-flows-integrity.test.ts
+++ b/test/actions-flows-integrity.test.ts
@@ -114,13 +114,66 @@ describe('notify recipients resolve to real audiences', () => {
   });
 });
 
-describe('opportunity amount rollup', () => {
-  it('a hook keeps opportunity.amount in sync with its line items', () => {
-    const h = hooks.find((x) => x.object === 'crm_opportunity_line_item');
-    expect(h, 'no rollup hook on crm_opportunity_line_item').toBeTruthy();
+describe('line-item rollups keep parent totals in sync', () => {
+  it('opportunity amount rollup fires on line-item insert/update/delete', () => {
+    const h = hooks.find((x) => x.name === 'opportunity_amount_rollup');
+    expect(h, 'no opportunity_amount_rollup hook').toBeTruthy();
     for (const ev of ['afterInsert', 'afterUpdate', 'afterDelete']) {
       expect(h.events, `rollup must fire on ${ev}`).toContain(ev);
     }
+  });
+
+  it('quote total rollup fires on line-item insert/update/delete', () => {
+    const h = hooks.find((x) => x.name === 'quote_total_rollup');
+    expect(h, 'no quote_total_rollup hook').toBeTruthy();
+    for (const ev of ['afterInsert', 'afterUpdate', 'afterDelete']) {
+      expect(h.events, `rollup must fire on ${ev}`).toContain(ev);
+    }
+  });
+
+  it('line-item price-fill hooks default price from the product on write', () => {
+    for (const name of ['opportunity_line_item_price_fill', 'quote_line_item_price_fill']) {
+      const h = hooks.find((x) => x.name === name);
+      expect(h, `no ${name} hook`).toBeTruthy();
+      expect(h.events).toContain('beforeInsert');
+    }
+  });
+});
+
+describe('lead conversion dedupes the contact too', () => {
+  it('looks up an existing contact before creating one', () => {
+    const f = flow('lead_conversion');
+    const find = nodeOf(f, 'find_contact');
+    expect(find, 'find_contact node missing — conversion would always create a duplicate contact').toBeTruthy();
+    expect(find.type).toBe('get_record');
+    expect(find.config?.objectName).toBe('crm_contact');
+    // Converge on a bare {contactId} id (no stale {contactId.id}).
+    expect(JSON.stringify(f)).not.toContain('{contactId.id}');
+  });
+});
+
+describe('lead auto-assignment', () => {
+  it('a beforeInsert hook assigns ownerless leads', () => {
+    const h = hooks.find((x) => x.name === 'lead_auto_assign');
+    expect(h, 'no lead_auto_assign hook').toBeTruthy();
+    expect(h.events).toContain('beforeInsert');
+  });
+});
+
+describe('search works via explicit searchableFields', () => {
+  it('objects with a formula nameField declare real searchableFields', () => {
+    // The formula nameField (display_title/full_name) can't be searched; each
+    // such object must list real columns or the picker/global search return 0.
+    const offenders: string[] = [];
+    for (const o of objects) {
+      const nf = o.nameField;
+      const nfType = nf ? o.fields?.[nf]?.type : undefined;
+      if (nfType === 'formula') {
+        const sf = o.searchableFields;
+        if (!Array.isArray(sf) || sf.length === 0) offenders.push(o.name);
+      }
+    }
+    expect(offenders, `formula-nameField objects missing searchableFields:\n${offenders.join(', ')}`).toEqual([]);
   });
 });
 

--- a/test/hooks-runtime.test.ts
+++ b/test/hooks-runtime.test.ts
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import oppLineItemHooks from '../src/objects/opportunity_line_item.hook';
+import quoteLineItemHooks from '../src/objects/quote_line_item.hook';
+import leadHooks from '../src/objects/lead.hook';
+
+/**
+ * Runtime hook tests — the REAL handler code, executed against a controllable
+ * in-memory data layer.
+ *
+ * The metadata-contract tests (actions-flows-integrity) prove a hook is WIRED;
+ * these prove it BEHAVES: the sum arithmetic, the skip-when-empty / skip-closed
+ * guards, the least-loaded assignment pick, and the product price default all
+ * run here with real inputs and asserted outputs. This is the layer `os build`
+ * / `validate` can't reach, and it can't be flaky (no kernel, no server, no
+ * timing) — it just invokes `hook.handler(ctx)` with a fake `ctx`.
+ */
+
+type Rec = Record<string, any>;
+
+/** A tiny ctx.api backed by in-memory arrays, matching the HookApi surface. */
+function makeApi(store: Record<string, Rec[]>) {
+  const calls: Array<{ op: string; object: string; args: any }> = [];
+  const match = (row: Rec, where: Rec = {}) =>
+    Object.entries(where).every(([k, v]) => row[k] === v);
+  const api = {
+    calls,
+    object(name: string) {
+      const rows = store[name] ?? (store[name] = []);
+      return {
+        async find(q: { filter?: Rec; where?: Rec } = {}) {
+          return rows.filter((r) => match(r, q.filter ?? q.where ?? {}));
+        },
+        async findOne(q: { filter?: Rec; where?: Rec } = {}) {
+          return rows.find((r) => match(r, q.filter ?? q.where ?? {})) ?? null;
+        },
+        async count(q: { filter?: Rec; where?: Rec } = {}) {
+          return rows.filter((r) => match(r, q.filter ?? q.where ?? {})).length;
+        },
+        async update(id: string, doc: Rec) {
+          calls.push({ op: 'update', object: name, args: { id, doc } });
+          const row = rows.find((r) => r.id === id);
+          if (row) Object.assign(row, doc);
+          return row;
+        },
+        async insert(doc: Rec) {
+          calls.push({ op: 'insert', object: name, args: doc });
+          rows.push(doc);
+          return doc;
+        },
+      };
+    },
+  };
+  return api;
+}
+
+const hookByName = (hooks: any, name: string) => {
+  const list = Array.isArray(hooks) ? hooks : [hooks];
+  const h = list.find((x) => x.name === name);
+  if (!h) throw new Error(`hook ${name} not found`);
+  return h;
+};
+
+describe('opportunity_amount_rollup', () => {
+  const rollup = hookByName(oppLineItemHooks, 'opportunity_amount_rollup');
+
+  it('sets amount to the sum of line extended prices (qty × price × (1−disc%))', async () => {
+    const store: Record<string, Rec[]> = {
+      crm_opportunity: [{ id: 'opp1', stage: 'qualification', amount: 500000 }],
+      crm_opportunity_line_item: [
+        { id: 'li1', crm_opportunity: 'opp1', quantity: 2, unit_price: 1000, discount: 0 },
+        { id: 'li2', crm_opportunity: 'opp1', quantity: 1, unit_price: 500, discount: 10 }, // 450
+      ],
+    };
+    const api = makeApi(store);
+    await rollup.handler({ event: 'afterInsert', input: { crm_opportunity: 'opp1' }, api } as any);
+    expect(store.crm_opportunity[0].amount).toBe(2450); // 2000 + 450
+    expect(api.calls.some((c) => c.op === 'update' && c.object === 'crm_opportunity')).toBe(true);
+  });
+
+  it('leaves amount untouched when there are no line items (never zeros a manual deal)', async () => {
+    const store: Record<string, Rec[]> = {
+      crm_opportunity: [{ id: 'opp1', stage: 'qualification', amount: 500000 }],
+      crm_opportunity_line_item: [],
+    };
+    const api = makeApi(store);
+    await rollup.handler({ event: 'afterDelete', input: {}, previous: { crm_opportunity: 'opp1' }, api } as any);
+    expect(store.crm_opportunity[0].amount).toBe(500000);
+    expect(api.calls.length).toBe(0);
+  });
+
+  it('skips closed deals (a settled amount is never rewritten by a line edit)', async () => {
+    const store: Record<string, Rec[]> = {
+      crm_opportunity: [{ id: 'opp1', stage: 'closed_won', amount: 999 }],
+      crm_opportunity_line_item: [{ id: 'li1', crm_opportunity: 'opp1', quantity: 5, unit_price: 100, discount: 0 }],
+    };
+    const api = makeApi(store);
+    await rollup.handler({ event: 'afterUpdate', input: { crm_opportunity: 'opp1' }, api } as any);
+    expect(store.crm_opportunity[0].amount).toBe(999); // unchanged
+  });
+});
+
+describe('quote_total_rollup', () => {
+  const rollup = hookByName(quoteLineItemHooks, 'quote_total_rollup');
+
+  it('recomputes subtotal, quote-level discount_amount, and total (+tax +shipping)', async () => {
+    const store: Record<string, Rec[]> = {
+      crm_quote: [{ id: 'q1', status: 'draft', discount: 10, tax: 50, shipping_handling: 25 }],
+      crm_quote_line_item: [
+        { id: 'l1', crm_quote: 'q1', quantity: 4, unit_price: 100, discount: 0 }, // 400
+        { id: 'l2', crm_quote: 'q1', quantity: 2, unit_price: 300, discount: 50 }, // 300
+      ],
+    };
+    const api = makeApi(store);
+    await rollup.handler({ event: 'afterInsert', input: { crm_quote: 'q1' }, api } as any);
+    const q = store.crm_quote[0];
+    expect(q.subtotal).toBe(700);           // 400 + 300
+    expect(q.discount_amount).toBe(70);     // 700 × 10%
+    expect(q.total_price).toBe(705);        // 700 − 70 + 50 + 25
+  });
+
+  it('skips accepted quotes', async () => {
+    const store: Record<string, Rec[]> = {
+      crm_quote: [{ id: 'q1', status: 'accepted', discount: 0, tax: 0, shipping_handling: 0, total_price: 111 }],
+      crm_quote_line_item: [{ id: 'l1', crm_quote: 'q1', quantity: 9, unit_price: 100, discount: 0 }],
+    };
+    const api = makeApi(store);
+    await rollup.handler({ event: 'afterUpdate', input: { crm_quote: 'q1' }, api } as any);
+    expect(store.crm_quote[0].total_price).toBe(111);
+  });
+});
+
+describe('line-item price fill', () => {
+  const fill = hookByName(oppLineItemHooks, 'opportunity_line_item_price_fill');
+
+  it('defaults list_price + unit_price from the product on insert', async () => {
+    const store: Record<string, Rec[]> = { crm_product: [{ id: 'p1', list_price: 250 }] };
+    const input: Rec = { crm_product: 'p1' }; // no unit_price entered
+    await fill.handler({ event: 'beforeInsert', input, api: makeApi(store) } as any);
+    expect(input.list_price).toBe(250);
+    expect(input.unit_price).toBe(250);
+  });
+
+  it('never clobbers a negotiated unit_price on update (only re-syncs list_price)', async () => {
+    const store: Record<string, Rec[]> = { crm_product: [{ id: 'p1', list_price: 250 }] };
+    const input: Rec = { crm_product: 'p1', unit_price: 199 };
+    await fill.handler({ event: 'beforeUpdate', input, api: makeApi(store) } as any);
+    expect(input.list_price).toBe(250);
+    expect(input.unit_price).toBe(199); // preserved
+  });
+});
+
+describe('lead_auto_assign', () => {
+  const assign = hookByName(leadHooks, 'lead_auto_assign');
+
+  it('assigns an ownerless lead to the rep with the fewest open leads', async () => {
+    const store: Record<string, Rec[]> = {
+      sys_user_position: [
+        { position: 'sales_rep', user_id: 'repA' },
+        { position: 'sales_rep', user_id: 'repB' },
+      ],
+      crm_lead: [
+        { id: 'x1', owner: 'repA', is_converted: false },
+        { id: 'x2', owner: 'repA', is_converted: false }, // repA has 2 open
+        { id: 'x3', owner: 'repB', is_converted: false }, // repB has 1 open
+      ],
+    };
+    const input: Rec = { company: 'NewCo' }; // no owner
+    await assign.handler({ event: 'beforeInsert', input, api: makeApi(store) } as any);
+    expect(input.owner).toBe('repB'); // least-loaded
+  });
+
+  it('is a no-op when there is no rep pool (never blocks intake)', async () => {
+    const store: Record<string, Rec[]> = { sys_user_position: [], crm_lead: [] };
+    const input: Rec = { company: 'NewCo' };
+    await assign.handler({ event: 'beforeInsert', input, api: makeApi(store) } as any);
+    expect(input.owner).toBeUndefined();
+  });
+
+  it('respects an explicit owner', async () => {
+    const store: Record<string, Rec[]> = {
+      sys_user_position: [{ position: 'sales_rep', user_id: 'repA' }],
+    };
+    const input: Rec = { company: 'NewCo', owner: 'someone' };
+    await assign.handler({ event: 'beforeInsert', input, api: makeApi(store) } as any);
+    expect(input.owner).toBe('someone');
+  });
+});


### PR DESCRIPTION
## What & why

Autonomously completes the follow-ups I recommended after the P0 merge (#467):
the search bug I found while testing, the P1 capability gaps from the
completeness review, and a real runtime-test layer. Branches off `main`.

## Fixes & features

### Lookup / global search was broken for most objects (bug)
Every object whose `nameField` is a FORMULA (`display_title` / `full_name`) had
zero-result search: `$search` auto-defaults to the display field, but a formula
isn't a real column, so the driver query returned nothing. Typing "Globex" in an
opportunity picker showed **未找到选项**; global search found nothing — across
account, campaign, case, contact, forecast, knowledge_article, lead, opportunity,
product, quote. **Fix:** declare explicit `searchableFields` (real, indexed
columns) per ADR-0061. Verified against the running server: `?search=Globex` now
returns the Globex opportunities (the exact endpoint the picker calls);
`?search=Atlas` finds the Atlas lead.

### Quote total rollup (P1)
`quote_total_rollup` keeps a quote's `subtotal` / `discount_amount` /
`total_price` in step with its line items (mirrors the P0 opportunity rollup;
same skip-empty / skip-accepted / re-parent guards).

### Line-item price fill (P1)
`*_price_fill` beforeInsert/beforeUpdate hooks finally implement what
`list_price`'s own description promised: stamp catalog `list_price` from the
chosen product and default the negotiated `unit_price` to it on create — never
clobbering a negotiated price on update. Applies to opportunity + quote lines.

### Lead auto-assignment (P1)
`lead_auto_assign` routes an **ownerless** new lead (import / web-to-lead / API)
to the sales rep with the fewest open leads — a self-balancing round-robin.
No-ops when no `sales_rep` position holders exist (never blocks intake); activates
once reps are provisioned.

### Lead conversion dedupes the contact too (P1)
Mirrors the P0 account dedupe: `find_contact` by email within the (possibly
reused) account, reuse-or-create, converging on a bare `{contactId}`. No more
duplicate contacts when re-converting a known person.

### Real runtime hook tests (`test/hooks-runtime.test.ts`, +10)
Invoke the **actual hook handlers** against a controllable in-memory api and
assert behaviour: rollup arithmetic + skip guards, price default-vs-preserve,
least-loaded assignment + empty-pool no-op + explicit-owner respect. This is the
logic `os build`/`validate` can't see, tested deterministically (no kernel, no
server, no timing → not flaky). Contract tests extended for the new
hooks/flow branch (+5). A full LiteKernel harness that also drives the flows is
the natural next extension.

## Test plan
- [x] `pnpm verify` green — validate + typecheck + build + **40/40** tests
- [x] Search verified against the running server (`?search=` now returns matches)
- [ ] Reviewer: type a partial name in any lookup picker → results appear; add a
  Product to an opportunity/quote → totals roll up; unit price prefilled from the
  product

🤖 Generated with [Claude Code](https://claude.com/claude-code)
