### PR TITLE
fix(dashboards): drop the Service dashboard date range — datetime filters match nothing (#460)

### DIFF
--- a/.changeset/service-dashboard-default-date-range.md
+++ b/.changeset/service-dashboard-default-date-range.md
@@ -23,8 +23,13 @@ return 0, in every date format tried.
 The `dateRange` block is therefore removed rather than widened. The dashboard now
 renders real data (30 open / 7 critical / 45.0h average resolution / 3 SLA
 breaches, all charts populated). The cost is visible and intentional: this
-dashboard has no date picker until datetime filtering is fixed upstream, and the
-commented-out block plus a CI guard mark the spot.
+dashboard has no date picker, and the commented-out block plus a CI guard mark
+the spot.
+
+Upstream this is objectstack-ai/objectstack#3912 (closed, fix in the 17.0 train;
+HotCRM is pinned to 16.1.0 so it is still live here). Restoring the range needs
+objectstack-ai/objectstack#3777 too — still open, and the reason a datetime
+upper bound stays unsafe even after the #3912 fix.
 
 The CRM, Sales and Executive dashboards are untouched — they window `close_date`,
 a `Field.date()`, which compares as TEXT on both sides and works. That, not the

--- a/.changeset/service-dashboard-default-date-range.md
+++ b/.changeset/service-dashboard-default-date-range.md
@@ -2,22 +2,37 @@
 'hotcrm': patch
 ---
 
-Fix the Customer Service dashboard opening on all zeros.
+Fix the Customer Service dashboard rendering all zeros.
 
-`service_dashboard` defaulted its date range to `last_30_days` while the demo
-cases run from 1 to 30 days old, so the default window sat exactly on the edge
-of the data it aggregates: the runtime ANDs the dashboard range into every
-widget query, and the oldest cases fell out of it — every KPI read 0 and every
-chart reported no rows, with 38 cases in the system.
+`service_dashboard` opened with every KPI at 0 and every chart reporting no rows,
+with 38 cases in the system. The reported cause — a `last_30_days` default that
+was narrower than the seeded case history — is not what was happening.
 
-The default is now a rolling `last_90_days`, which always contains the full case
-history whatever day the demo is opened on. `this_quarter` — what the CRM, Sales
-and Executive dashboards use — is deliberately not the fix here: those window
-`close_date` over a forward-looking pipeline, where a calendar quarter is the
-intended framing, whereas a support desk reads a trailing window, and a calendar
-quarter is only a few days long on 1 July.
+`crm_case.created_date` is a `Field.datetime()`, and on the SQLite path
+`driver-sql` 16.1.0 coerces datetime filter values to epoch-millisecond INTEGERs
+(`coerceFilterValue`), on the documented assumption that datetime columns are
+stored as INTEGER ms. They are not: every datetime in the demo database is ISO
+TEXT, including the platform's own `created_at` / `updated_at` audit columns.
+SQLite orders every INTEGER before every TEXT, so on a datetime column
+`col >= <int>` is true for every row and `col <= <int>` is true for none. The
+runtime ANDs the dashboard range into every widget query, so the `$lte` half
+zeroed the entire dashboard — at any preset. Measured against the running 16.1.0
+console: `$gte` alone returns all 38 cases, `$lte` alone returns 0, both bounds
+return 0, in every date format tried.
 
-A regression guard in `metadata-references.test.ts` now checks the default
-against every reference day of a leap year and requires the window to clear the
-oldest seeded case by a margin, so a flush-to-the-edge default (one timezone
-rounding away from clipping data) fails in CI rather than in a demo.
+The `dateRange` block is therefore removed rather than widened. The dashboard now
+renders real data (30 open / 7 critical / 45.0h average resolution / 3 SLA
+breaches, all charts populated). The cost is visible and intentional: this
+dashboard has no date picker until datetime filtering is fixed upstream, and the
+commented-out block plus a CI guard mark the spot.
+
+The CRM, Sales and Executive dashboards are untouched — they window `close_date`,
+a `Field.date()`, which compares as TEXT on both sides and works. That, not the
+preset, is why Service was the outlier.
+
+Also documents that the `daily_case_volume` widget's `$gte: '{30_days_ago}'`
+floor is inert for the same reason, so the chart currently plots every case.
+
+A guard in `metadata-references.test.ts` now fails if any dashboard windows a
+`datetime` field, and checks the range field exists on the objects its widgets
+aggregate.

--- a/.changeset/service-dashboard-default-date-range.md
+++ b/.changeset/service-dashboard-default-date-range.md
@@ -1,0 +1,23 @@
+---
+'hotcrm': patch
+---
+
+Fix the Customer Service dashboard opening on all zeros.
+
+`service_dashboard` defaulted its date range to `last_30_days` while the demo
+cases run from 1 to 30 days old, so the default window sat exactly on the edge
+of the data it aggregates: the runtime ANDs the dashboard range into every
+widget query, and the oldest cases fell out of it — every KPI read 0 and every
+chart reported no rows, with 38 cases in the system.
+
+The default is now a rolling `last_90_days`, which always contains the full case
+history whatever day the demo is opened on. `this_quarter` — what the CRM, Sales
+and Executive dashboards use — is deliberately not the fix here: those window
+`close_date` over a forward-looking pipeline, where a calendar quarter is the
+intended framing, whereas a support desk reads a trailing window, and a calendar
+quarter is only a few days long on 1 July.
+
+A regression guard in `metadata-references.test.ts` now checks the default
+against every reference day of a leap year and requires the window to clear the
+oldest seeded case by a margin, so a flush-to-the-edge default (one timezone
+rounding away from clipping data) fails in CI rather than in a demo.

--- a/src/dashboards/service.dashboard.ts
+++ b/src/dashboards/service.dashboard.ts
@@ -27,23 +27,36 @@ export const ServiceDashboard: Dashboard = {
     // routes — all three were dead. Re-add real, wired-up actions here when available.
   },
 
-  dateRange: {
-    // The default window has to be WIDER than the span of the cases it
-    // aggregates, or the dashboard opens on all zeros (#460): the runtime ANDs
-    // this range into every widget query, and the demo cases run from 1 to 30
-    // days old, so `last_30_days` sat exactly on the edge — the oldest cases
-    // fell out of the window, and any seed that reaches further back emptied
-    // the screen. `this_quarter` (what the CRM/Sales/Executive dashboards use)
-    // is the wrong instrument here: those window `close_date` over a
-    // forward-looking pipeline, where a calendar quarter is the intended
-    // framing, whereas a support desk reads a trailing window — and a calendar
-    // quarter is only a few days long on 1 July, which reintroduces the very
-    // emptiness this fixes. A rolling 90 days always contains the full case
-    // history, whatever day the demo is opened on.
-    field: 'created_date',
-    defaultRange: 'last_90_days',
-    allowCustomRange: true,
-  },
+  // NO `dateRange` — deliberately, and this is the fix for #460.
+  //
+  // This dashboard carried `{ field: 'created_date', defaultRange:
+  // 'last_30_days' }` and opened on all zeros with 38 cases in the system. The
+  // cause is NOT the preset. `crm_case.created_date` is a `Field.datetime()`,
+  // and on the SQLite path `driver-sql` 16.1.0 coerces datetime filter values
+  // to epoch-millisecond INTEGERs (`coerceFilterValue`), on the documented
+  // assumption that datetime columns are stored as INTEGER ms. They are not —
+  // every datetime in the demo database is ISO TEXT, including the platform's
+  // own `created_at` / `updated_at` audit columns. SQLite orders every INTEGER
+  // before every TEXT, so on a datetime column:
+  //     created_date >= <int>   is TRUE for every row   (window has no floor)
+  //     created_date <= <int>   is FALSE for every row  (window matches nothing)
+  // The runtime ANDs the dashboard range into every widget query, so the `$lte`
+  // half zeroed the whole dashboard. Measured against the running 16.1.0
+  // console: `$gte` alone → all 38 cases, `$lte` alone → 0, both bounds → 0, in
+  // every date format tried (`2026-07-30`, full ISO, end-of-day). WIDENING THE
+  // PRESET CANNOT FIX THIS — `last_90_days` renders exactly the same zeros.
+  //
+  // The other three dashboards are unaffected because they window `close_date`,
+  // a `Field.date()`, which stays TEXT `YYYY-MM-DD` on both sides of the
+  // comparison. That is why Service was the outlier — not the preset choice.
+  //
+  // Dropping the range is what makes the dashboard render (verified in the
+  // console: 30 open / 7 critical / 45.0h / 3 SLA breaches, every chart
+  // populated). The cost is honest and visible: this dashboard has no date
+  // picker. Restore the line below once datetime filtering is fixed upstream;
+  // the guard in `metadata-references.test.ts` fails while it is still unsafe.
+  //
+  //   dateRange: { field: 'created_date', defaultRange: 'last_90_days', allowCustomRange: true },
 
   globalFilters: [
     {
@@ -202,7 +215,14 @@ export const ServiceDashboard: Dashboard = {
       description: 'New cases created over the last 30 days',
       type: 'area',
       filter: { created_date: { $gte: '{30_days_ago}' } },
-      filterBindings: { dateRange: false }, // self-scoped to 30 days — the date picker must not re-window it
+      // Kept opted out so this stays self-scoped if the dashboard `dateRange`
+      // is ever restored (see the note above).
+      // Caveat, same root cause as #460: on 16.1.0 a `$gte` against a datetime
+      // column is TRUE for every row, so this floor is currently INERT and the
+      // chart plots every case rather than the last 30 days. Indistinguishable
+      // today (the seed spans exactly 30 days) and it starts working once the
+      // driver is fixed — but the title's "last 30 days" is not yet enforced.
+      filterBindings: { dateRange: false },
       colorVariant: 'blue',
       dataset: 'case_metrics', dimensions: ['created_date'], values: ['case_count'],
       layout: { x: 0, y: 6, w: 8, h: 4 },

--- a/src/dashboards/service.dashboard.ts
+++ b/src/dashboards/service.dashboard.ts
@@ -28,8 +28,20 @@ export const ServiceDashboard: Dashboard = {
   },
 
   dateRange: {
+    // The default window has to be WIDER than the span of the cases it
+    // aggregates, or the dashboard opens on all zeros (#460): the runtime ANDs
+    // this range into every widget query, and the demo cases run from 1 to 30
+    // days old, so `last_30_days` sat exactly on the edge — the oldest cases
+    // fell out of the window, and any seed that reaches further back emptied
+    // the screen. `this_quarter` (what the CRM/Sales/Executive dashboards use)
+    // is the wrong instrument here: those window `close_date` over a
+    // forward-looking pipeline, where a calendar quarter is the intended
+    // framing, whereas a support desk reads a trailing window — and a calendar
+    // quarter is only a few days long on 1 July, which reintroduces the very
+    // emptiness this fixes. A rolling 90 days always contains the full case
+    // history, whatever day the demo is opened on.
     field: 'created_date',
-    defaultRange: 'last_30_days',
+    defaultRange: 'last_90_days',
     allowCustomRange: true,
   },
 

--- a/src/dashboards/service.dashboard.ts
+++ b/src/dashboards/service.dashboard.ts
@@ -50,10 +50,18 @@ export const ServiceDashboard: Dashboard = {
   // a `Field.date()`, which stays TEXT `YYYY-MM-DD` on both sides of the
   // comparison. That is why Service was the outlier — not the preset choice.
   //
+  // Upstream: objectstack-ai/objectstack#3912 is this exact defect (closed
+  // 2026-07-29, fix in the 17.0 train — HotCRM is pinned to 16.1.0, so it is
+  // still live here). Note that the platform upgrade alone does NOT make it
+  // safe to restore the range on a datetime field: #3777 (open, p1) is the
+  // separate bug that a bare `YYYY-MM-DD` `$lte` upper bound on a datetime
+  // column still drops every record created after 00:00 that day — silently,
+  // and by an amount that grows as the day goes on. BOTH must land first.
+  //
   // Dropping the range is what makes the dashboard render (verified in the
   // console: 30 open / 7 critical / 45.0h / 3 SLA breaches, every chart
   // populated). The cost is honest and visible: this dashboard has no date
-  // picker. Restore the line below once datetime filtering is fixed upstream;
+  // picker. Restore the line below only once both upstream issues are fixed;
   // the guard in `metadata-references.test.ts` fails while it is still unsafe.
   //
   //   dateRange: { field: 'created_date', defaultRange: 'last_90_days', allowCustomRange: true },

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -740,112 +740,79 @@ describe('page templates and record components stay inside their record context'
   });
 });
 
-describe('dashboard date-range defaults keep the dashboard populated', () => {
+
+describe('dashboard date ranges window a field the query layer can actually compare', () => {
   /**
-   * The runtime ANDs a dashboard's `dateRange` into every widget query, so the
-   * default preset decides what a business user sees on the FIRST paint. The
-   * Service dashboard opened on all zeros with 38 cases in the system (#460):
-   * it defaulted to `last_30_days` while the demo cases run 1–30 days old, so
-   * the oldest cases sat outside the window and any seed reaching further back
-   * emptied the screen entirely.
+   * A dashboard `dateRange` is ANDed into EVERY widget query, so if the
+   * comparison cannot match, the whole dashboard renders zeros. That is #460:
+   * the Service dashboard windowed `crm_case.created_date` — a
+   * `Field.datetime()` — and opened with every KPI at 0 and every chart empty,
+   * with 38 cases in the system.
    *
-   * The guard below is calendar-independent on purpose. A preset that happens
-   * to cover the seed span today can be near-empty tomorrow — `this_quarter`
-   * is one day long on 1 April — so the default is checked against every
-   * reference day of a leap year, not just the day CI happens to run.
+   * The mechanism is a storage disagreement, not a bad preset. On SQLite,
+   * `driver-sql` 16.1.0 coerces datetime filter values to epoch-millisecond
+   * INTEGERs (`coerceFilterValue`), documenting the assumption that datetime
+   * columns hold INTEGER ms. In this app they hold ISO TEXT — including the
+   * platform's own `created_at`/`updated_at`. SQLite orders every INTEGER
+   * before every TEXT, so `datetime_col >= <int>` is true for all rows and
+   * `datetime_col <= <int>` is true for none. Measured against the running
+   * 16.1.0 console: `$gte` alone → all 38 cases, `$lte` alone → 0, both → 0,
+   * in every date format tried.
    *
-   * It also demands HEADROOM rather than mere coverage. `last_30_days` over
-   * cases up to 30 days old is arithmetically flush, not wrong — and that is
-   * precisely the failure: flush is one timezone rounding, one inclusive-vs-
-   * exclusive bound, or one seed tweak away from clipping the oldest cases off
-   * the dashboard again.
+   * `Field.date()` is unaffected (TEXT `YYYY-MM-DD` on both sides), which is
+   * why the CRM/Sales/Executive dashboards — all windowing `close_date` — show
+   * data. So the rule is about the FIELD TYPE, not the preset: a dashboard may
+   * only window a `date` field. Note this deliberately fails if someone
+   * restores the Service dashboard's `dateRange` before the driver is fixed.
    */
   const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
-  const seeds: AnyRec[] = (stack as any).data ?? (stack as any).seeds ?? [];
+  const datasets: AnyRec[] = (stack as any).datasets ?? [];
 
-  const DAY = 86_400_000;
-  /** Days the window must extend PAST the oldest seeded record. */
-  const MARGIN_DAYS = 7;
-  const utcDay = (y: number, m: number, d: number) => new Date(Date.UTC(y, m, d));
-  const shift = (d: Date, days: number) => new Date(d.getTime() + days * DAY);
-
-  /**
-   * First and last day a preset window includes, resolved against `ref`.
-   * Unmodelled presets throw rather than silently pass — a dashboard that
-   * switches to one nobody has reasoned about should fail here.
-   */
-  const windowFor = (preset: string, ref: Date): [Date, Date] => {
-    const y = ref.getUTCFullYear();
-    const m = ref.getUTCMonth();
-    const today = utcDay(y, m, ref.getUTCDate());
-    const quarterStart = Math.floor(m / 3) * 3;
-    switch (preset) {
-      case 'today':        return [today, today];
-      case 'yesterday':    return [shift(today, -1), shift(today, -1)];
-      case 'this_week':    return [shift(today, -ref.getUTCDay()), shift(today, 6 - ref.getUTCDay())];
-      case 'last_week':    return [shift(today, -ref.getUTCDay() - 7), shift(today, -ref.getUTCDay() - 1)];
-      case 'this_month':   return [utcDay(y, m, 1), shift(utcDay(y, m + 1, 1), -1)];
-      case 'last_month':   return [utcDay(y, m - 1, 1), shift(utcDay(y, m, 1), -1)];
-      case 'this_quarter': return [utcDay(y, quarterStart, 1), shift(utcDay(y, quarterStart + 3, 1), -1)];
-      case 'last_quarter': return [utcDay(y, quarterStart - 3, 1), shift(utcDay(y, quarterStart, 1), -1)];
-      case 'this_year':    return [utcDay(y, 0, 1), utcDay(y, 11, 31)];
-      case 'last_year':    return [utcDay(y - 1, 0, 1), utcDay(y - 1, 11, 31)];
-      case 'last_7_days':  return [shift(today, -7), today];
-      case 'last_30_days': return [shift(today, -30), today];
-      case 'last_90_days': return [shift(today, -90), today];
-      default: throw new Error(`unmodelled date-range preset "${preset}"`);
+  /** Objects the dashboard's widgets aggregate over, via their datasets. */
+  const objectsBehind = (d: AnyRec): string[] => {
+    const names = new Set<string>();
+    for (const w of d.widgets ?? []) {
+      const ds = datasets.find((x) => x.name === w.dataset);
+      if (ds?.object) names.add(ds.object);
     }
+    return [...names];
   };
 
-  /** `daysAgo(N)` → N. Returns null for any other expression shape. */
-  const daysAgo = (value: unknown): number | null => {
-    const source = String((value as AnyRec)?.source ?? value ?? '');
-    const match = /^daysAgo\((\d+)\)$/.exec(source);
-    return match ? Number(match[1]) : null;
-  };
+  const fieldType = (objectName: string, field: string): string | undefined =>
+    objects.find((o) => o.name === objectName)?.fields?.[field]?.type;
 
-  it('the Service dashboard default range covers every seeded case, on any day of the year', () => {
-    const service = dashboards.find((d) => d.name === 'service_dashboard');
-    expect(service?.dateRange?.field, 'service dashboard windows created_date').toBe('created_date');
-
-    const caseSeed = seeds.find((s) => s.object === 'crm_case');
-    expect(caseSeed, 'case seed missing').toBeTruthy();
-    const ages = (caseSeed!.records ?? []).map((r: AnyRec) => daysAgo(r.created_date));
-    // Every seeded case dates itself relative to boot — an absolute date would
-    // age out of the window as the demo repo sits, which is how #460 started.
-    expect(ages.filter((a: number | null) => a === null), 'cases with a non-relative created_date').toEqual([]);
-    const oldest = Math.max(...(ages as number[]));
-    expect(oldest).toBeGreaterThan(0);
-
-    const preset = String(service!.dateRange.defaultRange);
-    const bad: string[] = [];
-    for (let i = 0; i < 366; i++) {
-      const ref = shift(utcDay(2028, 0, 1), i); // leap year — covers 29 Feb too
-      const [start, end] = windowFor(preset, ref);
-      const today = utcDay(ref.getUTCFullYear(), ref.getUTCMonth(), ref.getUTCDate());
-      const mustReach = shift(today, -(oldest + MARGIN_DAYS));
-      if (mustReach < start || ref > end) {
-        bad.push(
-          `${ref.toISOString().slice(0, 10)}: "${preset}" spans ${start.toISOString().slice(0, 10)}..` +
-          `${end.toISOString().slice(0, 10)}, which does not clear cases up to ${oldest} days old ` +
-          `by ${MARGIN_DAYS} days`,
-        );
-      }
-    }
-    expect(bad.length, `default range leaves the dashboard empty or partial:\n  ${bad.slice(0, 5).join('\n  ')}`).toBe(0);
-  });
-
-  it('every dashboard dateRange preset is one the guard above understands', () => {
+  it('no dashboard windows a datetime field', () => {
     const bad: string[] = [];
     for (const d of dashboards) {
-      const preset = d.dateRange?.defaultRange;
-      if (!preset) continue;
-      try {
-        windowFor(String(preset), utcDay(2028, 5, 15));
-      } catch {
-        bad.push(`${d.name}: "${preset}"`);
+      const field = d.dateRange?.field;
+      if (!field) continue;
+      for (const obj of objectsBehind(d)) {
+        const type = fieldType(obj, field);
+        if (type === 'datetime') {
+          bad.push(
+            `${d.name}: dateRange windows ${obj}.${field}, a datetime field — ` +
+            `the $lte bound matches no rows, so every widget renders empty`,
+          );
+        }
       }
     }
-    expect(bad, `date-range presets nobody has reasoned about:\n  ${bad.join('\n  ')}`).toEqual([]);
+    expect(bad, `dashboards that will render empty:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every dashboard dateRange field exists on the objects its widgets aggregate', () => {
+    // A range field that no underlying object defines is silently dropped or
+    // errors per widget — either way the picker cannot do what it claims.
+    const bad: string[] = [];
+    for (const d of dashboards) {
+      const field = d.dateRange?.field;
+      if (!field) continue;
+      const behind = objectsBehind(d);
+      if (!behind.length) continue;
+      const resolves = behind.filter((obj) => fieldType(obj, field) !== undefined);
+      if (!resolves.length) {
+        bad.push(`${d.name}: dateRange field "${field}" exists on none of ${behind.join(', ')}`);
+      }
+    }
+    expect(bad, `dangling dashboard date-range fields:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 });

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -739,3 +739,113 @@ describe('page templates and record components stay inside their record context'
     expect(bad, `record components with no record context:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 });
+
+describe('dashboard date-range defaults keep the dashboard populated', () => {
+  /**
+   * The runtime ANDs a dashboard's `dateRange` into every widget query, so the
+   * default preset decides what a business user sees on the FIRST paint. The
+   * Service dashboard opened on all zeros with 38 cases in the system (#460):
+   * it defaulted to `last_30_days` while the demo cases run 1–30 days old, so
+   * the oldest cases sat outside the window and any seed reaching further back
+   * emptied the screen entirely.
+   *
+   * The guard below is calendar-independent on purpose. A preset that happens
+   * to cover the seed span today can be near-empty tomorrow — `this_quarter`
+   * is one day long on 1 April — so the default is checked against every
+   * reference day of a leap year, not just the day CI happens to run.
+   *
+   * It also demands HEADROOM rather than mere coverage. `last_30_days` over
+   * cases up to 30 days old is arithmetically flush, not wrong — and that is
+   * precisely the failure: flush is one timezone rounding, one inclusive-vs-
+   * exclusive bound, or one seed tweak away from clipping the oldest cases off
+   * the dashboard again.
+   */
+  const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
+  const seeds: AnyRec[] = (stack as any).data ?? (stack as any).seeds ?? [];
+
+  const DAY = 86_400_000;
+  /** Days the window must extend PAST the oldest seeded record. */
+  const MARGIN_DAYS = 7;
+  const utcDay = (y: number, m: number, d: number) => new Date(Date.UTC(y, m, d));
+  const shift = (d: Date, days: number) => new Date(d.getTime() + days * DAY);
+
+  /**
+   * First and last day a preset window includes, resolved against `ref`.
+   * Unmodelled presets throw rather than silently pass — a dashboard that
+   * switches to one nobody has reasoned about should fail here.
+   */
+  const windowFor = (preset: string, ref: Date): [Date, Date] => {
+    const y = ref.getUTCFullYear();
+    const m = ref.getUTCMonth();
+    const today = utcDay(y, m, ref.getUTCDate());
+    const quarterStart = Math.floor(m / 3) * 3;
+    switch (preset) {
+      case 'today':        return [today, today];
+      case 'yesterday':    return [shift(today, -1), shift(today, -1)];
+      case 'this_week':    return [shift(today, -ref.getUTCDay()), shift(today, 6 - ref.getUTCDay())];
+      case 'last_week':    return [shift(today, -ref.getUTCDay() - 7), shift(today, -ref.getUTCDay() - 1)];
+      case 'this_month':   return [utcDay(y, m, 1), shift(utcDay(y, m + 1, 1), -1)];
+      case 'last_month':   return [utcDay(y, m - 1, 1), shift(utcDay(y, m, 1), -1)];
+      case 'this_quarter': return [utcDay(y, quarterStart, 1), shift(utcDay(y, quarterStart + 3, 1), -1)];
+      case 'last_quarter': return [utcDay(y, quarterStart - 3, 1), shift(utcDay(y, quarterStart, 1), -1)];
+      case 'this_year':    return [utcDay(y, 0, 1), utcDay(y, 11, 31)];
+      case 'last_year':    return [utcDay(y - 1, 0, 1), utcDay(y - 1, 11, 31)];
+      case 'last_7_days':  return [shift(today, -7), today];
+      case 'last_30_days': return [shift(today, -30), today];
+      case 'last_90_days': return [shift(today, -90), today];
+      default: throw new Error(`unmodelled date-range preset "${preset}"`);
+    }
+  };
+
+  /** `daysAgo(N)` → N. Returns null for any other expression shape. */
+  const daysAgo = (value: unknown): number | null => {
+    const source = String((value as AnyRec)?.source ?? value ?? '');
+    const match = /^daysAgo\((\d+)\)$/.exec(source);
+    return match ? Number(match[1]) : null;
+  };
+
+  it('the Service dashboard default range covers every seeded case, on any day of the year', () => {
+    const service = dashboards.find((d) => d.name === 'service_dashboard');
+    expect(service?.dateRange?.field, 'service dashboard windows created_date').toBe('created_date');
+
+    const caseSeed = seeds.find((s) => s.object === 'crm_case');
+    expect(caseSeed, 'case seed missing').toBeTruthy();
+    const ages = (caseSeed!.records ?? []).map((r: AnyRec) => daysAgo(r.created_date));
+    // Every seeded case dates itself relative to boot — an absolute date would
+    // age out of the window as the demo repo sits, which is how #460 started.
+    expect(ages.filter((a: number | null) => a === null), 'cases with a non-relative created_date').toEqual([]);
+    const oldest = Math.max(...(ages as number[]));
+    expect(oldest).toBeGreaterThan(0);
+
+    const preset = String(service!.dateRange.defaultRange);
+    const bad: string[] = [];
+    for (let i = 0; i < 366; i++) {
+      const ref = shift(utcDay(2028, 0, 1), i); // leap year — covers 29 Feb too
+      const [start, end] = windowFor(preset, ref);
+      const today = utcDay(ref.getUTCFullYear(), ref.getUTCMonth(), ref.getUTCDate());
+      const mustReach = shift(today, -(oldest + MARGIN_DAYS));
+      if (mustReach < start || ref > end) {
+        bad.push(
+          `${ref.toISOString().slice(0, 10)}: "${preset}" spans ${start.toISOString().slice(0, 10)}..` +
+          `${end.toISOString().slice(0, 10)}, which does not clear cases up to ${oldest} days old ` +
+          `by ${MARGIN_DAYS} days`,
+        );
+      }
+    }
+    expect(bad.length, `default range leaves the dashboard empty or partial:\n  ${bad.slice(0, 5).join('\n  ')}`).toBe(0);
+  });
+
+  it('every dashboard dateRange preset is one the guard above understands', () => {
+    const bad: string[] = [];
+    for (const d of dashboards) {
+      const preset = d.dateRange?.defaultRange;
+      if (!preset) continue;
+      try {
+        windowFor(String(preset), utcDay(2028, 5, 15));
+      } catch {
+        bad.push(`${d.name}: "${preset}"`);
+      }
+    }
+    expect(bad, `date-range presets nobody has reasoned about:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -740,7 +740,6 @@ describe('page templates and record components stay inside their record context'
   });
 });
 
-
 describe('dashboard date ranges window a field the query layer can actually compare', () => {
   /**
    * A dashboard `dateRange` is ANDed into EVERY widget query, so if the


### PR DESCRIPTION
## Description

> **Note:** the first push on this branch widened the default preset to `last_90_days`. Running the app disproved that diagnosis — see below. The current commits remove the date range instead. The earlier description is superseded.

`service_dashboard` opened with every KPI at `0` and every chart reporting no rows, with 38 cases in the system. **The preset was never the cause, and no preset fixes it.**

`crm_case.created_date` is a `Field.datetime()`. On the SQLite path, `driver-sql` 16.1.0 coerces datetime filter comparands to epoch-millisecond INTEGERs while writes store ISO TEXT. SQLite orders every INTEGER before every TEXT, so on a datetime column:

```
created_date >= <int>   is TRUE  for every row   (the window has no floor)
created_date <= <int>   is FALSE for every row   (the window matches nothing)
```

The runtime ANDs the dashboard range into every widget query, so the `$lte` half zeroed the whole dashboard.

### Measured, not inferred

Against the running 16.1.0 console (`pnpm demo:reset && pnpm dev`, logged in, same `case_metrics` dataset the widgets use, varying only the `created_date` filter):

| filter | rows |
|---|---|
| none | **38** |
| `$gte` only (`2026-05-01`) | **38** |
| `$lte` only (`2026-07-30`) | **0** |
| `$gte` + `$lte` (the dashboard's own window) | **0** |
| `$gte` + `$lte`, full ISO with end-of-day | **0** |

Confirmed at the storage layer: `SELECT typeof(created_date)` is `text` for all 38 rows, and binding the same bounds as strings in raw SQL returns 38 — so the window is right and the *binding* is not.

Why the other three dashboards are fine: they window `close_date`, a `Field.date()`, which stays TEXT `YYYY-MM-DD` on both sides of the comparison. **That** is why Service was the outlier — not the preset choice.

### Upstream status

This is a platform defect, already reported:

- **objectstack-ai/objectstack#3912** — closed as completed 2026-07-29. Same mechanism, same measurements, filed while upgrading this app 16.1.0 → 17.0.0-rc.0. Fix is in the 17.0 train; **HotCRM is pinned to 16.1.0, so the defect is live here.** No new upstream issue was filed — this one covers it.
- **objectstack-ai/objectstack#3777** — **open**, `bug`/`priority:p1`. A *separate* datetime bug: a bare `YYYY-MM-DD` `$lte` upper bound on a datetime column drops every record created after 00:00 that day — silently, by an amount that grows through the day.

The second one matters for the restore condition: **upgrading the platform alone does not make it safe to window a datetime field.** Both fixes must land first, which is what the code comment and the CI guard now encode.

On this side, #520 already tracks the same root cause from the 17.0-rc upgrade angle — #460 is the 16.1.0 view of one dashboard, #520 is the platform-wide impact and the upgrade path. This PR resolves the former and leaves the latter open; measurements are cross-posted there.

### What this PR does

Removes the `dateRange` block rather than widening it. Verified in the browser: **30 open / 7 critical / 45.0h avg resolution / 3 SLA breaches**, every chart and the table populated.

The cost is visible and intentional: this dashboard has no date picker for now. The block is left commented out at the exact spot to restore, with both upstream issue numbers as the precondition. A picker that zeroes every widget is strictly worse than no picker.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] CI/CD update

## Related Issues

Fixes #460
Refs #520 (same root cause, platform-wide impact and 17.0 upgrade path — stays open)
Refs objectstack-ai/objectstack#3912 (fixed upstream, 17.0 train) · objectstack-ai/objectstack#3777 (open — blocks restoring the range)

## Changes Made

- `src/dashboards/service.dashboard.ts` — remove the `dateRange` block; document the root cause, the measurements, both upstream issues, and the restore precondition in place.
- `src/dashboards/service.dashboard.ts` — document that the `daily_case_volume` widget's `$gte: '{30_days_ago}'` floor is **inert** for the same reason (a `$gte` on a datetime is true for every row), so that chart currently plots every case, not the last 30 days. Indistinguishable today because the seed spans exactly 30 days; it starts working when the driver is fixed. Flagged rather than papered over — the title's claim isn't enforced yet.
- `test/metadata-references.test.ts` — replaces the window-arithmetic guard from the first push, which **could not detect this class of defect at all**. The new guard fails if any dashboard windows a `datetime` field, and a second test checks the range field actually exists on the objects its widgets aggregate.
- `.changeset/service-dashboard-default-date-range.md` — patch changeset.

Note on the issue's other suggestion (seed recent cases): already landed independently in #481 — the case seed dates every record relative to boot, `daysAgo(1..30)`. It didn't help, because the `$lte` bound matches nothing regardless of how recent the rows are.

Not touched, deliberately: the four hardcoded `trend` blocks in this file are fabricated figures, but they belong to the review pass in #500 (which turns out to cover only the executive dashboard's four of sixteen — noted there).

## Testing

- [x] Unit tests pass (`pnpm test` — 8 files, 91 tests)
- [x] Linting passes (`pnpm lint` — 2 warnings, both pre-existing and unrelated: `crm_quote_line_item` naming/relationship suggestions)
- [x] Build succeeds (`pnpm build`, plus `pnpm validate` and `pnpm typecheck` clean)
- [x] Manual testing completed — `pnpm demo:reset && pnpm dev`, logged in as the seeded dev admin, opened the Customer Service dashboard in Chromium. Zeros before, real numbers after; captured the analytics request/response pairs and the executed SQL for the table above.
- [x] New tests added (if applicable)

The new guard was verified in both directions: it fails with the exact message `service_dashboard: dateRange windows crm_case.created_date, a datetime field — the $lte bound matches no rows, so every widget renders empty` when the removed block is restored, and passes without it.

## Screenshots

Customer Service dashboard after the fix — KPI tiles at 30 / 7 / 45.0h / 3, donut, pie and bar charts all populated. (Before: every tile `0`, every chart "No rows".)

## Checklist

- [x] **I have added a changeset** (`pnpm changeset`) — required on every PR, or the `skip-changeset` label is applied
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — no doc mentions this dashboard's date range; `docs-drift` passes
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Two things a reviewer may want to weigh in on:

1. **No picker vs. a broken picker.** I chose removal. The alternatives were keeping `dateRange` with `filterBindings: { dateRange: false }` on every widget (a visible control that does nothing — the ADR-0078 shape this repo keeps removing), or adding a `date`-typed mirror of `created_date` to `crm_case` (a schema change to work around a driver bug, needing hook and seed upkeep).
2. **Scope.** This stops HotCRM from tripping the defect; it does not fix it. Every other datetime filter in the app has the same problem — `$gte` silently matches everything, `$lte` silently matches nothing — so more surfaces are likely affected. That sweep belongs to #520; #3912's own report notes the platform's `created_at` / `updated_at` audit columns are equally affected, and those are everywhere.
