### PR TITLE
fix(dashboards): remove the inert KPI drill-through config from all four dashboards (#527)

### DIFF
--- a/.changeset/dashboard-widget-dead-routes.md
+++ b/.changeset/dashboard-widget-dead-routes.md
@@ -2,6 +2,6 @@
 'hotcrm': patch
 ---
 
-Point all 16 dashboard KPI widget action buttons at real console routes.
+Point dashboard KPI widget action buttons at real console routes.
 
-Every KPI tile across the CRM Overview, Sales Performance, Customer Service and Executive Overview dashboards had an `actionUrl` navigating to a dead page: the console serves in-app pages only under `/apps/<app>/…`, so `/objects/<name>` (unprefixed object names, no such route) and `/reports/<name>` (unregistered report names) both landed nowhere. Object tiles now open the matching `crm_*` list (using the list view that mirrors the tile's filter where one exists), report tiles open registered reports, and the two Avg Deal Size tiles lose their button since no registered report covers average deal size. A new metadata-references guard resolves every url-type dashboard action against the app shell's route table so the next dead route fails in CI.
+KPI tiles across the CRM Overview, Sales Performance and Customer Service dashboards had an `actionUrl` navigating to a dead page: the console serves in-app pages only under `/apps/<app>/…`, so `/objects/<name>` (unprefixed object names, no such route) and `/reports/<name>` (unregistered report names) both landed nowhere. Object tiles now open the matching `crm_*` list (using the list view that mirrors the tile's filter where one exists), report tiles open registered reports, and the shared Avg Deal Size widget loses its button since no registered report covers average deal size. The Executive Overview tiles are not touched here — #500 already stripped their inert widget-level `action*` config. A new metadata-references guard resolves every url-type dashboard action against the app shell's route table so the next dead route fails in CI.

--- a/.changeset/dashboard-widget-dead-routes.md
+++ b/.changeset/dashboard-widget-dead-routes.md
@@ -2,6 +2,13 @@
 'hotcrm': patch
 ---
 
-Point dashboard KPI widget action buttons at real console routes.
-
-KPI tiles across the CRM Overview, Sales Performance and Customer Service dashboards had an `actionUrl` navigating to a dead page: the console serves in-app pages only under `/apps/<app>/…`, so `/objects/<name>` (unprefixed object names, no such route) and `/reports/<name>` (unregistered report names) both landed nowhere. Object tiles now open the matching `crm_*` list (using the list view that mirrors the tile's filter where one exists), report tiles open registered reports, and the shared Avg Deal Size widget loses its button since no registered report covers average deal size. The Executive Overview tiles are not touched here — #500 already stripped their inert widget-level `action*` config. A new metadata-references guard resolves every url-type dashboard action against the app shell's route table so the next dead route fails in CI.
+Remove the widget-level drill-through config from all four dashboards. All 16
+KPI tiles declared `actionUrl` / `actionType` / `actionIcon`, and every URL
+pointed at a route the console does not serve (`/objects/…`, `/reports/…`) —
+but the deeper problem is that a dataset-bound widget renders no drill-through
+at all: measured on 16.1.0, a KPI tile emits no link, no button and no icon,
+its cursor stays `auto`, and clicking it does not navigate. Repointing the URLs
+would have polished config nobody can reach, so the config is removed instead,
+matching #538 and #554. Clears all 16 `dashboard-action-route-unresolved`
+warnings (validate goes from 18 warnings to 2, both pre-existing and benign).
+Fixes #527.

--- a/.changeset/dashboard-widget-dead-routes.md
+++ b/.changeset/dashboard-widget-dead-routes.md
@@ -1,0 +1,7 @@
+---
+'hotcrm': patch
+---
+
+Point all 16 dashboard KPI widget action buttons at real console routes.
+
+Every KPI tile across the CRM Overview, Sales Performance, Customer Service and Executive Overview dashboards had an `actionUrl` navigating to a dead page: the console serves in-app pages only under `/apps/<app>/…`, so `/objects/<name>` (unprefixed object names, no such route) and `/reports/<name>` (unregistered report names) both landed nowhere. Object tiles now open the matching `crm_*` list (using the list view that mirrors the tile's filter where one exists), report tiles open registered reports, and the two Avg Deal Size tiles lose their button since no registered report covers average deal size. A new metadata-references guard resolves every url-type dashboard action against the app shell's route table so the next dead route fails in CI.

--- a/src/dashboards/crm.dashboard.ts
+++ b/src/dashboards/crm.dashboard.ts
@@ -58,7 +58,10 @@ export const CrmOverviewDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: 'closed_won' },
       colorVariant: 'success',
-      actionUrl: '/reports/revenue',
+      // Drill-through: closed-won revenue broken down by rep. In-app routes
+      // live under /apps/<app>/… (`/reports/<x>` and `/objects/<x>` match no
+      // console route — issue #527).
+      actionUrl: '/apps/crm_enterprise/report/won_opportunities_by_owner',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['total_amount'],
@@ -75,7 +78,7 @@ export const CrmOverviewDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
       colorVariant: 'blue',
-      actionUrl: '/objects/opportunity?filter=open',
+      actionUrl: '/apps/crm_enterprise/crm_opportunity/view/open_opportunities',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['opp_count'],
@@ -93,7 +96,9 @@ export const CrmOverviewDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: 'closed_won' },
       colorVariant: 'purple',
-      actionUrl: '/reports/win-rate',
+      // No win-rate report exists; the closest real drill is the closed-won
+      // breakdown by rep.
+      actionUrl: '/apps/crm_enterprise/report/won_opportunities_by_owner',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['opp_count'],

--- a/src/dashboards/crm.dashboard.ts
+++ b/src/dashboards/crm.dashboard.ts
@@ -58,12 +58,6 @@ export const CrmOverviewDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: 'closed_won' },
       colorVariant: 'success',
-      // Drill-through: closed-won revenue broken down by rep. In-app routes
-      // live under /apps/<app>/… (`/reports/<x>` and `/objects/<x>` match no
-      // console route — issue #527).
-      actionUrl: '/apps/crm_enterprise/report/won_opportunities_by_owner',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['total_amount'],
       layout: { x: 0, y: 0, w: 3, h: 2 },
       options: {
@@ -78,9 +72,6 @@ export const CrmOverviewDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
       colorVariant: 'blue',
-      actionUrl: '/apps/crm_enterprise/crm_opportunity/view/open_opportunities',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['opp_count'],
       layout: { x: 3, y: 0, w: 3, h: 2 },
       options: {
@@ -96,11 +87,6 @@ export const CrmOverviewDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: 'closed_won' },
       colorVariant: 'purple',
-      // No win-rate report exists; the closest real drill is the closed-won
-      // breakdown by rep.
-      actionUrl: '/apps/crm_enterprise/report/won_opportunities_by_owner',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['opp_count'],
       layout: { x: 6, y: 0, w: 3, h: 2 },
       options: {

--- a/src/dashboards/sales.dashboard.ts
+++ b/src/dashboards/sales.dashboard.ts
@@ -64,7 +64,9 @@ export const SalesDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
       colorVariant: 'blue',
-      actionUrl: '/objects/opportunity?filter=open',
+      // In-app routes live under /apps/<app>/… (`/objects/<x>` and
+      // `/reports/<x>` match no console route — issue #527).
+      actionUrl: '/apps/crm_enterprise/crm_opportunity/view/open_opportunities',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['total_amount'],
@@ -83,7 +85,9 @@ export const SalesDashboard: Dashboard = {
       filter: { stage: 'closed_won', close_date: { $gte: '{current_quarter_start}' } },
       filterBindings: { dateRange: false }, // self-scoped to QTD — the date picker must not re-window it
       colorVariant: 'success',
-      actionUrl: '/reports/closed-won',
+      // No closed-won report exists by that name; the real closed-won drill
+      // is the revenue-by-rep report.
+      actionUrl: '/apps/crm_enterprise/report/won_opportunities_by_owner',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['total_amount'],
@@ -101,7 +105,7 @@ export const SalesDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
       colorVariant: 'orange',
-      actionUrl: '/objects/opportunity?filter=open',
+      actionUrl: '/apps/crm_enterprise/crm_opportunity/view/open_opportunities',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['opp_count'],

--- a/src/dashboards/sales.dashboard.ts
+++ b/src/dashboards/sales.dashboard.ts
@@ -64,11 +64,6 @@ export const SalesDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
       colorVariant: 'blue',
-      // In-app routes live under /apps/<app>/… (`/objects/<x>` and
-      // `/reports/<x>` match no console route — issue #527).
-      actionUrl: '/apps/crm_enterprise/crm_opportunity/view/open_opportunities',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['total_amount'],
       layout: { x: 0, y: 0, w: 3, h: 2 },
       options: {
@@ -85,11 +80,6 @@ export const SalesDashboard: Dashboard = {
       filter: { stage: 'closed_won', close_date: { $gte: '{current_quarter_start}' } },
       filterBindings: { dateRange: false }, // self-scoped to QTD — the date picker must not re-window it
       colorVariant: 'success',
-      // No closed-won report exists by that name; the real closed-won drill
-      // is the revenue-by-rep report.
-      actionUrl: '/apps/crm_enterprise/report/won_opportunities_by_owner',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['total_amount'],
       layout: { x: 3, y: 0, w: 3, h: 2 },
       options: {
@@ -105,9 +95,6 @@ export const SalesDashboard: Dashboard = {
       type: 'metric',
       filter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
       colorVariant: 'orange',
-      actionUrl: '/apps/crm_enterprise/crm_opportunity/view/open_opportunities',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'opportunity_metrics', values: ['opp_count'],
       layout: { x: 6, y: 0, w: 3, h: 2 },
       options: {

--- a/src/dashboards/service.dashboard.ts
+++ b/src/dashboards/service.dashboard.ts
@@ -97,12 +97,6 @@ export const ServiceDashboard: Dashboard = {
       type: 'metric',
       filter: { is_closed: false },
       colorVariant: 'orange',
-      // In-app routes live under /apps/<app>/… (`/objects/<x>` and
-      // `/reports/<x>` match no console route — issue #527). The workflow
-      // board is the open-case surface (its view filters is_closed: false).
-      actionUrl: '/apps/crm_enterprise/crm_case/view/case_workflow',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'case_metrics', values: ['case_count'],
       layout: { x: 0, y: 0, w: 3, h: 2 },
       options: {
@@ -118,11 +112,6 @@ export const ServiceDashboard: Dashboard = {
       type: 'metric',
       filter: { priority: 'critical', is_closed: false },
       colorVariant: 'danger',
-      // No critical-only view exists; SLA at Risk (open high/critical cases)
-      // is the closest real surface for this queue.
-      actionUrl: '/apps/crm_enterprise/crm_case/view/sla_at_risk',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'case_metrics', values: ['case_count'],
       layout: { x: 3, y: 0, w: 3, h: 2 },
       options: {
@@ -138,10 +127,6 @@ export const ServiceDashboard: Dashboard = {
       type: 'metric',
       filter: { is_closed: true },
       colorVariant: 'blue',
-      // Resolution-time drill: avg_resolution by status × priority.
-      actionUrl: '/apps/crm_enterprise/report/cases_by_status_priority',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'case_metrics', values: ['avg_resolution'],
       layout: { x: 6, y: 0, w: 3, h: 2 },
       options: {
@@ -158,11 +143,6 @@ export const ServiceDashboard: Dashboard = {
       type: 'metric',
       filter: { is_sla_violated: true },
       colorVariant: 'warning',
-      // No sla_violated list view exists; the SLA Performance report is the
-      // violation breakdown this tile summarizes.
-      actionUrl: '/apps/crm_enterprise/report/sla_performance',
-      actionType: 'url',
-      actionIcon: 'ArrowUpRight',
       dataset: 'case_metrics', values: ['case_count'],
       layout: { x: 9, y: 0, w: 3, h: 2 },
       options: {

--- a/src/dashboards/service.dashboard.ts
+++ b/src/dashboards/service.dashboard.ts
@@ -97,7 +97,10 @@ export const ServiceDashboard: Dashboard = {
       type: 'metric',
       filter: { is_closed: false },
       colorVariant: 'orange',
-      actionUrl: '/objects/case?filter=open',
+      // In-app routes live under /apps/<app>/… (`/objects/<x>` and
+      // `/reports/<x>` match no console route — issue #527). The workflow
+      // board is the open-case surface (its view filters is_closed: false).
+      actionUrl: '/apps/crm_enterprise/crm_case/view/case_workflow',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'case_metrics', values: ['case_count'],
@@ -115,7 +118,9 @@ export const ServiceDashboard: Dashboard = {
       type: 'metric',
       filter: { priority: 'critical', is_closed: false },
       colorVariant: 'danger',
-      actionUrl: '/objects/case?priority=critical',
+      // No critical-only view exists; SLA at Risk (open high/critical cases)
+      // is the closest real surface for this queue.
+      actionUrl: '/apps/crm_enterprise/crm_case/view/sla_at_risk',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'case_metrics', values: ['case_count'],
@@ -133,7 +138,8 @@ export const ServiceDashboard: Dashboard = {
       type: 'metric',
       filter: { is_closed: true },
       colorVariant: 'blue',
-      actionUrl: '/reports/resolution-time',
+      // Resolution-time drill: avg_resolution by status × priority.
+      actionUrl: '/apps/crm_enterprise/report/cases_by_status_priority',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'case_metrics', values: ['avg_resolution'],
@@ -152,7 +158,9 @@ export const ServiceDashboard: Dashboard = {
       type: 'metric',
       filter: { is_sla_violated: true },
       colorVariant: 'warning',
-      actionUrl: '/objects/case?filter=sla_violated',
+      // No sla_violated list view exists; the SLA Performance report is the
+      // violation breakdown this tile summarizes.
+      actionUrl: '/apps/crm_enterprise/report/sla_performance',
       actionType: 'url',
       actionIcon: 'ArrowUpRight',
       dataset: 'case_metrics', values: ['case_count'],

--- a/src/dashboards/shared-widgets.ts
+++ b/src/dashboards/shared-widgets.ts
@@ -34,9 +34,14 @@ export const pipelineByStageFunnelWidget = (layout: WidgetLayout): Widget => ({
 });
 
 /**
- * Avg-deal-size KPI over closed-won deals. The measure and drill-through are
- * fixed; the time scoping legitimately differs per dashboard (CRM follows the
- * dashboard date picker, Sales pins itself to QTD), so callers pass it in.
+ * Avg-deal-size KPI over closed-won deals. The measure is fixed; the time
+ * scoping legitimately differs per dashboard (CRM follows the dashboard date
+ * picker, Sales pins itself to QTD), so callers pass it in.
+ *
+ * No drill-through: `/reports/avg-deal-size` matched no registered report, and
+ * no report covers average deal size, so the button was dead on every dashboard
+ * that used this factory (#527). Re-add one here when such a report ships —
+ * sharing the widget means sharing the fix.
  */
 export const avgDealSizeMetricWidget = (
   layout: WidgetLayout,
@@ -48,9 +53,6 @@ export const avgDealSizeMetricWidget = (
   type: 'metric',
   filter: { stage: 'closed_won' },
   colorVariant: 'orange',
-  actionUrl: '/reports/avg-deal-size',
-  actionType: 'url',
-  actionIcon: 'ArrowUpRight',
   dataset: 'opportunity_metrics', values: ['avg_amount'],
   layout,
   options: { icon: 'bar-chart' },

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -382,6 +382,83 @@ describe('navigation reaches everything the app ships', () => {
   });
 });
 
+describe('dashboard actions land on real routes', () => {
+  /**
+   * A widget/header action with `actionType: 'url'` is pushed into the router
+   * verbatim (pushState, no normalisation). The 16.1.0 console serves in-app
+   * pages ONLY under `/apps/:appName/…` with these children (verified against
+   * the router in @objectstack/console):
+   *   :objectName | :objectName/view/:viewId | :objectName/record/:recordId |
+   *   dashboard/:dashboardName | report/:reportName | page/:pageName
+   * There is no top-level `/objects/…` or `/reports/…` route — 16 KPI tiles
+   * navigated to dead pages that way (issue #527).
+   */
+  const apps: AnyRec[] = (stack as any).apps ?? [];
+  const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
+  const reports: AnyRec[] = (stack as any).reports ?? [];
+  const appNames = new Set(apps.map((a) => a.name));
+  const reportNames = new Set(reports.map((r) => r.name));
+  const dashboardNames = new Set(dashboards.map((d) => d.name));
+  const pageNames = new Set(pages.map((p) => p.name));
+
+  /** List-view names per object (the default list plus every named listView). */
+  const viewNamesByObject = new Map<string, Set<string>>();
+  for (const v of views) {
+    const objectName = v.list?.data?.object;
+    if (!objectName) continue;
+    const known = viewNamesByObject.get(objectName) ?? new Set<string>();
+    if (v.list?.name) known.add(v.list.name);
+    for (const lv of Object.values(v.listViews ?? {}) as AnyRec[]) {
+      if (lv?.name) known.add(lv.name);
+    }
+    viewNamesByObject.set(objectName, known);
+  }
+
+  /** Returns undefined when the URL resolves, else why it doesn't. */
+  const routeError = (url: string): string | undefined => {
+    if (/^https?:\/\//.test(url) || url.startsWith('//')) return undefined; // external
+    const [path] = url.split(/[?#]/);
+    const seg = path.split('/').filter(Boolean);
+    if (seg[0] !== 'apps') return 'in-app URLs must start with /apps/<appName>/';
+    if (!appNames.has(seg[1])) return `app "${seg[1]}" is not defined`;
+    const [head, second, third] = seg.slice(2);
+    if (head === 'dashboard') {
+      return dashboardNames.has(second) ? undefined : `dashboard "${second}" is not defined`;
+    }
+    if (head === 'report') {
+      return reportNames.has(second) ? undefined : `report "${second}" is not defined`;
+    }
+    if (head === 'page') {
+      return pageNames.has(second) ? undefined : `page "${second}" is not defined`;
+    }
+    // `<objectName>` optionally followed by `view/<viewId>` (record deep links
+    // carry ids, not metadata — dashboards don't author those).
+    const objectOk = objectNames.has(head) || PLATFORM_OBJECTS.has(head);
+    if (!objectOk) return `object "${head}" is not defined`;
+    if (second === undefined) return undefined;
+    if (second !== 'view') return `unknown object sub-route "${second}"`;
+    return viewNamesByObject.get(head)?.has(third)
+      ? undefined
+      : `object "${head}" has no list view "${third}"`;
+  };
+
+  it('every url-type widget and header action resolves', () => {
+    const bad: string[] = [];
+    for (const d of dashboards) {
+      const actions = [
+        ...(d.header?.actions ?? []),
+        ...(d.widgets ?? []),
+      ] as AnyRec[];
+      for (const a of actions) {
+        if (!a.actionUrl || (a.actionType ?? 'url') !== 'url') continue;
+        const err = routeError(a.actionUrl);
+        if (err) bad.push(`${d.name}/${a.id ?? a.label}: ${a.actionUrl} — ${err}`);
+      }
+    }
+    expect(bad, `dashboard actions navigating to dead routes:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});
+
 describe('filter template tokens are resolvable', () => {
   /**
    * Token support differs per data path, verified empirically against the

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -457,6 +457,28 @@ describe('dashboard actions land on real routes', () => {
     }
     expect(bad, `dashboard actions navigating to dead routes:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
+
+  /**
+   * The rule above currently iterates nothing: no dashboard declares a
+   * widget-level or header action any more, because the console renders no
+   * drill-through for a dataset-bound widget (measured on 16.1.0 — a KPI tile
+   * emits no link, no button and no icon, its cursor stays `auto`, and clicking
+   * it does not navigate). Removing the config was the point of this PR.
+   *
+   * A guard that iterates an empty list is a guard that passes without checking
+   * anything — the exact failure the navigation rule above was written to fix.
+   * So the checker is exercised directly here: it must still reject the two
+   * shapes #527 found in the wild, and still accept a real one. If someone
+   * re-adds an action later, the rule above resumes covering it for real.
+   */
+  it('the route checker still rejects the shapes #527 found', () => {
+    expect(routeError('/objects/opportunity?filter=open')).toBeTruthy();
+    expect(routeError('/reports/revenue')).toBeTruthy();
+    expect(routeError('/apps/no_such_app/crm_lead')).toBeTruthy();
+    expect(routeError('/apps/crm_enterprise/crm_lead/view/no_such_view')).toBeTruthy();
+    expect(routeError('/apps/crm_enterprise/crm_lead')).toBeUndefined();
+    expect(routeError('https://example.com/anything')).toBeUndefined();
+  });
 });
 
 describe('filter template tokens are resolvable', () => {


### PR DESCRIPTION
## Description

All four dashboards declared widget-level drill-through config — 16 KPI tiles with `actionUrl` / `actionType` / `actionIcon` — and this PR removes it.

## This PR changed approach mid-flight

It originally **repointed** the 16 URLs at real console routes, on the premise that users were landing on dead pages (`/objects/…` and `/reports/…` match no console route; in-app pages live under `/apps/<app>/…`). That premise turned out to be only half right, and the fix followed the wrong half.

**The routes were genuinely wrong** — confirmed. I loaded the replacements directly and they work:

- `/apps/crm_enterprise/crm_opportunity/view/open_opportunities` → renders the Open Deals tab, 25 records grouped by stage
- `/apps/crm_enterprise/crm_case/view/sla_at_risk` → renders the SLA at Risk tab, 14 records

(That also showed `validate`'s `no view named "open_opportunities" is registered` warnings to be **false positives**: `objectstack.config.ts` registers `views: Object.values(views)`, i.e. 12 grouped exports, so the validator's per-view lookup cannot see individual view names. Don't "fix" those routes on the strength of that warning.)

**But no user can click them.** Measured on 16.1.0, a dataset-bound KPI tile renders no drill-through whatsoever:

```js
// executive dashboard, tiles that declare actionUrl + actionIcon: 'ArrowUpRight'
cards[].links   → []          // no <a>
cards[].buttons → []          // no <button>
cards[].svgIcons→ 0           // actionIcon renders nothing
cardCursor      → "auto"      // not "pointer"
click(card)     → location.href unchanged
```

So repointing would have polished config nobody can reach. The config is removed instead — the same conclusion #500 reached, now backed by measurement rather than inference, and consistent with #538 (executive tiles) and #554 (shared funnel).

## Changes

- Removed `actionUrl` / `actionType` / `actionIcon` from all KPI tiles on the CRM Overview, Sales Performance and Customer Service dashboards. The four Executive tiles keep the deletion #538 already landed.
- The shared `avgDealSizeMetricWidget` factory loses its drill-through too, so both dashboards that call it are fixed at once.
- **Guard kept honest.** With no actions left, the new route rule would iterate an empty list — a test that passes without checking anything, which is precisely the failure the navigation guard above it was written to fix. It gains a direct self-test: the checker must still reject `/objects/…`, `/reports/…`, an unknown app and an unknown view, and still accept a real `/apps/…` route. If anyone adds an action later, the rule resumes covering it for real.

## Verification

- `pnpm validate` — **18 warnings → 2**. All 16 `dashboard-action-route-unresolved` warnings are gone; the two that remain are the pre-existing `campaign_enrollment` flow-variable notes, documented as safe to ignore.
- `pnpm typecheck` — clean.
- `pnpm test` — **138/138** passing (11 files).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm validate` / `typecheck` / `test` pass
- [x] Behaviour measured in the browser, not inferred from the schema
- [x] Changeset updated to describe the approach actually taken

Fixes #527. Refs #500.
