### PR TITLE
fix(crm): repair broken and conflicting automation across hooks and flows (#489)

### DIFF
--- a/.changeset/automation-hooks-flows-conflicts.md
+++ b/.changeset/automation-hooks-flows-conflicts.md
@@ -1,0 +1,11 @@
+---
+'hotcrm': patch
+---
+
+Repair broken and conflicting automation across hooks and flows (#489):
+case/task automation no longer fights itself (escalation is guarded by
+`escalated_date == null` on top of the status guards, and an afterInsert twin
+covers cases born critical), the stalled-deal sweep gains an idempotency gate
+so it nudges once per stall episode instead of every morning, and
+lead/campaign/contact and opportunity/quote/contract automations stop
+overwriting each other's writes.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,11 +1,11 @@
 # HotCRM Status
 
-> Snapshot date: July 28, 2026
+> Snapshot date: June 22, 2026
 > Source of truth: `pnpm validate`, `pnpm typecheck`, and `pnpm test`
 
 ## Summary
 
-HotCRM is a single ObjectStack marketplace app at version `2.2.2`. The app manifest is defined in [`objectstack.config.ts`](../objectstack.config.ts) with id `app.objectstack.hotcrm` and namespace `crm`.
+HotCRM is a single ObjectStack marketplace app at version `1.3.0`. The app manifest is defined in [`objectstack.config.ts`](../objectstack.config.ts) with id `app.objectstack.hotcrm` and namespace `crm`.
 
 ## ObjectStack Validation
 
@@ -13,9 +13,9 @@ Latest local validation:
 
 ```text
 HotCRM v2.2.2
-Data: 15 Objects  309 Fields
-UI: 1 Apps  12 Views  15 Pages  4 Dashboards  10 Reports  13 Actions
-Logic: 20 Flows  2 Agents
+Data: 16 Objects  318 Fields
+UI: 1 Apps  13 Views  15 Pages  4 Dashboards  10 Reports  14 Actions
+Logic: 21 Flows  2 Agents
 Security: 12 Positions  6 Permissions
 ```
 
@@ -31,7 +31,7 @@ pnpm validate
 | --- | --- | --- |
 | ObjectStack metadata validation | `pnpm validate` | Passes |
 | TypeScript | `pnpm typecheck` | Passes |
-| Unit tests | `pnpm test` | 8 files, 67 tests passing |
+| Unit tests | `pnpm test` | 1 file, 6 tests passing |
 
 Run the full project verification pipeline with:
 
@@ -43,9 +43,9 @@ pnpm verify
 
 | Requirement | Value |
 | --- | --- |
-| Node.js | `>=22` |
+| Node.js | `>=20` |
 | pnpm | `>=10.0.0` |
-| ObjectStack packages | `16.1.0` |
+| ObjectStack packages | `^7.7.0` |
 | Local dev port | `4001` |
 
 ## Current Metadata Inventory

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,11 +1,11 @@
 # HotCRM Status
 
-> Snapshot date: June 22, 2026
+> Snapshot date: July 30, 2026
 > Source of truth: `pnpm validate`, `pnpm typecheck`, and `pnpm test`
 
 ## Summary
 
-HotCRM is a single ObjectStack marketplace app at version `1.3.0`. The app manifest is defined in [`objectstack.config.ts`](../objectstack.config.ts) with id `app.objectstack.hotcrm` and namespace `crm`.
+HotCRM is a single ObjectStack marketplace app at version `2.2.2`. The app manifest is defined in [`objectstack.config.ts`](../objectstack.config.ts) with id `app.objectstack.hotcrm` and namespace `crm`.
 
 ## ObjectStack Validation
 
@@ -14,8 +14,8 @@ Latest local validation:
 ```text
 HotCRM v2.2.2
 Data: 16 Objects  318 Fields
-UI: 1 Apps  13 Views  15 Pages  4 Dashboards  10 Reports  14 Actions
-Logic: 21 Flows  2 Agents
+UI: 1 Apps  13 Views  8 Pages  4 Dashboards  10 Reports  13 Actions
+Logic: 23 Flows
 Security: 12 Positions  6 Permissions
 ```
 
@@ -31,7 +31,7 @@ pnpm validate
 | --- | --- | --- |
 | ObjectStack metadata validation | `pnpm validate` | Passes |
 | TypeScript | `pnpm typecheck` | Passes |
-| Unit tests | `pnpm test` | 1 file, 6 tests passing |
+| Unit tests | `pnpm test` | 9 files, 97 tests passing |
 
 Run the full project verification pipeline with:
 
@@ -43,9 +43,9 @@ pnpm verify
 
 | Requirement | Value |
 | --- | --- |
-| Node.js | `>=20` |
+| Node.js | `>=22` |
 | pnpm | `>=10.0.0` |
-| ObjectStack packages | `^7.7.0` |
+| ObjectStack packages | `16.1.0` |
 | Local dev port | `4001` |
 
 ## Current Metadata Inventory

--- a/src/actions/campaign.actions.ts
+++ b/src/actions/campaign.actions.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Action } from '@objectstack/spec/ui';
+import { P } from '@objectstack/spec';
+
+/**
+ * Enroll leads into this campaign.
+ *
+ * Flow-typed action: launches the `campaign_enrollment` screen flow (pick a
+ * lead status, enroll all eligible leads). The flow used to be a Monday cron
+ * with input variables that a cron firing never seeds — this action is its
+ * entry point now, following the proven `convert_lead` / `generate_quote`
+ * pattern (the console's flow-action trigger sends `{ recordId, objectName }`).
+ */
+export const EnrollLeadsAction: Action = {
+  name: 'enroll_leads',
+  label: 'Enroll Leads',
+  objectName: 'crm_campaign',
+  icon: 'user-plus',
+  type: 'flow',
+  target: 'campaign_enrollment',
+  locations: ['record_header', 'record_more'],
+  // Enrollment only makes sense while the campaign is open — the flow
+  // double-checks this server-side.
+  visible: P`record.status == "planning" || record.status == "in_progress"`,
+  successMessage: 'Eligible leads enrolled in campaign.',
+  refreshAfter: true,
+};

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -11,6 +11,7 @@
  * action and the screen flow under `src/flows/lead-conversion.flow.ts`
  * carries the implementation.
  */
+export { EnrollLeadsAction } from './campaign.actions';
 export { EscalateCaseAction, CloseCaseAction } from './case.actions';
 export { MarkPrimaryContactAction, SendEmailAction } from './contact.actions';
 export { LogCallAction, LogMeetingAction } from './global.actions';

--- a/src/actions/opportunity.actions.ts
+++ b/src/actions/opportunity.actions.ts
@@ -90,7 +90,7 @@ export const MassUpdateStageAction: Action = {
       if (!ids.length) throw new Error('mass_update_stage: no opportunity selected');
       let updated = 0;
       for (const id of ids) {
-        await ctx.api.object('crm_opportunity').update({ id, stage: newStage }, { where: { id } });
+        await ctx.api.object('crm_opportunity').update(id, { stage: newStage });
         updated++;
       }
       return { stage: newStage, updated };

--- a/src/docs/crm_sales.md
+++ b/src/docs/crm_sales.md
@@ -33,15 +33,17 @@ automatically:
 
 | Lead Score | Follow-up SLA | What happens |
 |---|---|---|
-| **Hot** — 4★ or higher | **1 day** | Manager is alerted to *assign within 24h*. |
-| Everything else | **3 days** | Lead is queued for assignment. |
+| **Hot** — 4★ or higher | **1 day** | The owner is alerted to *follow up within 24h*. |
+| Everything else | **3 days** | The owner gets a standard follow-up deadline. |
 
 **Lead Score** is the 1–5 star field on each lead (shown as *Lead Score* in the
 UI). A score of 4★ or more marks the lead "hot" and triggers the 1-day SLA.
 
-Every new lead lands in the **sales-manager queue**. Ownership is assigned by a
-manager — there is no automatic territory or round-robin assignment, so a lead
-sits in the queue until someone claims or assigns it. **Lead status** moves
+A lead created without an owner (web-to-lead, CSV import, API capture) is
+**auto-assigned to the sales rep with the fewest open leads** — a self-balancing
+round-robin over everyone holding the *Sales Rep* position. Leads created in the
+UI keep their creator as owner. Only when no rep pool exists yet does a lead
+stay ownerless for a manager to claim. **Lead status** moves
 `New → Contacted → Qualified → Unqualified`.
 
 ## 2. Converting a qualified lead

--- a/src/docs/crm_service.md
+++ b/src/docs/crm_service.md
@@ -33,8 +33,8 @@ An **hourly** sweep checks every open case. If a case passes its **SLA Due Date*
 without being resolved, the system automatically:
 
 - marks it **SLA Violated**,
-- **escalates** it (status → *Escalated*), and
-- alerts the owner and their manager.
+- **escalates** it (status → *Escalated*, with an escalation reason stamped), and
+- alerts the owner.
 
 You never have to manually catch a missed SLA — but you should work cases before
 the due date, because a breach is recorded permanently on the case.
@@ -44,13 +44,15 @@ the due date, because a breach is recorded permanently on the case.
 The moment a case is set to **Critical** priority, it escalates without waiting
 for the SLA clock:
 
-- it is **reassigned to the owner's manager**,
-- status moves to **Escalated** with an escalation reason stamped, and
-- a **high-priority follow-up task** is created (due the next day), with the
-  manager notified.
+- status moves to **Escalated** with an escalation reason stamped (the case
+  stays with its owner),
+- an **urgent follow-up task** is created for the account owner (due the next
+  day), and
+- the case owner is notified.
 
 > Two safety nets, two triggers: **priority = Critical** escalates *immediately*;
-> a **missed SLA Due Date** escalates *on breach*. Both reassign and alert.
+> a **missed SLA Due Date** escalates *on breach*. Both flag and alert; neither
+> reassigns the case.
 
 ## After a case closes — satisfaction follow-up (automatic)
 

--- a/src/flows/campaign-enrollment.flow.ts
+++ b/src/flows/campaign-enrollment.flow.ts
@@ -3,32 +3,83 @@
 import type * as Automation from '@objectstack/spec/automation';
 type Flow = Automation.Flow;
 
-/** Campaign Enrollment — scheduled flow to bulk enroll leads */
+/**
+ * Campaign Enrollment — screen flow to bulk-enroll leads into a campaign.
+ *
+ * Launched from the "Enroll Leads" action on a campaign record (the console's
+ * flow-action trigger seeds `recordId`). It was previously a `schedule` flow
+ * (Monday 9 AM cron) with `campaignId` / `leadStatus` input variables — but a
+ * cron firing seeds NO inputs (only the console's flow-action trigger does,
+ * cf. lead_conversion), so every run had both variables undefined: either it
+ * matched no campaign, or it mass-enrolled every open lead into a null
+ * campaign and died on the "Campaign required" validation. User-invoked with
+ * a real campaign id, plus per-lead dedupe, it now does what the label says.
+ *
+ * Eligibility: leads in the chosen status, not converted, with an email, and
+ * not opted out of email. Already-enrolled leads are skipped (idempotent —
+ * re-running the action tops up new eligible leads only).
+ *
+ * Campaign metric rollups (num_sent etc.) are owned by the
+ * `campaign_snapshot_metrics` hook — this flow does NOT write them (its old
+ * per-run `num_sent = {leadList.length}` overwrite clobbered prior batches).
+ */
 export const CampaignEnrollmentFlow: Flow = {
   name: 'campaign_enrollment',
   label: 'Enroll Leads in Campaign',
-  description: 'Bulk enroll leads into marketing campaigns',
-  type: 'schedule',
+  description: 'Bulk enroll eligible leads into this campaign (skips already-enrolled and opted-out leads).',
+  type: 'screen',
   status: 'active',
-  // Scheduled runs have no trigger user, so under the default runAs:'user' the
-  // data nodes execute UNSCOPED anyway. Declare runAs:'system' to make that
-  // RLS-bypassing elevation explicit and intended (ADR-0049, #1888).
-  runAs: 'system',
 
   variables: [
-    { name: 'campaignId', type: 'text', isInput: true, isOutput: false },
+    // `recordId` matches the console's flow-action trigger contract
+    // ({ recordId, objectName }) — cf. lead_conversion / quote_generation.
+    { name: 'recordId', type: 'text', isInput: true, isOutput: false },
     { name: 'leadStatus', type: 'text', isInput: true, isOutput: false },
   ],
 
   nodes: [
-    { id: 'start', type: 'start', label: 'Start (Monday 9 AM)', config: { schedule: '0 9 * * 1' } },
+    { id: 'start', type: 'start', label: 'Start', config: { objectName: 'crm_campaign' } },
+    {
+      id: 'screen_1', type: 'screen', label: 'Enrollment Criteria',
+      config: {
+        fields: [
+          {
+            name: 'leadStatus', label: 'Enroll leads in status', type: 'select', required: true,
+            defaultValue: 'new',
+            options: [
+              { label: 'New', value: 'new' },
+              { label: 'Contacted', value: 'contacted' },
+              { label: 'Qualified', value: 'qualified' },
+            ],
+          },
+        ],
+      },
+    },
     {
       id: 'get_campaign', type: 'get_record', label: 'Get Campaign',
-      config: { objectName: 'crm_campaign', filter: { id: '{campaignId}' }, outputVariable: 'campaignRecord' },
+      config: { objectName: 'crm_campaign', filter: { id: '{recordId}' }, outputVariable: 'campaignRecord' },
+    },
+    {
+      // Only enroll into campaigns that are actually running (or planned):
+      // topping up a completed/aborted campaign would corrupt its final
+      // snapshot metrics. (Status values: planning / in_progress / completed / aborted.)
+      id: 'check_campaign_open', type: 'decision', label: 'Campaign Open?',
+      config: { condition: 'campaignRecord.status == "planning" || campaignRecord.status == "in_progress"' },
     },
     {
       id: 'query_leads', type: 'get_record', label: 'Find Eligible Leads',
-      config: { objectName: 'crm_lead', filter: { status: '{leadStatus}', is_converted: false, email: { $ne: null } }, limit: 1000, outputVariable: 'leadList' },
+      config: {
+        objectName: 'crm_lead',
+        filter: {
+          status: '{leadStatus}',
+          is_converted: false,
+          email: { $ne: null },
+          // This is email-campaign enrollment — honour the opt-out flag.
+          email_opt_out: false,
+        },
+        limit: 1000,
+        outputVariable: 'leadList',
+      },
     },
     {
       id: 'loop_leads', type: 'loop', label: 'Process Each Lead',
@@ -38,30 +89,46 @@ export const CampaignEnrollmentFlow: Flow = {
         body: {
           nodes: [
             {
+              // Dedupe: skip leads already enrolled in THIS campaign, so a
+              // re-run tops up instead of double-enrolling (double rows
+              // inflated num_sent / response_rate).
+              id: 'find_existing_member', type: 'get_record', label: 'Already Enrolled?',
+              config: {
+                objectName: 'crm_campaign_member',
+                filter: { crm_campaign: '{recordId}', crm_lead: '{currentLead.id}' },
+                outputVariable: 'existingMember',
+              },
+            },
+            {
+              id: 'check_not_enrolled', type: 'decision', label: 'New Member?',
+              config: { condition: 'existingMember == null' },
+            },
+            {
               id: 'create_campaign_member', type: 'create_record', label: 'Add to Campaign',
               config: {
                 objectName: 'crm_campaign_member',
-                fields: { crm_campaign: '{campaignId}', crm_lead: '{currentLead.id}', status: 'sent', added_date: '{NOW()}' },
+                fields: { crm_campaign: '{recordId}', crm_lead: '{currentLead.id}', status: 'sent', added_date: '{NOW()}' },
               },
             },
           ],
-          edges: [],
+          edges: [
+            { id: 'b1', source: 'find_existing_member', target: 'check_not_enrolled', type: 'default' },
+            // Already enrolled → no edge → next lead.
+            { id: 'b2', source: 'check_not_enrolled', target: 'create_campaign_member', type: 'conditional', condition: 'existingMember == null', label: 'Enroll' },
+          ],
         },
       },
-    },
-    {
-      // Runs once after the loop completes; leadList is in outer scope.
-      id: 'update_campaign_stats', type: 'update_record', label: 'Update Campaign Stats',
-      config: { objectName: 'crm_campaign', filter: { id: '{campaignId}' }, fields: { num_sent: '{leadList.length}' } },
     },
     { id: 'end', type: 'end', label: 'End' },
   ],
 
   edges: [
-    { id: 'e1', source: 'start', target: 'get_campaign', type: 'default' },
-    { id: 'e2', source: 'get_campaign', target: 'query_leads', type: 'default' },
-    { id: 'e3', source: 'query_leads', target: 'loop_leads', type: 'default' },
-    { id: 'e4', source: 'loop_leads', target: 'update_campaign_stats', type: 'default' },
-    { id: 'e5', source: 'update_campaign_stats', target: 'end', type: 'default' },
+    { id: 'e1', source: 'start', target: 'screen_1', type: 'default' },
+    { id: 'e2', source: 'screen_1', target: 'get_campaign', type: 'default' },
+    { id: 'e3', source: 'get_campaign', target: 'check_campaign_open', type: 'default' },
+    // Closed campaign → no edge → flow ends without enrolling.
+    { id: 'e4', source: 'check_campaign_open', target: 'query_leads', type: 'conditional', condition: 'campaignRecord.status == "planning" || campaignRecord.status == "in_progress"', label: 'Open' },
+    { id: 'e5', source: 'query_leads', target: 'loop_leads', type: 'default' },
+    { id: 'e6', source: 'loop_leads', target: 'end', type: 'default' },
   ],
 };

--- a/src/flows/case-escalation.flow.ts
+++ b/src/flows/case-escalation.flow.ts
@@ -18,13 +18,18 @@ export const CaseEscalationFlow: Flow = {
   nodes: [
     {
       // Trigger wiring (7.4): bind to afterUpdate and gate on the critical
-      // transition. The re-fire guard MUST use `status` (a string enum), NOT the
-      // boolean `is_escalated`: this flow's own escalation write re-triggers
+      // transition. The re-fire guard MUST NOT rely on the boolean
+      // `is_escalated`: this flow's own escalation write re-triggers
       // record-after-update, and on SQLite/libsql a boolean persists as integer
       // `1`, so `record.is_escalated != true` is `1 != true` = true — the guard
       // never trips and the flow loops forever (it wedged a first-boot seed on
-      // 2026-07-06). The same write sets `status: 'escalated'`, so
-      // `status != "escalated"` reliably suppresses the second fire.
+      // 2026-07-06). Instead:
+      // - `escalated_date == null` marks "never escalated" (the escalation write
+      //   stamps it, suppressing the second fire AND any re-escalation when an
+      //   agent later moves the case back to in_progress to work it);
+      // - the status terms keep the flow off cases already escalated or already
+      //   finished — without them a critical case could never be resolved or
+      //   closed (the flow would yank `status` straight back to `escalated`).
       id: 'start', type: 'start', label: 'Start',
       config: {
         objectName: 'crm_case',
@@ -35,7 +40,11 @@ export const CaseEscalationFlow: Flow = {
         // close_case wrote status "closed", this flow immediately rewrote it
         // to "escalated"). Status strings are the reliable guard — comparing
         // the boolean is_closed suffers the SQLite `1 != true` trap above.
-        condition: 'record.priority == "critical" && record.status != "escalated" && record.status != "closed" && record.status != "resolved"',
+        // `escalated_date == null` additionally keeps a case that was already
+        // escalated once (then reopened) from being escalated again.
+        condition:
+          'record.priority == "critical" && record.escalated_date == null'
+          + ' && record.status != "escalated" && record.status != "resolved" && record.status != "closed"',
       },
     },
     {
@@ -56,23 +65,17 @@ export const CaseEscalationFlow: Flow = {
         fields: { is_escalated: true, escalation_reason: 'Auto-escalated: critical priority', escalated_date: '{NOW()}', status: 'escalated' },
       },
     },
-    {
-      id: 'create_task', type: 'create_record', label: 'Create Follow-up Task',
-      config: {
-        objectName: 'crm_task',
-        fields: {
-          subject: 'Follow up on escalated case: {caseRecord.case_number}',
-          related_to_type: 'crm_case',
-          related_to_case: '{record.id}',
-          owner: '{caseRecord.owner}',
-          priority: 'high', status: 'not_started', due_date: '{TODAY() + 1}',
-        },
-      },
-    },
+    // No `create_task` node here: the escalation write above flips `status` to
+    // `escalated`, which fires the `case_status_side_effects` hook — the single
+    // owner of escalation follow-up tasks (it also covers the `escalate_case`
+    // action and the SLA monitor). A second task node here produced duplicate,
+    // disagreeing tasks (case owner/high vs account owner/urgent) per escalation.
     {
       // ADR-0012: the dedicated `notify` node dispatches through the messaging
       // service (inbox + email + push). The legacy `script` + `actionType:'email'`
       // shape is a no-op stub in 7.4 and never delivered anything.
+      // Owner only: `{caseRecord.owner.manager}` cannot traverse a lookup in
+      // flow templates — it interpolates to the literal "undefined".
       id: 'notify_team', type: 'notify', label: 'Notify Support Team',
       config: {
         // Owner only. Flow templates cannot traverse a lookup (see the note on
@@ -85,7 +88,7 @@ export const CaseEscalationFlow: Flow = {
         severity: 'critical',
         topic: 'case_escalated',
         title: 'Case escalated: {caseRecord.case_number}',
-        body: 'Case {caseRecord.case_number} ({caseRecord.priority}) has been escalated. See the case for account and SLA details.',
+        body: 'Case {caseRecord.case_number} ({caseRecord.priority}) has been auto-escalated on critical priority. It remains assigned to you.',
         actionUrl: '/crm_case/{record.id}',
       },
     },
@@ -95,9 +98,8 @@ export const CaseEscalationFlow: Flow = {
   edges: [
     { id: 'e1', source: 'start', target: 'get_case', type: 'default' },
     { id: 'e2', source: 'get_case', target: 'assign_senior_agent', type: 'default' },
-    { id: 'e3', source: 'assign_senior_agent', target: 'create_task', type: 'default' },
-    { id: 'e4', source: 'create_task', target: 'notify_team', type: 'default' },
-    { id: 'e5', source: 'notify_team', target: 'end', type: 'default' },
+    { id: 'e3', source: 'assign_senior_agent', target: 'notify_team', type: 'default' },
+    { id: 'e4', source: 'notify_team', target: 'end', type: 'default' },
   ],
 };
 
@@ -105,8 +107,8 @@ export const CaseEscalationFlow: Flow = {
  * Insert-time twin of `case_escalation`: a record-change flow binds exactly one
  * hook event, so the afterUpdate flow above never sees cases that are BORN
  * critical (phone-in P1s — the common path). Same nodes/edges, only the start
- * node is rebound to afterInsert. The `status != "escalated"` guard carries
- * over untouched.
+ * node is rebound to afterInsert. The `escalated_date == null` + status guard
+ * carries over untouched (a case born critical has neither).
  */
 export const CaseEscalationOnCreateFlow: Flow = {
   ...CaseEscalationFlow,

--- a/src/flows/case-sla-monitor.flow.ts
+++ b/src/flows/case-sla-monitor.flow.ts
@@ -9,12 +9,12 @@ type Flow = Automation.Flow;
  * Complements `case_escalation` (which reacts to *priority* the moment a case
  * is saved) by adding the missing *time* dimension. The schema carries
  * `sla_due_date` and `is_sla_violated`, but nothing watched the clock — a case
- * could silently blow its SLA. This flow sweeps open cases whose `sla_due_date`
- * has passed without resolution, stamps the breach, escalates, and alerts the
- * owner and their manager.
+ * could silently blow its SLA. This flow sweeps open (not resolved/closed)
+ * cases whose `sla_due_date` has passed, stamps the breach, escalates, and
+ * alerts the owner.
  *
  * Capabilities exercised: scheduled trigger + `loop` + `update_record` +
- * `notify` to a manager chain.
+ * `notify`.
  */
 export const CaseSlaMonitorFlow: Flow = {
   name: 'case_sla_monitor',
@@ -35,7 +35,15 @@ export const CaseSlaMonitorFlow: Flow = {
       id: 'query_breached', type: 'get_record', label: 'Find Breached Cases',
       config: {
         objectName: 'crm_case',
-        filter: { is_closed: false, is_sla_violated: false, sla_due_date: { $lt: '{NOW()}' } },
+        // `$nin` (not `is_closed: false`): a case in `resolved` has met its SLA —
+        // work is finished — but `is_closed` only flips on `closed`, so the old
+        // filter stamped false breaches on resolved cases and dragged them back
+        // to `escalated`.
+        filter: {
+          status: { $nin: ['resolved', 'closed'] },
+          is_sla_violated: false,
+          sla_due_date: { $lt: '{NOW()}' },
+        },
         limit: 500,
         outputVariable: 'caseList',
       },
@@ -52,11 +60,24 @@ export const CaseSlaMonitorFlow: Flow = {
               config: {
                 objectName: 'crm_case',
                 filter: { id: '{currentCase.id}' },
-                fields: { is_sla_violated: true, is_escalated: true, status: 'escalated', escalated_date: '{NOW()}' },
+                // `escalation_reason` must accompany `is_escalated: true` — the
+                // object's `escalation_reason_required` validation (severity:
+                // error) rejects the whole write otherwise, turning this sweep
+                // into a silent no-op (cf. the same fix in case_escalation).
+                fields: {
+                  is_sla_violated: true,
+                  is_escalated: true,
+                  status: 'escalated',
+                  escalated_date: '{NOW()}',
+                  escalation_reason: 'Auto-escalated: SLA due date breached',
+                },
               },
             },
             {
-              id: 'notify_team', type: 'notify', label: 'Alert Owner & Manager',
+              // Owner only: `{currentCase.owner.manager}` cannot traverse a
+              // lookup in flow templates — it interpolates to the literal
+              // "undefined" (cf. case_escalation / opportunity_won_alert).
+              id: 'notify_team', type: 'notify', label: 'Alert Owner',
               config: {
                 // Owner only — `{currentCase.owner.manager}` dot-walks a
                 // lookup, which flow templates interpolate as "undefined".

--- a/src/flows/contact-welcome.flow.ts
+++ b/src/flows/contact-welcome.flow.ts
@@ -4,29 +4,44 @@ import type * as Automation from '@objectstack/spec/automation';
 type Flow = Automation.Flow;
 
 /**
- * Contact welcome — record-change flow on contact insert.
+ * New-contact alert — record-change flow on contact insert.
  *
  * Migrated from the removed `welcome_email` object workflow (7.7 dropped
- * `workflows[]`; on-create automation is now a `record_change` flow). Sends a
- * welcome notification to the new contact.
+ * `workflows[]`; on-create automation is now a `record_change` flow).
+ *
+ * Notifies the OWNER, not the contact: `notify` addresses platform users —
+ * a raw email address is stored verbatim as an inbox user_id and reaches
+ * nobody (the same phantom-audience bug fixed in lead_assignment). A true
+ * outbound welcome email to the contact needs an email connector action, not
+ * an inbox notification.
+ *
+ * Gated on `email_opt_out != true` so an opted-out contact triggers no
+ * outreach prompt, and skipped entirely when there is no owner to notify.
  */
 export const ContactWelcomeFlow: Flow = {
   name: 'contact_welcome',
   label: 'Contact Welcome',
-  description: 'On new contact: send a welcome notification.',
+  description: 'On new contact: prompt the owner to welcome them.',
   type: 'record_change',
   status: 'active',
   variables: [],
   nodes: [
-    { id: 'start', type: 'start', label: 'Start (contact created)', config: { objectName: 'crm_contact', triggerType: 'record-after-create' } },
     {
-      id: 'send_welcome', type: 'notify', label: 'Send Welcome',
+      id: 'start', type: 'start', label: 'Start (contact created)',
       config: {
-        to: ['{record.email}'],
-        channels: ['email'],
+        objectName: 'crm_contact',
+        triggerType: 'record-after-create',
+        condition: 'record.owner != null && record.email_opt_out != true',
+      },
+    },
+    {
+      id: 'send_welcome', type: 'notify', label: 'Prompt Owner to Welcome',
+      config: {
+        to: ['{record.owner}'],
+        channels: ['inbox', 'email'],
         topic: 'contact_welcome',
-        title: 'Welcome, {record.first_name} {record.last_name}',
-        body: 'Thanks for connecting with us, {record.first_name} {record.last_name}. Your account team will be in touch shortly.',
+        title: 'New contact: {record.first_name} {record.last_name}',
+        body: '{record.first_name} {record.last_name} was added as a contact. Reach out to welcome them.',
         actionUrl: '/crm_contact/{record.id}',
       },
     },

--- a/src/flows/contract-renewal.flow.ts
+++ b/src/flows/contract-renewal.flow.ts
@@ -35,13 +35,16 @@ export const ContractRenewalFlow: Flow = {
   nodes: [
     { id: 'start', type: 'start', label: 'Start (daily 08:00)', config: { schedule: '0 8 * * *' } },
     {
-      // Broad pre-filter (next 60 days); the per-record notice window is
-      // applied in the decision node below so each contract honours its own
-      // renewal_notice_days.
+      // Broad pre-filter (next 120 days — must cover the LARGEST
+      // renewal_notice_days in use, seeds go up to 90); the per-record notice
+      // window is applied in the decision node below so each contract honours
+      // its own renewal_notice_days. A pre-filter narrower than the largest
+      // notice period silently truncates it (a 90-day contract was invisible
+      // until 60 days out).
       id: 'query_contracts', type: 'get_record', label: 'Find Expiring Contracts',
       config: {
         objectName: 'crm_contract',
-        filter: { status: 'activated', end_date: { $gte: '{TODAY()}', $lte: '{TODAY() + 60}' } },
+        filter: { status: 'activated', end_date: { $gte: '{TODAY()}', $lte: '{TODAY() + 120}' } },
         limit: 500,
         outputVariable: 'contractList',
       },
@@ -56,6 +59,27 @@ export const ContractRenewalFlow: Flow = {
             {
               id: 'check_notice_window', type: 'decision', label: 'Within Notice Window?',
               config: { condition: 'timestamp(currentContract.end_date) <= daysFromNow(int(currentContract.renewal_notice_days))' },
+            },
+            {
+              // Idempotency gate: the sweep matches the same contract every
+              // day of its notice window — without this it created a duplicate
+              // task + notification (and, below, a duplicate pipeline-inflating
+              // renewal opportunity) per day. An open renewal task for this
+              // contract means this window was already handled.
+              id: 'find_existing_task', type: 'get_record', label: 'Already Reminded?',
+              config: {
+                objectName: 'crm_task',
+                filter: {
+                  related_to_account: '{currentContract.crm_account}',
+                  subject: 'Renewal due: contract {currentContract.contract_number}',
+                  status: { $nin: ['completed'] },
+                },
+                outputVariable: 'existingRenewalTask',
+              },
+            },
+            {
+              id: 'check_not_reminded', type: 'decision', label: 'First Reminder?',
+              config: { condition: 'existingRenewalTask == null' },
             },
             {
               id: 'create_renewal_task', type: 'create_record', label: 'Create Renewal Task',
@@ -87,6 +111,25 @@ export const ContractRenewalFlow: Flow = {
               config: { condition: 'currentContract.auto_renewal == true' },
             },
             {
+              // Second gate: never open a second renewal opportunity while one
+              // is still in flight for this account (belt-and-braces for the
+              // case where the task was completed but the deal is still open).
+              id: 'find_existing_renewal_opp', type: 'get_record', label: 'Open Renewal Deal Exists?',
+              config: {
+                objectName: 'crm_opportunity',
+                filter: {
+                  crm_account: '{currentContract.crm_account}',
+                  type: 'existing_renewal',
+                  stage: { $nin: ['closed_won', 'closed_lost'] },
+                },
+                outputVariable: 'existingRenewalOpp',
+              },
+            },
+            {
+              id: 'check_no_open_renewal', type: 'decision', label: 'No Open Renewal Deal?',
+              config: { condition: 'existingRenewalOpp == null' },
+            },
+            {
               id: 'create_renewal_opp', type: 'create_record', label: 'Open Renewal Opportunity',
               config: {
                 objectName: 'crm_opportunity',
@@ -104,12 +147,16 @@ export const ContractRenewalFlow: Flow = {
             },
           ],
           edges: [
-            // Only act when inside the per-contract notice window; "Not yet" paths
-            // simply have no edge, so the loop moves to the next item.
-            { id: 'b1', source: 'check_notice_window', target: 'create_renewal_task', type: 'conditional', condition: 'timestamp(currentContract.end_date) <= daysFromNow(int(currentContract.renewal_notice_days))', label: 'In window' },
-            { id: 'b2', source: 'create_renewal_task', target: 'notify_owner', type: 'default' },
-            { id: 'b3', source: 'notify_owner', target: 'check_auto_renewal', type: 'default' },
-            { id: 'b4', source: 'check_auto_renewal', target: 'create_renewal_opp', type: 'conditional', condition: 'currentContract.auto_renewal == true', label: 'Auto-renew' },
+            // Only act when inside the per-contract notice window; gates with
+            // no matching edge simply end the iteration, so the loop moves on.
+            { id: 'b1', source: 'check_notice_window', target: 'find_existing_task', type: 'conditional', condition: 'timestamp(currentContract.end_date) <= daysFromNow(int(currentContract.renewal_notice_days))', label: 'In window' },
+            { id: 'b2', source: 'find_existing_task', target: 'check_not_reminded', type: 'default' },
+            { id: 'b3', source: 'check_not_reminded', target: 'create_renewal_task', type: 'conditional', condition: 'existingRenewalTask == null', label: 'First reminder' },
+            { id: 'b4', source: 'create_renewal_task', target: 'notify_owner', type: 'default' },
+            { id: 'b5', source: 'notify_owner', target: 'check_auto_renewal', type: 'default' },
+            { id: 'b6', source: 'check_auto_renewal', target: 'find_existing_renewal_opp', type: 'conditional', condition: 'currentContract.auto_renewal == true', label: 'Auto-renew' },
+            { id: 'b7', source: 'find_existing_renewal_opp', target: 'check_no_open_renewal', type: 'default' },
+            { id: 'b8', source: 'check_no_open_renewal', target: 'create_renewal_opp', type: 'conditional', condition: 'existingRenewalOpp == null', label: 'Open renewal deal' },
           ],
         },
       },

--- a/src/flows/demo-bootstrap.flow.ts
+++ b/src/flows/demo-bootstrap.flow.ts
@@ -80,6 +80,11 @@ const TARGETS = [
   claim('opportunities', 'crm_opportunity', 'Opportunities'),
   claim('cases', 'crm_case', 'Cases'),
   claim('tasks', 'crm_task', 'Tasks'),
+  // Quotes and contracts are seeded ownerless too — without claiming them the
+  // contract_renewal / contract_expiration / quote_expiration notifies address
+  // a null owner and reach nobody (the exact failure this flow exists to fix).
+  claim('quotes', 'crm_quote', 'Quotes'),
+  claim('contracts', 'crm_contract', 'Contracts'),
 ];
 
 /**

--- a/src/flows/index.ts
+++ b/src/flows/index.ts
@@ -11,7 +11,7 @@ export { EscalateCaseFlow, CloseCaseFlow } from './case-actions.flow';
 export { LeadConversionFlow } from './lead-conversion.flow';
 export { ScheduleFollowUpFlow } from './schedule-followup.flow';
 export { DemoBootstrapFlow } from './demo-bootstrap.flow';
-export { OpportunityApprovalFlow } from './opportunity-approval.flow';
+export { OpportunityApprovalFlow, OpportunityApprovalOnCreateFlow } from './opportunity-approval.flow';
 export { QuoteGenerationFlow } from './quote-generation.flow';
 // Time/event-driven automation (scheduled + wait-node + record-change)
 export { ContractRenewalFlow } from './contract-renewal.flow';
@@ -34,7 +34,7 @@ import { EscalateCaseFlow, CloseCaseFlow } from './case-actions.flow';
 import { LeadConversionFlow } from './lead-conversion.flow';
 import { ScheduleFollowUpFlow } from './schedule-followup.flow';
 import { DemoBootstrapFlow } from './demo-bootstrap.flow';
-import { OpportunityApprovalFlow } from './opportunity-approval.flow';
+import { OpportunityApprovalFlow, OpportunityApprovalOnCreateFlow } from './opportunity-approval.flow';
 import { QuoteGenerationFlow } from './quote-generation.flow';
 import { ContractRenewalFlow } from './contract-renewal.flow';
 import { CaseSlaMonitorFlow } from './case-sla-monitor.flow';
@@ -61,6 +61,7 @@ export const allFlows: Flow[] = [
   ScheduleFollowUpFlow,
   DemoBootstrapFlow,
   OpportunityApprovalFlow,
+  OpportunityApprovalOnCreateFlow,
   QuoteGenerationFlow,
   // Time/event-driven automation
   ContractRenewalFlow,

--- a/src/flows/lead-assignment.flow.ts
+++ b/src/flows/lead-assignment.flow.ts
@@ -27,7 +27,7 @@ type Flow = Automation.Flow;
 export const LeadAssignmentFlow: Flow = {
   name: 'lead_assignment',
   label: 'New Lead Routing & SLA',
-  description: 'On new lead: set a rating-based follow-up SLA and route to the sales-manager queue.',
+  description: 'On new lead: set a rating-based follow-up SLA and alert the lead owner.',
   type: 'record_change',
   status: 'active',
 

--- a/src/flows/lead-conversion.flow.ts
+++ b/src/flows/lead-conversion.flow.ts
@@ -85,14 +85,16 @@ export const LeadConversionFlow: Flow = {
       config: { assignments: { accountId: '{matchedAccount.id}' } },
     },
     {
-      // Contact dedupe: within the (possibly reused) account, look for a contact
-      // with the same email before creating one — mirrors the account dedupe so
-      // re-converting a known person doesn't spawn a duplicate contact. Leads
-      // require an email, so the match key is reliable.
+      // Contact dedupe by email — GLOBAL, not per-account: crm_contact carries
+      // a global unique index on `email`, so an account-scoped lookup missed a
+      // same-email contact under another account, and the subsequent
+      // create_contact then exploded on the DB index AFTER the account was
+      // already created (orphaning it). Leads require an email, so the match
+      // key is reliable.
       id: 'find_contact', type: 'get_record', label: 'Find Existing Contact',
       config: {
         objectName: 'crm_contact',
-        filter: { email: '{leadRecord.email}', crm_account: '{accountId}' },
+        filter: { email: '{leadRecord.email}' },
         outputVariable: 'matchedContact',
       },
     },
@@ -135,8 +137,21 @@ export const LeadConversionFlow: Flow = {
           amount: '{opportunityAmount}', stage: 'prospecting', probability: 10,
           lead_source: '{leadRecord.lead_source}', close_date: '{TODAY() + 90}', owner: '{$User.Id}',
         },
-        outputVariable: 'opportunityId',
+        outputVariable: 'createdOpportunity',
       },
+    },
+    {
+      // Normalize both opportunity branches onto a single `opportunityId`
+      // (same pattern as accountId/contactId): on the "No" branch the create
+      // node never ran, so referencing `{createdOpportunity.id}` directly in
+      // mark_converted interpolated an unresolved placeholder into the
+      // converted_opportunity lookup.
+      id: 'use_new_opportunity', type: 'assignment', label: 'Use New Opportunity',
+      config: { assignments: { opportunityId: '{createdOpportunity.id}' } },
+    },
+    {
+      id: 'no_opportunity', type: 'assignment', label: 'No Opportunity',
+      config: { assignments: { opportunityId: null } },
     },
     {
       id: 'mark_converted', type: 'update_record', label: 'Mark Lead as Converted',
@@ -148,7 +163,7 @@ export const LeadConversionFlow: Flow = {
           // per the lead_status_progression state machine).
           is_converted: true, status: 'converted', converted_date: '{NOW()}',
           converted_account: '{accountId}', converted_contact: '{contactId}',
-          converted_opportunity: '{opportunityId.id}',
+          converted_opportunity: '{opportunityId}',
         },
       },
     },
@@ -188,8 +203,10 @@ export const LeadConversionFlow: Flow = {
     { id: 'e14', source: 'use_new_contact', target: 'decision_opportunity', type: 'default' },
     { id: 'e15', source: 'use_existing_contact', target: 'decision_opportunity', type: 'default' },
     { id: 'e16', source: 'decision_opportunity', target: 'create_opportunity', type: 'default', condition: 'vars.createOpportunity == true', label: 'Yes' },
-    { id: 'e17', source: 'decision_opportunity', target: 'mark_converted', type: 'default', condition: 'vars.createOpportunity != true', label: 'No' },
-    { id: 'e18', source: 'create_opportunity', target: 'mark_converted', type: 'default' },
+    { id: 'e17', source: 'decision_opportunity', target: 'no_opportunity', type: 'default', condition: 'vars.createOpportunity != true', label: 'No' },
+    { id: 'e18', source: 'create_opportunity', target: 'use_new_opportunity', type: 'default' },
+    { id: 'e18a', source: 'use_new_opportunity', target: 'mark_converted', type: 'default' },
+    { id: 'e18b', source: 'no_opportunity', target: 'mark_converted', type: 'default' },
     { id: 'e19', source: 'mark_converted', target: 'send_notification', type: 'default' },
     { id: 'e20', source: 'send_notification', target: 'end', type: 'default' },
   ],

--- a/src/flows/opportunity-approval.flow.ts
+++ b/src/flows/opportunity-approval.flow.ts
@@ -53,7 +53,13 @@ export const OpportunityApprovalFlow: Flow = {
         // Null-tolerant: rows inserted before approval_status had a field-level
         // defaultValue (e.g. flow-created opportunities) carry null, which must
         // still enter approval.
-        condition: 'record.amount > 100000 && (record.approval_status == "not_required" || record.approval_status == null)',
+        // Stage guard: a settled deal must never (re-)enter approval — the
+        // freeze hook rejects approval-status writes on closed records, so
+        // without this guard the flow opened a locked approval request it
+        // could never resolve (lockRecord held the closed record hostage).
+        condition:
+          'record.amount > 100000 && (record.approval_status == "not_required" || record.approval_status == null)'
+          + ' && record.stage != "closed_won" && record.stage != "closed_lost"',
       },
     },
     {
@@ -185,4 +191,26 @@ export const OpportunityApprovalFlow: Flow = {
     { id: 'e11', source: 'mark_rejected', target: 'notify_rejected', type: 'default' },
     { id: 'e12', source: 'notify_rejected', target: 'end', type: 'default' },
   ],
+};
+
+/**
+ * Insert-time twin of `opportunity_approval`: a record-change flow binds
+ * exactly one hook event, so the afterUpdate flow above never saw
+ * opportunities BORN over the threshold — flow-created deals (contract
+ * renewals, lead conversion) and API inserts skipped approval entirely,
+ * which is the exact population the start condition's null-tolerance was
+ * written for. Same nodes/edges, only the start node is rebound to
+ * afterInsert (mirrors `CaseEscalationOnCreateFlow`). The stage guard
+ * carries over, keeping seeded/imported closed deals out of approval.
+ */
+export const OpportunityApprovalOnCreateFlow: Flow = {
+  ...OpportunityApprovalFlow,
+  name: 'opportunity_approval_on_create',
+  label: 'Large Deal Approval (on create)',
+  description: 'Approval intake for opportunities created above the threshold (insert-time twin of opportunity_approval).',
+  nodes: OpportunityApprovalFlow.nodes.map((n) =>
+    n.id === 'start'
+      ? { ...n, config: { ...n.config, triggerType: 'record-after-create' } }
+      : n,
+  ),
 };

--- a/src/flows/opportunity-stagnation.flow.ts
+++ b/src/flows/opportunity-stagnation.flow.ts
@@ -8,8 +8,10 @@ type Flow = Automation.Flow;
  *
  * The opportunity carries `days_in_stage`, but nothing acted on it, so deals
  * could sit untouched in a stage indefinitely. This daily sweep finds open
- * opportunities stalled longer than the threshold, nudges the owner (and their
- * manager) and books a follow-up task so the deal re-enters the working set.
+ * opportunities stalled longer than the threshold, nudges the owner and books
+ * a follow-up task so the deal re-enters the working set. A deal with an
+ * open stall task is skipped (idempotency), so each stall episode produces
+ * exactly one nudge; completing the task re-arms it.
  *
  * Capabilities exercised: scheduled trigger + `loop` + `notify` + task
  * creation. Pipeline-hygiene automation is one of the highest-ROI uses of
@@ -52,10 +54,31 @@ export const OpportunityStagnationFlow: Flow = {
         body: {
           nodes: [
             {
-              id: 'notify_owner', type: 'notify', label: 'Nudge Owner & Manager',
+              // Idempotency gate: a still-open stall task means this deal was
+              // already nudged. Without this the daily sweep re-notified and
+              // re-created an identical task every morning for as long as the
+              // deal stayed stalled (unbounded duplicate pile-up).
+              id: 'find_existing_task', type: 'get_record', label: 'Already Nudged?',
               config: {
-                // Owner only — `{currentOpp.owner.manager}` dot-walks a
-                // lookup, which flow templates interpolate as "undefined".
+                objectName: 'crm_task',
+                filter: {
+                  related_to_opportunity: '{currentOpp.id}',
+                  subject: 'Advance stalled deal: {currentOpp.name}',
+                  status: { $nin: ['completed'] },
+                },
+                outputVariable: 'existingStallTask',
+              },
+            },
+            {
+              id: 'check_not_nudged', type: 'decision', label: 'First Nudge?',
+              config: { condition: 'existingStallTask == null' },
+            },
+            {
+              // Owner only: `{currentOpp.owner.manager}` cannot traverse a
+              // lookup in flow templates — it interpolates to the literal
+              // "undefined" (cf. opportunity_won_alert).
+              id: 'notify_owner', type: 'notify', label: 'Nudge Owner',
+              config: {
                 to: ['{currentOpp.owner}'],
                 channels: ['inbox', 'email'],
                 topic: 'deal_stalled',
@@ -80,7 +103,10 @@ export const OpportunityStagnationFlow: Flow = {
             },
           ],
           edges: [
-            { id: 'b1', source: 'notify_owner', target: 'create_followup_task', type: 'default' },
+            { id: 'b1', source: 'find_existing_task', target: 'check_not_nudged', type: 'default' },
+            // "Already nudged" has no edge, so the loop moves to the next item.
+            { id: 'b2', source: 'check_not_nudged', target: 'notify_owner', type: 'conditional', condition: 'existingStallTask == null', label: 'First nudge' },
+            { id: 'b3', source: 'notify_owner', target: 'create_followup_task', type: 'default' },
           ],
         },
       },

--- a/src/flows/opportunity-won-alert.flow.ts
+++ b/src/flows/opportunity-won-alert.flow.ts
@@ -27,7 +27,12 @@ export const OpportunityWonAlertFlow: Flow = {
       config: {
         objectName: 'crm_opportunity',
         triggerType: 'record-after-update',
-        condition: 'record.stage == "closed_won" && record.amount > 100000',
+        // `previous.stage` guard: fire on the TRANSITION into closed_won only.
+        // Without it every later edit of a won deal (demo-bootstrap owner
+        // claims, approval-status stamps, description tweaks) re-sent the
+        // congratulations blast. The trigger forwards `previous` into the
+        // condition scope (cf. the engine's record-change context).
+        condition: 'record.stage == "closed_won" && previous.stage != "closed_won" && record.amount > 100000',
       },
     },
     {

--- a/src/flows/quote-generation.flow.ts
+++ b/src/flows/quote-generation.flow.ts
@@ -55,6 +55,14 @@ export const QuoteGenerationFlow: Flow = {
       },
     },
     {
+      // Advance to `proposal` only from a PRE-proposal stage (the state
+      // machine allows `→ proposal` from all three). Re-writing `proposal` on
+      // a deal already at proposal/negotiation was an illegal self/backward
+      // transition — those deals keep their stage; the quote is still created.
+      id: 'check_stage', type: 'decision', label: 'Can Advance to Proposal?',
+      config: { condition: 'oppRecord.stage == "prospecting" || oppRecord.stage == "qualification" || oppRecord.stage == "needs_analysis"' },
+    },
+    {
       id: 'update_opportunity', type: 'update_record', label: 'Update Opportunity',
       config: {
         // No `last_activity_date` write: crm_opportunity has no such field
@@ -83,7 +91,9 @@ export const QuoteGenerationFlow: Flow = {
     { id: 'e1', source: 'start', target: 'screen_1', type: 'default' },
     { id: 'e2', source: 'screen_1', target: 'get_opportunity', type: 'default' },
     { id: 'e3', source: 'get_opportunity', target: 'create_quote', type: 'default' },
-    { id: 'e4', source: 'create_quote', target: 'update_opportunity', type: 'default' },
+    { id: 'e4', source: 'create_quote', target: 'check_stage', type: 'default' },
+    { id: 'e4a', source: 'check_stage', target: 'update_opportunity', type: 'conditional', condition: 'oppRecord.stage == "prospecting" || oppRecord.stage == "qualification" || oppRecord.stage == "needs_analysis"', label: 'Advance' },
+    { id: 'e4b', source: 'check_stage', target: 'notify_owner', type: 'conditional', condition: 'oppRecord.stage != "prospecting" && oppRecord.stage != "qualification" && oppRecord.stage != "needs_analysis"', label: 'Keep stage' },
     { id: 'e5', source: 'update_opportunity', target: 'notify_owner', type: 'default' },
     { id: 'e6', source: 'notify_owner', target: 'end', type: 'default' },
   ],

--- a/src/flows/task-urgent-alert.flow.ts
+++ b/src/flows/task-urgent-alert.flow.ts
@@ -23,7 +23,11 @@ export const TaskUrgentAlertFlow: Flow = {
       config: {
         objectName: 'crm_task',
         triggerType: 'record-after-create',
-        condition: 'record.priority == "urgent" && record.is_completed != true',
+        // Gate on the `status` enum, not the `is_completed` boolean: on
+        // SQLite/libsql booleans persist as integer 1, so `is_completed != true`
+        // is `1 != true` = always true and the guard never trips (cf. the same
+        // hazard documented in case_escalation).
+        condition: 'record.priority == "urgent" && record.status != "completed"',
       },
     },
     {

--- a/src/objects/account.hook.ts
+++ b/src/objects/account.hook.ts
@@ -32,7 +32,11 @@ const accountHook: Hook = {
 
     // Stamp last_activity_date when ownership or type changes (migrated from the
     // removed `update_last_activity` object workflow — 7.7 dropped workflows[]).
-    if (event === 'beforeUpdate') {
+    // USER writes only (`ctx.user?.id` — this repo's system-write signal, cf.
+    // opportunity/quote hooks): the demo_bootstrap flow claims ownerless seeded
+    // accounts as a system write every 10 minutes, and stamping those flattened
+    // every seeded activity date to "today", emptying the churn report buckets.
+    if (event === 'beforeUpdate' && ctx.user?.id) {
       const prev = ctx.previous ?? {};
       const ownerChanged = typeof input.owner !== 'undefined' && input.owner !== prev.owner;
       const typeChanged = typeof input.type !== 'undefined' && input.type !== prev.type;

--- a/src/objects/campaign.hook.ts
+++ b/src/objects/campaign.hook.ts
@@ -60,23 +60,18 @@ const campaignCompleted: Hook = {
       (typeof previous?.id === 'string' ? (previous.id as string) : undefined);
     if (!id) return;
 
-    const [
-      leads,
-      convertedLeads,
-      opportunities,
-      wonOpps,
-      members,
-      responded,
-      sent,
-      wonOppRecords,
-    ] = await Promise.all([
-      api.object('crm_lead').count({ filter: { campaign: id } }),
-      api.object('crm_lead').count({ filter: { campaign: id, is_converted: true } }),
+    // Lead attribution goes through the `crm_campaign_member` junction —
+    // `crm_lead` has NO `campaign` field, so the old direct-count queries
+    // (`crm_lead.count({ campaign: id })`) matched nothing and every lead
+    // metric snapshot was silently zero.
+    const [memberRows, opportunities, wonOpps, wonOppRecords] = await Promise.all([
+      api.object('crm_campaign_member').find({
+        filter: { crm_campaign: id },
+        fields: ['crm_lead', 'status'],
+        top: 5000,
+      }),
       api.object('crm_opportunity').count({ filter: { crm_campaign: id } }),
       api.object('crm_opportunity').count({ filter: { crm_campaign: id, stage: 'closed_won' } }),
-      api.object('crm_campaign_member').count({ filter: { crm_campaign: id } }),
-      api.object('crm_campaign_member').count({ filter: { crm_campaign: id, status: 'responded' } }),
-      api.object('crm_campaign_member').count({ filter: { crm_campaign: id, status: 'sent' } }),
       api.object('crm_opportunity').find({
         filter: { crm_campaign: id, stage: 'closed_won' },
         fields: ['amount'],
@@ -84,17 +79,33 @@ const campaignCompleted: Hook = {
       }),
     ]);
 
+    const members = memberRows.length;
+    const responded = memberRows.filter((r) => r.status === 'responded').length;
+    const leadIds = Array.from(
+      new Set(
+        memberRows
+          .map((r) => (typeof r.crm_lead === 'string' ? r.crm_lead : ''))
+          .filter(Boolean),
+      ),
+    );
+    const convertedLeads =
+      leadIds.length > 0
+        ? await api.object('crm_lead').count({ filter: { id: { $in: leadIds }, is_converted: true } })
+        : 0;
+
     const actualRevenue = wonOppRecords.reduce((sum, row) => {
       const amt = typeof row.amount === 'number' ? row.amount : Number(row.amount) || 0;
       return sum + amt;
     }, 0);
 
     await api.object('crm_campaign').update(id, {
-      num_leads: leads,
+      num_leads: leadIds.length,
       num_converted_leads: convertedLeads,
       num_opportunities: opportunities,
       num_won_opportunities: wonOpps,
-      num_sent: sent || members,
+      // "Total members enrolled" — the single definition of num_sent. The old
+      // `sent || members` under-counted as members progressed past `sent`.
+      num_sent: members,
       num_responses: responded,
       actual_revenue: actualRevenue,
     });

--- a/src/objects/campaign.object.ts
+++ b/src/objects/campaign.object.ts
@@ -121,11 +121,15 @@ export const Campaign = ObjectSchema.create({
       min: 0,
     }),
     
+    // NOT `readonly` (here and on the num_* snapshot fields below): the
+    // campaign_snapshot_metrics hook writes these through the data API, and
+    // 16.x drops writes to readonly fields (#2948) — same reason num_sent was
+    // already opened up. With readonly on, the completion snapshot silently
+    // persisted nothing but num_sent.
     actual_revenue: Field.currency({ 
       label: 'Actual Revenue',
       scale: 2,
       min: 0,
-      readonly: true,
     }),
     
     // Metrics
@@ -135,8 +139,8 @@ export const Campaign = ObjectSchema.create({
       min: 0,
     }),
     
-    // NOT `readonly`: the campaign_enrollment flow writes this rollup
-    // (16.x drops readonly writes, #2948).
+    // NOT `readonly`: the campaign_snapshot_metrics hook writes this rollup
+    // (16.x drops readonly writes, #2948). Definition: total members enrolled.
     num_sent: Field.number({
       label: 'Number Sent',
       min: 0,
@@ -145,31 +149,26 @@ export const Campaign = ObjectSchema.create({
     num_responses: Field.number({
       label: 'Number of Responses',
       min: 0,
-      readonly: true,
     }),
     
     num_leads: Field.number({
       label: 'Number of Leads',
       min: 0,
-      readonly: true,
     }),
     
     num_converted_leads: Field.number({
       label: 'Converted Leads',
       min: 0,
-      readonly: true,
     }),
     
     num_opportunities: Field.number({
       label: 'Opportunities Created',
       min: 0,
-      readonly: true,
     }),
     
     num_won_opportunities: Field.number({
       label: 'Won Opportunities',
       min: 0,
-      readonly: true,
     }),
     
     // Calculated Metrics (Formula Fields)

--- a/src/objects/campaign_member.object.ts
+++ b/src/objects/campaign_member.object.ts
@@ -76,9 +76,11 @@ export const CampaignMember = ObjectSchema.create({
       ],
     }),
 
+    // NOT `readonly`: the campaign_enrollment flow writes this stamp, and
+    // 16.x drops writes to readonly fields (#2948) — every member landed with
+    // a null Added Date while the flag was on.
     added_date: Field.datetime({
       label: 'Added Date',
-      readonly: true,
       group: 'response',
     }),
 

--- a/src/objects/case.hook.ts
+++ b/src/objects/case.hook.ts
@@ -7,7 +7,8 @@ import type { HookApi } from './_hook-api';
  * Case SLA & escalation hook.
  *
  * - For `critical` cases without `sla_due_date`, sets a 4-hour SLA.
- * - On escalation: creates a follow-up task assigned to the account owner.
+ * - On escalation: creates a follow-up task assigned to the account owner
+ *   (the single owner of escalation tasks — flows must not create their own).
  * - On `resolved`: stamps `closed_date` (proxy for the resolution time — there is
  *   no resolved_date field) and bumps account `last_activity_date`.
  */
@@ -127,12 +128,12 @@ const caseSideEffects: Hook = {
       });
     }
 
-    // Resolution rollup
+    // Resolution rollup. Note: no date is stamped here — `closed_date` belongs
+    // exclusively to the `closed` transition (stamped by `case_sla_defaults`).
+    // The old "closed_date as a proxy for resolved_date" write both corrupted
+    // resolution metrics (a resolved-then-closed case kept its resolve time as
+    // its close time) and re-entered the record-change trigger surface.
     if (input.status === 'resolved' && previous.status !== 'resolved') {
-      if (caseId && !input.closed_date && !previous.closed_date) {
-        // Use closed_date as a proxy for resolved_date (schema field).
-        await api.object('crm_case').update(caseId, { closed_date: new Date().toISOString() });
-      }
       if (accountId) {
         await api.object('crm_account').update(accountId, {
           last_activity_date: new Date().toISOString().slice(0, 10),

--- a/src/objects/contact.hook.ts
+++ b/src/objects/contact.hook.ts
@@ -6,63 +6,47 @@ import type { HookApi } from './_hook-api';
 /**
  * Contact integrity hook.
  *
- * - On insert/update, dedupes by `email` within the same `crm_account`.
- * - On email/phone change, propagates the new value to opportunities where this
- *   contact is the `primary_contact` (best-effort rollup).
+ * - On insert/update, dedupes by `email` GLOBALLY — matching the schema's
+ *   global unique index on `email`. (The old per-account lookup let a
+ *   cross-account duplicate sail past the friendly check and explode on the
+ *   DB index instead, mid-conversion.)
  * - On delete, refuses if the contact is referenced by an active opportunity,
  *   open quote or active contract.
+ *
+ * No email/phone propagation to opportunities: `crm_opportunity` has no
+ * `contact_email` / `contact_phone` columns — the old afterUpdate rollup
+ * wrote nonexistent fields and was silently swallowed. Opportunities reach
+ * the live values through their `primary_contact` lookup.
  */
 
 const contactHook: Hook = {
   name: 'contact_integrity',
   object: 'crm_contact',
-  events: ['beforeInsert', 'beforeUpdate', 'afterUpdate', 'beforeDelete'],
+  events: ['beforeInsert', 'beforeUpdate', 'beforeDelete'],
   priority: 200,
   description:
-    'Dedupe contacts per account, propagate contact info to linked opportunities, and protect referenced contacts from deletion.',
+    'Dedupe contacts by email and protect referenced contacts from deletion.',
   handler: async (ctx: HookContext) => {
     const { event, input } = ctx;
     const api = ctx.api as HookApi | undefined;
 
     if ((event === 'beforeInsert' || event === 'beforeUpdate') && api) {
       const email = typeof input.email === 'string' ? input.email.toLowerCase() : '';
-      const account = typeof input.crm_account === 'string' ? input.crm_account : ctx.previous?.crm_account;
-      if (email && account) {
+      if (email) {
         input.email = email;
+        // GLOBAL lookup (no account scope): the unique index on `email` is
+        // global, so this guard must be at least as strict to fire first with
+        // a readable error.
         const dup = await api.object('crm_contact').findOne({
-          where: { email, crm_account: account },
+          where: { email },
         });
         const dupId = (dup as { id?: string } | null)?.id;
         const selfId = ctx.previous?.id ?? input.id;
         if (dup && dupId !== selfId) {
           throw new Error(
-            `Another contact (${dupId}) with email ${email} already exists in this account.`,
+            `Another contact (${dupId}) with email ${email} already exists.`,
           );
         }
-      }
-    }
-
-    if (event === 'afterUpdate' && api) {
-      const previous = ctx.previous;
-      const id = previous?.id ?? input.id;
-      if (!id) return;
-      const patch: Record<string, unknown> = {};
-      if (typeof input.email === 'string' && input.email !== previous?.email) {
-        patch.contact_email = input.email;
-      }
-      if (typeof input.phone === 'string' && input.phone !== previous?.phone) {
-        patch.contact_phone = input.phone;
-      }
-      if (Object.keys(patch).length === 0) return;
-      try {
-        await api.object('crm_opportunity').updateMany({
-          where: { primary_contact: id },
-          doc: patch,
-        });
-      } catch {
-        // Best-effort propagation — never break the parent write. No `console`
-        // in the L2 hook sandbox (QuickJS): a log call here would throw its own
-        // ReferenceError and mask the real failure (cf. lead_auto_assign / #471).
       }
     }
 

--- a/src/objects/contract.hook.ts
+++ b/src/objects/contract.hook.ts
@@ -8,13 +8,14 @@ import type { HookApi } from './_hook-api';
  *
  * - Validates `end_date` ≈ `start_date + contract_term_months`.
  * - Rejects shrinking `end_date` after activation.
- * - On `activated`: stamps `signed_date` (if missing), promotes the account to `customer`,
- *   and schedules a renewal task 60 days before `end_date`.
- *
- * Helpers (monthsBetween, addDays) are declared INSIDE each handler body — L2
- * hook bodies run body-only in the QuickJS sandbox, so module scope is not
- * visible at runtime. See opportunity.hook.ts for the full rationale.
+ * - On `activated`: stamps `signed_date` (if missing) and promotes the account
+ *   to `customer`. Renewal reminders are owned by the `contract_renewal` flow.
  */
+
+// NB: helpers used by handlers are declared INSIDE each handler — L2 hook
+// bodies run body-only in the QuickJS sandbox, so module scope is not
+// available at runtime (cf. opportunity.hook.ts). Module-level copies were
+// dead code that invited silent divergence.
 
 const contractValidation: Hook = {
   name: 'contract_validation',
@@ -88,12 +89,6 @@ const contractActivation: Hook = {
     const api = ctx.api as HookApi | undefined;
     if (!api) return;
 
-    function addDays(iso: string, days: number): string {
-      const d = new Date(iso);
-      d.setDate(d.getDate() + days);
-      return d.toISOString().slice(0, 10);
-    }
-
     const id =
       (typeof input.id === 'string' && input.id) ||
       (typeof previous?.id === 'string' ? (previous.id as string) : undefined);
@@ -117,22 +112,10 @@ const contractActivation: Hook = {
       }
     }
 
-    if (endDate) {
-      const renewalDue = addDays(endDate, -60);
-      await api.object('crm_task').insert({
-        subject: `Renewal review for contract ${id ?? ''}`.trim(),
-        status: 'not_started',
-        priority: 'high',
-        type: 'follow_up',
-        due_date: renewalDue,
-        owner:
-          (typeof input.owner === 'string' && input.owner) ||
-          (typeof previous?.owner === 'string' && previous.owner) ||
-          ctx.user?.id,
-        related_to_type: 'crm_account',
-        related_to_account: accountId,
-      });
-    }
+    // No renewal task here: renewal reminders are owned by the
+    // `contract_renewal` scheduled flow, which honours the per-contract
+    // `renewal_notice_days`. The activation-time task this hook used to
+    // create hardcoded a 60-day notice and duplicated the flow's task.
   },
 };
 

--- a/src/objects/lead.hook.ts
+++ b/src/objects/lead.hook.ts
@@ -9,11 +9,13 @@ import type { HookApi } from './_hook-api';
  * - Auto-scores incoming leads into `rating` (1-5) using industry/title/email/phone weights.
  * - Refuses edits to a converted lead.
  * - When status flips to `qualified`, schedules a follow-up `crm_task` for the current user.
- *
- * Helpers (computeRating etc.) are declared INSIDE each handler body — L2 hook
- * bodies run body-only in the QuickJS sandbox, so module scope is not visible
- * at runtime. See opportunity.hook.ts for the full rationale.
  */
+
+// NB: the scoring constants + computeRating live INSIDE lead_automation's
+// handler — L2 hook bodies run body-only in the QuickJS sandbox, so module
+// scope is not available at runtime. A module-level copy previously lived
+// here too; it was dead code that silently diverged from the copy that
+// actually runs, so it was removed. Tune the weights in the handler.
 
 /**
  * Lead auto-assignment (load-balanced round-robin).
@@ -32,12 +34,18 @@ import type { HookApi } from './_hook-api';
  * Runs beforeInsert so the downstream lead_assignment flow (afterInsert) sees
  * the assigned owner and routes its SLA alert to that rep. Territory-based
  * routing is a future extension on top of this pool query.
+ *
+ * Priority 250 — hooks run in ASCENDING priority order, so this must run
+ * AFTER `lead_automation` (200): its guest branch strips a client-spoofed
+ * `owner` from anonymous Web-to-Lead submissions. At the old priority 150
+ * this hook assigned an owner first and the guest strip then deleted it,
+ * landing every web-to-lead ownerless — the exact case this hook exists for.
  */
 const leadAutoAssignHook: Hook = {
   name: 'lead_auto_assign',
   object: 'crm_lead',
   events: ['beforeInsert'],
-  priority: 150,
+  priority: 250,
   description: 'Assign ownerless new leads to the least-loaded sales rep.',
   handler: async (ctx: HookContext) => {
     const { input } = ctx;
@@ -115,8 +123,10 @@ const leadHook: Hook = {
       if (HIGH_VALUE_INDUSTRIES.has(industry)) score += 1;
       if (employees >= 200) score += 0.5;
       if (revenue >= 10_000_000) score += 0.5;
+      // Cap at 5, floor at 1, round to WHOLE stars — `rating` is a 1-5 star
+      // field; half values rendered inconsistently in the star widget.
       const clamped = Math.max(1, Math.min(5, score));
-      return Math.round(clamped * 2) / 2;
+      return Math.round(clamped);
     }
 
     if (event === 'beforeInsert') {
@@ -144,10 +154,31 @@ const leadHook: Hook = {
       }
     }
 
-    if (event === 'beforeUpdate') {
+    // Converted-lead lock — USER edits only (`ctx.user?.id` is this repo's
+    // system-write signal, cf. opportunity/quote/account hooks): a blanket
+    // throw also rejected system writes (demo-bootstrap owner claims, flow
+    // backfills) and blocked ALL fields, far beyond the schema's own
+    // `cannot_edit_converted` validation (identity fields only). Narrative
+    // notes and framework-managed columns stay editable; identity and
+    // conversion fields stay locked.
+    if (event === 'beforeUpdate' && ctx.user?.id) {
       const previous = ctx.previous;
-      if (previous?.is_converted === true || previous?.status === 'converted') {
-        throw new Error('Cannot edit a converted lead. Make changes on the converted records instead.');
+      const wasConverted = previous?.is_converted === true || previous?.status === 'converted';
+      if (wasConverted) {
+        const ALLOWED = new Set([
+          'description', 'notes',
+          // Framework-managed / system columns (cf. opportunity.hook.ts).
+          'id', 'owner', 'owner_id', 'created_at', 'updated_at',
+          'created_by', 'updated_by', 'space_id', 'organization_id', 'org_id', 'version',
+        ]);
+        const violating = Object.keys(input).filter(
+          (k) => !ALLOWED.has(k) && input[k] !== previous?.[k],
+        );
+        if (violating.length > 0) {
+          throw new Error(
+            `Cannot edit a converted lead (attempted: ${violating.join(', ')}). Make changes on the converted records instead.`,
+          );
+        }
       }
     }
 

--- a/src/objects/opportunity.hook.ts
+++ b/src/objects/opportunity.hook.ts
@@ -43,6 +43,11 @@ const opportunityValidationHook: Hook = {
       'id', 'owner', 'owner_id', 'created_at', 'updated_at',
       'created_by', 'updated_by', 'space_id', 'organization_id', 'org_id', 'version',
     ]);
+    // Approval verdicts must be allowed to land even if the deal closes while
+    // the request is in flight — the opportunity_approval flow writes these
+    // via the user-context resume, and rejecting them left the record locked
+    // with a permanently pending approval.
+    const APPROVAL_FIELDS = new Set(['approval_status', 'approved_date']);
     // Stage → forecast category (migrated from the removed
     // `set_forecast_category_by_stage` object workflow — 7.7 dropped workflows[]).
     const STAGE_FORECAST: Record<string, string> = {
@@ -74,7 +79,7 @@ const opportunityValidationHook: Hook = {
       const isClosed = prevStage === 'closed_won' || prevStage === 'closed_lost';
       if (isClosed) {
         const violating = Object.keys(input).filter(
-          (k) => !NARRATIVE_FIELDS.has(k) && !SYSTEM_FIELDS.has(k) && input[k] !== previous[k],
+          (k) => !NARRATIVE_FIELDS.has(k) && !SYSTEM_FIELDS.has(k) && !APPROVAL_FIELDS.has(k) && input[k] !== previous[k],
         );
         if (violating.length > 0) {
           throw new Error(
@@ -114,6 +119,12 @@ const opportunityValidationHook: Hook = {
       // Stamp close_date when transitioning into closed_won
       if (input.stage === 'closed_won' && previous.stage !== 'closed_won' && !input.close_date) {
         input.close_date = new Date().toISOString().slice(0, 10);
+      }
+      // Reset the stage-age counter on any stage change so a deal that
+      // advances stops matching the stagnation sweep. (Readonly fields are
+      // writable from before-hooks via input mutation.)
+      if (typeof input.stage === 'string' && input.stage !== previous.stage) {
+        input.days_in_stage = 0;
       }
     }
   },

--- a/src/objects/opportunity.object.ts
+++ b/src/objects/opportunity.object.ts
@@ -315,10 +315,17 @@ export const Opportunity = ObjectSchema.create({
       message: 'Invalid opportunity stage transition',
       field: 'stage',
       transitions: {
-        prospecting: ['qualification', 'closed_lost'],
-        qualification: ['needs_analysis', 'closed_lost'],
+        // `→ proposal` is legal from every pre-proposal stage: the
+        // quote_generation flow fast-forwards the deal to `proposal` when a
+        // quote is generated, which can happen at any open stage.
+        prospecting: ['qualification', 'proposal', 'closed_lost'],
+        qualification: ['needs_analysis', 'proposal', 'closed_lost'],
         needs_analysis: ['proposal', 'closed_lost'],
-        proposal: ['negotiation', 'closed_lost'],
+        // `proposal → closed_won` is legal: the quote_on_accepted hook closes
+        // the linked deal directly from the CPQ path (quote_generation parks
+        // the opportunity at `proposal`; an accepted quote wins it without a
+        // separate negotiation step).
+        proposal: ['negotiation', 'closed_won', 'closed_lost'],
         negotiation: ['closed_won', 'closed_lost'],
         closed_won: [],
         closed_lost: [],

--- a/src/objects/product.hook.ts
+++ b/src/objects/product.hook.ts
@@ -8,8 +8,9 @@ import type { HookApi } from './_hook-api';
  *
  * - Enforces `list_price >= cost`.
  * - Normalizes `sku` to uppercase.
- * - Refuses delete when the product is referenced by an active opportunity or quote;
- *   suggests deactivating instead.
+ * - Refuses delete when the product is referenced by ANY opportunity or quote
+ *   line item (historical included — deals keep their line history); suggests
+ *   deactivating (`is_active=false`) instead.
  */
 
 const productHook: Hook = {

--- a/src/objects/quote.hook.ts
+++ b/src/objects/quote.hook.ts
@@ -9,11 +9,11 @@ import type { HookApi } from './_hook-api';
  * - Defaults `expiration_date` to `quote_date + 30 days` when missing.
  * - Freezes quotes once `accepted` or `expired`.
  * - On `accepted`, drafts a contract and pushes the linked opportunity to `closed_won`.
- *
- * Helpers (addDays) are declared INSIDE each handler body — L2 hook bodies run
- * body-only in the QuickJS sandbox, so module scope is not visible at runtime.
- * See opportunity.hook.ts for the full rationale.
  */
+
+// NB: helpers used by handlers are declared INSIDE each handler — L2 hook
+// bodies run body-only in the QuickJS sandbox, so module scope is not
+// available at runtime (cf. opportunity.hook.ts).
 
 const quoteValidation: Hook = {
   name: 'quote_workflow',
@@ -83,9 +83,11 @@ const quoteAccepted: Hook = {
     const api = ctx.api as HookApi | undefined;
     if (!api) return;
 
-    function addDays(iso: string, days: number): string {
+    // Real calendar months — `days * 30` shorted a 12-month term by ~5 days
+    // and only slipped past contract_validation's ±1-month tolerance by luck.
+    function addMonths(iso: string, months: number): string {
       const d = new Date(iso);
-      d.setDate(d.getDate() + days);
+      d.setMonth(d.getMonth() + months);
       return d.toISOString().slice(0, 10);
     }
 
@@ -119,7 +121,7 @@ const quoteAccepted: Hook = {
       status: 'draft',
       contract_term_months: months,
       start_date: today,
-      end_date: addDays(today, months * 30),
+      end_date: addMonths(today, months),
       contract_value: totalPrice,
       contract_type: 'subscription',
       description: `Auto-drafted from accepted quote ${quoteId ?? ''}`.trim(),

--- a/src/objects/task.hook.ts
+++ b/src/objects/task.hook.ts
@@ -8,7 +8,8 @@ import type { HookApi } from './_hook-api';
  *
  * - On `completed` transition, stamps `completed_date` and `progress_percent=100`.
  * - Warns when `reminder_date` is after `due_date`.
- * - Bubbles `last_activity_date` to the polymorphic parent (account/opportunity/lead).
+ * - Bubbles activity to the polymorphic parent (account `last_activity_date`,
+ *   lead `last_contacted_date`).
  */
 
 const taskValidation: Hook = {
@@ -22,10 +23,9 @@ const taskValidation: Hook = {
     const previous = ctx.previous;
 
     // Land `reminder_sent` as a real boolean on insert, never NULL. The
-    // task_due_reminder sweep filters `reminder_sent != true`, and SQL's
-    // three-valued logic means NULL rows never match `!= true` — so without
-    // this, freshly-created tasks (column defaulted at the schema layer but
-    // stored NULL) would never be picked up by the reminder sweep.
+    // task_due_reminder sweep de-dups on `reminder_date` (cleared after each
+    // send), not on this flag — but keep it a real boolean so the audit trail
+    // and any future `!= true` filter behave under SQL three-valued logic.
     if (!previous && input.reminder_sent == null) {
       input.reminder_sent = false;
     }
@@ -68,7 +68,7 @@ const taskValidation: Hook = {
       (typeof input.due_date === 'string' && input.due_date) ||
       (typeof previous?.due_date === 'string' && (previous.due_date as string)) ||
       undefined;
-    if (reminder && due && reminder.slice(0, 10) > due) {
+    if (reminder && due && reminder.slice(0, 10) > due.slice(0, 10)) {
       throw new Error(
         `Reminder (${reminder}) is after the due date (${due}); reminders should fire before the deadline.`,
       );
@@ -208,10 +208,17 @@ const taskBubble: Hook = {
       undefined;
     if (!targetId) return;
 
-    // Only bubble to objects that have a `last_activity_date` field (account/lead).
-    if (targetType !== 'crm_account' && targetType !== 'crm_lead') return;
+    // Only bubble to objects that carry an activity timestamp, and use each
+    // object's own field: `crm_lead` has no `last_activity_date` — its activity
+    // signal is `last_contacted_date` (a datetime, so pass full ISO).
+    const activityWriteByType: Record<string, Record<string, string>> = {
+      crm_account: { last_activity_date: today },
+      crm_lead: { last_contacted_date: new Date().toISOString() },
+    };
+    const activityWrite = activityWriteByType[targetType];
+    if (!activityWrite) return;
     try {
-      await api.object(targetType).update(targetId, { last_activity_date: today });
+      await api.object(targetType).update(targetId, activityWrite);
     } catch {
       // Best-effort activity bubble; never break the parent write. No `console`
       // in the L2 hook sandbox (would throw ReferenceError — cf. #471).

--- a/src/objects/task.object.ts
+++ b/src/objects/task.object.ts
@@ -170,13 +170,13 @@ export const Task = ObjectSchema.create({
       readonly: true,
     }),
 
-    // Set by the `task_due_reminder` schedule flow once a reminder has fired,
-    // so the hourly sweep never re-alerts the same task. Reset to false if you
-    // push `reminder_date` into the future.
+    // Set by the `task_due_reminder` schedule flow once a reminder has fired
+    // (the sweep de-dups on `reminder_date`, which it clears; this flag is the
+    // audit trail). NOT readonly: 16.x drops flow writes to readonly fields
+    // (#2948) — same reason crm_case.is_sla_violated/escalated_date are open.
     reminder_sent: Field.boolean({
       label: 'Reminder Sent',
       defaultValue: false,
-      readonly: true,
     }),
 
     // Progress


### PR DESCRIPTION
Refs objectstack-ai/hotcrm#489 — deliberately **not** an auto-closing reference: one item from that issue is only half-addressed here (see "Knowingly left open" below), so #489 stays open to carry it.

Cross-audit of all 14 object hooks and 19 flows; 20+ runtime-level defects fixed in two commits. All silent at test level — full `pnpm verify` (validate + typecheck + build + 97 tests) passes before and after.

## Conflicts (hook vs flow fighting over the same job)
- Case escalation created duplicate follow-up tasks (flow + hook, disagreeing on owner/priority); hook is now the single task creator.
- Contract activation hook hardcoded a 60-day renewal task, duplicating the renewal flow that honours per-contract `renewal_notice_days`; flow owns renewals now.
- `lead_auto_assign` (priority 150) ran before the guest-sanitize branch (200) that deletes spoofed owners — every web-to-lead landed ownerless; moved to 250.
- `num_sent` had two conflicting writers; single definition (total members) owned by the snapshot hook.

## Broken automation
- Case SLA monitor's escalation write was rejected by the `escalation_reason_required` validation — the whole hourly sweep was a silent no-op.
- Campaign metrics counted leads via nonexistent `crm_lead.campaign`; now via the `crm_campaign_member` junction. Six metric fields un-readonly'd (16.x drops readonly writes, #2948).
- Contact hook pushed nonexistent `contact_email/contact_phone` onto opportunities; task hook wrote `last_activity_date` onto leads (no such field).
- `campaign_enrollment` was a cron whose input variables were never seeded; converted to a screen flow launched from a new "Enroll Leads" action, with dedupe and opt-out filtering.

## Runaway triggers / missing idempotency
- Critical cases re-escalated forever (could never be worked, resolved, or closed); guard now excludes terminal states and already-escalated cases.
- `contract_renewal` created a duplicate task, notification and pipeline-inflating renewal opportunity every day of the notice window; now idempotent. Same for `opportunity_stagnation`.
- `opportunity_won_alert` re-fired on every edit of a won deal; now transition-gated.
- Approval flow locked closed deals forever and never saw flow/API-created deals; stage guard + on-create twin + freeze-hook allowance for approval verdicts.

Plus: real calendar months in quote→contract drafting, legal state-machine transitions for the CPQ path, global contact dedupe matching the unique index, `mass_update_stage` update() signature, notify audiences that actually resolve, and doc drift fixes.

## Knowingly left open (why this is `Refs`, not `Fixes`)

**`days_in_stage` still has no daily incrementer.** #489 reported that the field has no writer at all, so `opportunity_stagnation`'s `days_in_stage > 14` filter only ever matched seeded demo rows. This PR adds a *reset* to `0` on stage change (`opportunity.hook.ts`), which is the correct half of the behaviour — but nothing advances the counter afterwards. It is a plain `Field.number`, not a formula, and `crm_opportunity` has no stage-entry timestamp to compute from, so on real data the field stays `0` and the stagnation sweep still never fires.

The proper fix is schema-shaped: add a `stage_entry_date` written by the hook on stage change, and redefine `days_in_stage` as a formula over it (cheaper and more accurate than a nightly full-table sweep). That is a bigger, team-visible change than this PR's scope, so #489 stays open to track it rather than being auto-closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LHy7fZ3xA2M4SmvPSwj2w

