### PR TITLE
feat(crm): give every shipped capability a way in, and finish the Chinese sidebar

### DIFF
--- a/src/apps/crm.app.ts
+++ b/src/apps/crm.app.ts
@@ -48,6 +48,40 @@ export const CrmApp = App.create({
         { id: 'nav_opportunity', type: 'object', objectName: 'crm_opportunity', label: 'Opportunities', icon: 'target' },
         { id: 'nav_pipeline',    type: 'object', objectName: 'crm_opportunity', viewName: 'pipeline_kanban', label: 'Pipeline', icon: 'columns-3' },
         { id: 'nav_quote',       type: 'object', objectName: 'crm_quote',       label: 'Quotes',        icon: 'receipt' },
+        // Contracts close the sales cycle: quote → signed agreement → renewal.
+        // The object, its views and its renewal automation all shipped, but
+        // there was no way to reach any of it from the app.
+        { id: 'nav_contract',    type: 'object', objectName: 'crm_contract',    label: 'Contracts',     icon: 'file-signature' },
+        { id: 'nav_sales_dashboard', type: 'dashboard', dashboardName: 'sales_dashboard', label: 'Sales Performance', icon: 'chart-line' },
+      ],
+    },
+
+    {
+      // Everything a rep owes someone. `crm_task` had views, seed data, a
+      // recurrence hook and two reminder flows, and no entry point — the only
+      // way to see a task was to open the record it hung off.
+      id: 'group_work',
+      type: 'group',
+      label: 'My Work',
+      icon: 'list-checks',
+      expanded: true,
+      children: [
+        { id: 'nav_my_tasks', type: 'object', objectName: 'crm_task', viewName: 'my_open_tasks', label: 'My Tasks', icon: 'circle-check' },
+        { id: 'nav_all_tasks', type: 'object', objectName: 'crm_task', label: 'All Tasks', icon: 'list' },
+      ],
+    },
+
+    {
+      // Campaigns drive lead_source and the campaign-member records that
+      // "Add to Campaign" writes — with no nav entry the marketing half of
+      // the data model was invisible.
+      id: 'group_marketing',
+      type: 'group',
+      label: 'Marketing',
+      icon: 'megaphone',
+      children: [
+        { id: 'nav_campaign', type: 'object', objectName: 'crm_campaign', label: 'Campaigns', icon: 'megaphone' },
+        { id: 'nav_product',  type: 'object', objectName: 'crm_product',  label: 'Products',  icon: 'package' },
       ],
     },
 
@@ -60,6 +94,7 @@ export const CrmApp = App.create({
       children: [
         { id: 'nav_case',      type: 'object', objectName: 'crm_case',              label: 'Cases',     icon: 'life-buoy' },
         { id: 'nav_knowledge', type: 'object', objectName: 'crm_knowledge_article', label: 'Knowledge', icon: 'book-open' },
+        { id: 'nav_service_dashboard', type: 'dashboard', dashboardName: 'service_dashboard', label: 'Service Overview', icon: 'gauge' },
       ],
     },
 
@@ -71,6 +106,8 @@ export const CrmApp = App.create({
       children: [
         // Trimmed to three high-signal reports. Full report catalogue still
         // ships as metadata; admins can pin more from the report picker.
+        { id: 'nav_crm_dashboard',            type: 'dashboard', dashboardName: 'crm_overview_dashboard', label: 'CRM Overview',      icon: 'layout-dashboard' },
+        { id: 'nav_forecast',                 type: 'object', objectName: 'crm_forecast',                 label: 'Forecasts',         icon: 'trending-up' },
         { id: 'nav_report_pipeline_coverage', type: 'report', reportName: 'pipeline_coverage_by_quarter', label: 'Pipeline Coverage', icon: 'columns-3' },
         { id: 'nav_report_lead_inflow',       type: 'report', reportName: 'lead_inflow_by_month_source',  label: 'Lead Inflow',       icon: 'trending-up' },
         { id: 'nav_report_sla',               type: 'report', reportName: 'sla_performance',              label: 'SLA Performance',   icon: 'timer' },

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -225,8 +225,10 @@ export const zhCN: TranslationData = {
         status: {
           label: '状态',
           options: {
+            // 已确认 / 未通过 是同一个动作(线索确认)的正反两面;原先的
+            // 已确认 / 不合格 出自两套说法,在状态条上并排时读起来不成对。
             new: '新建', contacted: '已联系', qualified: '已确认',
-            unqualified: '不合格', converted: '已转化',
+            unqualified: '未通过', converted: '已转化',
           },
         },
         lead_source: {
@@ -681,12 +683,47 @@ export const zhCN: TranslationData = {
     crm_enterprise: {
       label: 'HotCRM',
       description: '涵盖销售、服务和市场营销的客户关系管理系统',
+      // Keyed by navigation-node `id` (a flat keyspace regardless of depth).
+      // The groups were translated but every leaf was not, so the sidebar read
+      // "销售 / Leads / Accounts / …" — half Chinese, half English. `group_products`
+      // and `group_analytics` were translations for nodes that don't exist.
       navigation: {
+        nav_home: { label: '首页' },
+
         group_sales: { label: '销售' },
+        nav_lead: { label: '线索' },
+        nav_account: { label: '客户' },
+        nav_account_workbench: { label: '客户工作台' },
+        nav_contact: { label: '联系人' },
+        nav_opportunity: { label: '商机' },
+        nav_pipeline: { label: '销售管道' },
+        nav_quote: { label: '报价' },
+        nav_contract: { label: '合同' },
+        nav_sales_dashboard: { label: '销售业绩' },
+
+        group_work: { label: '我的工作' },
+        nav_my_tasks: { label: '我的任务' },
+        nav_all_tasks: { label: '全部任务' },
+
+        group_marketing: { label: '市场营销' },
+        nav_campaign: { label: '营销活动' },
+        nav_product: { label: '产品' },
+
         group_service: { label: '服务' },
-        group_marketing: { label: '营销' },
-        group_products: { label: '产品' },
-        group_analytics: { label: '数据分析' },
+        nav_case: { label: '服务案例' },
+        nav_knowledge: { label: '知识库' },
+        nav_service_dashboard: { label: '服务概览' },
+
+        group_insights: { label: '数据洞察' },
+        nav_crm_dashboard: { label: 'CRM 总览' },
+        nav_forecast: { label: '销售预测' },
+        nav_report_pipeline_coverage: { label: '管道覆盖率' },
+        nav_report_lead_inflow: { label: '线索流入' },
+        nav_report_sla: { label: 'SLA 达成' },
+
+        group_approvals: { label: '审批' },
+        nav_approval_requests: { label: '待我审批' },
+        nav_approval_processes: { label: '审批流程' },
       },
     },
   },

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -229,3 +229,73 @@ describe('priority queues sort by urgency, not alphabetically', () => {
     expect(bad, `${bad.join('\n  ')}`).toEqual([]);
   });
 });
+
+describe('navigation reaches everything the app ships', () => {
+  const apps: AnyRec[] = (stack as any).apps ?? [];
+  const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
+  const reports: AnyRec[] = (stack as any).reports ?? [];
+
+  /** Flatten the (possibly nested) navigation tree. */
+  const navNodes = (app: AnyRec): AnyRec[] =>
+    (app.navigation ?? []).flatMap(function walk(n: AnyRec): AnyRec[] {
+      return [n, ...(n.children ?? []).flatMap(walk)];
+    });
+  const allNodes = apps.flatMap(navNodes);
+
+  it('every nav entry points at something that exists', () => {
+    const dashboardNames = new Set(dashboards.map((d) => d.name));
+    const reportNames = new Set(reports.map((r) => r.name));
+    const bad: string[] = [];
+    for (const n of allNodes) {
+      // `sys_*` are platform objects the app legitimately links to (the
+      // approval inbox and process list); those nodes carry their own
+      // `requiresObject` guard for installs where the plugin is absent.
+      if (n.objectName && !n.objectName.startsWith('sys_') && !objectNames.has(n.objectName)) {
+        bad.push(`${n.id}: object "${n.objectName}" is not defined`);
+      }
+      if (n.dashboardName && !dashboardNames.has(n.dashboardName)) {
+        bad.push(`${n.id}: dashboard "${n.dashboardName}" is not defined`);
+      }
+      if (n.reportName && !reportNames.has(n.reportName)) {
+        bad.push(`${n.id}: report "${n.reportName}" is not defined`);
+      }
+    }
+    expect(bad, `dangling navigation targets:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('no user-facing object is stranded without a way to reach it', () => {
+    // Campaigns, Contracts, Products, Forecasts and Tasks each shipped with
+    // views, seed data and automation — and no entry point. The only way to
+    // see a task was to open the record it hung off.
+    const reachable = new Set(allNodes.map((n) => n.objectName).filter(Boolean));
+    const stranded = objects
+      .map((o) => o.name)
+      .filter((name: string) =>
+        // Line items and junctions are edited inside their parent, never
+        // reached on their own.
+        !/_line_item$|_member$/.test(name) && !reachable.has(name));
+    expect(stranded, `objects with no navigation entry:\n  ${stranded.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every dashboard is reachable', () => {
+    const reachable = new Set(allNodes.map((n) => n.dashboardName).filter(Boolean));
+    const stranded = dashboards.map((d) => d.name).filter((n: string) => !reachable.has(n));
+    expect(stranded, `dashboards nobody can open:\n  ${stranded.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every navigation node has a zh-CN label', () => {
+    // The groups were translated and the leaves were not, so the sidebar read
+    // half Chinese, half English.
+    const translations: AnyRec[] = (stack as any).translations ?? [];
+    const zh = translations.find((t) => t.locale === 'zh-CN' || t.name === 'zh-CN');
+    if (!zh) return; // no zh bundle in this build — nothing to assert
+    const bad: string[] = [];
+    for (const app of apps) {
+      const nav = zh.data?.apps?.[app.name]?.navigation ?? zh.apps?.[app.name]?.navigation ?? {};
+      for (const n of navNodes(app)) {
+        if (n.id && !nav[n.id]?.label) bad.push(`${app.name}/${n.id}`);
+      }
+    }
+    expect(bad, `navigation nodes with no zh-CN label:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Five objects, two dashboards and half the sidebar labels were unreachable or
untranslated. Nothing was broken — it just couldn't be found.

Navigation orphans
- `crm_task` had views, seed data, a recurrence hook and two reminder flows,
  and no entry point: the only way to see a task was to open the record it
  hung off. Now a "My Work" group with My Tasks / All Tasks.
- `crm_contract` closes the sales cycle (quote → signed agreement → renewal)
  and has renewal automation; added under Sales after Quotes.
- `crm_campaign` and `crm_product` drive lead_source and the campaign-member
  records that "Add to Campaign" writes — the whole marketing half of the data
  model was invisible. New "Marketing" group.
- `crm_forecast` added under Insights.
- `sales_dashboard`, `service_dashboard` and `crm_overview_dashboard` were
  authored, translated, and openable by nobody. Now on Sales, Service and
  Insights respectively.

Chinese sidebar
- `apps.crm_enterprise.navigation` translated the five group nodes and none of
  the leaves, so the sidebar read "销售 / Leads / Accounts / …" — half
  Chinese, half English. Two of the five keys (`group_products`,
  `group_analytics`) were for nodes that don't exist. Every node id now has a
  label.
- Lead status `unqualified` was "不合格" next to `qualified` "已确认" — two
  different framings sitting side by side on the status path. Now "未通过".

Four contract tests guard it: every nav target resolves to a real object /
dashboard / report (platform `sys_*` excepted, those nodes carry their own
`requiresObject` guard), no user-facing object is stranded without an entry,
every dashboard is reachable, and every nav node has a zh-CN label. The
dashboard test found `crm_overview_dashboard` on its first run.

Verified in the browser: the sidebar reads 首页 / 线索 / 客户 / 客户工作台 /
联系人 / 商机 / 销售管道 / 报价 / 合同 / 销售业绩, followed by 我的工作 and
市场营销. `pnpm verify` green — 67 tests.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)