### PR TITLE
Remove legacy string rowActions that duplicate list_item auto-injection

### DIFF
--- a/.changeset/remove-legacy-string-rowactions.md
+++ b/.changeset/remove-legacy-string-rowactions.md
@@ -1,0 +1,7 @@
+---
+'hotcrm': patch
+---
+
+Remove legacy string `rowActions` entries that duplicated `list_item` auto-injection.
+
+Actions declaring `locations: ['list_item']` (`convert_lead`, `schedule_followup`, `generate_quote`, `escalate_case`) auto-inject their row-menu entries. Naming them again as `rowActions` strings went through objectui's legacy path, which dispatches the string as an action *type* — producing a second, dead menu item (zero network requests plus a green success toast on click). The lead, opportunity, and case list views now keep only the built-in `edit`/`delete` affordances in `rowActions`, and a metadata guard test fails CI if a `rowActions` string ever shadows a `list_item` action again.

--- a/src/views/case.view.ts
+++ b/src/views/case.view.ts
@@ -55,9 +55,11 @@ export const CaseViews = defineView({
       { name: 'at_risk', label: 'SLA at Risk', icon: 'clock-alert', view: 'sla_at_risk' },
       { name: 'mine', label: 'My Cases', icon: 'user', view: 'my_open_cases' },
     ],
-    // Escalate straight from the queue — the action already declared
-    // `list_item` placement but no case view surfaced it.
-    rowActions: ['edit', 'escalate_case'],
+    // Escalate straight from the queue: escalate_case's own `locations:
+    // ['list_item']` auto-injects the row-menu item. Do not repeat it here as
+    // a string — the legacy rowActions path dispatches the string as an
+    // action TYPE, yielding a duplicate, dead entry (objectui#2960).
+    rowActions: ['edit'],
   },
 
   listViews: {

--- a/src/views/lead.view.ts
+++ b/src/views/lead.view.ts
@@ -84,11 +84,13 @@ export const LeadViews = defineView({
       view: 'detail_form', // Use named form view
     },
     
-    // List Actions — every name here must be a defined Action (or a built-in
-    // edit/delete). The previous mass_update / mass_delete / assign_owner
-    // referenced actions that were never defined, so the toolbar buttons did
-    // nothing.
-    rowActions: ['edit', 'delete', 'convert_lead', 'schedule_followup'],
+    // List Actions — built-ins only. `convert_lead` / `schedule_followup`
+    // must NOT be repeated here: they already declare `locations:
+    // ['list_item']` on their Action defs, which auto-injects the menu item.
+    // A string entry here goes through the legacy rowActions path (the string
+    // is dispatched as an action TYPE — objectstack-ai/objectui#2960), which
+    // produced a second, dead "Convert Lead" item next to the working one.
+    rowActions: ['edit', 'delete'],
     // Built-in `exportOptions` covers CSV export; no export action needed.
     bulkActions: ['create_campaign'],
     

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -70,12 +70,14 @@ export const OpportunityViews = defineView({
       { name: 'stale', label: 'Stale', icon: 'triangle-alert', view: 'stale_opportunities' },
       { name: 'closing', label: 'Closing Soon', icon: 'calendar-check', view: 'closing_this_quarter' },
     ],
-    // List-level entry points: generate_quote runs per row (its flow needs
-    // one recordId); mass_update_stage stays wired even though console
-    // 16.1.0 cannot deliver bulk selections yet (tracked in issue #508 — see
-    // the note in opportunity.actions.ts). Built-in `exportOptions` covers
-    // CSV export.
-    rowActions: ['edit', 'generate_quote'],
+    // List-level entry points: generate_quote reaches the row menu via its
+    // own `locations: ['list_item']` — repeating it here as a string would go
+    // through the legacy rowActions path and render a duplicate, dead item
+    // (objectstack-ai/objectui#2960). mass_update_stage stays wired even
+    // though console 16.1.0 cannot deliver bulk selections yet (tracked in
+    // issue #508 — see the note in opportunity.actions.ts). Built-in
+    // `exportOptions` covers CSV export.
+    rowActions: ['edit'],
     bulkActions: ['mass_update_stage'],
   },
 

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -503,6 +503,28 @@ describe('list-level action references resolve', () => {
     }
     expect(bad, `dangling list action references:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
+
+  it('no rowAction repeats an action that already declares list_item placement', () => {
+    // An Action with `locations: ['list_item']` auto-injects its row-menu
+    // entry. Naming it AGAIN as a rowActions string goes through objectui's
+    // legacy path, which dispatches the string as an action TYPE — producing
+    // a second, dead menu item (issue #535 / objectstack-ai/objectui#2960).
+    const listItemActions = new Set(
+      actions.filter((a) => (a.locations ?? []).includes('list_item')).map((a) => a.name),
+    );
+    const bad: string[] = [];
+    for (const v of views) {
+      const lists = [v.list, ...Object.values(v.listViews ?? {})].filter(Boolean) as AnyRec[];
+      for (const list of lists) {
+        for (const name of list.rowActions ?? []) {
+          if (typeof name === 'string' && listItemActions.has(name)) {
+            bad.push(`view "${list.name ?? 'default'}": "${name}" duplicates its list_item auto-injection`);
+          }
+        }
+      }
+    }
+    expect(bad, `redundant string rowActions:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
 });
 
 describe('row colors and kanban groups key off real option values', () => {


### PR DESCRIPTION
## Description

The lead list's row menu showed two conversion entries: the working one auto-injected by the object-level `convert_lead` Action (via `locations: ['list_item']`), plus a dead "Convert Lead" from the view's string entry `rowActions: ['convert_lead']`. objectui's legacy string-rowActions path dispatches the string as an action *type* (objectstack-ai/objectui#2960), so clicking it made zero network requests but still flashed a green success toast.

The sweep requested in #535 found the same redundant-string pattern in the opportunity and case views (`generate_quote` and `escalate_case` both declare `list_item` too). All three views now keep only the built-in `edit`/`delete` affordances in `rowActions`. `bulkActions` are untouched — the issue and objectui#2960 are specific to the row-menu `list_item` path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] CI/CD update

## Related Issues

Fixes #535
Related to #524, objectstack-ai/objectui#2960

## Changes Made

- `src/views/lead.view.ts` — removed `'convert_lead'` and `'schedule_followup'` from `rowActions`; both Actions declare `locations: ['list_item']` (`lead.actions.ts`), so both were duplicated as dead entries
- `src/views/opportunity.view.ts` — removed `'generate_quote'` (declares `list_item` at `opportunity.actions.ts:134`)
- `src/views/case.view.ts` — removed `'escalate_case'` (declares `list_item` at `case.actions.ts:20`); rewrote the comment there, which had claimed the string was needed to surface the action — exactly the misunderstanding #535 corrects
- `test/metadata-references.test.ts` — added a regression guard: no `rowActions` string may name an Action whose `locations` include `list_item`, so this pattern fails CI instead of surfacing as a duplicate menu item in a demo
- `.changeset/remove-legacy-string-rowactions.md` — patch changeset

## Testing

- [x] Unit tests pass (`npm test`) — 90/90, including the new guard
- [x] Linting passes (`npm run lint`) — only pre-existing warnings, none from this change
- [x] Build succeeds (`npm run build`)
- [ ] Manual testing completed
- [x] New tests added (if applicable)

## Screenshots

N/A — metadata-only change; the visible effect is the removal of the duplicate dead "Convert Lead" row-menu item.

## Checklist

- [x] **I have added a changeset** (`pnpm changeset`) — required on every PR, or the `skip-changeset` label is applied
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The fix relies on the documented platform behavior that `locations: ['list_item']` auto-injects the row-menu entry; the platform-side dispatch bug in the legacy string path is tracked separately in objectstack-ai/objectui#2960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYQMcUCirUqbdFjMeDNqpw

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYQMcUCirUqbdFjMeDNqpw)_