### PR TITLE
fix(data): scope every uniqueness constraint per organization

### DIFF
--- a/.changeset/unique-declarations-per-tenant.md
+++ b/.changeset/unique-declarations-per-tenant.md
@@ -1,0 +1,38 @@
+---
+'hotcrm': patch
+---
+
+Scope every uniqueness constraint per organization, so a second tenant can actually be onboarded.
+
+Four objects declared platform-wide unique indexes on values that are only
+unique inside one organization. On a multi-tenant deployment each of them
+rejects the second organization's perfectly valid record.
+
+- `crm_contact.email`, `crm_lead.email`, `crm_product.sku` each declared the
+  uniqueness TWICE: field-level `unique: true` plus a single-column
+  `indexes: [{ fields: [...], unique: true }]`. Since framework #3696 the
+  field-level form is scoped per tenant — `(organization_id, email)` — while a
+  declared index is materialized over exactly its `fields`, i.e. platform-wide.
+  Declaring both left the global index enforcing the old behaviour and the
+  per-tenant constraint unreachable, so two organizations could not each know
+  `john@acme.com` or each stock SKU `ABC-123`. The redundant index is removed;
+  the field-level declaration already builds the tenant composite.
+
+- `crm_case.case_number` is worse, and was NOT a double declaration — just a
+  global unique index on an **autonumber**. The platform's autonumber sequence
+  is per tenant, so every organization counts from 1 and the second one's
+  `CASE-00001` is rejected on insert: precisely the collision framework #3696
+  exists to prevent. The index is now spelled out as
+  `['organization_id', 'case_number']` so the constraint matches the sequence
+  that feeds it.
+
+Verified end-to-end: a freshly migrated database now carries
+`uniq_crm_contact_organization_id_email`,
+`uniq_crm_lead_organization_id_email`,
+`uniq_crm_product_organization_id_sku` and
+`uniq_crm_case_organization_id_case_number`, with `os migrate plan` reporting
+the schema in sync.
+
+The first three are exactly what the new framework lint
+`unique/double-declaration` (framework#3991) flags; the stack is now clean
+under it.

--- a/src/objects/case.object.ts
+++ b/src/objects/case.object.ts
@@ -254,8 +254,15 @@ export const Case = ObjectSchema.create({
   },
   
   // Database indexes for performance
+  //
+  // `case_number` is an autonumber (`CASE-{00000}`), and the platform's
+  // autonumber sequence is PER TENANT — every organization counts from 1. A
+  // platform-wide unique index on it therefore rejects the second
+  // organization's `CASE-00001` on insert: the exact collision framework #3696
+  // exists to prevent. Spelled out as the tenant composite so the constraint
+  // matches the sequence that feeds it.
   indexes: [
-    { fields: ['case_number'], unique: true },
+    { fields: ['organization_id', 'case_number'], unique: true },
     { fields: ['crm_account'] },
     { fields: ['owner'] },
     { fields: ['status'] },

--- a/src/objects/contact.object.ts
+++ b/src/objects/contact.object.ts
@@ -176,9 +176,17 @@ export const Contact = ObjectSchema.create({
   },
   
   // Database indexes for performance
+  //
+  // NOTE: no `{ fields: ['email'], unique: true }` here. Email uniqueness is
+  // declared on the field itself (`unique: true`), which since framework #3696
+  // materializes as the tenant composite `(organization_id, email)` — unique
+  // WITHIN an organization, which is what a multi-tenant CRM wants (two orgs
+  // may each know john@acme.com). A declared single-column index is taken
+  // verbatim, i.e. platform-wide, so declaring both left the global index
+  // enforcing the old behaviour and the per-tenant constraint unreachable
+  // (framework#3991 `unique/double-declaration`).
   indexes: [
     { fields: ['crm_account'] },
-    { fields: ['email'], unique: true },
     { fields: ['owner'] },
     { fields: ['last_name', 'first_name'] },
   ],
@@ -198,8 +206,8 @@ export const Contact = ObjectSchema.create({
   // Validation Rules
   // `email_unique_per_account` (type: 'unique') was removed in 7.6 — the
   // standalone unique-validation type no longer exists (ADR-0032 validation
-  // union). Email uniqueness is already enforced (globally, which is stricter
-  // than per-account) by the `{ fields: ['email'], unique: true }` index above.
+  // union). Email uniqueness is enforced by the field-level `unique: true`
+  // above, scoped per organization since framework #3696.
 
   // Workflow Rules
   // NOTE: object `workflows[]` were removed in @objectstack 7.7. Field-updates

--- a/src/objects/lead.object.ts
+++ b/src/objects/lead.object.ts
@@ -259,8 +259,14 @@ export const Lead = ObjectSchema.create({
   // status state machines are now expressed in the validation union.
 
   // Database indexes for performance
+  //
+  // No `{ fields: ['email'], unique: true }` here: the field-level
+  // `unique: true` already builds the tenant composite `(organization_id,
+  // email)` since framework #3696. Declaring the single-column index too made
+  // the platform-wide constraint win and left the per-tenant one unreachable
+  // (framework#3991) — two organizations must be able to work the same lead
+  // address independently.
   indexes: [
-    { fields: ['email'], unique: true },
     { fields: ['owner'] },
     { fields: ['status'] },
     { fields: ['company'] },

--- a/src/objects/product.object.ts
+++ b/src/objects/product.object.ts
@@ -191,9 +191,15 @@ export const Product = ObjectSchema.create({
   },
   
   // Database indexes
+  //
+  // No `{ fields: ['sku'], unique: true }` here: the field-level `unique: true`
+  // already builds the tenant composite `(organization_id, sku)` since
+  // framework #3696. Declaring the single-column index too made the
+  // platform-wide constraint win and left the per-tenant one unreachable
+  // (framework#3991) — an SKU is unique inside a catalogue, and two
+  // organizations may legitimately both stock "ABC-123".
   indexes: [
     { fields: ['name'] },
-    { fields: ['sku'], unique: true },
     { fields: ['category'] },
     { fields: ['is_active'] },
   ],


### PR DESCRIPTION
## Description

四个对象把「只在单个组织内唯一」的值声明成了**平台级唯一**。在多租户部署下,每一处都会拒绝第二个组织完全合法的记录。

发现于 framework#3955 的复核过程 —— 用 HotCRM 的真实 metadata 验证框架修复时,顺带暴露出这批声明本身的问题。

### 三处「双声明」

`crm_contact.email`、`crm_lead.email`、`crm_product.sku` 各自把唯一性**声明了两次**:

```ts
email: Field.email({ unique: true }),              // 字段级
indexes: [{ fields: ['email'], unique: true }],    // 对象级
```

两种写法刻意不同(见 `IndexSchema`):自 framework #3696 起,字段级 `unique: true` 是**租户内**唯一 —— 物化为 `(organization_id, email)`;而声明索引严格按 `fields` 物化,即**跨租户全局**唯一。

同时写两个的后果是:物理上更严格的全局索引生效,字段级的租户复合约束成为**永远触发不到的死约束**。两个组织无法各自认识 `john@acme.com`,也无法各自上架 SKU `ABC-123`。

修法:删掉重复的单列索引 —— 字段级声明本就会建出租户复合索引。

### 一处更严重的:`crm_case.case_number`

这处**不是**双声明,但问题更实:一个 **autonumber** 字段上挂着全局唯一索引。

```ts
case_number: Field.autonumber({ format: 'CASE-{00000}' }),
indexes: [{ fields: ['case_number'], unique: true }],   // ← 全局
```

平台的 autonumber 序列是**按租户**计数的 —— 每个组织都从 1 开始。于是第二个组织的 `CASE-00001` 在 insert 时被全局索引拒绝,这正是 framework #3696 要消除的碰撞。已显式写成 `['organization_id', 'case_number']`,让约束与喂给它的序列对齐。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Related to objectstack-ai/objectstack#3991(新增的 `unique/double-declaration` lint,前三处正是它的命中项)
Related to objectstack-ai/objectstack#3955(复核该 issue 时发现)
Related to objectstack-ai/objectstack#3696(租户作用域化,即语义分叉的来源)

## Changes Made

- `src/objects/contact.object.ts` —— 移除 `{ fields: ['email'], unique: true }`;同步订正下方一处已过期的注释(原写「globally, which is stricter than per-account」)
- `src/objects/lead.object.ts` —— 移除 `{ fields: ['email'], unique: true }`
- `src/objects/product.object.ts` —— 移除 `{ fields: ['sku'], unique: true }`
- `src/objects/case.object.ts` —— `['case_number']` → `['organization_id', 'case_number']`
- 每处都留了注释说明为何**不**在此声明单列唯一索引,避免被再次「补」回来

## Testing

- [x] Build succeeds (`objectstack build`)
- [x] Linting passes —— 在 framework#3991 的新 lint 下 `unique/double-declaration` 命中数由 **3 → 0**
- [x] Manual testing completed

端到端验证(HotCRM 跑在含 framework#3981 修复的构建上):全新迁移出的库现在带的是

```
uniq_crm_contact_organization_id_email
uniq_crm_lead_organization_id_email
uniq_crm_product_organization_id_sku
uniq_crm_case_organization_id_case_number
```

且 `os migrate plan` 报告 `Physical schema is in sync with metadata`。

## Additional Notes

**对已有部署的影响**:这几处都是**放宽**约束(全局唯一 → 租户内唯一),不会让既有数据违规,`os migrate` 归类为 safe。单租户部署行为不变。

**留给维护者判断的两处**(本 PR 未动):`crm_account.name` 与 `crm_competitor.name` 也声明了单列全局唯一索引。它们没有字段级 `unique`,所以不构成矛盾,但「两个组织不能各有一个叫 Acme 的客户」在多租户下同样可疑。若确认要按租户隔离,同样改成 `['organization_id', 'name']` 即可;若是有意为之(例如竞争对手是平台级共享字典),维持现状并加一行注释说明会更好。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcphmGzBuWwF8SaYPSCtCw)_