### PR TITLE
fix(stackblitz): turn off the OIDC provider so the demo can log in

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -3,6 +3,7 @@
   "startCommand": "npm install --omit=dev --omit=optional --no-audit --no-fund && npm run dev",
   "env": {
     "OS_DATABASE_URL": ".objectstack/data/hotcrm.wasm.db",
-    "OS_DATABASE_DRIVER": "sqlite-wasm"
+    "OS_DATABASE_DRIVER": "sqlite-wasm",
+    "OS_OIDC_PROVIDER_ENABLED": "false"
   }
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 HotCRM is a complete, opinionated CRM built as the **first official application** on the [ObjectStack](https://cloud.objectos.app) marketplace. Install it into any ObjectStack environment in one click and get a working CRM in 30 seconds — or fork it as the canonical example of how to build your own marketplace app.
 
-> **Try it in your browser (no install):** click the StackBlitz badge above. It boots HotCRM in a WebContainer using `@objectstack/driver-sqlite-wasm` (sql.js) instead of `better-sqlite3`, which can't compile inside the WebContainer sandbox. `.stackblitzrc` sets `OS_DATABASE_DRIVER=sqlite-wasm` so the runtime picks the WASM driver automatically. The sandbox boots with `npm install --omit=dev --omit=optional` — WebContainers forbid `npm i -g`, and their bundled pnpm 8 can't read this repo's lockfile — so first load takes ~2 min while npm installs. Local development still uses pnpm 10 as usual.
+> **Try it in your browser (no install):** click the StackBlitz badge above. It boots HotCRM in a WebContainer using `@objectstack/driver-sqlite-wasm` (sql.js) instead of `better-sqlite3`, which can't compile inside the WebContainer sandbox. `.stackblitzrc` sets `OS_DATABASE_DRIVER=sqlite-wasm` so the runtime picks the WASM driver automatically. The sandbox boots with `npm install --omit=dev --omit=optional` — WebContainers forbid `npm i -g`, and their bundled pnpm 8 can't read this repo's lockfile — so first load takes ~2 min while npm installs. It also sets `OS_OIDC_PROVIDER_ENABLED=false`: the OIDC provider signs tokens with Ed25519, which the WebContainer's WebCrypto can't generate, and the failure surfaced as a 500 on login. Sign in with `admin@objectos.ai` / `admin123`. Local development still uses pnpm 10 with every feature on.
 
 ---
 


### PR DESCRIPTION
## Problem

The WebContainer demo boots (#484) but **login returns 500**:

```
[Better Auth]: OperationError DOMException [OperationError]
  at Object.cfrgGenerateKey ...
  [cause]: TypeError: o.run is not a function
  ... at Module.createJwk (better-auth/dist/plugins/jwt/utils.mjs:61)
  ... at resolveSigningKey (better-auth/dist/plugins/jwt/sign.mjs:76)
```

better-auth's JWT plugin generates its signing key with `generateKeyPair('EdDSA')`. WebContainer's WebCrypto has no Ed25519, so `cfrgGenerateKey` throws. The plugin's `after` hook on `/get-session` signs a `set-auth-jwt` header for every session, so the first authenticated request after sign-in dies.

## Why this is the app-level lever

The JWT plugin is only registered when the OIDC provider is enabled, and that defaults to enabled because the MCP server is (`@objectstack/plugin-auth`):

```js
resolveOidcProviderEnabled = env.OS_OIDC_PROVIDER_ENABLED ?? config.oidcProvider ?? isMcpServerEnabled()  // → true
```

`plugin-auth` hardcodes `jwt({ schema })` with no `jwks.keyPairConfig`, so an app cannot pick a different algorithm. The env flag is the only knob.

## Fix

`.stackblitzrc` sets `OS_OIDC_PROVIDER_ENABLED=false` for the browser demo only. It loses third-party OAuth / MCP token issuance — which needs a real HTTPS client anyway. Email/password login, the CRM, and the MCP endpoint itself are unaffected. Local dev and CI keep every feature on.

## Verification (live WebContainer, this branch)

| Check | Before | After |
|---|---|---|
| `/api/v1/auth/jwks` | 500 `DOMException` | **404** (plugin gone) |
| `POST /api/v1/auth/sign-in/email` | 500 | **200** |
| `/api/v1/auth/get-session` | 500 | **200**, returns the admin user |
| `/api/v1/auth/config` | `oidcProvider:true` | `"oidcProvider":false` |

`pnpm verify` green locally (validate + typecheck + build + 67 tests).

## Upstream follow-up

`@objectstack/plugin-auth` should pass a `jwks.keyPairConfig.alg` the host supports (or fall back when Ed25519 keygen throws) instead of relying on better-auth's EdDSA default — that would fix every WebContainer/edge host, not just this demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)