### PR TITLE
fix(skills): drop the per-skill `permissions` keys — the field does not exist in SkillSchema

### DIFF
--- a/src/skills/case-triage.skill.ts
+++ b/src/skills/case-triage.skill.ts
@@ -27,6 +27,4 @@ classify a case:
   triggerConditions: [
     { field: 'objectName', operator: 'eq', value: 'crm_case' },
   ],
-
-  permissions: ['crm:case:write'],
 });

--- a/src/skills/customer-360.skill.ts
+++ b/src/skills/customer-360.skill.ts
@@ -24,6 +24,4 @@ customer / account / contact:
     'give me the full picture',
     'account summary',
   ],
-
-  permissions: ['crm:account:read'],
 });

--- a/src/skills/email-drafting.skill.ts
+++ b/src/skills/email-drafting.skill.ts
@@ -25,6 +25,4 @@ export const EmailDraftingSkill = defineSkill({
     'optimise subject line',
     'email template',
   ],
-
-  permissions: ['crm:email:write'],
 });

--- a/src/skills/lead-qualification.skill.ts
+++ b/src/skills/lead-qualification.skill.ts
@@ -36,6 +36,4 @@ export const LeadQualificationSkill = defineSkill({
   triggerConditions: [
     { field: 'objectName', operator: 'eq', value: 'crm_lead' },
   ],
-
-  permissions: ['crm:lead:read'],
 });

--- a/src/skills/live-data.skill.ts
+++ b/src/skills/live-data.skill.ts
@@ -52,6 +52,4 @@ record (account, contact, lead, opportunity, case, quote, etc.):
     'pipeline',
     'forecast',
   ],
-
-  permissions: ['crm:read'],
 });

--- a/src/skills/revenue-forecasting.skill.ts
+++ b/src/skills/revenue-forecasting.skill.ts
@@ -30,6 +30,4 @@ risk, or deal slippage:
   triggerConditions: [
     { field: 'objectName', operator: 'in', value: ['crm_opportunity', 'dashboard'] },
   ],
-
-  permissions: ['crm:opportunity:read'],
 });


### PR DESCRIPTION
All six skills declared `permissions: ['crm:…']`. `SkillSchema` has no such field, so Zod strips the key at parse time — it granted and restricted **nothing** while reading as a security control. That is the ADR-0049 prohibited shape (a security-shaped declaration that lies), flagged in objectstack-ai/objectstack#3820 §4.

Where access is actually gated:

- **agent level** — `agent.access` / `agent.permissions`, enforced at the chat route;
- **tool level** — each tool's own authz when invoked.

The spec now documents this directly on `SkillSchema` (objectstack-ai/objectstack#3871), so the next author — human or AI — is told before writing the key instead of having it silently vanish.

Diff is deletion-only (12 lines across 6 `*.skill.ts`). `pnpm typecheck`, `objectstack validate`, and the test suite (8 files / 67 tests) all pass.

Refs objectstack-ai/objectstack#3820 · sibling PRs objectstack-ai/objectstack#3871, objectstack-ai/cloud#904

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHjroNkLkajskKbJaidko4

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHjroNkLkajskKbJaidko4)_