### PR TITLE
fix(stackblitz): boot the WebContainer demo with npm, not a global pnpm install

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,6 +1,6 @@
 {
   "installDependencies": false,
-  "startCommand": "npm i -g pnpm@10.33.0 && pnpm install && pnpm dev",
+  "startCommand": "npm install --omit=dev --omit=optional --no-audit --no-fund && npm run dev",
   "env": {
     "OS_DATABASE_URL": ".objectstack/data/hotcrm.wasm.db",
     "OS_DATABASE_DRIVER": "sqlite-wasm"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 HotCRM is a complete, opinionated CRM built as the **first official application** on the [ObjectStack](https://cloud.objectos.app) marketplace. Install it into any ObjectStack environment in one click and get a working CRM in 30 seconds — or fork it as the canonical example of how to build your own marketplace app.
 
-> **Try it in your browser (no install):** click the StackBlitz badge above. It boots HotCRM in a WebContainer using `@objectstack/driver-sqlite-wasm` (sql.js) instead of `better-sqlite3`, which can't compile inside the WebContainer sandbox. `.stackblitzrc` sets `OS_DATABASE_DRIVER=sqlite-wasm` so the runtime picks the WASM driver automatically. First load takes ~60s while pnpm installs.
+> **Try it in your browser (no install):** click the StackBlitz badge above. It boots HotCRM in a WebContainer using `@objectstack/driver-sqlite-wasm` (sql.js) instead of `better-sqlite3`, which can't compile inside the WebContainer sandbox. `.stackblitzrc` sets `OS_DATABASE_DRIVER=sqlite-wasm` so the runtime picks the WASM driver automatically. The sandbox boots with `npm install --omit=dev --omit=optional` — WebContainers forbid `npm i -g`, and their bundled pnpm 8 can't read this repo's lockfile — so first load takes ~2 min while npm installs. Local development still uses pnpm 10 as usual.
 
 ---
 


### PR DESCRIPTION
## Problem

The **Open in StackBlitz** badge lands users in a dead shell:

```
npm error code EACCES
npm error path /usr/local/lib/node_modules/pnpm
npm error EACCES: permission denied, mkdir '/usr/local/lib/node_modules/pnpm'
```

WebContainers no longer let the sandbox user write `/usr/local/lib`, so the `npm i -g pnpm@10.33.0` shim added in #464 fails on the very first step.

## Why not just fix pnpm

Tested each alternative in a live WebContainer — none survive:

| Attempt | Result |
|---|---|
| Bundled `pnpm 8.15.6` | fails `engines.pnpm >=10` under `engine-strict=true`; can't read lockfileVersion 9.0 |
| `npx pnpm@10.33.0 install` | StackBlitz's global `/home/.pnpm/.pnpmfile.cjs` calls `mkdirSync(undefined)` under pnpm 10 → `ERR_INVALID_ARG_TYPE` |
| workspace resolution | `ENOENT: ... apps/docs/.npmrc` |

## Fix

`.stackblitzrc` now boots with the preinstalled npm, which needs no global write:

```
npm install --omit=dev --omit=optional --no-audit --no-fund && npm run dev
```

- `--omit=dev` skips playwright/vitest/typescript — the CLI bundles its own esbuild + tsx, so `objectstack.config.ts` still compiles
- `--omit=optional` skips `better-sqlite3`, which can't build in the sandbox anyway; the demo runs on the sqlite-wasm driver
- install drops from ~4 min to ~1.5 min

Local dev and CI keep using pnpm 10 — config + docs only.

## Verification

In a live WebContainer: install succeeds, `npm run dev` compiles `dist/objectstack.json` (936 KB), binds 20 flows, and serves **HTTP 200** on :4001 with the console HTML shell.

Locally: `pnpm verify` green (validate + typecheck + build + 67 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)