### PR TITLE
fix(crm): drop console.* from hook catch blocks (L2 sandbox has no console)

### DIFF
--- a/src/objects/contact.hook.ts
+++ b/src/objects/contact.hook.ts
@@ -59,8 +59,10 @@ const contactHook: Hook = {
           where: { primary_contact: id },
           doc: patch,
         });
-      } catch (err) {
-        console.warn('[contact_integrity] propagate to opportunity failed:', err);
+      } catch {
+        // Best-effort propagation — never break the parent write. No `console`
+        // in the L2 hook sandbox (QuickJS): a log call here would throw its own
+        // ReferenceError and mask the real failure (cf. lead_auto_assign / #471).
       }
     }
 

--- a/src/objects/lead.hook.ts
+++ b/src/objects/lead.hook.ts
@@ -208,9 +208,10 @@ const leadHook: Hook = {
           related_to_type: 'crm_lead',
           related_to_lead: leadId,
         });
-      } catch (err) {
-        // Side-effect failure must not break the parent transaction.
-        console.warn('[lead_automation] failed to create follow-up task:', err);
+      } catch {
+        // Side-effect failure must not break the parent transaction. No
+        // `console` in the L2 hook sandbox — logging would throw its own
+        // ReferenceError and mask the real failure (cf. #471).
       }
     }
   },

--- a/src/objects/task.hook.ts
+++ b/src/objects/task.hook.ts
@@ -155,8 +155,9 @@ const taskRecurrence: Hook = {
 
     try {
       await api.object('crm_task').insert(doc);
-    } catch (err) {
-      console.warn('[task_recurrence] failed to spawn next occurrence:', err);
+    } catch {
+      // Best-effort; never break the parent write. No `console` in the L2 hook
+      // sandbox — logging here would throw its own ReferenceError (cf. #471).
     }
   },
 };
@@ -201,8 +202,9 @@ const taskBubble: Hook = {
     if (targetType !== 'crm_account' && targetType !== 'crm_lead') return;
     try {
       await api.object(targetType).update(targetId, { last_activity_date: today });
-    } catch (err) {
-      console.warn('[task_activity_bubble] update failed:', err);
+    } catch {
+      // Best-effort activity bubble; never break the parent write. No `console`
+      // in the L2 hook sandbox (would throw ReferenceError — cf. #471).
     }
   },
 };


### PR DESCRIPTION
Defensive follow-up to #471. Four hook error-paths (contact_integrity, task_recurrence, task_activity_bubble, lead_automation follow-up) logged via console.warn in their catch. The L2 hook sandbox (QuickJS) has no `console`, so if any runs in the strict sandbox the log throws its own ReferenceError and masks the real failure — exactly what broke anonymous Web-to-Lead in #471. None are currently reachable on the anonymous public forms, so this is hardening, not an active bug; they now swallow silently. verify green: validate + typecheck + build + 47/47 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)