### PR TITLE
fix(crm): lead_auto_assign must not break anonymous Web-to-Lead (regression from #468)

### DIFF
--- a/src/objects/lead.hook.ts
+++ b/src/objects/lead.hook.ts
@@ -71,32 +71,46 @@ const leadAutoAssignHook: Hook = {
     const api = ctx.api as HookApi | undefined;
     if (!api) return;
 
-    // Rep pool = holders of the sales_rep position.
-    const holders = await api.object('sys_user_position').find({
-      where: { position: 'sales_rep' }, fields: ['user_id'], top: 1000,
-    });
-    const repIds = Array.from(
-      new Set(
-        (holders ?? [])
-          .map((r) => (typeof r.user_id === 'string' ? r.user_id : ''))
-          .filter(Boolean),
-      ),
-    );
-    if (repIds.length === 0) return; // no pool → leave ownerless (no-op)
-
-    // Pick the rep with the fewest OPEN (non-converted) leads.
-    let best: string | undefined;
-    let bestCount = Infinity;
-    for (const repId of repIds) {
-      const openCount = await api.object('crm_lead').count({
-        where: { owner: repId, is_converted: false },
+    // Auto-assignment is a best-effort ENHANCEMENT — it must NEVER block lead
+    // creation. In particular an anonymous Web-to-Lead submission runs under the
+    // public-form grant, which permits only create/read-back on crm_lead and
+    // DENIES `find` on sys_user_position; letting that denial propagate would
+    // reject the whole insert and break the public form. So the pool lookup +
+    // load balancing are wrapped: on ANY error (permission, etc.) we log and
+    // leave the lead ownerless (a manager / the lead_assignment flow routes it).
+    try {
+      // Rep pool = holders of the sales_rep position.
+      const holders = await api.object('sys_user_position').find({
+        where: { position: 'sales_rep' }, fields: ['user_id'], top: 1000,
       });
-      if (openCount < bestCount) {
-        bestCount = openCount;
-        best = repId;
+      const repIds = Array.from(
+        new Set(
+          (holders ?? [])
+            .map((r) => (typeof r.user_id === 'string' ? r.user_id : ''))
+            .filter(Boolean),
+        ),
+      );
+      if (repIds.length === 0) return; // no pool → leave ownerless (no-op)
+
+      // Pick the rep with the fewest OPEN (non-converted) leads.
+      let best: string | undefined;
+      let bestCount = Infinity;
+      for (const repId of repIds) {
+        const openCount = await api.object('crm_lead').count({
+          where: { owner: repId, is_converted: false },
+        });
+        if (openCount < bestCount) {
+          bestCount = openCount;
+          best = repId;
+        }
       }
+      if (best) input.owner = best;
+    } catch {
+      // Swallow: auto-assignment must never block the insert. Common case is the
+      // anonymous public-form context, which can't read sys_user_position — the
+      // lead is still captured, ownerless, for downstream routing. (No `console`
+      // here — the L2 hook sandbox doesn't define it.)
     }
-    if (best) input.owner = best;
   },
 };
 

--- a/test/hooks-runtime.test.ts
+++ b/test/hooks-runtime.test.ts
@@ -186,4 +186,22 @@ describe('lead_auto_assign', () => {
     await assign.handler({ event: 'beforeInsert', input, api: makeApi(store) } as any);
     expect(input.owner).toBe('someone');
   });
+
+  it('never throws when the rep-pool lookup is denied (anonymous Web-to-Lead)', async () => {
+    // The public-form grant denies `find` on sys_user_position. The hook must
+    // swallow that and leave the lead ownerless — NOT reject the insert.
+    const api: any = {
+      object() {
+        return {
+          async find() { throw new Error("Access denied: not 'find' on 'sys_user_position'"); },
+          async count() { return 0; },
+        };
+      },
+    };
+    const input: Rec = { company: 'FromWebForm' };
+    await expect(
+      assign.handler({ event: 'beforeInsert', input, api } as any),
+    ).resolves.toBeUndefined();
+    expect(input.owner).toBeUndefined(); // ownerless, but the insert proceeds
+  });
 });


### PR DESCRIPTION
## What & why

**Web-to-Lead is already a platform capability** — declared in this app via the
`web_to_lead` form view (`sharing.allowAnonymous: true`, `publicLink:
/forms/contact-us`) + the `guest_portal` profile (anonymous INSERT-only on
`crm_lead`). No custom endpoint needed. But verifying it end-to-end surfaced
that **#468 silently broke it**.

The new `lead_auto_assign` beforeInsert hook calls
`api.object('sys_user_position').find(...)` to pick a rep. An anonymous
submission (`POST /api/v1/forms/contact-us/submit`) runs under the public-form
grant, which permits ONLY create/read-back on `crm_lead` and **denies** `find`
on `sys_user_position` — so the denial propagated and rejected the whole insert.

## Fix

Auto-assignment is best-effort — it must never block lead creation. Wrap the
pool lookup + load-balancing so ANY error is swallowed and the lead is still
created **ownerless** (a manager / the `lead_assignment` flow routes it). Also
dropped the `console.warn` in the catch — the L2 hook sandbox (QuickJS) has no
`console`, so it threw its own `ReferenceError` in the anonymous context.

## Verified end-to-end (unauthenticated curl vs the running server)
- `POST /forms/contact-us/submit` → **200**, creates `crm_lead`, `owner: null`,
  `status: 'new'`, rating auto-scored, `lead_source: 'web'`;
- `POST /forms/support/submit` → **200**, creates `crm_case` (Web-to-Case was
  never affected — no auto-assign on cases);
- `GET /forms/contact-us` → 200, returns the public form spec.

+1 regression test: the hook resolves (doesn't throw) when the
`sys_user_position` lookup is denied.

## Test plan
- [x] `pnpm verify` green — validate + typecheck + build + **47/47** tests
- [x] Both public forms submit successfully as an anonymous visitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)