### PR TITLE
fix(lead-conversion): make the conversion screen completable (objectstack#3528)

### DIFF
--- a/.changeset/lead-conversion-screen-completable.md
+++ b/.changeset/lead-conversion-screen-completable.md
@@ -1,0 +1,31 @@
+---
+'hotcrm': patch
+---
+
+Make the lead-conversion screen completable.
+
+Pressing **Submit** on the `lead_conversion` screen did nothing — zero network
+requests, run paused forever (objectstack#3528). Two of that issue's three causes
+were in this repo's own metadata:
+
+- **`visibleWhen` was written in the wrong dialect.** On a screen field it is
+  bare CEL over the screen's own field names, not the `{var}` template dialect
+  this flow uses correctly everywhere else (filters, `update_record` fields,
+  decision conditions). `'{createOpportunity} == true'` never resolved, so
+  `opportunityName` — a field the author had made conditional — rendered
+  unconditionally *and* was enforced as `required`. Submit blocked on an input
+  the user was never meant to see.
+- **`createOpportunity` was required with no default.** An untouched checkbox
+  holds `undefined`, which the runner counts as unanswered. So "convert this lead
+  *without* an opportunity", the commonest path, blocked on a box the user had
+  deliberately left clear. `defaultValue: false` makes "no" a real answer.
+
+Also: `.gitignore` now ignores `node_modules` without a trailing slash. The
+slashed form matches directories only, so a *symlink* named `node_modules` is a
+plain blob to git and slips past the ignore entirely — one got committed that
+way, and CI failed with `ERR_PNPM_ENOENT … mkdir node_modules/@objectstack`
+because checkout restores a dangling symlink that pnpm cannot mkdir through.
+
+The third cause in objectstack#3528 — `crm_account.industry` holding fewer values
+than `crm_lead.industry`, aborting conversion mid-flow — was fixed separately by
+the shared `INDUSTRY_OPTIONS` picklist (#490).

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
-node_modules/
+# No trailing slash. `node_modules/` matches directories only, so a *symlink*
+# named `node_modules` — what a containerised checkout leaves behind when deps
+# live outside the tree — is a plain blob to git and slips past the ignore. One
+# got committed that way, and CI died on `ERR_PNPM_ENOENT … mkdir
+# node_modules/@objectstack`: checkout restores a dangling symlink and pnpm
+# cannot mkdir through it.
+node_modules
 dist/
 .env
 *.log
@@ -13,7 +19,7 @@ coverage/
 tmp/
 
 # Monorepo specific
-packages/*/node_modules/
+packages/*/node_modules
 packages/*/dist/
 packages/*/.turbo/
 .pnpm-store/

--- a/src/flows/lead-conversion.flow.ts
+++ b/src/flows/lead-conversion.flow.ts
@@ -27,10 +27,19 @@ export const LeadConversionFlow: Flow = {
     {
       id: 'screen_1', type: 'screen', label: 'Conversion Details',
       config: {
+        // `visibleWhen` on a screen field is BARE CEL over the screen's own
+        // field names — not the `{var}` template dialect the rest of this flow
+        // uses for filters, `update_record` fields and decision conditions. The
+        // client re-evaluates the predicate against the values collected so far,
+        // which is why it cannot be a server-interpolated template.
         fields: [
-          { name: 'createOpportunity', label: 'Create Opportunity?', type: 'boolean', required: true },
-          { name: 'opportunityName', label: 'Opportunity Name', type: 'text', required: true, visibleWhen: '{createOpportunity} == true' },
-          { name: 'opportunityAmount', label: 'Opportunity Amount', type: 'currency', visibleWhen: '{createOpportunity} == true' },
+          // `defaultValue: false` is load-bearing. An untouched checkbox holds
+          // `undefined`, which the runner counts as an unanswered required
+          // field — so "convert this lead WITHOUT an opportunity", the commonest
+          // path, blocked Submit on a box the user deliberately left clear.
+          { name: 'createOpportunity', label: 'Create Opportunity?', type: 'boolean', required: true, defaultValue: false },
+          { name: 'opportunityName', label: 'Opportunity Name', type: 'text', required: true, visibleWhen: 'createOpportunity == true' },
+          { name: 'opportunityAmount', label: 'Opportunity Amount', type: 'currency', visibleWhen: 'createOpportunity == true' },
         ],
       },
     },


### PR DESCRIPTION
App half of objectstack#3528 — the issue reported against this app. Platform halves shipped: objectstack#3552 (SDK `resume`), objectstack#3771 (server forwards `visibleWhen`), objectui#2899 (console honours it), objectstack#3788 (`.objectui-sha` bump).

HotCRM is where #3528 was reported: pressing **Submit** on the lead-conversion screen did nothing, issued zero network requests, and left the flow paused forever. Two of the three causes are in this repo's own metadata.

## 1. `visibleWhen` was written in the wrong dialect

```diff
-visibleWhen: '{createOpportunity} == true'
+visibleWhen: 'createOpportunity == true'
```

On a screen field `visibleWhen` is **bare CEL over the screen's own field names**. The client re-evaluates it against the values collected so far — which is exactly why it cannot be a server-interpolated template. `{createOpportunity}` is the `{var}` dialect this flow uses correctly *everywhere else* (`get_record` filters, `update_record` fields, decision expressions), and as a predicate it never resolves.

So `opportunityName` — a field the author had made conditional — rendered unconditionally *and* was enforced as `required`. Submit blocked on an input the user was never meant to see.

Nothing complained, and nothing could: `FlowNodeSchema.config` is `z.record(z.unknown())`, so no layer validates screen field keys at author time. Confusing two dialects that both appear in the same file is an easy mistake to make and currently an invisible one. Filed as objectstack#4027.

## 2. `createOpportunity` was required with no default

An untouched checkbox holds `undefined`, which the runner counts as an unanswered required field. So *"convert this lead **without** an opportunity"* — the commonest path — blocked Submit on a box the user had deliberately left clear.

`defaultValue: false` makes "no" an actual answer. This is load-bearing, not cosmetic: without it the screen is un-submittable even once the platform honours `visibleWhen`.

## 3. `crm_account.industry` — dropped, already fixed on main

The earlier revision of this branch widened the account's `industry` enum to match the lead's, because `create_account` copies `{leadRecord.industry}` straight across and the account held only 6 of the lead's 15 values. That has since been fixed on `main` independently: both objects now share the `INDUSTRY_OPTIONS` picklist (#490). The change is no longer carried here.

## Rebuilt onto current main

`main` moved by ~90 files while this sat, so rather than rebase through the drift the branch was reset onto `409b92b3` and the two live fixes re-applied. The diff is now three files.

**This also removes a committed `node_modules` symlink** that the previous revision carried (a `120000` blob pointing at a sandbox path). That, not a corrupt Actions cache, was what failed CI:

```
ERR_PNPM_ENOENT  [importPackage .../node_modules/@objectstack/driver-sqlite-wasm]
ENOENT: no such file or directory, mkdir '.../node_modules/@objectstack'
```

Checkout restores a dangling symlink and pnpm cannot `mkdir` through it. `.gitignore` is fixed at the root cause: `node_modules/` with a trailing slash matches **directories only**, so a symlink of that name is a plain blob to git and slipped past the ignore entirely. Both `node_modules` entries lose the slash.

## Test plan

All run on this branch at `3f8a3637`:

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` | ✅ done in 6.9s — the previous CI failure does not reproduce |
| `pnpm typecheck` (`tsc --noEmit`) | ✅ clean |
| `pnpm validate` | ✅ passed — 16 objects, 318 fields, 22 flows |
| `pnpm test` (vitest) | ✅ 89 passed (8 files) |
| `pnpm lint` | ✅ no errors (2 warnings + 9 suggestions, all pre-existing line-item relationship hints, untouched by this diff) |

Browser end-to-end for this flow was recorded on the earlier revision, against `objectstack dev` with the platform PRs applied:

```
→ POST /api/v1/automation/lead_conversion/trigger        (paused)
   rendered: ["Create Opportunity? *"]                    ← Opportunity Name/Amount correctly hidden
   click Submit
→ POST .../runs/run_63d43c4c.../resume  {"inputs":{"createOpportunity":false}}
   toast "Done" · dialog closed · 0 server errors         ← ran to completion
```

Before these changes, on the same server and the same lead, the dialog rendered all three fields and Submit issued **no request at all**. The metadata fixes here are unchanged from that run; only the redundant `industry` edit and the stray symlink were dropped.

## Ordering

Both remaining fixes need objectstack#3771 + objectui#2899, which are merged and pinned — so this is live as soon as it lands. Left as a draft for a maintainer to flip.