### PR TITLE
docs(readme): 体量统计从行数改为 token 数——强调装得进智能体上下文窗口

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 # HotCRM
 
 > **The reference app for AI-written enterprise software.** A complete CRM —
-> 15 objects, 17 flows, 4 dashboards, 2 AI copilots, 4 languages — written as
-> ~17,000 lines of typed [ObjectStack](https://github.com/objectstack-ai/objectstack)
-> metadata, so the whole app still fits in a single agent context window.
+> 15 objects, 17 flows, 4 dashboards, 2 AI copilots, 4 languages — is roughly
+> **170k tokens** of typed [ObjectStack](https://github.com/objectstack-ai/objectstack)
+> metadata (~18,000 lines): the entire enterprise CRM fits in a single agent
+> context window, so an AI can hold it whole, reason about it, and refactor it.
 > **Install it online in one click, or fork it and build & ask with Claude
 > Code** — it's the reference implementation every marketplace app forks from.
 


### PR DESCRIPTION
## Description

按维护者反馈:"~17,000 lines" 不如 token 数有表达力。首屏改为 **~170k tokens**(当前 src 实测 672,869 字符 ÷ ~4,共 18,043 行,行数保留为括号内次要数字),并把核心论断落在"整个企业级 CRM 装得进单个智能体上下文窗口,AI 能整体持有、推理、重构"。

## Type of Change

- [x] Documentation update

## Changes Made

- README 首屏引言:行数 → token 数为主、行数为辅,补"fits in a single agent context window"论断
- 数字为最新 main 实测(18,043 行,≈170k token)

## Testing

- [x] 仅文档改动,无需构建/测试

## Additional Notes

建议同步把仓库 About 里的 "~17,000 lines" 改为:

> The reference app for AI-written enterprise software: a complete CRM — 15 objects, flows, dashboards, AI copilots — in ~170k tokens of typed ObjectStack metadata. The whole app fits in one agent context window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk

---
_Generated by [Claude Code](https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk)_