### PR TITLE
ci(labeler): run on pull_request_target so fork PRs can be labelled

### DIFF
--- a/.changeset/labeler-fork-pr-permissions.md
+++ b/.changeset/labeler-fork-pr-permissions.md
@@ -1,0 +1,19 @@
+---
+'hotcrm': patch
+---
+
+Fix the PR Labeler workflow failing on every pull request opened from a fork.
+
+`labeler.yml` triggered on `pull_request`, which hands a **read-only**
+`GITHUB_TOKEN` to runs originating from a forked repository — the job-level
+`permissions: pull-requests: write` is silently downgraded, it is not an error
+GitHub reports up front. `actions/labeler` therefore got a 403 on
+`set-labels-for-an-issue` and the check went red on every contributor PR, while
+same-repo Dependabot PRs labelled fine and masked the problem.
+
+The trigger is now `pull_request_target`, which runs in the base repo's context
+where the requested write scope is actually granted. The `actions/checkout` step
+is gone with it: checking out under `pull_request_target` is the well-known
+privileged-code-execution footgun, and it was never needed — `actions/labeler`
+resolves `.github/labeler.yml` over the API at the base commit, so the label
+rules always come from the base branch and a fork cannot substitute its own.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,18 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  # `pull_request_target`, not `pull_request`: a `pull_request` run triggered by a
+  # fork gets a read-only GITHUB_TOKEN no matter what the `permissions:` block
+  # below asks for, so `actions/labeler` died with
+  # "Resource not accessible by integration" on every fork PR while same-repo
+  # (e.g. Dependabot) PRs labelled fine. `pull_request_target` runs in the base
+  # repo's context, where the requested `pull-requests: write` is actually granted.
+  #
+  # Safe here because nothing from the PR head is checked out or executed — the
+  # job only calls the labels API. `actions/labeler` reads `.github/labeler.yml`
+  # from the base branch via the API (it resolves it at `github.sha`, which under
+  # this trigger is the base commit), so a fork cannot supply its own label rules.
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -11,11 +22,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-      
+      # Deliberately no `actions/checkout` step: checking out under
+      # `pull_request_target` is the classic privileged-code-execution footgun,
+      # and it buys nothing — labeler fetches its configuration over the API.
       - name: Label PR based on changed files
         uses: actions/labeler@v6
         with:


### PR DESCRIPTION
## Description

The **PR Labeler** check has been failing with `Resource not accessible by integration` on every pull request opened from a fork — most recently [run 30431222584](https://github.com/objectstack-ai/hotcrm/actions/runs/30431222584/job/90508669471) on #533.

The workflow's `permissions:` block was already correct. The problem is the trigger: GitHub hands `pull_request` runs originating from a **fork** a read-only `GITHUB_TOKEN` and silently downgrades the job's `pull-requests: write` request rather than reporting it, so `actions/labeler` got a 403 on `set-labels-for-an-issue`.

Head-repo of every recent labeler run confirms it:

| Run | Head repo | Result |
|---|---|---|
| 30431222584 (#533) | `yinlianghui/hotcrm` (fork) | fail |
| 30430466092, 30422712159, 30418881648 | `yinlianghui/hotcrm` (fork) | fail |
| 30425961919 (Dependabot) | `objectstack-ai/hotcrm` | pass |

Same-repo Dependabot PRs kept passing, which masked the problem.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] CI/CD update

## Changes Made

- `.github/workflows/labeler.yml`: trigger is now `pull_request_target`, which runs in the base repo's context where the requested write scope is actually granted.
- Removed the `actions/checkout` step. Checking out under `pull_request_target` is the well-known privileged-code-execution footgun, and it was never needed here — `actions/labeler` falls back to fetching `.github/labeler.yml` over the API at `github.context.sha`, which under this trigger is the **base** commit. Label rules therefore always come from the base branch and a fork cannot substitute its own.

### Why this is safe

Nothing from the PR head is checked out or executed; the job only calls the labels API. This is the pattern the trigger is intended for.

## Testing

- [x] Unit tests pass (`npm test`) — 8 test files, 88 tests passed
- [x] `labeler.yml` parses and resolves to the intended trigger / permissions / steps
- [x] Verified against `actions/labeler@v6`'s bundled source that the config is fetched via `repos.getContent({ ref: github.context.sha })` when no local checkout is present

## Note on rollout

`pull_request_target` always runs the workflow file **from the base branch**, so #533's labeler check stays red until this lands on `main`. Once merged, a re-run or a new push on #533 will label correctly.

---
_Generated by [Claude Code](https://claude.com/claude-code)_
