### PR TITLE
test(forecast): pin seed calendar alignment behind the This Quarter view (#530)

### DIFF
--- a/.changeset/forecast-seed-alignment-tests.md
+++ b/.changeset/forecast-seed-alignment-tests.md
@@ -1,0 +1,22 @@
+---
+'hotcrm': patch
+---
+
+Add regression tests pinning forecast seed calendar alignment (#530).
+
+The "This Quarter" forecast view rendered empty because seeded quarterly
+snapshots carried relative `period_start` dates (`daysAgo(45)` →
+mid-month values like 2026-06-13) that an exact-match
+`period_start equals {current_quarter_start}` filter can never hit. The
+seeds were rewritten to real calendar periods in #516 and the view's
+unresolvable token filter removed in #515, but nothing in CI guarded the
+invariant — it had already regressed silently once.
+
+`test/forecast-seeds.test.ts` now asserts that every seeded forecast
+snapshot starts exactly on its calendar quarter/month boundary, that
+`period_end` closes the same period, that `period_label` matches the
+dialect `forecast.hook.ts` derives (`Q3 2026` / `Aug 2026`), that a
+snapshot exists for the current calendar quarter (the row any
+this-quarter filter must be able to match), and that `period_label`
+values stay unique since they are the seed upsert identity. Verified to
+fail 6/8 against the pre-#516 seed data.

--- a/test/forecast-seeds.test.ts
+++ b/test/forecast-seeds.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { CrmSeedData } from '../src/data/index';
+
+/**
+ * Forecast seed calendar-alignment guards (#530).
+ *
+ * A "this quarter" filter — whether the list view's old
+ * `period_start equals {this_quarter_start}` or the token-resolving
+ * `{current_quarter_start}` a platform upgrade enables — compares against the
+ * exact first day of the calendar quarter. The original seeds used relative
+ * dates (`daysAgo(45)` → e.g. 2026-06-13), so exact-match could never hit and
+ * the "This Quarter" tab rendered empty for every visitor (#530). The seeds
+ * were rewritten to compute real calendar periods in the hook's dialect;
+ * these tests pin that invariant so it cannot silently drift back.
+ *
+ * All date math is UTC, mirroring both the seed module and
+ * `forecast.hook.ts`. The seed module computes "now" when it is imported and
+ * this file computes "now" when it runs — the same process moments apart — so
+ * the current-quarter assertion is stable except in the pathological case of
+ * a run straddling midnight UTC on a quarter boundary.
+ */
+
+type SeedRec = Record<string, unknown>;
+
+const forecastSeed = CrmSeedData.find((s: any) => s.object === 'crm_forecast') as
+  | { records: SeedRec[] }
+  | undefined;
+
+const records: SeedRec[] = forecastSeed?.records ?? [];
+const quarterRecs = records.filter((r) => r.period === 'quarter');
+const monthRecs = records.filter((r) => r.period === 'month');
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const pad = (n: number) => String(n).padStart(2, '0');
+const isoDate = (d: Date) => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+const parseUtc = (s: string) => new Date(`${s}T00:00:00Z`);
+
+describe('forecast seed periods are calendar-true (#530)', () => {
+  it('the forecast seed dataset exists with quarter and month snapshots', () => {
+    expect(forecastSeed, 'no seed dataset for crm_forecast').toBeDefined();
+    expect(quarterRecs.length).toBeGreaterThanOrEqual(1);
+    expect(monthRecs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('every period_start is a concrete ISO date, not a relative-date macro', () => {
+    const bad = records
+      .filter((r) => typeof r.period_start !== 'string' || !ISO_DATE.test(r.period_start as string))
+      .map((r) => `${r.period_label}: ${String(r.period_start)}`);
+    expect(bad, `non-literal period_start values:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('quarterly snapshots start exactly on a calendar quarter boundary', () => {
+    const bad: string[] = [];
+    for (const r of quarterRecs) {
+      const start = parseUtc(r.period_start as string);
+      if (start.getUTCDate() !== 1 || start.getUTCMonth() % 3 !== 0) {
+        bad.push(`${r.period_label}: period_start ${r.period_start} is not a quarter start`);
+      }
+    }
+    expect(bad, bad.join('\n')).toEqual([]);
+  });
+
+  it('monthly snapshots start on the first of the month', () => {
+    const bad: string[] = [];
+    for (const r of monthRecs) {
+      const start = parseUtc(r.period_start as string);
+      if (start.getUTCDate() !== 1) {
+        bad.push(`${r.period_label}: period_start ${r.period_start} is not a month start`);
+      }
+    }
+    expect(bad, bad.join('\n')).toEqual([]);
+  });
+
+  it('period_end closes the same period that period_start opens', () => {
+    const bad: string[] = [];
+    for (const r of records) {
+      const start = parseUtc(r.period_start as string);
+      const months = r.period === 'quarter' ? 3 : 1;
+      const expected = isoDate(new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + months, 0)));
+      if (r.period_end !== expected) {
+        bad.push(`${r.period_label}: period_end ${String(r.period_end)}, expected ${expected}`);
+      }
+    }
+    expect(bad, bad.join('\n')).toEqual([]);
+  });
+
+  it('period_label matches what forecast.hook.ts would derive from period_start', () => {
+    // Hooks never run over seeds and only fill BLANK labels, so a seeded label
+    // in any other dialect ('This Quarter', 'Q3-2026', …) sticks forever and
+    // list groupings mix vocabularies (#490).
+    const bad: string[] = [];
+    for (const r of records) {
+      const start = parseUtc(r.period_start as string);
+      const expected =
+        r.period === 'quarter'
+          ? `Q${Math.floor(start.getUTCMonth() / 3) + 1} ${start.getUTCFullYear()}`
+          : `${MONTHS[start.getUTCMonth()]} ${start.getUTCFullYear()}`;
+      if (r.period_label !== expected) {
+        bad.push(`${String(r.period_label)}: hook would derive "${expected}"`);
+      }
+    }
+    expect(bad, bad.join('\n')).toEqual([]);
+  });
+
+  it('a quarterly snapshot exists for the current calendar quarter', () => {
+    // The row a "this quarter" equals-filter must be able to hit.
+    const now = new Date();
+    const currentQuarterStart = isoDate(
+      new Date(Date.UTC(now.getUTCFullYear(), Math.floor(now.getUTCMonth() / 3) * 3, 1)),
+    );
+    const hit = quarterRecs.find((r) => r.period_start === currentQuarterStart);
+    expect(
+      hit,
+      `no quarter snapshot with period_start ${currentQuarterStart}; got: ${quarterRecs
+        .map((r) => r.period_start)
+        .join(', ')}`,
+    ).toBeDefined();
+  });
+
+  it('period_label values are unique (they are the upsert identity)', () => {
+    const labels = records.map((r) => String(r.period_label));
+    const dupes = labels.filter((l, i) => labels.indexOf(l) !== i);
+    expect(dupes, `duplicate period_label seeds would clobber each other: ${dupes.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

Issue #530 reports the Forecast "This Quarter" list view is permanently empty: an exact-match `period_start equals {current_quarter_start}` filter (resolving to e.g. `2026-07-01`) can never hit seed rows whose quarterly `period_start` values were relative dates (`daysAgo(45)` → mid-month values like `2026-06-13` / `2026-03-15`).

The underlying defect is already fixed on `main` — landed the same day the issue was filed:

- **#516** (`fdac915`) rewrote the forecast seeds to compute real calendar quarter/month boundaries in TS (UTC, mirroring `forecast.hook.ts`), which is exactly option 1 of the issue's "建议二选一".
- **#515** (`628e413`) removed the view's unresolvable `{this_quarter_start}` token filter (the 16.1 list data path resolves no date macros), so the Quarterly tab now shows all quarter snapshots newest-first.

What was still missing is a CI guard: this invariant regressed silently once, and nothing prevented the seeds from drifting back to relative dates — which would re-empty any this-quarter filter the moment a platform upgrade (e.g. the `upgrade/objectstack-17` branch, where `{current_quarter_start}` does resolve) reintroduces one. This PR adds that guard.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) — new regression tests only
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] CI/CD update

## Related Issues

Fixes #530
Related to #490, #515, #516

## Changes Made

- Added `test/forecast-seeds.test.ts` asserting, for the `crm_forecast` seed dataset:
  - every `period_start` is a concrete ISO date, not a relative-date macro;
  - quarterly snapshots start exactly on a calendar quarter boundary, monthly snapshots on the first of the month;
  - `period_end` closes the same period `period_start` opens;
  - `period_label` matches the dialect `forecast.hook.ts` derives (`Q3 2026` / `Aug 2026`);
  - a quarterly snapshot exists for the **current** calendar quarter — the row any this-quarter equals-filter must be able to match;
  - `period_label` values are unique (they are the seed upsert identity).
- Added changeset `.changeset/forecast-seed-alignment-tests.md`.

## Testing

- [x] Unit tests pass (`npm test`) — 97/97 across 9 files
- [ ] Linting passes (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [x] Manual testing completed — verified the new suite **fails 6/8** when run against the pre-#516 seed data (`fc8716d`), i.e. it catches exactly the regression #530 describes
- [x] New tests added (if applicable)

## Screenshots

N/A — test-only change.

## Checklist

- [x] **I have added a changeset** (`pnpm changeset`) — required on every PR, or the `skip-changeset` label is applied
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The `upgrade/objectstack-17` branch referenced in the issue is not on this remote; it was evidently cut before #515/#516 landed. When that upgrade rebases onto current `main` it inherits calendar-aligned seeds, so a restored `period_start equals {current_quarter_start}` filter will match — and these tests will keep it matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HQV8wzXaypyB3mW3nvVqN

---
_Generated by [Claude Code](https://claude.ai/code/session_016HQV8wzXaypyB3mW3nvVqN)_