### PR TITLE
fix(i18n): stop raw picklist values leaking into rendered names and titles (#461)

### DIFF
--- a/.changeset/contact-name-lowercase-salutation.md
+++ b/.changeset/contact-name-lowercase-salutation.md
@@ -1,0 +1,7 @@
+---
+'hotcrm': patch
+---
+
+Drop the raw salutation value from Contact and Lead name formulas so records no longer render as "ms Emily Davis".
+
+`crm_contact.full_name` (and `crm_lead.full_name` / `display_title`) joined `record.salutation` ahead of the name fields. `salutation` is a picklist, so a formula sees the stored VALUE (`mr`, `ms`, `dr`) rather than the label, and every contact and lead rendered with a lowercase prefix in list views, detail titles, and lookups. The formula language offers no proper-case or option-label lookup, and hardcoding `"Ms."` would bake English into a stored value, so the name is now built from `first_name` + `last_name` alone (the Salesforce convention); `salutation` remains its own field and keeps its translated label on forms and detail pages.

--- a/.changeset/opportunity-title-raw-stage-value.md
+++ b/.changeset/opportunity-title-raw-stage-value.md
@@ -1,0 +1,9 @@
+---
+'hotcrm': patch
+---
+
+Stop the Opportunity record title from rendering the raw `stage` value, and guard the whole picklist-rendering class in CI.
+
+`crm_opportunity.nameField` pointed at a `display_title` formula composed as `record.name + " - " + record.stage`. A formula sees the stored select VALUE, never the translated label, so every deal titled itself "Enterprise Deal - closed_won" in lookup pickers, related lists, breadcrumbs and search results — in every locale. The ADR-0079 migration inherited this from the render-time template `'{name} - {stage}'`, which could resolve the label; a formula cannot. `nameField` is now the plain `name` column (a real, indexed field — so `$search` resolves on it directly) and `stage` still leads the highlight strip, translated.
+
+Three guards were added to `test/metadata-references.test.ts` so this class fails at PR time instead of during dogfooding: option translations must be keyed by option value (not English label); translated object/field keys must name real objects and fields; and no formula may render a select field into its output string (branching on a select stays legal). The existing zh-CN navigation-label guard looked up `translations.find(t => t.locale === 'zh-CN')`, but the app ships one bundle keyed by locale — the lookup matched nothing and the test returned early, asserting nothing. It now resolves the locale pack correctly and asserts the pack exists.

--- a/src/objects/contact.object.ts
+++ b/src/objects/contact.object.ts
@@ -45,9 +45,14 @@ export const Contact = ObjectSchema.create({
     }),
 
     // Formula field - Full name
+    // `salutation` is a picklist, so the formula sees the raw VALUE (`ms`, `dr`),
+    // not the label — names rendered as "ms Emily Davis" in lists and details
+    // (#461). The formula language has no proper-case or option-label lookup, and
+    // hardcoding "Ms." would defeat translation, so the name is built from the
+    // name fields alone; salutation stays its own (translated) field.
     full_name: Field.formula({
       label: 'Full Name',
-      expression: F`joinNonEmpty([record.salutation, record.first_name, record.last_name], ' ')`,
+      expression: F`joinNonEmpty([record.first_name, record.last_name], ' ')`,
       group: 'identity',
     }),
 

--- a/src/objects/lead.object.ts
+++ b/src/objects/lead.object.ts
@@ -49,9 +49,12 @@ export const Lead = ObjectSchema.create({
       group: 'identity',
     }),
 
+    // `salutation` is a picklist, so the formula sees the raw VALUE (`ms`, `dr`),
+    // not the label — names rendered as "ms Emily Davis" in lists and details
+    // (#461). Dropped here and from `display_title` below, matching Contact.
     full_name: Field.formula({
       label: 'Full Name',
-      expression: F`joinNonEmpty([record.salutation, record.first_name, record.last_name], ' ')`,
+      expression: F`joinNonEmpty([record.first_name, record.last_name], ' ')`,
       group: 'identity',
     }),
 
@@ -60,7 +63,7 @@ export const Lead = ObjectSchema.create({
     // plus `company`, so the title resolves from real stored values.
     display_title: Field.formula({
       label: 'Display Title',
-      expression: F`joinNonEmpty([record.salutation, record.first_name, record.last_name], ' ') + " - " + record.company`,
+      expression: F`joinNonEmpty([record.first_name, record.last_name], ' ') + " - " + record.company`,
       group: 'identity',
     }),
 

--- a/src/objects/opportunity.object.ts
+++ b/src/objects/opportunity.object.ts
@@ -1,4 +1,4 @@
-import { F, P, cel } from '@objectstack/spec';
+import { P, cel } from '@objectstack/spec';
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { ObjectSchema, Field } from '@objectstack/spec/data';
@@ -14,13 +14,17 @@ export const Opportunity = ObjectSchema.create({
   // ADR-0090 D1/D7: OWD is an authored decision. Owner + high-value management sharing rule.
   sharingModel: 'private',
   // ADR-0079: render-only `titleFormat` retired in favor of `nameField`.
-  // `stage` is a select — the formula references its stored value directly
-  // (no label resolution), matching ADR-0079 guidance.
-  nameField: 'display_title',
-  // Explicit search targets (ADR-0061). REQUIRED because nameField is a
-  // FORMULA (display_title/full_name): without this, $search auto-defaults to
-  // the formula field, which isn't a real column, so the lookup picker + global
-  // search silently return zero. These are real, indexed columns.
+  // The original template was '{name} - {stage}'. A render-time template could
+  // resolve `stage` to its translated label; a FORMULA cannot — it sees the
+  // stored select VALUE — so the migrated `display_title` titled every deal
+  // "Enterprise Deal - closed_won" in lookups, related lists and search, in
+  // every locale (#461, same defect as Contact `full_name`). The formula
+  // language has no option-label lookup, so the title is now the plain `name`
+  // column; `stage` still leads the highlight strip below, translated.
+  nameField: 'name',
+  // Explicit search targets (ADR-0061). `name` is a real indexed column, so
+  // $search resolves on its own here; the list is kept explicit to pin the
+  // intent (other objects whose nameField IS a formula rely on it).
   searchableFields: ['name'],
   highlightFields: ['name', 'crm_account', 'amount', 'stage', 'owner'],
 
@@ -43,13 +47,8 @@ export const Opportunity = ObjectSchema.create({
       group: 'basic',
     }),
 
-    // ADR-0079 record title (was titleFormat '{name} - {stage}').
-    // `stage` is referenced by its stored select value.
-    display_title: Field.formula({
-      label: 'Display Title',
-      expression: F`record.name + " - " + record.stage`,
-      group: 'basic',
-    }),
+    // (No `display_title` formula — see `nameField` above: composing the title
+    // from `stage` leaked the raw select value into every rendered title.)
 
     // Relationships
     crm_account: Field.lookup('crm_account', {

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -28,6 +28,21 @@ const objectNames = new Set(objects.map((o) => o.name));
 const profileNames = new Set(profiles.map((p) => p.name));
 
 /**
+ * Locale packs, flattened to `[locale, pack]` pairs.
+ *
+ * `stack.translations` holds ONE `TranslationBundle` keyed by locale
+ * (`{ en: {...}, 'zh-CN': {...} }`) — NOT a list of per-locale records. A
+ * `translations.find(t => t.locale === 'zh-CN')` therefore matches nothing and
+ * silently turns its test into a no-op, which is how the navigation guard
+ * below spent its life passing without asserting anything.
+ */
+const localePacks: [string, AnyRec][] = ((stack as any).translations ?? []).flatMap(
+  (bundle: AnyRec) => Object.entries(bundle) as [string, AnyRec][],
+);
+const packFor = (locale: string): AnyRec | undefined =>
+  localePacks.find(([name]) => name === locale)?.[1];
+
+/**
  * Audit columns the platform adds to every object. They are real at runtime
  * (`?sort=created_at desc` works) but never appear in the authored `fields`
  * map, so a reference to one is legitimate.
@@ -351,12 +366,13 @@ describe('navigation reaches everything the app ships', () => {
   it('every navigation node has a zh-CN label', () => {
     // The groups were translated and the leaves were not, so the sidebar read
     // half Chinese, half English.
-    const translations: AnyRec[] = (stack as any).translations ?? [];
-    const zh = translations.find((t) => t.locale === 'zh-CN' || t.name === 'zh-CN');
-    if (!zh) return; // no zh bundle in this build — nothing to assert
+    const zh = packFor('zh-CN');
+    // Assert, don't skip: the old lookup used the wrong bundle shape, found no
+    // pack, and returned early — a green test that checked nothing.
+    expect(zh, 'no zh-CN locale pack found in stack.translations').toBeTruthy();
     const bad: string[] = [];
     for (const app of apps) {
-      const nav = zh.data?.apps?.[app.name]?.navigation ?? zh.apps?.[app.name]?.navigation ?? {};
+      const nav = zh?.apps?.[app.name]?.navigation ?? {};
       for (const n of navNodes(app)) {
         if (n.id && !nav[n.id]?.label) bad.push(`${app.name}/${n.id}`);
       }
@@ -552,6 +568,109 @@ describe('row colors and kanban groups key off real option values', () => {
       }
     }
     expect(bad, `broken kanban groupings:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});
+
+describe('picklist values never reach the UI unresolved', () => {
+  /**
+   * A select field stores a VALUE (`ms`, `waiting_customer`, `existing_upgrade`)
+   * and the UI resolves it to the locale's label at render time. Every #461
+   * defect was that resolution failing, in one of two ways — a lookup that
+   * misses (the translation is keyed by something that is not an option value)
+   * or a lookup that never happens (a formula splices the stored value straight
+   * into a string). Both are invisible in review and only surface as English —
+   * or worse, `closed_won` — sitting in an otherwise-translated screen.
+   */
+  const selectOptionsOf = (objDef: AnyRec, field: string): string[] | undefined => {
+    const options = objDef.fields?.[field]?.options;
+    return Array.isArray(options) && options.length
+      ? options.map((o: AnyRec) => String(o.value))
+      : undefined;
+  };
+
+  it('option translations are keyed by option VALUE, not by English label', () => {
+    // Opportunity `type` was keyed by label ('Existing Customer - Upgrade':
+    // '老客户升级'). The resolver matches by value, so deal type rendered in
+    // English on every non-en locale while `stage`/`status` — keyed by value —
+    // translated fine, which is exactly what made it hard to spot.
+    const bad: string[] = [];
+    for (const [locale, pack] of localePacks) {
+      for (const [objName, objT] of Object.entries<AnyRec>(pack?.objects ?? {})) {
+        const objDef = objects.find((o) => o.name === objName);
+        if (!objDef) continue; // covered by the key-resolution test below
+        for (const [fieldName, fieldT] of Object.entries<AnyRec>(objT?.fields ?? {})) {
+          if (!fieldT?.options) continue;
+          const values = selectOptionsOf(objDef, fieldName);
+          if (!values) {
+            bad.push(`${locale}: ${objName}.${fieldName} translates options but the field has none`);
+            continue;
+          }
+          for (const key of Object.keys(fieldT.options)) {
+            if (!values.includes(key)) {
+              bad.push(`${locale}: ${objName}.${fieldName} option key "${key}" is not an option value`);
+            }
+          }
+        }
+      }
+    }
+    expect(bad, `option translations that resolve to nothing:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('translated object and field keys name real objects and fields', () => {
+    // A translation keyed to a renamed/removed field is dead weight that reads
+    // as coverage — the bundle looks complete while the screen stays English.
+    const bad: string[] = [];
+    for (const [locale, pack] of localePacks) {
+      for (const [objName, objT] of Object.entries<AnyRec>(pack?.objects ?? {})) {
+        if (!objectNames.has(objName)) {
+          bad.push(`${locale}: translates "${objName}", which is not a defined object`);
+          continue;
+        }
+        const known = fieldsOf(objName);
+        for (const fieldName of Object.keys(objT?.fields ?? {})) {
+          if (!known.includes(fieldName)) {
+            bad.push(`${locale}: "${objName}" has no field "${fieldName}"`);
+          }
+        }
+      }
+    }
+    expect(bad, `translations keyed to nothing:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('no formula renders a select field into its output string', () => {
+    // `full_name` = joinNonEmpty([salutation, first_name, last_name]) printed
+    // "ms Emily Davis"; opportunity `display_title` = name + " - " + stage
+    // titled deals "Enterprise Deal - closed_won". The formula language has no
+    // option-label lookup (only upper/lower), so a select simply cannot be
+    // rendered from a formula — it has to stay its own field.
+    //
+    // Only RENDERING is flagged. Branching on a select (`record.stage ==
+    // "closed_won" ? …`) never puts the value on screen and stays legal.
+    const rendersSelect = (source: string, field: string): boolean => {
+      const ref = `record\\.${field}\\b`;
+      // joinNonEmpty([...]) — every element lands in the output string.
+      for (const m of source.matchAll(/joinNonEmpty\(\s*\[([^\]]*)\]/g)) {
+        if (new RegExp(ref).test(m[1])) return true;
+      }
+      // String concatenation on either side: `" - " + record.x` / `record.x + " - "`.
+      return new RegExp(`(["']\\s*\\+\\s*${ref})|(${ref}\\s*\\+\\s*["'])`).test(source);
+    };
+
+    const bad: string[] = [];
+    for (const objDef of objects) {
+      for (const [fieldName, field] of Object.entries<AnyRec>(objDef.fields ?? {})) {
+        // `expression` is `{ dialect, source }` once the F tag is evaluated.
+        const source: unknown = field?.expression?.source ?? field?.expression;
+        if (typeof source !== 'string') continue;
+        for (const other of Object.keys(objDef.fields ?? {})) {
+          if (!selectOptionsOf(objDef, other)) continue;
+          if (rendersSelect(source, other)) {
+            bad.push(`${objDef.name}.${fieldName} renders select "${other}": ${source}`);
+          }
+        }
+      }
+    }
+    expect(bad, `formulas printing raw select values:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Description

A select field stores a **value** (`ms`, `waiting_customer`, `existing_upgrade`) and the UI resolves it to the locale's label at render time. Every defect in #461 was that resolution failing. This PR fixes the one that was still live, plus a fourth instance of the same class found while building a guard for it, and adds tests so the class fails at PR time instead of during dogfooding.

**1. Contact / Lead names showed a lowercase salutation** (the reported bug). `crm_contact.full_name` joined `record.salutation` ahead of the name fields; a formula sees the stored value, so contacts rendered as **"ms Emily Davis"** in list views, detail titles and lookups. `crm_lead.full_name` / `display_title` carried the identical formula and the identical defect, so both objects are fixed. The formula language exposes only `upper`/`lower` — no proper-case, no option-label lookup — and hardcoding `"Ms."` would bake English into a stored value, so the name is now `first_name` + `last_name` (the Salesforce `Name` convention). `salutation` remains its own field and keeps its translated label on forms and detail pages.

**2. Opportunity titles showed the raw stage value** (found by the new guard, not reported). `crm_opportunity.nameField` pointed at a `display_title` formula composed as `record.name + " - " + record.stage`, so every deal titled itself **"Enterprise Deal - closed_won"** in lookup pickers, related lists, breadcrumbs and search results, in every locale. The ADR-0079 migration inherited this from the render-time template `'{name} - {stage}'`, which *could* resolve the label; a formula cannot. `nameField` is now the plain `name` column — a real indexed field, so `$search` resolves on it directly — and `stage` still leads the highlight strip, translated.

**On the other two defects reported in #461:** both had already landed on `main` before this branch. I verified them against current sources rather than re-fixing them, and the new tests now cover both:

- **Case status-path typo** — `src/pages/case_detail.page.ts` declares `{ value: 'waiting_customer', … }`, matching the `crm_case.status` option (#480 / #515). A `record:path` stage guard already existed in the suite; the other `record:path` components (opportunity, lead) were swept and match their option sets too.
- **Opportunity `type` options keyed by English label** — all four locale bundles key by value (#498).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] CI/CD update

## Related Issues

Fixes #461

## Changes Made

- `src/objects/contact.object.ts` — `full_name` drops `record.salutation`
- `src/objects/lead.object.ts` — `full_name` and `display_title` drop `record.salutation`
- `src/objects/opportunity.object.ts` — `nameField` moves from the `display_title` formula to the real `name` column; the formula field is removed
- `test/metadata-references.test.ts` — three new guards, plus a repair to an existing one (below)
- Two changesets (patch)

## Testing

- [x] Unit tests pass (`pnpm test` — 92 passed, up from 89)
- [x] Linting passes (`pnpm lint` — 2 warnings, both pre-existing and unrelated)
- [x] Build succeeds (`pnpm build`); `pnpm validate` and `pnpm typecheck` also pass
- [ ] Manual testing completed
- [x] New tests added (if applicable)

### New guards, and how they were verified

Each guard was checked by **reintroducing its defect and confirming the test goes red** — a guard for a silent bug is worthless if it can pass vacuously:

| Guard | Mutation applied | Result |
| :--- | :--- | :--- |
| Option translations keyed by option **value**, not English label | re-keyed zh-CN `type` to `'Existing Customer - Upgrade'` | ✅ red |
| Translated object/field keys name real objects and fields | added `nonexistent_field` to the zh-CN contact pack | ✅ red |
| No formula renders a select field into its output string | restored `record.name + " - " + record.stage` | ✅ red |
| zh-CN navigation labels (existing test, repaired) | broke the locale lookup | ✅ red |

The formula guard flags **rendering only** — `joinNonEmpty([...])` members and string concatenation. Branching on a select (`record.stage == "closed_won" ? …`) never puts the value on screen and stays legal.

**The repaired guard is worth calling out.** `every navigation node has a zh-CN label` looked up `translations.find(t => t.locale === 'zh-CN')`, but the app ships **one** `TranslationBundle` keyed by locale (`{ en: {...}, 'zh-CN': {...} }`), not a list of per-locale records. The lookup matched nothing, hit `if (!zh) return`, and asserted nothing — green since the day it was written. It now resolves the locale pack correctly and asserts the pack exists. (The nav labels themselves were all present, so this repair surfaced no new failures.)

## Screenshots

n/a — text-only rendering changes.

## Checklist

- [x] **I have added a changeset** (`pnpm changeset`) — required on every PR, or the `skip-changeset` label is applied
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**No data migration, verified against platform internals (16.1.0, the pinned dependency).** Formula fields are fully virtual and evaluated at read time: `@objectstack/driver-sql` creates **no column** for `type: "formula"` (`case "formula": return; // Virtual — no column`, and `fieldHasColumn()` returns false), and `@objectstack/objectql` compiles a formula plan per query and applies it in memory to `find`/`findOne` results, excluding formula fields from the SQL projection. Nothing is ever persisted, so every record — existing rows included — evaluates the **new** expressions on the next read. No recompute, no backfill, no schema drift from removing `display_title` (there was no column to drop).

One thing worth a maintainer's eye: `crm_opportunity.display_title` is **removed**, not emptied. Nothing in `src/` referenced it (views, pages, reports, datasets and cubes were all checked), and per the above it never existed as a DB column — but any external API consumer selecting `display_title` on opportunities would need to switch to `name`. If external compatibility matters more than cleanliness, the field could instead be kept as a deprecated alias of `name` (`expression: record.name`); I went with removal since the repo treats metadata as the single source of truth.