### PR TITLE
feat(crm): give reps their own work queues, and fix "My Open Deals" opening on losses

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,6 +1,6 @@
 {
   "installDependencies": false,
-  "startCommand": "npm i -g pnpm@10.33.0 && pnpm install && pnpm dev",
+  "startCommand": "npm install --omit=dev --omit=optional --no-audit --no-fund && npm run dev",
   "env": {
     "OS_DATABASE_URL": ".objectstack/data/hotcrm.wasm.db",
     "OS_DATABASE_DRIVER": "sqlite-wasm"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 HotCRM is a complete, opinionated CRM built as the **first official application** on the [ObjectStack](https://cloud.objectos.app) marketplace. Install it into any ObjectStack environment in one click and get a working CRM in 30 seconds — or fork it as the canonical example of how to build your own marketplace app.
 
-> **Try it in your browser (no install):** click the StackBlitz badge above. It boots HotCRM in a WebContainer using `@objectstack/driver-sqlite-wasm` (sql.js) instead of `better-sqlite3`, which can't compile inside the WebContainer sandbox. `.stackblitzrc` sets `OS_DATABASE_DRIVER=sqlite-wasm` so the runtime picks the WASM driver automatically. First load takes ~60s while pnpm installs.
+> **Try it in your browser (no install):** click the StackBlitz badge above. It boots HotCRM in a WebContainer using `@objectstack/driver-sqlite-wasm` (sql.js) instead of `better-sqlite3`, which can't compile inside the WebContainer sandbox. `.stackblitzrc` sets `OS_DATABASE_DRIVER=sqlite-wasm` so the runtime picks the WASM driver automatically. The sandbox boots with `npm install --omit=dev --omit=optional` — WebContainers forbid `npm i -g`, and their bundled pnpm 8 can't read this repo's lockfile — so first load takes ~2 min while npm installs. Local development still uses pnpm 10 as usual.
 
 ---
 

--- a/src/apps/crm.app.ts
+++ b/src/apps/crm.app.ts
@@ -65,8 +65,19 @@ export const CrmApp = App.create({
       label: 'My Work',
       icon: 'list-checks',
       expanded: true,
+      // These are ListViews, not a dashboard, and that is deliberate. A
+      // "My Day" dashboard was built and removed: dashboard widget filters do
+      // NOT interpolate `{current_user}` / `{current_user_id}` — the literal
+      // string reaches the query and matches no owner, so every widget renders
+      // 0. Proven side by side on one dashboard: `{current_user}` → 0,
+      // `{current_user_id}` → 0, no owner filter → 10,100,081. The token is
+      // implemented in platform-objects (the ListView data path) and has no
+      // counterpart in service-analytics. Filed upstream; until it lands, a
+      // ListView is the only surface where "mine" actually means mine.
       children: [
         { id: 'nav_my_tasks', type: 'object', objectName: 'crm_task', viewName: 'my_open_tasks', label: 'My Tasks', icon: 'circle-check' },
+        { id: 'nav_my_deals', type: 'object', objectName: 'crm_opportunity', viewName: 'my_open_deals', label: 'My Deals', icon: 'target' },
+        { id: 'nav_my_leads', type: 'object', objectName: 'crm_lead', viewName: 'my_leads', label: 'My Leads', icon: 'user-plus' },
         { id: 'nav_all_tasks', type: 'object', objectName: 'crm_task', label: 'All Tasks', icon: 'list' },
       ],
     },

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -7,3 +7,4 @@ export { ProductDataset } from './product.dataset';
 export { AccountDataset } from './account.dataset';
 export { ContactDataset } from './contact.dataset';
 export { LeadDataset } from './lead.dataset';
+export { TaskDataset } from './task.dataset';

--- a/src/datasets/task.dataset.ts
+++ b/src/datasets/task.dataset.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/ui';
+
+/**
+ * Task analytics dataset (ADR-0021).
+ *
+ * Added for the "My Day" dashboard — `crm_task` had views, seed data and
+ * automation but no semantic layer, so a rep's own workload could not be
+ * counted or broken down anywhere.
+ *
+ * `priority_rank` is exposed alongside `priority` so a breakdown can be
+ * ordered by urgency; sorting on the raw select compares option strings and
+ * inverts it (normal > low > high > urgent).
+ */
+export const TaskDataset = defineDataset({
+  name: 'task_metrics',
+  label: 'Task Metrics',
+  description: 'Semantic layer for task workload and completion',
+  object: 'crm_task',
+  dimensions: [
+    { name: 'status', label: 'Status', field: 'status', type: 'string' },
+    { name: 'priority', label: 'Priority', field: 'priority', type: 'string' },
+    { name: 'priority_rank', label: 'Urgency', field: 'priority_rank', type: 'number' },
+    { name: 'type', label: 'Type', field: 'type', type: 'string' },
+    { name: 'due_date', label: 'Due Date', field: 'due_date', type: 'date' },
+    { name: 'is_overdue', label: 'Overdue', field: 'is_overdue', type: 'boolean' },
+    { name: 'is_completed', label: 'Completed', field: 'is_completed', type: 'boolean' },
+  ],
+  measures: [
+    { name: 'task_count', label: 'Tasks', aggregate: 'count' },
+    { name: 'avg_progress', label: 'Avg Progress', aggregate: 'avg', field: 'progress_percent', format: '0.0%' },
+  ],
+});

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -703,6 +703,8 @@ export const zhCN: TranslationData = {
 
         group_work: { label: '我的工作' },
         nav_my_tasks: { label: '我的任务' },
+        nav_my_deals: { label: '我的商机' },
+        nav_my_leads: { label: '我的线索' },
         nav_all_tasks: { label: '全部任务' },
 
         group_marketing: { label: '市场营销' },

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -165,9 +165,12 @@ export const OpportunityViews = defineView({
       label: 'My Open Deals',
       data: { provider: 'object', object: 'crm_opportunity' },
       columns: ['name', 'crm_account', 'stage', 'amount', 'close_date'],
+      // "Open" has to exclude BOTH closed stages. Excluding only closed_won
+      // meant a rep's own queue opened on their lost deals, sorted to the top
+      // by close_date — the least actionable rows in the system.
       filter: [
         { field: 'owner', operator: 'equals', value: '{current_user_id}' },
-        { field: 'stage', operator: 'not_equals', value: 'closed_won' },
+        { field: 'stage', operator: 'not_in', value: ['closed_won', 'closed_lost'] },
       ],
       sort: [{ field: 'close_date', order: 'asc' }],
     },


### PR DESCRIPTION
A rep opening this CRM lands on the executive overview — company revenue,
every account, pipeline across the whole team. It answers a management
question, not theirs: *what do I do today?*

The intended fix was a "My Day" dashboard. It was built, and then removed,
because dashboard widget filters do NOT interpolate the current user.

Proven side by side on one dashboard, three widgets over the same seeded data:

    filter                      result
    owner: {current_user}       0
    owner: {current_user_id}    0
    (no owner filter)           10,100,081   ✓

The token is implemented in `platform-objects` (the ListView data path, where
`{current_user_id}` demonstrably works — My Leads returns 21 rows) and has no
counterpart anywhere in `service-analytics`. So every widget of a user-scoped
dashboard renders 0, silently. The pre-existing
`service_dashboard.my_open_cases_by_priority` widget has been broken this way
since it was written; nobody noticed because until the previous commit no
record had an owner at all. Filed upstream.

So the personal queues are ListViews, which is the surface where "mine"
actually means mine:

  • My Work → My Tasks / My Deals / My Leads, all owner-filtered.

While wiring My Deals up, it turned out `my_open_deals` excluded `closed_won`
but not `closed_lost` — so a rep's own queue opened on 48 rows led by their
lost deals, sorted to the top by close date. The least actionable records in
the system, first. Now 38 rows, all genuinely in play, soonest close first.

Also adds the `task_metrics` dataset. `crm_task` had views, seed data, a
recurrence hook and two reminder flows but no semantic layer, so task workload
could not be aggregated anywhere. It exposes `priority_rank` alongside
`priority` so a breakdown can be ordered by urgency rather than by the raw
option strings.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)