### PR TITLE
Fix license inconsistency: standardize on Apache-2.0 (#487)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ Contributors will be:
 
 ## 📄 License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the Apache License, Version 2.0.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2024 HotCRM Team
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.legacy.md
+++ b/README.legacy.md
@@ -8,7 +8,7 @@
 [![CI](https://github.com/objectstack-ai/hotcrm/workflows/CI/badge.svg)](https://github.com/objectstack-ai/hotcrm/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/objectstack-ai/hotcrm/workflows/CodeQL%20Security%20Analysis/badge.svg)](https://github.com/objectstack-ai/hotcrm/actions/workflows/codeql.yml)
 [![Code Quality](https://github.com/objectstack-ai/hotcrm/workflows/Code%20Quality/badge.svg)](https://github.com/objectstack-ai/hotcrm/actions/workflows/code-quality.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 ![Objects](https://img.shields.io/badge/Objects-~148-brightgreen)
 ![Tests](https://img.shields.io/badge/Tests-3799%20passing-brightgreen)
 ![Spec](https://img.shields.io/badge/%40objectstack%2Fspec-v3.0.11-blue)
@@ -848,7 +848,7 @@ For workflow configuration details, see the individual workflow files in [.githu
 
 ## 📄 License
 
-MIT License - see LICENSE file for details
+Apache-2.0 License - see LICENSE file for details
 
 ## 🤝 Contributing
 

--- a/objectstack.manifest.json
+++ b/objectstack.manifest.json
@@ -9,7 +9,7 @@
   "category": "crm",
   "isStarter": false,
   "publisher": "objectstack",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "iconUrl": "https://raw.githubusercontent.com/objectstack-ai/hotcrm/main/assets/icon.svg",
   "homepageUrl": "https://github.com/objectstack-ai/hotcrm",
   "tags": ["crm", "sales", "accounts", "leads", "opportunities", "cases", "campaigns"],

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hotcrm",
   "version": "2.2.2",
   "description": "HotCRM - Production CRM built on ObjectStack",
+  "license": "Apache-2.0",
   "private": true,
   "main": "./objectstack.config.ts",
   "types": "./objectstack.config.ts",

--- a/scripts/publish-marketplace.mjs
+++ b/scripts/publish-marketplace.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright (c) 2026 ObjectStack contributors. MIT license.
+// Copyright (c) 2026 ObjectStack contributors. Licensed under the Apache-2.0 license.
 
 /**
  * publish-marketplace.mjs

--- a/src/apps/crm.app.ts
+++ b/src/apps/crm.app.ts
@@ -47,6 +47,9 @@ export const CrmApp = App.create({
         { id: 'nav_contact',     type: 'object', objectName: 'crm_contact',     label: 'Contacts',      icon: 'user' },
         { id: 'nav_opportunity', type: 'object', objectName: 'crm_opportunity', label: 'Opportunities', icon: 'target' },
         { id: 'nav_pipeline',    type: 'object', objectName: 'crm_opportunity', viewName: 'pipeline_kanban', label: 'Pipeline', icon: 'columns-3' },
+        // Competitive intel — the battlecard catalog opportunities link to
+        // via the multi-value `crm_competitors` lookup.
+        { id: 'nav_competitor',  type: 'object', objectName: 'crm_competitor',  label: 'Competitors',   icon: 'swords' },
         { id: 'nav_quote',       type: 'object', objectName: 'crm_quote',       label: 'Quotes',        icon: 'receipt' },
         // Contracts close the sales cycle: quote → signed agreement → renewal.
         // The object, its views and its renewal automation all shipped, but

--- a/src/dashboards/crm.dashboard.ts
+++ b/src/dashboards/crm.dashboard.ts
@@ -128,6 +128,7 @@ export const CrmOverviewDashboard: Dashboard = {
       description: 'Closed-won revenue over the last 12 months',
       type: 'area',
       filter: { stage: 'closed_won', close_date: { $gte: '{12_months_ago}' } },
+      filterBindings: { dateRange: false }, // self-scoped to 12 months — the date picker must not narrow it
       colorVariant: 'success',
       dataset: 'opportunity_metrics', dimensions: ['close_date'], values: ['total_amount'],
       layout: { x: 0, y: 2, w: 9, h: 4 },

--- a/src/dashboards/executive.dashboard.ts
+++ b/src/dashboards/executive.dashboard.ts
@@ -67,6 +67,9 @@ export const ExecutiveDashboard: Dashboard = {
       description: 'Closed-won revenue this year',
       type: 'metric',
       filter: { stage: 'closed_won', close_date: { $gte: '{current_year_start}' } },
+      // Self-scoped to YTD; without this the injected dashboard dateRange
+      // (default this_quarter) is ANDed in and the tile shows quarter revenue.
+      filterBindings: { dateRange: false },
       colorVariant: 'success',
       actionUrl: '/reports/revenue-ytd',
       actionType: 'url',
@@ -148,6 +151,7 @@ export const ExecutiveDashboard: Dashboard = {
       description: 'Closed-won revenue over the last 12 months',
       type: 'area',
       filter: { stage: 'closed_won', close_date: { $gte: '{12_months_ago}' } },
+      filterBindings: { dateRange: false }, // self-scoped to 12 months — the date picker must not narrow it
       colorVariant: 'success',
       dataset: 'opportunity_metrics', dimensions: ['close_date'], values: ['total_amount'],
       layout: { x: 0, y: 2, w: 8, h: 4 },
@@ -170,6 +174,7 @@ export const ExecutiveDashboard: Dashboard = {
       description: 'YTD closed-won revenue split by customer industry',
       type: 'donut',
       filter: { stage: 'closed_won', close_date: { $gte: '{current_year_start}' } },
+      filterBindings: { dateRange: false }, // self-scoped to YTD — the date picker must not narrow it
       colorVariant: 'blue',
       dataset: 'opportunity_metrics', dimensions: ['account_industry'], values: ['total_amount'],
       layout: { x: 8, y: 2, w: 4, h: 4 },

--- a/src/dashboards/sales.dashboard.ts
+++ b/src/dashboards/sales.dashboard.ts
@@ -80,6 +80,7 @@ export const SalesDashboard: Dashboard = {
       description: 'Revenue closed this quarter',
       type: 'metric',
       filter: { stage: 'closed_won', close_date: { $gte: '{current_quarter_start}' } },
+      filterBindings: { dateRange: false }, // self-scoped to QTD — the date picker must not re-window it
       colorVariant: 'success',
       actionUrl: '/reports/closed-won',
       actionType: 'url',
@@ -116,6 +117,7 @@ export const SalesDashboard: Dashboard = {
       description: 'Average value of closed-won deals this quarter',
       type: 'metric',
       filter: { stage: 'closed_won', close_date: { $gte: '{current_quarter_start}' } },
+      filterBindings: { dateRange: false }, // self-scoped to QTD — the date picker must not re-window it
       colorVariant: 'purple',
       actionUrl: '/reports/avg-deal-size',
       actionType: 'url',
@@ -152,6 +154,7 @@ export const SalesDashboard: Dashboard = {
       description: 'Closed-won revenue, last 12 months',
       type: 'area',
       filter: { stage: 'closed_won', close_date: { $gte: '{12_months_ago}' } },
+      filterBindings: { dateRange: false }, // self-scoped to 12 months — the date picker must not narrow it
       colorVariant: 'success',
       dataset: 'opportunity_metrics', dimensions: ['close_date'], values: ['total_amount'],
       layout: { x: 6, y: 2, w: 6, h: 4 },

--- a/src/dashboards/service.dashboard.ts
+++ b/src/dashboards/service.dashboard.ts
@@ -190,6 +190,7 @@ export const ServiceDashboard: Dashboard = {
       description: 'New cases created over the last 30 days',
       type: 'area',
       filter: { created_date: { $gte: '{30_days_ago}' } },
+      filterBindings: { dateRange: false }, // self-scoped to 30 days — the date picker must not re-window it
       colorVariant: 'blue',
       dataset: 'case_metrics', dimensions: ['created_date'], values: ['case_count'],
       layout: { x: 0, y: 6, w: 8, h: 4 },

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -15,6 +15,7 @@ import { Opportunity } from '../objects/opportunity.object';
 import { Product } from '../objects/product.object';
 import { Task } from '../objects/task.object';
 import { Case } from '../objects/case.object';
+import { Competitor } from '../objects/competitor.object';
 import { Campaign } from '../objects/campaign.object';
 import { Contract } from '../objects/contract.object';
 import { Quote } from '../objects/quote.object';
@@ -294,6 +295,75 @@ const leads = defineSeed(Lead, {
   ]
 });
 
+// ─── Competitors ──────────────────────────────────────────────────────
+// Seeded BEFORE opportunities: the opportunity seed references these by
+// name through the multi-value `crm_competitors` lookup.
+//
+// ⚠️ Platform gap: SeedLoaderService resolves natural keys only for STRING
+// lookup values — an ARRAY (multi-value lookup) trips its object-value guard
+// and the field is silently dropped from the write. The `crm_competitors`
+// arrays on the opportunity records below document intent and will start
+// resolving if the loader gains array support; until then, links must be
+// (re)applied after a demo:reset via the opportunity form or SQL.
+const competitors = defineSeed(Competitor, {
+  mode: 'upsert',
+  externalId: 'name',
+  records: [
+    {
+      name: 'SalesForge',
+      website: 'https://salesforge.example.com',
+      main_products: 'SalesForge Cloud（销售云）、ForgeService（客服云）、ForgeAnalytics（BI 分析）',
+      threat_level: 'high',
+      our_advantages: `- **开放架构**：元数据全部开源，客户可自持部署，不被平台锁定
+- **AI 原生**：Copilot 深度嵌入销售流程，而非事后附加的聊天窗
+- **实施周期**：平均上线 4 周，对方通常需要 3-6 个月`,
+      our_disadvantages: `- 生态与插件市场规模差距明显（对方 5000+ 应用）
+- 品牌认知度低，大企业采购名单里常被默认排除
+- 行业合规认证（FedRAMP 等）尚未齐全`,
+      notes: '大客户竞标中最常遇到的对手，尤其是制造与金融行业。',
+      is_active: true,
+    },
+    {
+      name: 'HubNexus',
+      website: 'https://hubnexus.example.com',
+      main_products: '营销自动化套件、免费版 CRM、内容运营工具',
+      threat_level: 'medium',
+      our_advantages: `- 企业级权限/审批/共享模型完整，对方主打中小客户
+- 复杂销售流程（CPQ、多级审批）开箱即用
+- 数据模型可定制，对方对象扩展能力有限`,
+      our_disadvantages: `- 对方免费入门版获客能力强，中小客户先入为主
+- 营销自动化功能比我们成熟（邮件旅程、落地页）`,
+      notes: '在中小客户与营销驱动型团队中常见；Acme 的市场部曾用其 2 年合约压过我们一单。',
+      is_active: true,
+    },
+    {
+      name: 'ZenDeal',
+      website: 'https://zendeal.example.com',
+      main_products: '轻量销售管道工具、移动端 CRM',
+      threat_level: 'low',
+      our_advantages: `- 报表/预测/审批等企业功能齐全，对方只有基础管道
+- 可随业务自定义对象，对方模型固定`,
+      our_disadvantages: `- 上手门槛比对方高，10 人以下团队更偏好其极简体验
+- 单价高于对方入门套餐`,
+      notes: '主要出现在小额快单里，输单影响有限。',
+      is_active: true,
+    },
+    {
+      name: 'LegacySoft CRM',
+      website: 'https://legacysoft.example.com',
+      main_products: '本地部署 CRM 套件、行业定制开发服务',
+      threat_level: 'medium',
+      our_advantages: `- 云原生 + 持续升级，对方大版本升级需停机数天
+- 现代 UI 与移动体验，对方界面停留在上一代
+- 订阅制成本透明，对方定制开发费用高昂`,
+      our_disadvantages: `- 对方在政企/军工等强本地化场景有多年存量关系
+- 完全离线部署场景我们暂不支持`,
+      notes: '存量替换型商机的主要对手；决策链偏好"用熟不用生"。',
+      is_active: true,
+    },
+  ],
+});
+
 // ─── Opportunities ────────────────────────────────────────────────────
 const opportunities = defineSeed(Opportunity, {
   mode: 'upsert',
@@ -310,6 +380,7 @@ const opportunities = defineSeed(Opportunity, {
       forecast_category: 'pipeline',
       lead_source: 'web',
       days_in_stage: 12,
+      crm_competitors: ['SalesForge', 'HubNexus'],
       description: `Upgrade from Standard to Enterprise edition for the
 NA + EMEA teams. Drivers: (1) AI agent governance becomes a hard
 requirement after their internal compliance review, (2) advanced
@@ -327,6 +398,7 @@ analytics seats for the Ops org, (3) priority support SLA.`,
       forecast_category: 'pipeline',
       lead_source: 'referral',
       days_in_stage: 45,
+      crm_competitors: ['SalesForge', 'LegacySoft CRM'],
     },
     {
       name: 'Wayne Enterprise License',
@@ -339,6 +411,7 @@ analytics seats for the Ops org, (3) priority support SLA.`,
       forecast_category: 'commit',
       lead_source: 'partner',
       days_in_stage: 7,
+      crm_competitors: ['SalesForge'],
     },
     {
       name: 'Initech Cloud Migration',
@@ -420,6 +493,7 @@ analytics seats for the Ops org, (3) priority support SLA.`,
       type: 'existing_upgrade',
       forecast_category: 'omitted',
       lead_source: 'cold_call',
+      crm_competitors: ['HubNexus'],
       description: `Tried to bolt on the Marketing Cloud module via cold outbound. Lost because Acme's marketing org is already on a 2-year HubSpot contract. Revisit in Q3 when that contract is up for renewal.`,
     },
     {
@@ -1183,6 +1257,7 @@ export const CrmSeedData = [
   accounts,
   contacts,
   leads,
+  competitors,
   opportunities,
   products,
   tasks,

--- a/src/objects/competitor.object.ts
+++ b/src/objects/competitor.object.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+import { cel } from '@objectstack/spec';
+
+/**
+ * Competitor Object
+ *
+ * Competitive-intelligence catalog: who we compete against, what they sell,
+ * and how we stack up. Opportunities reference these records through the
+ * multi-value `crm_competitors` lookup, replacing the former hard-coded
+ * "Competitor A/B/C" multiselect.
+ */
+export const Competitor = ObjectSchema.create({
+  name: 'crm_competitor',
+  label: 'Competitor',
+  pluralLabel: 'Competitors',
+  icon: 'swords',
+  description: 'Competitors we encounter in deals, with battlecard notes',
+
+  // Competitive intel is a shared catalog — org-visible, owner-edited,
+  // same posture as the campaign catalog (ADR-0090 D1/D7).
+  sharingModel: 'public_read',
+  highlightFields: ['name', 'threat_level', 'main_products', 'website'],
+
+  fieldGroups: [
+    { key: 'basic', label: 'Basic Information', icon: 'building' },
+    { key: 'battlecard', label: 'Battlecard', icon: 'swords' },
+  ],
+
+  fields: {
+    name: Field.text({
+      label: 'Competitor Name',
+      required: true,
+      searchable: true,
+      maxLength: 255,
+      group: 'basic',
+    }),
+
+    website: Field.url({
+      label: 'Website',
+      group: 'basic',
+    }),
+
+    main_products: Field.textarea({
+      label: 'Main Products',
+      description: 'Flagship products / services we run into',
+      group: 'basic',
+    }),
+
+    threat_level: Field.select({
+      label: 'Threat Level',
+      required: true,
+      defaultValue: 'medium',
+      trackHistory: true,
+      group: 'basic',
+      options: [
+        { label: 'Low', value: 'low', color: '#00AA00' },
+        { label: 'Medium', value: 'medium', color: '#FFA500', default: true },
+        { label: 'High', value: 'high', color: '#FF0000' },
+      ],
+    }),
+
+    our_advantages: Field.markdown({
+      label: 'Our Advantages',
+      description: 'Where we win against this competitor',
+      group: 'battlecard',
+    }),
+
+    our_disadvantages: Field.markdown({
+      label: 'Our Disadvantages',
+      description: 'Where they beat us — objections to prepare for',
+      group: 'battlecard',
+    }),
+
+    notes: Field.markdown({
+      label: 'Notes',
+      group: 'battlecard',
+    }),
+
+    owner: Field.lookup('sys_user', {
+      defaultValue: cel`os.user.id`,
+      label: 'Intel Owner',
+      group: 'basic',
+    }),
+
+    is_active: Field.boolean({
+      label: 'Active',
+      defaultValue: true,
+      group: 'basic',
+    }),
+  },
+
+  indexes: [
+    { fields: ['name'], unique: true },
+    { fields: ['threat_level'] },
+  ],
+
+  enable: {
+    apiEnabled: true,
+    apiMethods: ['get', 'list', 'create', 'update', 'delete', 'search'],
+  },
+});

--- a/src/objects/index.ts
+++ b/src/objects/index.ts
@@ -11,6 +11,7 @@ export { Account } from './account.object';
 export { Campaign } from './campaign.object';
 export { CampaignMember } from './campaign_member.object';
 export { Case } from './case.object';
+export { Competitor } from './competitor.object';
 export { Contact } from './contact.object';
 export { Contract } from './contract.object';
 export { Forecast } from './forecast.object';

--- a/src/objects/opportunity.object.ts
+++ b/src/objects/opportunity.object.ts
@@ -157,16 +157,14 @@ export const Opportunity = ObjectSchema.create({
       ]
     }),
 
-    // Competitor Analysis
-    competitors: Field.select({
+    // Competitor Analysis — multi-value lookup into the crm_competitor
+    // catalog (replaces the former hard-coded "Competitor A/B/C" multiselect;
+    // new column name keeps the schema change additive on existing DBs).
+    crm_competitors: Field.lookup('crm_competitor', {
       label: 'Competitors',
       multiple: true,
+      description: 'Competitors we are up against in this deal',
       group: 'competition',
-      options: [
-        { label: 'Competitor A', value: 'competitor_a' },
-        { label: 'Competitor B', value: 'competitor_b' },
-        { label: 'Competitor C', value: 'competitor_c' },
-      ]
     }),
 
     // Campaign tracking

--- a/src/pages/opportunity_detail.page.ts
+++ b/src/pages/opportunity_detail.page.ts
@@ -95,7 +95,7 @@ export const OpportunityDetailPage: Page = {
                         {
                           name: 'info',
                           label: 'Opportunity Information',
-                          fields: ['name', 'crm_account', 'owner', 'type', 'lead_source', 'crm_campaign'],
+                          fields: ['name', 'crm_account', 'owner', 'type', 'lead_source', 'crm_campaign', 'crm_competitors'],
                         },
                         {
                           name: 'crm_forecast',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -309,7 +309,7 @@ export const en: TranslationData = {
             partner: 'Partner', advertisement: 'Advertisement', cold_call: 'Cold Call',
           },
         },
-        competitors: { label: 'Competitors' },
+        crm_competitors: { label: 'Competitors', help: 'Competitors we are up against in this deal' },
         crm_campaign: { label: 'Campaign' },
         days_in_stage: { label: 'Days in Current Stage' },
         is_private: { label: 'Private' },
@@ -577,6 +577,34 @@ export const en: TranslationData = {
         campaign_gantt: { label: 'Campaign Schedule' },
         campaign_calendar: { label: 'Launch Calendar' },
         campaign_timeline: { label: 'Marketing Timeline' },
+      },
+    },
+
+    crm_competitor: {
+      label: 'Competitor',
+      pluralLabel: 'Competitors',
+      description: 'Competitors we encounter in deals, with battlecard notes',
+      fields: {
+        name: { label: 'Competitor Name' },
+        website: { label: 'Website' },
+        main_products: { label: 'Main Products', help: 'Flagship products / services we run into' },
+        threat_level: {
+          label: 'Threat Level',
+          options: { low: 'Low', medium: 'Medium', high: 'High' },
+        },
+        our_advantages: { label: 'Our Advantages', help: 'Where we win against this competitor' },
+        our_disadvantages: { label: 'Our Disadvantages', help: 'Where they beat us — objections to prepare for' },
+        notes: { label: 'Notes' },
+        owner: { label: 'Intel Owner' },
+        is_active: { label: 'Active' },
+      },
+      _views: {
+        all_competitors: { label: 'All Competitors' },
+        high_threat: { label: 'High Threat' },
+      },
+      _sections: {
+        basic: { label: 'Basic Information' },
+        battlecard: { label: 'Battlecard' },
       },
     },
 

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -287,7 +287,7 @@ export const esES: TranslationData = {
             partner: 'Socio', advertisement: 'Publicidad', cold_call: 'Llamada en Frío',
           },
         },
-        competitors: { label: 'Competidores' },
+        crm_competitors: { label: 'Competidores' },
         crm_campaign: { label: 'Campaña' },
         days_in_stage: { label: 'Días en Etapa Actual' },
         is_private: { label: 'Privado' },
@@ -535,6 +535,34 @@ export const esES: TranslationData = {
         campaign_gantt: { label: 'Programación de Campañas' },
         campaign_calendar: { label: 'Calendario de Campañas' },
         campaign_timeline: { label: 'Línea de Tiempo de Marketing' },
+      },
+    },
+
+    crm_competitor: {
+      label: 'Competidor',
+      pluralLabel: 'Competidores',
+      description: 'Competidores que encontramos en las oportunidades, con notas de batalla',
+      fields: {
+        name: { label: 'Nombre del Competidor' },
+        website: { label: 'Sitio Web' },
+        main_products: { label: 'Productos Principales' },
+        threat_level: {
+          label: 'Nivel de Amenaza',
+          options: { low: 'Bajo', medium: 'Medio', high: 'Alto' },
+        },
+        our_advantages: { label: 'Nuestras Ventajas' },
+        our_disadvantages: { label: 'Nuestras Desventajas' },
+        notes: { label: 'Notas' },
+        owner: { label: 'Responsable' },
+        is_active: { label: 'Activo' },
+      },
+      _views: {
+        all_competitors: { label: 'Todos los Competidores' },
+        high_threat: { label: 'Amenaza Alta' },
+      },
+      _sections: {
+        basic: { label: 'Información Básica' },
+        battlecard: { label: 'Tarjeta de Batalla' },
       },
     },
 

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -287,7 +287,7 @@ export const jaJP: TranslationData = {
             partner: 'パートナー', advertisement: '広告', cold_call: 'コールドコール',
           },
         },
-        competitors: { label: '競合他社' },
+        crm_competitors: { label: '競合他社' },
         crm_campaign: { label: 'キャンペーン' },
         days_in_stage: { label: '現ステージ滞在日数' },
         is_private: { label: '非公開' },
@@ -535,6 +535,34 @@ export const jaJP: TranslationData = {
         campaign_gantt: { label: 'キャンペーン日程' },
         campaign_calendar: { label: 'キャンペーンカレンダー' },
         campaign_timeline: { label: 'マーケティングタイムライン' },
+      },
+    },
+
+    crm_competitor: {
+      label: '競合他社',
+      pluralLabel: '競合他社',
+      description: '商談で遭遇する競合他社とバトルカード情報',
+      fields: {
+        name: { label: '競合名' },
+        website: { label: 'ウェブサイト' },
+        main_products: { label: '主要製品' },
+        threat_level: {
+          label: '脅威レベル',
+          options: { low: '低', medium: '中', high: '高' },
+        },
+        our_advantages: { label: '自社の強み' },
+        our_disadvantages: { label: '自社の弱み' },
+        notes: { label: 'メモ' },
+        owner: { label: '担当者' },
+        is_active: { label: '有効' },
+      },
+      _views: {
+        all_competitors: { label: '全競合他社' },
+        high_threat: { label: '高脅威' },
+      },
+      _sections: {
+        basic: { label: '基本情報' },
+        battlecard: { label: 'バトルカード' },
       },
     },
 

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -694,7 +694,7 @@ export const zhCN: TranslationData = {
             partner: '合作伙伴', advertisement: '广告', cold_call: '陌生拜访',
           },
         },
-        competitors: { label: '竞争对手' },
+        crm_competitors: { label: '竞争对手', help: '本商机中遇到的竞争对手' },
         crm_campaign: { label: '营销活动' },
         days_in_stage: { label: '当前阶段天数' },
         is_private: { label: '私密' },
@@ -760,6 +760,34 @@ export const zhCN: TranslationData = {
             },
           },
         },
+      },
+    },
+
+    crm_competitor: {
+      label: '竞争对手',
+      pluralLabel: '竞争对手',
+      description: '商机中遇到的竞争对手及其作战卡信息',
+      fields: {
+        name: { label: '竞争对手名称' },
+        website: { label: '官网' },
+        main_products: { label: '主营产品', help: '经常正面竞争的核心产品/服务' },
+        threat_level: {
+          label: '威胁等级',
+          options: { low: '低', medium: '中', high: '高' },
+        },
+        our_advantages: { label: '我方优势', help: '与该竞争对手相比我们的赢单点' },
+        our_disadvantages: { label: '我方劣势', help: '对方领先之处——需提前准备的异议应对' },
+        notes: { label: '备注' },
+        owner: { label: '情报负责人' },
+        is_active: { label: '是否活跃' },
+      },
+      _views: {
+        all_competitors: { label: '全部竞争对手' },
+        high_threat: { label: '高威胁' },
+      },
+      _sections: {
+        basic: { label: '基本信息' },
+        battlecard: { label: '竞争作战卡' },
       },
     },
 
@@ -873,6 +901,7 @@ export const zhCN: TranslationData = {
         nav_contact: { label: '联系人' },
         nav_opportunity: { label: '商机' },
         nav_pipeline: { label: '销售管道' },
+        nav_competitor: { label: '竞争对手' },
         nav_quote: { label: '报价' },
         nav_contract: { label: '合同' },
         nav_sales_dashboard: { label: '销售业绩' },

--- a/src/views/competitor.view.ts
+++ b/src/views/competitor.view.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineView } from '@objectstack/spec/ui';
+
+/**
+ * Competitor Views
+ *
+ *   • grid       — full competitor catalog with threat levels
+ *   • high_threat — the deals-at-risk shortlist
+ */
+export const CompetitorViews = defineView({
+  list: {
+    type: 'grid',
+    name: 'all_competitors',
+    label: 'All Competitors',
+    data: { provider: 'object', object: 'crm_competitor' },
+    columns: [
+      { field: 'name', width: 220, sortable: true, link: true, pinned: 'left' },
+      { field: 'threat_level', width: 120, sortable: true, align: 'center' },
+      { field: 'main_products', width: 320 },
+      { field: 'website', width: 200 },
+      { field: 'owner', width: 150 },
+      { field: 'is_active', width: 100, align: 'center' },
+    ],
+    // NOTE: sorting on `threat_level` orders by the stored option VALUE
+    // (alphabetical: high < low < medium), not by option position — so a
+    // "threat desc" sort renders 中/低/高 in a random-looking order. Sort by
+    // name instead; the threat filter chips cover the triage use case.
+    sort: [{ field: 'name', order: 'asc' }],
+    pagination: { pageSize: 25 },
+    selection: { type: 'multiple' },
+    userFilters: {
+      element: 'dropdown',
+      fields: [{ field: 'threat_level' }, { field: 'is_active' }],
+    },
+  },
+
+  listViews: {
+    /** High-threat shortlist */
+    high_threat: {
+      name: 'high_threat',
+      type: 'grid',
+      label: 'High Threat',
+      data: { provider: 'object', object: 'crm_competitor' },
+      columns: ['name', 'main_products', 'our_disadvantages', 'owner'],
+      filter: [{ field: 'threat_level', operator: 'equals', value: 'high' }],
+      sort: [{ field: 'name', order: 'asc' }],
+    },
+  },
+
+  form: {
+    type: 'simple',
+    data: { provider: 'object', object: 'crm_competitor' },
+    sections: [
+      {
+        label: 'Basic Information',
+        columns: 2,
+        fields: [
+          { field: 'name', required: true },
+          'threat_level',
+          'website',
+          'owner',
+          { field: 'main_products', colSpan: 2 },
+          'is_active',
+        ],
+      },
+      {
+        label: 'Battlecard',
+        columns: 1,
+        fields: ['our_advantages', 'our_disadvantages', 'notes'],
+      },
+    ],
+  },
+});

--- a/src/views/contract.view.ts
+++ b/src/views/contract.view.ts
@@ -6,6 +6,7 @@ import { defineView } from '@objectstack/spec/ui';
  * Contract Views
  *
  *   • grid     — contract register with renewal info
+ *   • kanban   — status board (draft → in approval → activated → …)
  *   • calendar — start/end dates
  *   • gantt    — contract terms timeline
  *   • timeline — chronological contract stream
@@ -32,10 +33,11 @@ export const ContractViews = defineView({
     pagination: { pageSize: 25 },
     selection: { type: 'multiple' },
     appearance: {
-      allowedVisualizations: ['grid', 'calendar', 'gantt', 'timeline'],
+      allowedVisualizations: ['grid', 'kanban', 'calendar', 'gantt', 'timeline'],
     },
     tabs: [
       { name: 'all', label: 'All', view: 'all_contracts', isDefault: true, pinned: true },
+      { name: 'board', label: 'Status Board', icon: 'columns-3', view: 'status_board' },
       { name: 'renewals', label: 'Renewals', icon: 'calendar', view: 'renewal_calendar' },
       { name: 'terms', label: 'Terms', icon: 'gantt-chart', view: 'contract_gantt' },
       { name: 'timeline', label: 'Timeline', icon: 'git-commit-horizontal', view: 'contract_timeline' },
@@ -43,6 +45,22 @@ export const ContractViews = defineView({
   },
 
   listViews: {
+    /** Status kanban board — one column per contract status */
+    status_board: {
+      name: 'status_board',
+      type: 'kanban',
+      label: 'Status Board',
+      data: { provider: 'object', object: 'crm_contract' },
+      columns: ['contract_number', 'crm_account', 'end_date', 'status'],
+      kanban: {
+        groupByField: 'status',
+        summarizeField: 'contract_value',
+        // contract_number is already the card title — list only the extra fields
+        columns: ['crm_account', 'end_date', 'status'],
+      },
+      sort: [{ field: 'end_date', order: 'asc' }],
+    },
+
     /** Renewal calendar (highlights upcoming end dates) */
     renewal_calendar: {
       name: 'renewal_calendar',

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -7,6 +7,7 @@ export { OpportunityViews } from './opportunity.view';
 export { TaskViews } from './task.view';
 export { CaseViews } from './case.view';
 export { CampaignViews } from './campaign.view';
+export { CompetitorViews } from './competitor.view';
 export { ContractViews } from './contract.view';
 export { ForecastViews } from './forecast.view';
 export { KnowledgeArticleViews } from './knowledge_article.view';

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -242,7 +242,7 @@ export const OpportunityViews = defineView({
       {
         label: 'Sales Strategy',
         columns: 1,
-        fields: ['next_step', 'competitors'],
+        fields: ['next_step', 'crm_competitors'],
       },
     ],
   },

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -283,6 +283,29 @@ describe('navigation reaches everything the app ships', () => {
     expect(stranded, `dashboards nobody can open:\n  ${stranded.join('\n  ')}`).toEqual([]);
   });
 
+  it('widgets that window the dateRange field opt out of the injected date range', () => {
+    // The runtime injects the dashboard-level dateRange into every widget
+    // query (framework#2501) unless the widget opts out via `filterBindings`.
+    // A widget that carries its OWN window on the same field gets the two
+    // ANDed: the Executive "Total Revenue (YTD)" tile silently showed
+    // this-quarter revenue (781k instead of the year's 2.6M), and the
+    // "last 12 months" trend chart collapsed to the current quarter's points.
+    // Self-described windows ("YTD", "QTD", "last 12 months") must not follow
+    // the picker — their titles don't.
+    const bad: string[] = [];
+    for (const d of dashboards) {
+      const rangeField = d.dateRange?.field;
+      if (!rangeField) continue;
+      for (const w of d.widgets ?? []) {
+        if (w.filter?.[rangeField] === undefined) continue;
+        if (w.filterBindings?.dateRange !== false) {
+          bad.push(`${d.name}/${w.id}: filters on "${rangeField}" but still binds the dashboard dateRange`);
+        }
+      }
+    }
+    expect(bad, `widgets fighting the dashboard date picker:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
   it('every navigation node has a zh-CN label', () => {
     // The groups were translated and the leaves were not, so the sidebar read
     // half Chinese, half English.


### PR DESCRIPTION
## Description

The repository declared conflicting licenses: `LICENSE` and `objectstack.manifest.json` said MIT, while the README badge/footer and every source file header said Apache-2.0 — and `scripts/publish-marketplace.mjs` published that contradictory pair to the marketplace. This PR standardizes everything on **Apache-2.0**, the license the project publicly advertises (commit `3546eae`):

- `LICENSE`: replace the MIT text with the canonical Apache-2.0 license text
- `objectstack.manifest.json`: `"license"` field `MIT` → `Apache-2.0` (the value published to the marketplace)
- `package.json`: add `"license": "Apache-2.0"` (fallback source for the marketplace publish script)
- `CONTRIBUTING.md`: state that contributions are licensed under Apache-2.0
- `README.legacy.md`: update the license badge and license section
- `scripts/publish-marketplace.mjs`: align the file header with the rest of the codebase

⚠️ **Note for reviewers**: the head branch is based on an older `main` (`d0e2765`) from the fork and additionally carries three fork-side commits beyond the license fix: `7b68275` feat(competitor): competitor management module, `5e41bec` feat(contract): status kanban board view, and `efa59ab` fix(dashboards): dateRange filter opt-outs. Their commit messages reference `#1`/`#2`/`#3` (fork-local issue numbers, unrelated to this repo's #1–#3). If only the license fix is wanted here, the branch should be rebased onto the latest `main` with just `3546eae` before merging.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] CI/CD update

## Related Issues

Fixes #487

## Changes Made

- Replaced the MIT text in `LICENSE` with the canonical Apache-2.0 license text
- Changed `objectstack.manifest.json` `license` from `MIT` to `Apache-2.0` and added `"license": "Apache-2.0"` to `package.json` so the marketplace publish script has a consistent source
- Updated `CONTRIBUTING.md`, `README.legacy.md`, and the `scripts/publish-marketplace.mjs` file header to consistently state Apache-2.0

## Testing

- [x] Unit tests pass (`npm test`) — all tests pass on the head branch
- [ ] Linting passes (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] Manual testing completed
- [ ] New tests added (if applicable)

## Screenshots

N/A — license/documentation changes only.

## Checklist

- [ ] **I have added a changeset** (`pnpm changeset`) — required on every PR, or the `skip-changeset` label is applied
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- No changeset is included: the license fix carries no publishable code change, so the `skip-changeset` label may be appropriate; alternatively the head branch predates the new changeset CI requirement (`0437c9f`) and will need one (or the label) to pass CI.
- The head branch also includes three fork-side commits unrelated to #487 (see the note in the Description). Happy to have the branch rebased to contain only `3546eae` if maintainers prefer a minimal diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmS4beF8foorE7ykRdKcLU

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmS4beF8foorE7ykRdKcLU)_