### PR TITLE
fix(crm): repair dangling UI references, fix inverted priority queues, and put the day's work first

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -14,5 +14,5 @@
 export { EscalateCaseAction, CloseCaseAction } from './case.actions';
 export { MarkPrimaryContactAction, SendEmailAction } from './contact.actions';
 export { LogCallAction, LogMeetingAction, ExportToCsvAction } from './global.actions';
-export { ConvertLeadAction, CreateCampaignAction } from './lead.actions';
+export { ConvertLeadAction, CreateCampaignAction, ScheduleFollowUpAction } from './lead.actions';
 export { CloneOpportunityAction, MassUpdateStageAction, GenerateQuoteAction } from './opportunity.actions';

--- a/src/actions/lead.actions.ts
+++ b/src/actions/lead.actions.ts
@@ -29,6 +29,36 @@ export const ConvertLeadAction: Action = {
 };
 
 /**
+ * Schedule the next follow-up on a lead.
+ *
+ * The gap this fills: `log_call` / `log_meeting` record what already happened
+ * (a `sys_activity` timeline entry), but nothing put the NEXT touch on the
+ * rep's list. Filing that follow-up meant leaving the lead, opening the
+ * Related tab, finding the Tasks block, and hand-picking the lead back as the
+ * parent — four steps for the single most common thing a rep does after a call.
+ *
+ * Flow-typed, not `type: 'modal'`: modal actions are non-functional in 16.1.0
+ * (the console resolves the action's `target` as an object name, so submitting
+ * one dies on `GET /api/v1/meta/object/<target>` → 400 — reproducible on the
+ * pre-existing `log_call` too). The screen flow under
+ * `src/flows/schedule-followup.flow.ts` collects the same fields and does the
+ * write; that mechanism is proven by `convert_lead` above.
+ */
+export const ScheduleFollowUpAction: Action = {
+  name: 'schedule_followup',
+  label: 'Schedule Follow-up',
+  objectName: 'crm_lead',
+  icon: 'calendar-plus',
+  type: 'flow',
+  target: 'schedule_followup',
+  locations: ['record_header', 'list_item'],
+  // A converted or disqualified lead has no next touch to schedule.
+  visible: P`record.is_converted == false && record.status != "unqualified" && record.status != "converted"`,
+  successMessage: 'Follow-up scheduled.',
+  refreshAfter: true,
+};
+
+/**
  * Add selected leads to a Campaign.
  *
  * Modal-typed action: collects a campaign id then writes one

--- a/src/flows/index.ts
+++ b/src/flows/index.ts
@@ -8,6 +8,7 @@ import type { Flow } from '@objectstack/spec/automation';
 export { CampaignEnrollmentFlow } from './campaign-enrollment.flow';
 export { CaseEscalationFlow, CaseEscalationOnCreateFlow } from './case-escalation.flow';
 export { LeadConversionFlow } from './lead-conversion.flow';
+export { ScheduleFollowUpFlow } from './schedule-followup.flow';
 export { OpportunityApprovalFlow } from './opportunity-approval.flow';
 export { QuoteGenerationFlow } from './quote-generation.flow';
 // Time/event-driven automation (scheduled + wait-node + record-change)
@@ -28,6 +29,7 @@ export { TaskDueReminderFlow } from './task-due-reminder.flow';
 import { CampaignEnrollmentFlow } from './campaign-enrollment.flow';
 import { CaseEscalationFlow, CaseEscalationOnCreateFlow } from './case-escalation.flow';
 import { LeadConversionFlow } from './lead-conversion.flow';
+import { ScheduleFollowUpFlow } from './schedule-followup.flow';
 import { OpportunityApprovalFlow } from './opportunity-approval.flow';
 import { QuoteGenerationFlow } from './quote-generation.flow';
 import { ContractRenewalFlow } from './contract-renewal.flow';
@@ -50,6 +52,7 @@ export const allFlows: Flow[] = [
   CaseEscalationFlow,
   CaseEscalationOnCreateFlow,
   LeadConversionFlow,
+  ScheduleFollowUpFlow,
   OpportunityApprovalFlow,
   QuoteGenerationFlow,
   // Time/event-driven automation

--- a/src/flows/schedule-followup.flow.ts
+++ b/src/flows/schedule-followup.flow.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type * as Automation from '@objectstack/spec/automation';
+type Flow = Automation.Flow;
+
+/**
+ * Schedule Follow-up — one screen, one task, straight off the lead header.
+ *
+ * The gap this closes: `log_call` / `log_meeting` record what already happened,
+ * but nothing put the NEXT touch on the rep's list. Filing that follow-up meant
+ * leaving the lead, opening the Related tab, finding the Tasks block and
+ * re-picking the lead as the parent — four steps for the single most common
+ * thing a rep does after a call.
+ *
+ * Implemented as a SCREEN FLOW rather than a `type: 'modal'` action: modal
+ * actions are non-functional in 16.1.0 (the console resolves the action's
+ * `target` as an object name and the submit dies on
+ * `GET /api/v1/meta/object/<target>` → 400, even though the spec defines
+ * `target` for modals as "the modal/page name to open"). Flow-typed actions
+ * are the mechanism that demonstrably works today — `convert_lead` uses it.
+ */
+export const ScheduleFollowUpFlow: Flow = {
+  name: 'schedule_followup',
+  label: 'Schedule Follow-up',
+  description: 'Create the next follow-up task on a lead, already linked and owned.',
+  type: 'screen',
+  status: 'active',
+
+  variables: [
+    // MUST be `recordId` — the console's flow-action contract seeds only that
+    // name (and its camelCase object alias); a custom name arrives undefined.
+    { name: 'recordId', type: 'text', isInput: true, isOutput: false },
+    { name: 'subject', type: 'text', isInput: true, isOutput: false },
+    { name: 'dueDate', type: 'date', isInput: true, isOutput: false },
+    { name: 'activityType', type: 'text', isInput: true, isOutput: false },
+    { name: 'priority', type: 'text', isInput: true, isOutput: false },
+    { name: 'notes', type: 'text', isInput: true, isOutput: false },
+  ],
+
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start', config: { objectName: 'crm_lead' } },
+    {
+      id: 'screen_1', type: 'screen', label: 'Schedule Follow-up',
+      config: {
+        fields: [
+          { name: 'subject', label: 'What is the next step?', type: 'text', required: true },
+          { name: 'dueDate', label: 'Due Date', type: 'date', required: true },
+          {
+            name: 'activityType', label: 'Activity Type', type: 'select',
+            options: [
+              { label: 'Call', value: 'call' },
+              { label: 'Email', value: 'email' },
+              { label: 'Meeting', value: 'meeting' },
+              { label: 'Demo', value: 'demo' },
+              { label: 'Follow-up', value: 'follow_up' },
+            ],
+          },
+          {
+            name: 'priority', label: 'Priority', type: 'select',
+            options: [
+              { label: 'Low', value: 'low' },
+              { label: 'Normal', value: 'normal' },
+              { label: 'High', value: 'high' },
+              { label: 'Urgent', value: 'urgent' },
+            ],
+          },
+          { name: 'notes', label: 'Notes', type: 'textarea' },
+        ],
+      },
+    },
+    {
+      id: 'get_lead', type: 'get_record', label: 'Get Lead Record',
+      config: { objectName: 'crm_lead', filter: { id: '{recordId}' }, outputVariable: 'leadRecord' },
+    },
+    {
+      id: 'create_task', type: 'create_record', label: 'Create Follow-up Task',
+      config: {
+        objectName: 'crm_task',
+        fields: {
+          subject: '{subject}',
+          due_date: '{dueDate}',
+          type: '{activityType}',
+          priority: '{priority}',
+          description: '{notes}',
+          status: 'not_started',
+          owner: '{$User.Id}',
+          // Polymorphic parent: both halves are required for the lead's
+          // Related tab to pick the task up.
+          related_to_type: 'crm_lead',
+          related_to_lead: '{recordId}',
+        },
+        outputVariable: 'createdTask',
+      },
+    },
+    {
+      // Keep the lead's own follow-up date in step with the task that was just
+      // filed, so the Hot Leads view (sorted by next_followup_date) reflects
+      // the commitment the rep actually made.
+      id: 'stamp_lead', type: 'update_record', label: 'Stamp Next Follow-up Date',
+      config: {
+        objectName: 'crm_lead',
+        filter: { id: '{recordId}' },
+        fields: { next_followup_date: '{dueDate}' },
+      },
+    },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+
+  edges: [
+    { id: 'e1', source: 'start', target: 'screen_1', type: 'default' },
+    { id: 'e2', source: 'screen_1', target: 'get_lead', type: 'default' },
+    { id: 'e3', source: 'get_lead', target: 'create_task', type: 'default' },
+    { id: 'e4', source: 'create_task', target: 'stamp_lead', type: 'default' },
+    { id: 'e5', source: 'stamp_lead', target: 'end', type: 'default' },
+  ],
+};

--- a/src/objects/case.hook.ts
+++ b/src/objects/case.hook.ts
@@ -37,6 +37,15 @@ const caseValidation: Hook = {
       (typeof input.priority === 'string' && input.priority) ||
       (typeof ctx.previous?.priority === 'string' && (ctx.previous.priority as string)) ||
       undefined;
+
+    // Materialise the urgency ordinal so queue views can sort by it. Sorting
+    // on `priority` itself compares raw strings and inverts urgency
+    // (medium > low > high > critical).
+    if (priority) {
+      const rank: Record<string, number> = { low: 1, medium: 2, high: 3, critical: 4 };
+      input.priority_rank = rank[priority] ?? 1;
+    }
+
     if (priority === 'critical' && !input.sla_due_date && !ctx.previous?.sla_due_date) {
       const due = new Date();
       due.setHours(due.getHours() + 4);

--- a/src/objects/case.object.ts
+++ b/src/objects/case.object.ts
@@ -102,7 +102,19 @@ export const Case = ObjectSchema.create({
         { label: 'Critical', value: 'critical', color: '#FF0000' },
       ]
     }),
-    
+
+    // Sortable ordinal for `priority`. Ordering a queue by the select field
+    // itself sorts the raw strings, so `priority desc` yields
+    // medium > low > high > critical — the exact inversion of urgency, which
+    // buried every critical case at the bottom of the agent's queue. Select
+    // options carry no ordinal in the spec, so the rank is materialised here
+    // and stamped by `case_sla_defaults`; queue views sort on it instead.
+    priority_rank: Field.number({
+      label: 'Priority Rank',
+      readonly: true,
+      defaultValue: 1,
+    }),
+
     type: Field.select({
       label: 'Case Type',
       group: 'basic',

--- a/src/objects/task.hook.ts
+++ b/src/objects/task.hook.ts
@@ -30,6 +30,17 @@ const taskValidation: Hook = {
       input.reminder_sent = false;
     }
 
+    // Materialise the urgency ordinal so the to-do queue can sort by it —
+    // sorting on `priority` itself compares raw strings and inverts urgency.
+    const effPriority =
+      (typeof input.priority === 'string' && input.priority) ||
+      (typeof previous?.priority === 'string' && (previous.priority as string)) ||
+      undefined;
+    if (effPriority) {
+      const rank: Record<string, number> = { low: 1, normal: 2, high: 3, urgent: 4 };
+      input.priority_rank = rank[effPriority] ?? 2;
+    }
+
     if (input.status === 'completed' && previous?.status !== 'completed') {
       if (!input.completed_date) input.completed_date = new Date().toISOString();
       if (typeof input.progress_percent !== 'number') input.progress_percent = 100;

--- a/src/objects/task.object.ts
+++ b/src/objects/task.object.ts
@@ -31,6 +31,11 @@ export const Task = ObjectSchema.create({
       label: 'Status',
       required: true,
       trackHistory: true,
+      // Field-level default, not just the option flag: the option `default`
+      // only preselects in some form surfaces, so a quick-create modal opened
+      // from a related list left this required field blank and the rep had to
+      // pick "Not Started" by hand every time.
+      defaultValue: 'not_started',
       options: [
         { label: 'Not Started', value: 'not_started', color: '#808080', default: true },
         { label: 'In Progress', value: 'in_progress', color: '#FFA500' },
@@ -44,14 +49,27 @@ export const Task = ObjectSchema.create({
       label: 'Priority',
       required: true,
       trackHistory: true,
+      // `normal` is the default rather than `low`: a rep filing a to-do has
+      // made no priority judgement, and defaulting everything to Low made the
+      // field meaningless (nothing ever sorted above the noise).
+      defaultValue: 'normal',
       options: [
-        { label: 'Low', value: 'low', color: '#4169E1', default: true },
-        { label: 'Normal', value: 'normal', color: '#00AA00' },
+        { label: 'Low', value: 'low', color: '#4169E1' },
+        { label: 'Normal', value: 'normal', color: '#00AA00', default: true },
         { label: 'High', value: 'high', color: '#FFA500' },
         { label: 'Urgent', value: 'urgent', color: '#FF0000' },
       ]
     }),
-    
+
+    // Sortable ordinal for `priority` — see crm_case.priority_rank. Sorting on
+    // the select itself compares raw strings (normal > low > high > urgent),
+    // which pushes urgent work to the bottom of the to-do queue.
+    priority_rank: Field.number({
+      label: 'Priority Rank',
+      readonly: true,
+      defaultValue: 2,
+    }),
+
     type: Field.select({
       label: 'Task Type',
       options: [

--- a/src/pages/app_launcher.page.ts
+++ b/src/pages/app_launcher.page.ts
@@ -61,7 +61,7 @@ export const AppLauncherPage: Page = {
   ],
   
   isDefault: false,
-  assignedProfiles: ['sales_user', 'sales_manager', 'service_user', 'system_administrator'],
+  assignedProfiles: ['sales_rep', 'sales_manager', 'service_agent', 'system_admin'],
   
   aria: {
     ariaLabel: 'App Launcher Page',

--- a/src/pages/case_detail.page.ts
+++ b/src/pages/case_detail.page.ts
@@ -56,11 +56,15 @@ export const CaseDetailPage: Page = {
           id: 'case_highlights',
           label: 'Key Information',
           properties: {
+            // crm_case carries a single `sla_due_date` plus the derived
+            // `is_sla_violated` flag — the split response/resolution deadlines
+            // named here do not exist, so the agent's most time-critical fact
+            // was missing from the strip entirely.
             fields: [
               'status',
               'priority',
-              'sla_response_due',
-              'sla_resolution_due',
+              'sla_due_date',
+              'is_sla_violated',
               'owner',
               'crm_account',
             ],
@@ -75,7 +79,10 @@ export const CaseDetailPage: Page = {
             stages: [
               { value: 'new', label: 'New' },
               { value: 'in_progress', label: 'In Progress' },
-              { value: 'waiting_on_customer', label: 'Waiting on Customer' },
+              // The status option is `waiting_customer`; the longer spelling
+              // matched no option, so this stage never lit up and rendered
+              // untranslated next to its neighbours.
+              { value: 'waiting_customer', label: 'Waiting on Customer' },
               { value: 'escalated', label: 'Escalated' },
               { value: 'resolved', label: 'Resolved' },
               { value: 'closed', label: 'Closed' },
@@ -127,8 +134,10 @@ export const CaseDetailPage: Page = {
                             'priority',
                             'owner',
                             'is_escalated',
-                            'sla_response_due',
-                            'sla_resolution_due',
+                            'escalation_reason',
+                            'sla_due_date',
+                            'is_sla_violated',
+                            'resolution_time_hours',
                           ],
                         },
                         {
@@ -210,7 +219,7 @@ export const CaseDetailPage: Page = {
   ],
 
   isDefault: true,
-  assignedProfiles: ['service_agent', 'service_manager', 'system_administrator'],
+  assignedProfiles: ['service_agent', 'system_admin'],
 
   aria: {
     ariaLabel: 'Case Detail Page',

--- a/src/pages/home.page.ts
+++ b/src/pages/home.page.ts
@@ -178,7 +178,7 @@ export const SalesHomePage: Page = {
   ],
   
   isDefault: true,
-  assignedProfiles: ['sales_user', 'sales_manager'],
+  assignedProfiles: ['sales_rep', 'sales_manager'],
   
   aria: {
     ariaLabel: 'Sales Home Page',

--- a/src/pages/lead_detail.page.ts
+++ b/src/pages/lead_detail.page.ts
@@ -81,10 +81,14 @@ export const LeadDetailPage: Page = {
           label: 'Lead Status Path',
           properties: {
             statusField: 'status',
+            // `converted` is the terminal WIN state and must be on the path —
+            // without it the strip reads as if "Unqualified" were the goal, and
+            // a converted lead had no stage to light up at all.
             stages: [
               { value: 'new', label: 'New' },
               { value: 'contacted', label: 'Contacted' },
               { value: 'qualified', label: 'Qualified' },
+              { value: 'converted', label: 'Converted' },
               { value: 'unqualified', label: 'Unqualified' },
             ],
           },
@@ -173,8 +177,13 @@ export const LeadDetailPage: Page = {
                               label: 'Tasks',
                               properties: {
                                 objectName: 'crm_task',
-                                relationshipField: 'lead_id',
-                                columns: ['subject', 'status', 'priority', 'due_date', 'assigned_to'],
+                                // crm_task links back through the polymorphic
+                                // `related_to_lead` lookup; there is no `lead_id`
+                                // column, so the old binding matched nothing and
+                                // this list read "0" no matter how many follow-ups
+                                // the rep had filed.
+                                relationshipField: 'related_to_lead',
+                                columns: ['subject', 'status', 'priority', 'due_date', 'owner'],
                                 sort: [
                                   { field: 'due_date', order: 'asc' }
                                 ],
@@ -183,51 +192,6 @@ export const LeadDetailPage: Page = {
                                 filter: [['status', '!=', 'completed']],
                                 showViewAll: true,
                                 actions: ['new_task', 'edit', 'complete'],
-                              },
-                            },
-                          ],
-                        },
-                        {
-                          label: 'Events',
-                          icon: 'calendar',
-                          collapsed: true,
-                          children: [
-                            {
-                              type: 'record:related_list',
-                              id: 'related_events',
-                              label: 'Events',
-                              properties: {
-                                objectName: 'event',
-                                relationshipField: 'lead_id',
-                                columns: ['subject', 'start_date', 'end_date', 'location'],
-                                sort: [
-                                  { field: 'start_date', order: 'desc' }
-                                ],
-                                limit: 5,
-                                showViewAll: true,
-                                actions: ['new_event'],
-                              },
-                            },
-                          ],
-                        },
-                        {
-                          label: 'Notes & Attachments',
-                          icon: 'paperclip',
-                          collapsed: true,
-                          children: [
-                            {
-                              type: 'record:related_list',
-                              id: 'related_files',
-                              label: 'Files',
-                              properties: {
-                                objectName: 'file',
-                                relationshipField: 'parent_id',
-                                columns: ['title', 'file_type', 'size', 'created_by', 'created_date'],
-                                sort: [
-                                  { field: 'created_date', order: 'desc' }
-                                ],
-                                limit: 5,
-                                showViewAll: true,
                               },
                             },
                           ],
@@ -246,7 +210,10 @@ export const LeadDetailPage: Page = {
                     id: 'lead_activity',
                     label: 'Activity Timeline',
                     properties: {
-                      types: ['crm_task', 'event', 'email', 'call', 'note'],
+                      // Only `crm_task` exists in this app — `event` / `email` /
+                      // `call` / `note` were aspirational object names that the
+                      // timeline silently skipped.
+                      types: ['crm_task'],
                       limit: 20,
                       showCompleted: false,
                     },
@@ -258,18 +225,16 @@ export const LeadDetailPage: Page = {
                 icon: 'history',
                 children: [
                   {
-                    type: 'record:related_list',
-                    id: 'field_history',
+                    // `record:history` is the platform's own audit feed over the
+                    // fields marked `trackHistory` (status / rating / owner).
+                    // The hand-rolled version queried an object named
+                    // `field_history`, which this app does not define, so the
+                    // tab could only ever render empty.
+                    type: 'record:history',
+                    id: 'lead_history',
                     label: 'Field History',
                     properties: {
-                      objectName: 'field_history',
-                      relationshipField: 'record_id',
-                      columns: ['field', 'old_value', 'new_value', 'changed_by', 'changed_date'],
-                      sort: [
-                        { field: 'changed_date', order: 'desc' }
-                      ],
                       limit: 25,
-                      showViewAll: true,
                     },
                   },
                 ],
@@ -284,8 +249,10 @@ export const LeadDetailPage: Page = {
   // Make this the default page for leads
   isDefault: true,
 
-  // Assign to specific profiles
-  assignedProfiles: ['sales_user', 'sales_manager', 'system_administrator'],
+  // Assign to specific profiles. These must match the profile `name`s declared
+  // in src/profiles — `sales_user` / `system_administrator` never existed, so
+  // the assignment silently matched nobody.
+  assignedProfiles: ['sales_rep', 'sales_manager', 'system_admin'],
 
   // ARIA accessibility
   aria: {

--- a/src/pages/lead_detail.page.ts
+++ b/src/pages/lead_detail.page.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { Page } from '@objectstack/spec/ui';
-import { ConvertLeadAction } from '../actions/lead.actions';
+import { ConvertLeadAction, ScheduleFollowUpAction } from '../actions/lead.actions';
 
 /**
  * Lead Detail Record Page
@@ -61,7 +61,10 @@ export const LeadDetailPage: Page = {
             subtitle: '{company}',
             icon: 'user-plus',
             breadcrumb: true,
-            actions: [ConvertLeadAction],
+            // Convert is the outcome; scheduling the next touch is the daily
+            // act. Both belong in the header — the follow-up used to be four
+            // clicks deep in the Related tab.
+            actions: [ConvertLeadAction, ScheduleFollowUpAction],
           },
         },
         // Salesforce-style Highlights Panel: a horizontal strip of the

--- a/src/pages/opportunity_detail.page.ts
+++ b/src/pages/opportunity_detail.page.ts
@@ -231,7 +231,7 @@ export const OpportunityDetailPage: Page = {
   ],
 
   isDefault: true,
-  assignedProfiles: ['sales_user', 'sales_manager', 'system_administrator'],
+  assignedProfiles: ['sales_rep', 'sales_manager', 'system_admin'],
 
   aria: {
     ariaLabel: 'Opportunity Detail Page',

--- a/src/pages/utility_bar.page.ts
+++ b/src/pages/utility_bar.page.ts
@@ -54,7 +54,7 @@ export const UtilityBarPage: Page = {
   ],
   
   isDefault: false,
-  assignedProfiles: ['sales_user', 'sales_manager', 'service_user', 'system_administrator'],
+  assignedProfiles: ['sales_rep', 'sales_manager', 'service_agent', 'system_admin'],
   
   aria: {
     ariaLabel: 'Utility Bar',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -335,6 +335,7 @@ export const en: TranslationData = {
         loss_details: { label: 'Loss/Win Details' },
       },
       _views: {
+        open_opportunities: { label: 'Open Deals' },
         all_opportunities: { label: 'All Opportunities' },
         pipeline_kanban: { label: 'Sales Pipeline' },
         close_date_calendar: { label: 'Forecast Calendar' },

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -293,6 +293,7 @@ export const esES: TranslationData = {
         is_private: { label: 'Privado' },
       },
       _views: {
+        open_opportunities: { label: 'Oportunidades Abiertas' },
         all_opportunities: { label: 'Todas las Oportunidades' },
         pipeline_kanban: { label: 'Pipeline de Ventas' },
         close_date_calendar: { label: 'Calendario de Pronóstico' },

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -293,6 +293,7 @@ export const jaJP: TranslationData = {
         is_private: { label: '非公開' },
       },
       _views: {
+        open_opportunities: { label: '進行中の商談' },
         all_opportunities: { label: '全商談' },
         pipeline_kanban: { label: 'セールスパイプライン' },
         close_date_calendar: { label: '予測カレンダー' },

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -640,6 +640,7 @@ export const zhCN: TranslationData = {
         loss_details: { label: '赢/丢单详情' },
       },
       _views: {
+        open_opportunities: { label: '进行中商机' },
         all_opportunities: { label: '全部商机' },
         pipeline_kanban: { label: '销售流水线' },
         close_date_calendar: { label: '预测日历' },

--- a/src/views/case.view.ts
+++ b/src/views/case.view.ts
@@ -29,8 +29,11 @@ export const CaseViews = defineView({
       { field: 'is_escalated', width: 110, align: 'center' },
       { field: 'owner', width: 150 },
     ],
+    // Sort on the materialised ordinal, not the select itself: `priority desc`
+    // compares raw strings and lands medium > low > high > critical, burying
+    // every critical case at the bottom of the queue.
     sort: [
-      { field: 'priority', order: 'desc' },
+      { field: 'priority_rank', order: 'desc' },
       { field: 'sla_due_date', order: 'asc' },
     ],
     rowColor: {
@@ -106,7 +109,7 @@ export const CaseViews = defineView({
       data: { provider: 'object', object: 'crm_case' },
       columns: ['case_number', 'subject', 'crm_account', 'priority', 'sla_due_date', 'owner'],
       filter: [{ field: 'is_escalated', operator: 'equals', value: true }],
-      sort: [{ field: 'priority', order: 'desc' }],
+      sort: [{ field: 'priority_rank', order: 'desc' }],
     },
 
     /** SLA-at-risk: open, high/urgent priority cases needing attention */

--- a/src/views/lead.view.ts
+++ b/src/views/lead.view.ts
@@ -29,17 +29,15 @@ export const LeadViews = defineView({
     // Column Configuration with Enhanced Features
     columns: [
       {
-        field: 'first_name',
-        label: 'First Name',
-        width: 150,
+        // One name column, not two. Splitting first/last spent 300px to say
+        // what "Alice Martinez" says in one, and hung the record link off the
+        // given name alone — so opening a person meant aiming at their first
+        // name specifically.
+        field: 'full_name',
+        label: 'Name',
+        width: 200,
         sortable: true,
         link: true, // Primary navigation link
-      },
-      {
-        field: 'last_name',
-        label: 'Last Name',
-        width: 150,
-        sortable: true,
       },
       {
         field: 'company',
@@ -218,6 +216,80 @@ export const LeadViews = defineView({
    * Additional Named List Views
    */
   listViews: {
+    // Declaration order IS tab order in the console. These three working
+    // queues used to sit AFTER the kanban / calendar / gallery views, which
+    // pushed all of them into the "3 more" overflow menu — so the one screen
+    // a rep opens this list for was the one they had to go hunting for, while
+    // three presentation modes held the front row.
+
+    /**
+     * My Leads — a rep's own queue, hottest first.
+     */
+    my_leads: {
+      name: 'my_leads',
+      type: 'grid',
+      label: 'My Leads',
+      data: {
+        provider: 'object',
+        object: 'crm_lead',
+      },
+      columns: ['full_name', 'company', 'email', 'status', 'rating'],
+      filter: [
+        { field: 'owner', operator: 'equals', value: '{current_user_id}' },
+      ],
+      sort: [
+        { field: 'rating', order: 'desc' },
+        { field: 'created_at', order: 'desc' }
+      ],
+    },
+
+    /**
+     * Hot Leads — Ready for immediate follow-up
+     * (Set by the auto_flag_hot_lead workflow)
+     */
+    hot_leads: {
+      name: 'hot_leads',
+      type: 'grid',
+      label: '🔥 Hot Leads',
+      data: { provider: 'object', object: 'crm_lead' },
+      columns: ['full_name', 'company', 'phone', 'email', 'rating', 'next_followup_date', 'owner'],
+      // The HOTTEST actionable subset (rating >= 4.5) — a tighter cut than the
+      // "High Priority" view (rating >= 4) so the two are not duplicates. Hot
+      // Leads is what a rep works first; sort by next-follow-up so the most
+      // time-sensitive surface on top. (Operator-only filters; the view runtime
+      // does not resolve date template strings.)
+      filter: [
+        { field: 'rating', operator: 'greater_than_or_equal', value: 4.5 },
+        { field: 'status', operator: 'in', value: ['new', 'contacted'] },
+      ],
+      sort: [{ field: 'next_followup_date', order: 'asc' }],
+    },
+
+    /**
+     * High Priority Leads
+     */
+    high_priority: {
+      name: 'high_priority',
+      type: 'grid',
+      label: 'High Priority',
+      data: {
+        provider: 'object',
+        object: 'crm_lead',
+      },
+      columns: ['full_name', 'company', 'email', 'status', 'rating', 'lead_source'],
+      filter: [
+        { field: 'rating', operator: 'greater_than_or_equal', value: 4 },
+        { field: 'status', operator: 'in', value: ['new', 'contacted'] },
+      ],
+      rowColor: {
+        field: 'rating',
+        colors: {
+          '5': '#00AA00',
+          '4': '#FFA500',
+        },
+      },
+    },
+
     /**
      * Kanban Board View
      */
@@ -279,72 +351,6 @@ export const LeadViews = defineView({
       },
     },
     
-    /**
-     * My Leads - Filtered View
-     */
-    my_leads: {
-      name: 'my_leads',
-      type: 'grid',
-      label: 'My Leads',
-      data: {
-        provider: 'object',
-        object: 'crm_lead',
-      },
-      columns: ['first_name', 'last_name', 'company', 'email', 'status', 'rating'],
-      filter: [
-        { field: 'owner', operator: 'equals', value: '{current_user_id}' },
-      ],
-      sort: [
-        { field: 'rating', order: 'desc' },
-        { field: 'created_at', order: 'desc' }
-      ],
-    },
-    
-    /**
-     * High Priority Leads
-     */
-    high_priority: {
-      name: 'high_priority',
-      type: 'grid',
-      label: 'High Priority',
-      data: {
-        provider: 'object',
-        object: 'crm_lead',
-      },
-      columns: ['first_name', 'last_name', 'company', 'email', 'status', 'rating', 'lead_source'],
-      filter: [
-        { field: 'rating', operator: 'greater_than_or_equal', value: 4 },
-        { field: 'status', operator: 'in', value: ['new', 'contacted'] },
-      ],
-      rowColor: {
-        field: 'rating',
-        colors: {
-          '5': '#00AA00',
-          '4': '#FFA500',
-        },
-      },
-    },
-    /**
-     * Hot Leads — Ready for immediate follow-up
-     * (Set by the auto_flag_hot_lead workflow)
-     */
-    hot_leads: {
-      name: 'hot_leads',
-      type: 'grid',
-      label: '🔥 Hot Leads',
-      data: { provider: 'object', object: 'crm_lead' },
-      columns: ['first_name', 'last_name', 'company', 'phone', 'email', 'rating', 'next_followup_date', 'owner'],
-      // The HOTTEST actionable subset (rating >= 4.5) — a tighter cut than the
-      // "High Priority" view (rating >= 4) so the two are not duplicates. Hot
-      // Leads is what a rep works first; sort by next-follow-up so the most
-      // time-sensitive surface on top. (Operator-only filters; the view runtime
-      // does not resolve date template strings.)
-      filter: [
-        { field: 'rating', operator: 'greater_than_or_equal', value: 4.5 },
-        { field: 'status', operator: 'in', value: ['new', 'contacted'] },
-      ],
-      sort: [{ field: 'next_followup_date', order: 'asc' }],
-    },
   },
 
   /**

--- a/src/views/lead.view.ts
+++ b/src/views/lead.view.ts
@@ -180,15 +180,15 @@ export const LeadViews = defineView({
         collapsible: true,
         collapsed: true,
         columns: 2,
+        // `crm_lead` stores the location in one composite `Field.address`;
+        // the discrete street/city/state/postal_code/country columns this
+        // section used to list do not exist on the object, so the whole
+        // section rendered blank.
         fields: [
           {
-            field: 'street',
-            colSpan: 2, // Full width
+            field: 'address',
+            colSpan: 2,
           },
-          'city',
-          'state',
-          'postal_code',
-          'country',
         ],
       },
       {
@@ -423,15 +423,10 @@ export const LeadViews = defineView({
         {
           label: 'Address',
           columns: 2,
+          // Single composite `Field.address` — see the note on the default
+          // form's Address section.
           fields: [
-            { field: 'street', colSpan: 2 },
-            'city',
-            {
-              field: 'state',
-              dependsOn: 'country', // Cascade: country determines available states
-            },
-            'postal_code',
-            'country',
+            { field: 'address', colSpan: 2 },
           ],
         },
         {
@@ -731,15 +726,10 @@ export const LeadViews = defineView({
           collapsible: true,
           collapsed: true,
           columns: 2,
+          // Single composite `Field.address` — the discrete street/city/state/
+          // postal_code/country columns do not exist on crm_lead.
           fields: [
-            { field: 'street', colSpan: 2 },
-            'city',
-            {
-              field: 'state',
-              dependsOn: 'country', // Country determines state options
-            },
-            'postal_code',
-            'country',
+            { field: 'address', colSpan: 2 },
           ],
         },
         {

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -13,11 +13,21 @@ import { defineView } from '@objectstack/spec/ui';
  *   • gallery  — pinboard / executive review cards
  */
 export const OpportunityViews = defineView({
+  // The landing view is OPEN deals, not every deal ever recorded.
+  //
+  // Sorted by close_date ascending and unfiltered, "All Opportunities" opened
+  // on settled history: the first screen was 7 closed-won and 4 closed-lost
+  // records, and a rep had to scroll past months of finished business to reach
+  // anything they could still act on. The full unfiltered list is still one
+  // click away on the "All Opportunities" tab.
   list: {
     type: 'grid',
-    name: 'all_opportunities',
-    label: 'All Opportunities',
+    name: 'open_opportunities',
+    label: 'Open Deals',
     data: { provider: 'object', object: 'crm_opportunity' },
+    filter: [
+      { field: 'stage', operator: 'not_in', value: ['closed_won', 'closed_lost'] },
+    ],
     columns: [
       { field: 'name', width: 220, sortable: true, link: true },
       { field: 'crm_account', label: 'Account', width: 180 },
@@ -50,16 +60,43 @@ export const OpportunityViews = defineView({
       allowedVisualizations: ['grid', 'kanban', 'calendar', 'timeline', 'gallery'],
     },
     tabs: [
-      { name: 'all', label: 'All', view: 'all_opportunities', isDefault: true, pinned: true },
+      { name: 'open', label: 'Open Deals', icon: 'target', view: 'open_opportunities', isDefault: true, pinned: true },
+      { name: 'mine', label: 'My Deals', icon: 'user', view: 'my_open_deals' },
       { name: 'pipeline', label: 'Pipeline', icon: 'columns-3', view: 'pipeline_kanban' },
+      { name: 'all', label: 'All Opportunities', view: 'all_opportunities' },
       { name: 'crm_forecast', label: 'Forecast', icon: 'calendar', view: 'close_date_calendar' },
       { name: 'timeline', label: 'Timeline', icon: 'git-commit-horizontal', view: 'deal_timeline' },
       { name: 'cards', label: 'Cards', icon: 'gallery-thumbnails', view: 'deal_gallery' },
-      { name: 'mine', label: 'My Deals', icon: 'user', view: 'my_open_deals' },
     ],
   },
 
   listViews: {
+    /**
+     * All Opportunities — the unfiltered book, including closed business.
+     *
+     * Demoted from the landing view (see the note on `list` above) but kept
+     * whole: reporting, audits and win/loss reviews all need the closed rows,
+     * and a manager reaches this in one click.
+     */
+    all_opportunities: {
+      name: 'all_opportunities',
+      type: 'grid',
+      label: 'All Opportunities',
+      data: { provider: 'object', object: 'crm_opportunity' },
+      columns: [
+        { field: 'name', width: 220, sortable: true, link: true },
+        { field: 'crm_account', label: 'Account', width: 180 },
+        { field: 'stage', width: 140, sortable: true },
+        { field: 'amount', width: 140, align: 'right', sortable: true, summary: 'sum' },
+        { field: 'probability', width: 110, align: 'right' },
+        { field: 'expected_revenue', width: 160, align: 'right', summary: 'sum' },
+        { field: 'close_date', width: 140, sortable: true },
+        { field: 'owner', width: 150 },
+      ],
+      sort: [{ field: 'close_date', order: 'desc' }],
+      showRecordCount: true,
+    },
+
     /** Drag-and-drop sales pipeline */
     pipeline_kanban: {
       name: 'pipeline_kanban',

--- a/src/views/task.view.ts
+++ b/src/views/task.view.ts
@@ -139,7 +139,7 @@ export const TaskViews = defineView({
         { field: 'status', operator: 'in', value: ['not_started', 'in_progress'] },
         { field: 'priority', operator: 'in', value: ['high', 'urgent'] },
       ],
-      sort: [{ field: 'due_date', order: 'asc' }, { field: 'priority', order: 'desc' }],
+      sort: [{ field: 'due_date', order: 'asc' }, { field: 'priority_rank', order: 'desc' }],
     },
 
     /** Overdue / open tasks across the team — sorted oldest-due first */

--- a/src/views/task.view.ts
+++ b/src/views/task.view.ts
@@ -170,14 +170,21 @@ export const TaskViews = defineView({
       {
         label: 'Task',
         columns: 2,
+        // `type` (call / email / meeting / demo) is what makes an activity
+        // history readable and is the first thing a rep reaches for after the
+        // subject — it was missing entirely. `description` captures what was
+        // actually said on the call. `progress_percent` moved to the Effort
+        // section: a task being filed is 0% by definition, so a percentage
+        // slider on the create form is noise.
         fields: [
           { field: 'subject', required: true, colSpan: 2 },
+          { field: 'type', required: false },
           { field: 'status', required: true },
           'priority',
           'due_date',
-          'reminder_date',
           'owner',
-          'progress_percent',
+          'reminder_date',
+          { field: 'description', colSpan: 2 },
         ],
       },
       {
@@ -199,10 +206,12 @@ export const TaskViews = defineView({
         columns: 2,
         fields: [
           'is_recurring',
+          'recurrence_type',
           'recurrence_interval',
           'recurrence_end_date',
           'estimated_hours',
           'actual_hours',
+          'progress_percent',
         ],
       },
     ],

--- a/test/flow-followup.test.ts
+++ b/test/flow-followup.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { AutomationEngine, installBuiltinNodes } from '@objectstack/service-automation';
+import { ScheduleFollowUpFlow } from '../src/flows/schedule-followup.flow';
+
+/**
+ * schedule_followup flow runtime harness — the real automation engine over an
+ * in-memory data engine (same recipe as flow-conversion / flow-quote).
+ *
+ * What this pins: the task is created with BOTH halves of the polymorphic
+ * parent (`related_to_type` + `related_to_lead`). Getting only one of them
+ * right is silent — the write succeeds and the task simply never appears on
+ * the lead's Related tab, which is exactly the bug this feature exists to fix.
+ */
+
+type Rec = Record<string, any>;
+
+function makeDataEngine() {
+  const store: Record<string, Rec[]> = {};
+  let seq = 0;
+  const rows = (o: string) => (store[o] ??= []);
+  const match = (r: Rec, where: Rec = {}) =>
+    Object.entries(where).every(([k, v]) => r[k] === v);
+  return {
+    store,
+    async insert(object: string, data: Rec) {
+      const rec = { id: `${object}_${++seq}`, ...data };
+      rows(object).push(rec);
+      return rec;
+    },
+    async find(object: string, opts: Rec = {}) {
+      return rows(object).filter((r) => match(r, opts.where ?? opts.filter ?? {}));
+    },
+    async findOne(object: string, opts: Rec = {}) {
+      return rows(object).find((r) => match(r, opts.where ?? opts.filter ?? {})) ?? null;
+    },
+    async update(object: string, data: Rec, opts: Rec = {}) {
+      const affected = rows(object).filter((r) => match(r, opts.where ?? opts.filter ?? {}));
+      for (const r of affected) Object.assign(r, data);
+      return { modified: affected.length };
+    },
+  };
+}
+
+const logger: any = { info() {}, warn() {}, error() {}, debug() {}, trace() {}, child() { return logger; } };
+
+function buildEngine(data: ReturnType<typeof makeDataEngine>) {
+  const ctx: any = {
+    logger,
+    getService: (name: string) => (name === 'data' || name === 'objectql' ? data : undefined),
+  };
+  const engine = new AutomationEngine(logger);
+  installBuiltinNodes(engine, ctx);
+  engine.registerFlow('schedule_followup', ScheduleFollowUpFlow);
+  return engine;
+}
+
+async function runFollowUp(engine: AutomationEngine, leadId: string, screen: Rec) {
+  const started: any = await engine.execute('schedule_followup', {
+    params: { recordId: leadId }, userId: 'user_1', event: 'manual',
+  } as any);
+  const runId = started.runId ?? started.run?.id;
+  await engine.resume(runId, { variables: screen } as any);
+}
+
+describe('schedule_followup flow — runtime', () => {
+  it('creates a task bound to the lead through BOTH polymorphic halves', async () => {
+    const data = makeDataEngine();
+    data.store.crm_lead = [{
+      id: 'lead_1', first_name: 'Alice', last_name: 'Martinez',
+      company: 'NextGen Retail', status: 'new',
+    }];
+    const engine = buildEngine(data);
+
+    await runFollowUp(engine, 'lead_1', {
+      subject: 'Send the retail proposal',
+      dueDate: '2026-07-30',
+      activityType: 'email',
+      priority: 'high',
+      notes: 'Asked for pricing on the 12-store rollout.',
+    });
+
+    const tasks = data.store.crm_task ?? [];
+    expect(tasks).toHaveLength(1);
+    const task = tasks[0];
+    expect(task.subject).toBe('Send the retail proposal');
+    expect(task.due_date).toBe('2026-07-30');
+    expect(task.type).toBe('email');
+    expect(task.priority).toBe('high');
+    expect(task.status).toBe('not_started');
+    // Both halves — the discriminator AND the lookup. With only one the write
+    // still succeeds and the task silently never shows on the lead.
+    expect(task.related_to_type).toBe('crm_lead');
+    expect(task.related_to_lead).toBe('lead_1');
+  });
+
+  it('stamps next_followup_date on the lead so Hot Leads reflects the commitment', async () => {
+    const data = makeDataEngine();
+    data.store.crm_lead = [{ id: 'lead_1', first_name: 'Alice', status: 'contacted' }];
+    const engine = buildEngine(data);
+
+    await runFollowUp(engine, 'lead_1', {
+      subject: 'Book the demo',
+      dueDate: '2026-08-04',
+      activityType: 'demo',
+      priority: 'normal',
+    });
+
+    expect(data.store.crm_lead[0].next_followup_date).toBe('2026-08-04');
+  });
+});

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -1,0 +1,231 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import stack from '../objectstack.config';
+
+/**
+ * Dangling-reference guards for UI metadata.
+ *
+ * `os validate` / `build` check metadata SHAPE — that a page declares a
+ * `relationshipField`, that a view section lists `fields` — but never that the
+ * named field, object, or profile actually exists. Every reference below was a
+ * real defect found by clicking through the app, and each failed silently: the
+ * related list rendered "0", the form section rendered blank, the profile
+ * assignment matched nobody. Nothing errored, so nothing was noticed.
+ *
+ * These tests resolve every UI reference against the objects/profiles the app
+ * really defines, so the next bad name fails in CI instead of in a demo.
+ */
+
+type AnyRec = Record<string, any>;
+const objects: AnyRec[] = (stack as any).objects ?? [];
+const pages: AnyRec[] = (stack as any).pages ?? [];
+const views: AnyRec[] = (stack as any).views ?? [];
+const profiles: AnyRec[] = (stack as any).permissions ?? [];
+
+const objectNames = new Set(objects.map((o) => o.name));
+const profileNames = new Set(profiles.map((p) => p.name));
+
+/**
+ * Audit columns the platform adds to every object. They are real at runtime
+ * (`?sort=created_at desc` works) but never appear in the authored `fields`
+ * map, so a reference to one is legitimate.
+ */
+const SYSTEM_FIELDS = ['id', 'created_at', 'updated_at', 'created_by', 'updated_by'];
+
+const fieldsOf = (obj: string) => [
+  ...Object.keys(objects.find((o) => o.name === obj)?.fields ?? {}),
+  ...SYSTEM_FIELDS,
+];
+
+/** Walk an arbitrary metadata tree, yielding every node that has a `type`. */
+function* walk(node: unknown): Generator<AnyRec> {
+  if (Array.isArray(node)) {
+    for (const item of node) yield* walk(item);
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  const rec = node as AnyRec;
+  if (typeof rec.type === 'string') yield rec;
+  for (const value of Object.values(rec)) yield* walk(value);
+}
+
+describe('page component references resolve', () => {
+  const components = pages.flatMap((p) => [...walk(p.regions), ...walk(p.slots)]);
+
+  it('every record:related_list names a real object and a real relationship field', () => {
+    const bad: string[] = [];
+    for (const c of components) {
+      if (c.type !== 'record:related_list') continue;
+      const objectName = c.properties?.objectName;
+      const relField = c.properties?.relationshipField;
+      if (!objectNames.has(objectName)) {
+        bad.push(`${c.id}: objectName "${objectName}" is not a defined object`);
+        continue;
+      }
+      if (relField && !fieldsOf(objectName).includes(relField)) {
+        bad.push(`${c.id}: "${objectName}" has no field "${relField}"`);
+      }
+    }
+    expect(bad, `dangling related-list references:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every related-list column is a real field on its object', () => {
+    const bad: string[] = [];
+    for (const c of components) {
+      if (c.type !== 'record:related_list') continue;
+      const objectName = c.properties?.objectName;
+      if (!objectNames.has(objectName)) continue; // covered by the test above
+      const known = fieldsOf(objectName);
+      for (const col of c.properties?.columns ?? []) {
+        const name = typeof col === 'string' ? col : col?.field;
+        if (name && !known.includes(name)) {
+          bad.push(`${c.id}: "${objectName}" has no column "${name}"`);
+        }
+      }
+    }
+    expect(bad, `dangling related-list columns:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('record:activity only lists object types this app defines', () => {
+    const bad: string[] = [];
+    for (const c of components) {
+      if (c.type !== 'record:activity') continue;
+      for (const t of c.properties?.types ?? []) {
+        if (!objectNames.has(t)) bad.push(`${c.id}: activity type "${t}" is not a defined object`);
+      }
+    }
+    expect(bad, `dangling activity types:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('record:details / record:highlights / record:path only name real fields on the page object', () => {
+    const bad: string[] = [];
+    for (const page of pages) {
+      if (!page.object || !objectNames.has(page.object)) continue;
+      const known = fieldsOf(page.object);
+      for (const c of [...walk(page.regions), ...walk(page.slots)]) {
+        const named: string[] = [];
+        if (c.type === 'record:highlights') named.push(...(c.properties?.fields ?? []));
+        if (c.type === 'record:details') {
+          for (const s of c.properties?.sections ?? []) named.push(...(s.fields ?? []));
+        }
+        if (c.type === 'record:path' && c.properties?.statusField) {
+          named.push(c.properties.statusField);
+        }
+        for (const f of named) {
+          if (typeof f === 'string' && !known.includes(f)) {
+            bad.push(`${page.name} / ${c.id}: "${page.object}" has no field "${f}"`);
+          }
+        }
+      }
+    }
+    expect(bad, `dangling record-component fields:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('record:path stages are real options of the status field', () => {
+    const bad: string[] = [];
+    for (const page of pages) {
+      if (!page.object || !objectNames.has(page.object)) continue;
+      const objDef = objects.find((o) => o.name === page.object);
+      for (const c of [...walk(page.regions), ...walk(page.slots)]) {
+        if (c.type !== 'record:path') continue;
+        const statusField = c.properties?.statusField;
+        const options = objDef?.fields?.[statusField]?.options ?? [];
+        if (!options.length) continue;
+        const values = new Set(options.map((o: AnyRec) => o.value));
+        for (const stage of c.properties?.stages ?? []) {
+          if (!values.has(stage.value)) {
+            bad.push(`${page.name}: path stage "${stage.value}" is not an option of ${statusField}`);
+          }
+        }
+      }
+    }
+    expect(bad, `dangling path stages:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('assignedProfiles name real profiles', () => {
+    const bad: string[] = [];
+    for (const page of pages) {
+      for (const p of page.assignedProfiles ?? []) {
+        if (!profileNames.has(p)) bad.push(`${page.name}: profile "${p}" is not defined`);
+      }
+    }
+    expect(bad, `dangling profile assignments:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});
+
+describe('view field references resolve', () => {
+  /** Views are keyed by object; `defineView` output carries the object on its data provider. */
+  const viewObjectOf = (v: AnyRec): string | undefined =>
+    v.list?.data?.object ?? v.form?.data?.object ?? v.object;
+
+  it('every form section field is a real field on the view object', () => {
+    const bad: string[] = [];
+    for (const v of views) {
+      const objectName = viewObjectOf(v);
+      if (!objectName || !objectNames.has(objectName)) continue;
+      const known = fieldsOf(objectName);
+      // The default `form` plus every named form under `forms`.
+      const forms = [v.form, ...Object.values(v.forms ?? {})].filter(Boolean) as AnyRec[];
+      for (const form of forms) {
+        for (const section of form.sections ?? []) {
+          for (const f of section.fields ?? []) {
+            const name = typeof f === 'string' ? f : f?.field;
+            if (name && !known.includes(name)) {
+              bad.push(`${objectName} form "${form.name ?? 'default'}": no field "${name}"`);
+            }
+          }
+        }
+      }
+    }
+    expect(bad, `dangling form fields:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every list sort targets a real field', () => {
+    const bad: string[] = [];
+    for (const v of views) {
+      const objectName = viewObjectOf(v);
+      if (!objectName || !objectNames.has(objectName)) continue;
+      const known = fieldsOf(objectName);
+      const lists = [v.list, ...Object.values(v.views ?? {})].filter(Boolean) as AnyRec[];
+      for (const list of lists) {
+        for (const s of list.sort ?? []) {
+          if (s.field && !known.includes(s.field)) {
+            bad.push(`${objectName} view "${list.name ?? 'default'}": sorts on missing "${s.field}"`);
+          }
+        }
+      }
+    }
+    expect(bad, `dangling sort fields:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});
+
+describe('priority queues sort by urgency, not alphabetically', () => {
+  /**
+   * `priority desc` on the select itself compares the raw option strings, so
+   * cases came back medium > low > high > critical — the exact inversion of
+   * urgency. Queue views must sort on the materialised `priority_rank`.
+   */
+  const rankedObjects = ['crm_case', 'crm_task'];
+
+  it.each(rankedObjects)('%s defines a numeric priority_rank', (objectName) => {
+    const field = objects.find((o) => o.name === objectName)?.fields?.priority_rank;
+    expect(field, `${objectName}.priority_rank missing`).toBeTruthy();
+    expect(field.type).toBe('number');
+  });
+
+  it('no view sorts on the raw priority select', () => {
+    const bad: string[] = [];
+    for (const v of views) {
+      const lists = [v.list, ...Object.values(v.views ?? {})].filter(Boolean) as AnyRec[];
+      for (const list of lists) {
+        for (const s of list.sort ?? []) {
+          if (s.field === 'priority') {
+            bad.push(`view "${list.name ?? list.label ?? 'default'}" sorts on raw priority`);
+          }
+        }
+      }
+    }
+    expect(bad, `${bad.join('\n  ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Second business-user walkthrough of the app as it stands — no new capabilities, just "what's broken and what's in the way" for a sales rep and a service agent doing their normal day.

## What was broken (commit 1)

A whole class of UI metadata naming fields, objects and profiles that don't exist. Every one failed *silently*: the list rendered "0", the highlights slot rendered blank, the path stage never lit, the profile assignment matched nobody. Nothing errored, so nothing was noticed.

| | Was | Now |
|---|---|---|
| Lead → Open Tasks | bound to `lead_id` (no such column) → always 0 | `related_to_lead`; the `assigned_to` column is `owner` |
| Lead → Events / Files / History | queried `event` / `file` / `field_history`, none of which this app defines | dead blocks removed; History uses the platform's `record:history` |
| Lead → status path | ended at *Unqualified*, so losing the lead read as the goal | `converted` added as the terminal win state |
| Case → highlights & SLA section | `sla_response_due` / `sla_resolution_due` (don't exist) → agent's most time-critical facts absent | `sla_due_date` + `is_sla_violated`, plus escalation_reason and resolution_time_hours |
| Case → path stage | `waiting_on_customer` ≠ the `waiting_customer` option → never lit, rendered untranslated | matches the option |
| Lead forms ×3 | street/city/state/postal_code/country; the object has one composite `address` | one `address` field |
| Six pages | assigned to `sales_user` / `service_user` / `system_administrator` / `service_manager` — none are profiles here | `sales_rep` / `service_agent` / `system_admin` |

**Priority queues sorted backwards.** `priority desc` on the select compares raw strings, so cases came back `medium > low > high > critical` — the exact inversion of urgency, burying every critical case at the bottom of the agent's queue. Select options carry no ordinal in the spec, so `crm_case` and `crm_task` now materialise `priority_rank` (stamped in their before-hooks) and the queue views sort on that.

`test/metadata-references.test.ts` resolves every page/view reference against the objects and profiles the app really defines. **It found three of the case defects above on its first run.**

## What was in the way (commit 2)

| | Was | Now |
|---|---|---|
| Opportunities landing | "All", close_date ascending → first screen was 7 closed-won + 4 closed-lost | **Open Deals**; the full book is one tab over |
| Lead tabs | My Leads / Hot Leads / High Priority hidden behind "3 more"; Calendar and Cards up front | working queues first |
| Lead list | first + last name in two columns, link on the given name only | one `full_name` column |
| Task form | no `type` (call/email/meeting), no `description`, but a progress slider on a brand-new task | type + description added; progress moved to Effort |
| Task recurrence | `recurrence_type` missing from the form, and the hook returns early without it | added — recurring tasks were recurring in name only |

**New: Schedule Follow-up.** `log_call` / `log_meeting` record what already happened; nothing put the *next* touch on the rep's list. Filing it meant leaving the lead → Related tab → Tasks block → re-pick the lead as parent. Now one header action writes the task already linked and owned, and stamps the lead's `next_followup_date` so Hot Leads reflects the commitment.

## Two platform bugs found, filed upstream

Both are Console-side; the backend is correct in each case.

- **objectstack-ai/objectstack#3528** — pressing Submit on a screen flow issues **zero network requests**. `lead_conversion` renders its screen and then commits nothing (account count unchanged, lead still `new`). The resume route exists and works over HTTP; `@objectstack/client` has no `resume` method for the Console to call.
- **objectstack-ai/objectstack#3530** — modal-typed actions resolve `target` as an *object* and die on `GET /meta/object/<target>` → 400, though the spec defines `target` for modals as the page name. Reproduces on every modal action in the app.

Together these make every interactive custom action non-functional in 16.1.0. Schedule Follow-up is authored as a screen flow (the mechanism `convert_lead` uses) rather than a modal for that reason — its server side is verified end-to-end over HTTP and by `test/flow-followup.test.ts`, so it will work the moment #3528 lands.

## Verified

`pnpm verify` green — build + **60 tests** (was 47; +11 metadata-reference guards, +2 follow-up flow).

Checked in the browser against a freshly seeded DB: critical cases now head the queue; the lead's Related tab shows a real task with a real owner; the status path shows 已转化; the case strip shows SLA 到期 + SLA 违反; Open Deals lands on 谈判/提案 instead of closed business; lead tabs lead with My/Hot/High Priority; the name column is one column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
