### PR TITLE
fix(i18n): re-key dead option/section/widget translations; add missing zh-CN coverage

### DIFF
--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -81,9 +81,9 @@ export const en: TranslationData = {
         department: {
           label: 'Department',
           options: {
-            Executive: 'Executive', Sales: 'Sales', Marketing: 'Marketing',
-            Engineering: 'Engineering', Support: 'Support', Finance: 'Finance',
-            HR: 'Human Resources', Operations: 'Operations',
+            executive: 'Executive', sales: 'Sales', marketing: 'Marketing',
+            engineering: 'Engineering', support: 'Support', finance: 'Finance',
+            hr: 'Human Resources', operations: 'Operations',
           },
         },
         owner: { label: 'Contact Owner' },
@@ -286,17 +286,17 @@ export const en: TranslationData = {
         type: {
           label: 'Type',
           options: {
-            'New Business': 'New Business',
-            'Existing Customer - Upgrade': 'Existing Customer - Upgrade',
-            'Existing Customer - Renewal': 'Existing Customer - Renewal',
-            'Existing Customer - Expansion': 'Existing Customer - Expansion',
+            new_business: 'New Business',
+            existing_upgrade: 'Existing Customer - Upgrade',
+            existing_renewal: 'Existing Customer - Renewal',
+            existing_expansion: 'Existing Customer - Expansion',
           },
         },
         forecast_category: {
           label: 'Forecast Category',
           options: {
-            Pipeline: 'Pipeline', 'Best Case': 'Best Case',
-            Commit: 'Commit', Omitted: 'Omitted', Closed: 'Closed',
+            pipeline: 'Pipeline', best_case: 'Best Case',
+            commit: 'Commit', omitted: 'Omitted', closed: 'Closed',
           },
         },
         description: { label: 'Description' },
@@ -460,8 +460,6 @@ export const en: TranslationData = {
         is_active: { label: 'Active' },
         is_taxable: { label: 'Taxable' },
         product_manager: { label: 'Product Manager' },
-        image_url: { label: 'Product Image' },
-        datasheet_url: { label: 'Datasheet URL' },
         image: { label: 'Product Image' },
         datasheet: { label: 'Datasheet' },
       },
@@ -581,6 +579,71 @@ export const en: TranslationData = {
         campaign_timeline: { label: 'Marketing Timeline' },
       },
     },
+
+    crm_campaign_member: {
+      label: 'Campaign Member',
+      pluralLabel: 'Campaign Members',
+      description: 'Leads and contacts touched by a campaign, with response status',
+      fields: {
+        member_number: { label: 'Member Number' },
+        crm_campaign: { label: 'Campaign' },
+        crm_lead: { label: 'Lead' },
+        crm_contact: { label: 'Contact' },
+        status: {
+          label: 'Status',
+          options: {
+            sent: 'Sent', opened: 'Opened', clicked: 'Clicked',
+            responded: 'Responded', converted: 'Converted', bounced: 'Bounced',
+            unsubscribed: 'Unsubscribed',
+          },
+        },
+        added_date: { label: 'Added Date' },
+        first_opened_date: { label: 'First Opened' },
+        first_clicked_date: { label: 'First Clicked' },
+        response_date: { label: 'Response Date' },
+        has_responded: { label: 'Has Responded' },
+      },
+      _sections: {
+        basic: { label: 'Basic Information' },
+        response: { label: 'Response Tracking' },
+      },
+    },
+
+    crm_opportunity_line_item: {
+      label: 'Opportunity Line Item',
+      pluralLabel: 'Opportunity Line Items',
+      description: 'Per-product pricing lines under an opportunity',
+      fields: {
+        crm_opportunity: { label: 'Opportunity' },
+        crm_product: { label: 'Product' },
+        description: { label: 'Description' },
+        quantity: { label: 'Quantity' },
+        list_price: { label: 'List Price' },
+        unit_price: { label: 'Sales Price' },
+        discount: { label: 'Discount %' },
+        total_price: { label: 'Total' },
+        line_number: { label: 'Line #' },
+      },
+    },
+
+    crm_quote_line_item: {
+      label: 'Quote Line Item',
+      pluralLabel: 'Quote Line Items',
+      description: 'Per-product pricing lines under a quote',
+      fields: {
+        crm_quote: { label: 'Quote' },
+        crm_product: { label: 'Product' },
+        description: { label: 'Description' },
+        quantity: { label: 'Quantity' },
+        list_price: { label: 'List Price' },
+        unit_price: { label: 'Sales Price' },
+        discount: { label: 'Discount %' },
+        subtotal: { label: 'Subtotal' },
+        tax_rate: { label: 'Tax Rate %' },
+        total_price: { label: 'Total' },
+        line_number: { label: 'Line #' },
+      },
+    },
   },
 
   globalActions: {
@@ -679,7 +742,7 @@ export const en: TranslationData = {
         avg_deal_size: { title: 'Avg Deal Size', description: 'Average value of closed-won deals this quarter' },
         pipeline_by_stage: { title: 'Pipeline by Stage', description: 'Open opportunity value at each sales stage' },
         monthly_revenue_trend: { title: 'Monthly Revenue Trend', description: 'Closed-won revenue, last 12 months' },
-        opportunities_by_owner: { title: 'Opportunities by Owner', description: 'Open pipeline value per sales rep' },
+        pipeline_by_forecast_category: { title: 'Pipeline by Forecast Category', description: 'Open pipeline grouped by sales forecast category' },
         lead_source_breakdown: { title: 'Lead Source', description: 'Where our pipeline is coming from' },
         open_pipeline_by_owner: { title: 'Open Pipeline by Owner', description: 'In-flight pipeline value, deal count and avg win probability per rep' },
         pipeline_stage_by_source: { title: 'Pipeline by Stage × Lead Source', description: 'Cross-tab of open opportunity amount by stage and source' },

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -65,9 +65,9 @@ export const esES: TranslationData = {
         department: {
           label: 'Departamento',
           options: {
-            Executive: 'Ejecutivo', Sales: 'Ventas', Marketing: 'Marketing',
-            Engineering: 'Ingeniería', Support: 'Soporte', Finance: 'Finanzas',
-            HR: 'Recursos Humanos', Operations: 'Operaciones',
+            executive: 'Ejecutivo', sales: 'Ventas', marketing: 'Marketing',
+            engineering: 'Ingeniería', support: 'Soporte', finance: 'Finanzas',
+            hr: 'Recursos Humanos', operations: 'Operaciones',
           },
         },
         owner: { label: 'Propietario de Contacto' },
@@ -264,17 +264,17 @@ export const esES: TranslationData = {
         type: {
           label: 'Tipo',
           options: {
-            'New Business': 'Nuevo Negocio',
-            'Existing Customer - Upgrade': 'Cliente Existente - Mejora',
-            'Existing Customer - Renewal': 'Cliente Existente - Renovación',
-            'Existing Customer - Expansion': 'Cliente Existente - Expansión',
+            new_business: 'Nuevo Negocio',
+            existing_upgrade: 'Cliente Existente - Mejora',
+            existing_renewal: 'Cliente Existente - Renovación',
+            existing_expansion: 'Cliente Existente - Expansión',
           },
         },
         forecast_category: {
           label: 'Categoría de Pronóstico',
           options: {
-            Pipeline: 'Pipeline', 'Best Case': 'Mejor Caso',
-            Commit: 'Compromiso', Omitted: 'Omitida', Closed: 'Cerrada',
+            pipeline: 'Pipeline', best_case: 'Mejor Caso',
+            commit: 'Compromiso', omitted: 'Omitida', closed: 'Cerrada',
           },
         },
         description: { label: 'Descripción' },
@@ -418,8 +418,6 @@ export const esES: TranslationData = {
         is_active: { label: 'Activo' },
         is_taxable: { label: 'Imponible' },
         product_manager: { label: 'Gerente de Producto' },
-        image_url: { label: 'Imagen de Producto' },
-        datasheet_url: { label: 'URL de Ficha Técnica' },
         image: { label: 'Imagen de Producto' },
         datasheet: { label: 'Ficha Técnica' },
       },
@@ -539,6 +537,71 @@ export const esES: TranslationData = {
         campaign_timeline: { label: 'Línea de Tiempo de Marketing' },
       },
     },
+
+    crm_campaign_member: {
+      label: 'Miembro de Campaña',
+      pluralLabel: 'Miembros de Campaña',
+      description: 'Prospectos y contactos alcanzados por una campaña, con su estado de respuesta',
+      fields: {
+        member_number: { label: 'Número de Miembro' },
+        crm_campaign: { label: 'Campaña' },
+        crm_lead: { label: 'Prospecto' },
+        crm_contact: { label: 'Contacto' },
+        status: {
+          label: 'Estado',
+          options: {
+            sent: 'Enviado', opened: 'Abierto', clicked: 'Clicado',
+            responded: 'Respondido', converted: 'Convertido', bounced: 'Rebotado',
+            unsubscribed: 'Dado de Baja',
+          },
+        },
+        added_date: { label: 'Fecha de Alta' },
+        first_opened_date: { label: 'Primera Apertura' },
+        first_clicked_date: { label: 'Primer Clic' },
+        response_date: { label: 'Fecha de Respuesta' },
+        has_responded: { label: 'Ha Respondido' },
+      },
+      _sections: {
+        basic: { label: 'Información Básica' },
+        response: { label: 'Seguimiento de Respuesta' },
+      },
+    },
+
+    crm_opportunity_line_item: {
+      label: 'Línea de Oportunidad',
+      pluralLabel: 'Líneas de Oportunidad',
+      description: 'Líneas de precio por producto dentro de una oportunidad',
+      fields: {
+        crm_opportunity: { label: 'Oportunidad' },
+        crm_product: { label: 'Producto' },
+        description: { label: 'Descripción' },
+        quantity: { label: 'Cantidad' },
+        list_price: { label: 'Precio de Lista' },
+        unit_price: { label: 'Precio de Venta' },
+        discount: { label: 'Descuento (%)' },
+        total_price: { label: 'Total' },
+        line_number: { label: 'Nº de Línea' },
+      },
+    },
+
+    crm_quote_line_item: {
+      label: 'Línea de Presupuesto',
+      pluralLabel: 'Líneas de Presupuesto',
+      description: 'Líneas de precio por producto dentro de un presupuesto',
+      fields: {
+        crm_quote: { label: 'Presupuesto' },
+        crm_product: { label: 'Producto' },
+        description: { label: 'Descripción' },
+        quantity: { label: 'Cantidad' },
+        list_price: { label: 'Precio de Lista' },
+        unit_price: { label: 'Precio de Venta' },
+        discount: { label: 'Descuento (%)' },
+        subtotal: { label: 'Subtotal' },
+        tax_rate: { label: 'Tasa de Impuesto (%)' },
+        total_price: { label: 'Total' },
+        line_number: { label: 'Nº de Línea' },
+      },
+    },
   },
 
   globalActions: {
@@ -637,7 +700,7 @@ export const esES: TranslationData = {
         avg_deal_size: { title: 'Tamaño medio del negocio', description: 'Valor medio de los negocios cerrados ganados este trimestre' },
         pipeline_by_stage: { title: 'Pipeline por etapa', description: 'Valor de oportunidades abiertas en cada etapa de venta' },
         monthly_revenue_trend: { title: 'Tendencia mensual de ingresos', description: 'Ingresos cerrados ganados de los últimos 12 meses' },
-        opportunities_by_owner: { title: 'Oportunidades por responsable', description: 'Valor del pipeline abierto por representante' },
+        pipeline_by_forecast_category: { title: 'Pipeline por categoría de pronóstico', description: 'Pipeline abierto agrupado por categoría de pronóstico de ventas' },
         lead_source_breakdown: { title: 'Origen del prospecto', description: 'De dónde proviene nuestro pipeline' },
         open_pipeline_by_owner: { title: 'Pipeline abierto por responsable', description: 'Valor del pipeline en curso, número de negocios y probabilidad media de cierre por comercial' },
         pipeline_stage_by_source: { title: 'Pipeline por Etapa × Origen', description: 'Tabla cruzada del importe de oportunidades abiertas por etapa y origen' },

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -65,9 +65,9 @@ export const jaJP: TranslationData = {
         department: {
           label: '部門',
           options: {
-            Executive: '経営層', Sales: '営業部', Marketing: 'マーケティング部',
-            Engineering: 'エンジニアリング部', Support: 'サポート部', Finance: '経理部',
-            HR: '人事部', Operations: 'オペレーション部',
+            executive: '経営層', sales: '営業部', marketing: 'マーケティング部',
+            engineering: 'エンジニアリング部', support: 'サポート部', finance: '経理部',
+            hr: '人事部', operations: 'オペレーション部',
           },
         },
         owner: { label: '所有者' },
@@ -264,17 +264,17 @@ export const jaJP: TranslationData = {
         type: {
           label: 'タイプ',
           options: {
-            'New Business': '新規ビジネス',
-            'Existing Customer - Upgrade': '既存顧客 - アップグレード',
-            'Existing Customer - Renewal': '既存顧客 - 更新',
-            'Existing Customer - Expansion': '既存顧客 - 拡大',
+            new_business: '新規ビジネス',
+            existing_upgrade: '既存顧客 - アップグレード',
+            existing_renewal: '既存顧客 - 更新',
+            existing_expansion: '既存顧客 - 拡大',
           },
         },
         forecast_category: {
           label: '売上予測カテゴリ',
           options: {
-            Pipeline: 'パイプライン', 'Best Case': '最良ケース',
-            Commit: 'コミット', Omitted: '除外', Closed: '完了',
+            pipeline: 'パイプライン', best_case: '最良ケース',
+            commit: 'コミット', omitted: '除外', closed: '完了',
           },
         },
         description: { label: '説明' },
@@ -418,8 +418,6 @@ export const jaJP: TranslationData = {
         is_active: { label: '有効' },
         is_taxable: { label: '課税対象' },
         product_manager: { label: 'プロダクトマネージャー' },
-        image_url: { label: '製品画像' },
-        datasheet_url: { label: 'データシートURL' },
         image: { label: '製品画像' },
         datasheet: { label: 'データシート' },
       },
@@ -539,6 +537,71 @@ export const jaJP: TranslationData = {
         campaign_timeline: { label: 'マーケティングタイムライン' },
       },
     },
+
+    crm_campaign_member: {
+      label: 'キャンペーンメンバー',
+      pluralLabel: 'キャンペーンメンバー',
+      description: 'キャンペーンの対象となったリード・連絡先とその反応状況',
+      fields: {
+        member_number: { label: 'メンバー番号' },
+        crm_campaign: { label: 'キャンペーン' },
+        crm_lead: { label: 'リード' },
+        crm_contact: { label: '連絡先' },
+        status: {
+          label: 'ステータス',
+          options: {
+            sent: '送信済', opened: '開封済', clicked: 'クリック済',
+            responded: '応答済', converted: '変換済', bounced: 'バウンス',
+            unsubscribed: '配信停止',
+          },
+        },
+        added_date: { label: '追加日時' },
+        first_opened_date: { label: '初回開封' },
+        first_clicked_date: { label: '初回クリック' },
+        response_date: { label: '応答日時' },
+        has_responded: { label: '応答済' },
+      },
+      _sections: {
+        basic: { label: '基本情報' },
+        response: { label: '反応トラッキング' },
+      },
+    },
+
+    crm_opportunity_line_item: {
+      label: '商談商品明細',
+      pluralLabel: '商談商品明細',
+      description: '商談配下の製品別価格明細行',
+      fields: {
+        crm_opportunity: { label: '商談' },
+        crm_product: { label: '製品' },
+        description: { label: '説明' },
+        quantity: { label: '数量' },
+        list_price: { label: '定価' },
+        unit_price: { label: '販売価格' },
+        discount: { label: '割引率（%）' },
+        total_price: { label: '合計' },
+        line_number: { label: '行番号' },
+      },
+    },
+
+    crm_quote_line_item: {
+      label: '見積明細',
+      pluralLabel: '見積明細',
+      description: '見積配下の製品別価格明細行',
+      fields: {
+        crm_quote: { label: '見積' },
+        crm_product: { label: '製品' },
+        description: { label: '説明' },
+        quantity: { label: '数量' },
+        list_price: { label: '定価' },
+        unit_price: { label: '販売価格' },
+        discount: { label: '割引率（%）' },
+        subtotal: { label: '小計' },
+        tax_rate: { label: '税率（%）' },
+        total_price: { label: '合計' },
+        line_number: { label: '行番号' },
+      },
+    },
   },
 
   globalActions: {
@@ -637,7 +700,7 @@ export const jaJP: TranslationData = {
         avg_deal_size: { title: '平均商談規模', description: '今四半期の成立済み商談の平均金額' },
         pipeline_by_stage: { title: 'フェーズ別パイプライン', description: '各営業フェーズのオープン商談金額' },
         monthly_revenue_trend: { title: '月次売上トレンド', description: '過去12か月の成立済み売上' },
-        opportunities_by_owner: { title: '担当者別商談', description: '営業担当ごとのオープンパイプライン金額' },
+        pipeline_by_forecast_category: { title: '予測カテゴリ別パイプライン', description: '売上予測カテゴリ別のオープンパイプライン金額' },
         lead_source_breakdown: { title: 'リードソース', description: 'パイプラインの流入元' },
         open_pipeline_by_owner: { title: '担当者別オープンパイプライン', description: '営業担当者ごとの進行中パイプライン金額・商談数・平均勝率' },
         pipeline_stage_by_source: { title: 'ステージ × リードソース', description: 'ステージとソース別の進行中商談金額のクロス集計' },

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -579,7 +579,10 @@ export const zhCN: TranslationData = {
         end_date: { label: '结束日期' },
         expected_revenue: { label: '预期收入' },
         description: { label: '描述' },
-        channel: { label: '主要渠道' },
+        channel: {
+          label: '主要渠道',
+          options: { digital: '数字渠道', social: '社交媒体', email: '邮件', events: '线下活动', partner: '合作伙伴' },
+        },
         budgeted_cost: { label: '预算成本' },
         actual_cost: { label: '实际成本' },
         actual_revenue: { label: '实际收入' },

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -63,6 +63,14 @@ export const zhCN: TranslationData = {
         enterprise_accounts: { label: '企业客户', description: '年营收最高的大客户' },
         my_accounts: { label: '我的客户', description: '由当前用户负责的客户' },
       },
+      _sections: {
+        basic: { label: '基本信息' },
+        financials: { label: '财务信息' },
+        contact_info: { label: '联系信息' },
+        ownership: { label: '归属与状态' },
+        branding: { label: '品牌' },
+        system: { label: '系统' },
+      },
     },
 
     crm_contact: {
@@ -82,9 +90,9 @@ export const zhCN: TranslationData = {
         department: {
           label: '部门',
           options: {
-            Executive: '管理层', Sales: '销售部', Marketing: '市场部',
-            Engineering: '工程部', Support: '支持部', Finance: '财务部',
-            HR: '人力资源', Operations: '运营部',
+            executive: '管理层', sales: '销售部', marketing: '市场部',
+            engineering: '工程部', support: '支持部', finance: '财务部',
+            hr: '人力资源', operations: '运营部',
           },
         },
         owner: { label: '联系人负责人' },
@@ -121,7 +129,19 @@ export const zhCN: TranslationData = {
         },
         send_email: {
           label: '发送邮件',
+          params: {
+            subject: { label: '主题' },
+            body: { label: '正文' },
+          },
         },
+      },
+      _sections: {
+        identity: { label: '身份信息' },
+        account_info: { label: '客户与职务' },
+        contact_info: { label: '联系方式' },
+        mailing_address: { label: '邮寄地址' },
+        additional: { label: '附加信息' },
+        preferences: { label: '沟通偏好' },
       },
     },
 
@@ -165,6 +185,12 @@ export const zhCN: TranslationData = {
         my_drafts: { label: '我的草稿' },
         stale_articles: { label: '过期 (>180 天)' },
       },
+      _sections: {
+        basic: { label: '文章信息' },
+        content: { label: '内容' },
+        taxonomy: { label: '分类' },
+        metrics: { label: '互动数据' },
+      },
     },
 
     crm_forecast: {
@@ -196,6 +222,11 @@ export const zhCN: TranslationData = {
         all_forecasts: { label: '全部预测' },
         this_quarter_forecasts: { label: '本季度' },
         my_forecast: { label: '我的预测' },
+      },
+      _sections: {
+        basic: { label: '快照' },
+        amounts: { label: '金额' },
+        meta: { label: '来源' },
       },
     },
 
@@ -264,11 +295,21 @@ export const zhCN: TranslationData = {
         high_priority: { label: '高优先级' },
       },
       _sections: {
+        // Detail-page `record:details` section names (lead_detail.page.ts)
         info: { label: '线索信息' },
         crm_contact: { label: '联系方式' },
         detail: { label: '线索详情' },
         address: { label: '地址' },
         description: { label: '描述' },
+        // Object-level section keys (lead.object.ts) used by record forms
+        identity: { label: '身份信息' },
+        company_info: { label: '公司信息' },
+        contact_info: { label: '联系方式' },
+        qualification: { label: '资格评估' },
+        assignment: { label: '分配' },
+        additional: { label: '附加信息' },
+        preferences: { label: '沟通偏好' },
+        conversion: { label: '转化' },
       },
       _actions: {
         convert_lead: {
@@ -321,6 +362,13 @@ export const zhCN: TranslationData = {
         quote_pipeline: { label: '报价流水线' },
         quote_calendar: { label: '报价日历' },
       },
+      _sections: {
+        basic: { label: '报价信息' },
+        pricing: { label: '价格' },
+        terms: { label: '条款与有效期' },
+        address: { label: '地址' },
+        system: { label: '系统' },
+      },
     },
 
     crm_contract: {
@@ -361,6 +409,14 @@ export const zhCN: TranslationData = {
         renewal_calendar: { label: '续约日历' },
         contract_gantt: { label: '合同条款' },
         contract_timeline: { label: '合同时间线' },
+      },
+      _sections: {
+        basic: { label: '合同信息' },
+        parties: { label: '签约方' },
+        terms: { label: '条款与日期' },
+        value: { label: '合同金额' },
+        status: { label: '状态与审批' },
+        renewal: { label: '续约' },
       },
     },
 
@@ -420,12 +476,31 @@ export const zhCN: TranslationData = {
           label: '升级工单',
           confirmText: '此操作会将工单升级到升级处理团队，是否继续？',
           successMessage: '工单升级成功！',
+          params: {
+            reason: { label: '升级原因' },
+          },
         },
         close_case: {
           label: '关闭工单',
           confirmText: '确定要关闭此工单吗？',
           successMessage: '工单已成功关闭！',
+          params: {
+            resolution: { label: '解决方案' },
+          },
         },
+      },
+      _sections: {
+        // Detail-page `record:details` section names (case_detail.page.ts)
+        info: { label: '工单信息' },
+        status: { label: '状态与 SLA' },
+        description: { label: '描述' },
+        // Object-level section keys (case.object.ts) used by record forms
+        basic: { label: '工单信息' },
+        origin: { label: '来源与路由' },
+        sla: { label: 'SLA 与优先级' },
+        resolution: { label: '解决方案' },
+        escalation: { label: '升级' },
+        system: { label: '系统' },
       },
     },
 
@@ -448,8 +523,6 @@ export const zhCN: TranslationData = {
           options: { low: '低', normal: '普通', high: '高', urgent: '紧急' },
         },
         due_date: { label: '截止日期' },
-        assigned_to: { label: '负责人' },
-        related_to: { label: '关联对象' },
         type: { label: '任务类型' },
         reminder_date: { label: '提醒时间' },
         completed_date: { label: '完成日期' },
@@ -490,20 +563,20 @@ export const zhCN: TranslationData = {
         type: {
           label: '类型',
           options: {
-            email: '邮件营销', webinar: '线上研讨会', event: '线下活动',
-            advertising: '广告', 'direct-mail': '直邮', telemarketing: '电话营销',
+            email: '邮件营销', webinar: '线上研讨会', trade_show: '展会',
+            conference: '行业会议', direct_mail: '直邮', social_media: '社交媒体',
+            content: '内容营销', partner: '伙伴联合营销',
           },
         },
         status: {
           label: '状态',
           options: {
-            planned: '已计划', in_progress: '进行中',
+            planning: '规划中', in_progress: '进行中',
             completed: '已完成', aborted: '已中止',
           },
         },
         start_date: { label: '开始日期' },
         end_date: { label: '结束日期' },
-        budget: { label: '预算' },
         expected_revenue: { label: '预期收入' },
         description: { label: '描述' },
         channel: { label: '主要渠道' },
@@ -543,10 +616,9 @@ export const zhCN: TranslationData = {
           label: '产品类别',
           options: {
             software: '软件', hardware: '硬件', service: '服务',
-            subscription: '订阅', training: '培训',
+            subscription: '订阅', support: '支持服务',
           },
         },
-        price: { label: '单价' },
         cost: { label: '成本' },
         is_active: { label: '是否启用' },
         description: { label: '描述' },
@@ -557,8 +629,6 @@ export const zhCN: TranslationData = {
         reorder_point: { label: '补货阈值' },
         is_taxable: { label: '应税' },
         product_manager: { label: '产品经理' },
-        image_url: { label: '产品图片' },
-        datasheet_url: { label: '规格书链接' },
         image: { label: '产品图片' },
         datasheet: { label: '规格书' },
       },
@@ -566,6 +636,11 @@ export const zhCN: TranslationData = {
         all_products: { label: '全部产品' },
         product_catalog: { label: '产品目录' },
         low_stock: { label: '低库存' },
+      },
+      _sections: {
+        basic: { label: '产品信息' },
+        pricing: { label: '价格与计费' },
+        metadata: { label: '资源' },
       },
     },
 
@@ -593,17 +668,17 @@ export const zhCN: TranslationData = {
         type: {
           label: '类型',
           options: {
-            'New Business': '新业务',
-            'Existing Customer - Upgrade': '老客户升级',
-            'Existing Customer - Renewal': '老客户续约',
-            'Existing Customer - Expansion': '老客户拓展',
+            new_business: '新业务',
+            existing_upgrade: '老客户升级',
+            existing_renewal: '老客户续约',
+            existing_expansion: '老客户拓展',
           },
         },
         forecast_category: {
           label: '预测类别',
           options: {
-            Pipeline: '管道', 'Best Case': '最佳情况',
-            Commit: '承诺', Omitted: '已排除', Closed: '已关闭',
+            pipeline: '管道', best_case: '最佳情况',
+            commit: '承诺', omitted: '已排除', closed: '已关闭',
           },
         },
         description: { label: '描述' },
@@ -651,9 +726,17 @@ export const zhCN: TranslationData = {
         my_open_deals: { label: '我的进行中商机' },
       },
       _sections: {
+        // Detail-page `record:details` section names (opportunity_detail.page.ts)
         info: { label: '商机信息' },
         crm_forecast: { label: '阶段与预测' },
         description: { label: '描述' },
+        // Object-level section keys (opportunity.object.ts) used by record forms
+        basic: { label: '基本信息' },
+        financials: { label: '财务信息' },
+        sales_process: { label: '销售流程' },
+        classification: { label: '分类' },
+        competition: { label: '竞争与营销' },
+        notes: { label: '备注与下一步' },
       },
       _actions: {
         clone_opportunity: {
@@ -663,7 +746,82 @@ export const zhCN: TranslationData = {
         mass_update_stage: {
           label: '更新阶段',
           successMessage: '商机阶段已更新！',
+          params: {
+            stage: {
+              label: '新阶段',
+              options: {
+                prospecting: '寻找客户', qualification: '资格审查',
+                needs_analysis: '需求分析', proposal: '提案',
+                negotiation: '谈判', closed_won: '成交', closed_lost: '失败',
+              },
+            },
+          },
         },
+      },
+    },
+
+    crm_campaign_member: {
+      label: '活动成员',
+      pluralLabel: '活动成员',
+      description: '营销活动所触达的线索与联系人及其响应状态',
+      fields: {
+        member_number: { label: '成员编号' },
+        crm_campaign: { label: '营销活动' },
+        crm_lead: { label: '线索' },
+        crm_contact: { label: '联系人' },
+        status: {
+          label: '状态',
+          options: {
+            sent: '已发送', opened: '已打开', clicked: '已点击',
+            responded: '已响应', converted: '已转化', bounced: '已退回',
+            unsubscribed: '已退订',
+          },
+        },
+        added_date: { label: '加入时间' },
+        first_opened_date: { label: '首次打开' },
+        first_clicked_date: { label: '首次点击' },
+        response_date: { label: '响应时间' },
+        has_responded: { label: '已响应' },
+      },
+      _sections: {
+        basic: { label: '基本信息' },
+        response: { label: '响应跟踪' },
+      },
+    },
+
+    crm_opportunity_line_item: {
+      label: '商机产品明细',
+      pluralLabel: '商机产品明细',
+      description: '商机下按产品拆分的报价行',
+      fields: {
+        crm_opportunity: { label: '关联商机' },
+        crm_product: { label: '产品' },
+        description: { label: '描述' },
+        quantity: { label: '数量' },
+        list_price: { label: '标价' },
+        unit_price: { label: '销售单价' },
+        discount: { label: '折扣（%）' },
+        total_price: { label: '总计' },
+        line_number: { label: '行号' },
+      },
+    },
+
+    crm_quote_line_item: {
+      label: '报价单明细',
+      pluralLabel: '报价单明细',
+      description: '报价单下按产品拆分的报价行',
+      fields: {
+        crm_quote: { label: '关联报价单' },
+        crm_product: { label: '产品' },
+        description: { label: '描述' },
+        quantity: { label: '数量' },
+        list_price: { label: '标价' },
+        unit_price: { label: '销售单价' },
+        discount: { label: '折扣（%）' },
+        subtotal: { label: '小计' },
+        tax_rate: { label: '税率（%）' },
+        total_price: { label: '总计' },
+        line_number: { label: '行号' },
       },
     },
   },
@@ -672,6 +830,21 @@ export const zhCN: TranslationData = {
     log_call: {
       label: '记录通话',
       successMessage: '通话记录成功！',
+      params: {
+        subject: { label: '通话主题' },
+        duration: { label: '时长（分钟）' },
+        notes: { label: '通话记录' },
+      },
+    },
+    log_meeting: {
+      label: '记录会议',
+      successMessage: '会议记录成功！',
+      params: {
+        subject: { label: '会议主题' },
+        duration: { label: '时长（分钟）' },
+        attendees: { label: '参会人' },
+        notes: { label: '会议纪要' },
+      },
     },
     export_csv: {
       label: '导出 CSV',
@@ -799,7 +972,7 @@ export const zhCN: TranslationData = {
         avg_deal_size: { title: '平均订单金额', description: '本季度已成交商机的平均金额' },
         pipeline_by_stage: { title: '阶段管道分布', description: '按阶段统计的进行中商机金额' },
         monthly_revenue_trend: { title: '月度收入趋势', description: '过去 12 个月的已成交收入' },
-        opportunities_by_owner: { title: '负责人商机分布', description: '各销售负责的进行中商机' },
+        pipeline_by_forecast_category: { title: '预测类别管道分布', description: '按预测类别统计的进行中管道金额' },
         lead_source_breakdown: { title: '线索来源分布', description: '按来源统计的线索数量' },
         open_pipeline_by_owner: { title: '按负责人统计进行中管道', description: '各销售负责人的进行中管道金额、商机数与平均赢单概率' },
         pipeline_stage_by_source: { title: '阶段 × 线索来源', description: '按阶段和来源交叉统计进行中商机金额' },


### PR DESCRIPTION
Fixes #497 (items 1–6; item 7 is a confirmed platform-level gap, see below).

Bundle-only changes under `src/translations/` — no object/page/flow/action metadata touched.

## What changed

- **Re-key dead option translations to real machine values** in all 4 locales: `crm_contact.department`, `crm_opportunity.type`, `crm_opportunity.forecast_category`; zh-CN additionally `crm_campaign.type` (dead `event`/`advertising`/`direct-mail`/`telemarketing` dropped, real `trade_show`/`conference`/`direct_mail`/`social_media`/`content`/`partner` added), `crm_campaign.status` (`planned` → `planning`), `crm_product.category` (`training` dropped, `support` added), and a new `crm_campaign.channel` options block.
- **Drop dead field keys**: `crm_task.assigned_to`/`related_to`, `crm_campaign.budget`, `crm_product.price` (zh-CN); `crm_product.image_url`/`datasheet_url` (all locales).
- **Add the 3 objects missing from every bundle** — `crm_campaign_member` (incl. 7 member-status options), `crm_opportunity_line_item`, `crm_quote_line_item` — in all 4 locales.
- **Add zh-CN `_sections`** for account/contact/product/quote/contract/forecast/knowledge_article/case, and extend lead/opportunity/case with the object-level section keys *alongside* the existing page-level `record:details` names (both are live lookup surfaces — see the correction in #497 item 4).
- **Add zh-CN action `params` translations** (`escalate_case.reason`, `close_case.resolution`, `send_email.subject/body`, `mass_update_stage.stage` incl. its 7 stage options, `log_call`) and the missing `log_meeting` global action entry.
- **Re-key `sales_dashboard` widget** `opportunities_by_owner` → `pipeline_by_forecast_category` in all 4 locales.

ja-JP / es-ES values for the new blocks were machine-authored — native review welcome.

## Verified in-app (locale zh-CN, fresh demo DB)

- Contact list/detail: Department renders 工程部; detail sections 身份信息 / 客户与职务 / 沟通偏好.
- Opportunity detail: Type 新业务, Forecast Category 承诺.
- Campaign list/detail: status 规划中, type 展会, channel 数字渠道 / 线下活动 / 合作伙伴.
- Product list: category incl. 支持服务 (`support`).
- Account detail sections: 基本信息 / 财务信息 / 联系信息 / 归属与状态 / 系统.
- Action modals: 更新阶段 → 新阶段 + Chinese stage options; 发送邮件 → 主题 / 正文; 升级工单 → 升级原因.
- Sales dashboard: 预测类别管道分布 widget title resolves; no `Opportunities by Owner` leftovers.
- `pnpm validate` ✓, `pnpm typecheck` ✓, `os i18n check` default locale fully covered; mechanical key-vs-value scan clean.

## Not fixed here (platform-level, detailed in #497)

- Flow notification text (item 7): the runtime `objects.*` schema has no `_notifications` slot, nothing consumes it, and flows persist already-interpolated English literals into `sys_notification.payload` — needs a platform mechanism.
- Surfaces that don't consume existing translations: form-modal section tabs, action confirm dialogs (`confirmText`), action modal titles (page metadata), view-switcher tabs.
- `log_call` / `log_meeting` translations are included but could not be visually verified — those global actions have no visible entry point in the current console build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
