### PR TITLE
fix(security): drop profile grants on the removed crm_competitor object

### DIFF
--- a/.changeset/dangling-competitor-grants.md
+++ b/.changeset/dangling-competitor-grants.md
@@ -1,0 +1,10 @@
+---
+'hotcrm': patch
+---
+
+Remove the four profile grants on `crm_competitor`, an object that no longer
+exists. `main` failed `pnpm validate` with four cross-reference errors: #547
+added the grants while the competitor module was still present, the demo-only
+competitor module was removed separately, and the two merged cleanly on text
+while contradicting each other on meaning. `sales_rep`, `sales_manager`,
+`marketing_user` and `system_admin` no longer reference the removed object.

--- a/src/profiles/marketing-user.profile.ts
+++ b/src/profiles/marketing-user.profile.ts
@@ -21,9 +21,8 @@ export const MarketingUserProfile = {
     // the campaigns this profile can already read; deleting membership history
     // stays a manager/admin privilege, matching every other object here.
     crm_campaign_member: { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: false, viewAllRecords: false, modifyAllRecords: false },
-    // Read-only reference: competitive intel for positioning, knowledge
-    // articles for campaign copy. Both are public_read catalogs.
-    crm_competitor:        { allowCreate: false, allowRead: true, allowEdit: false, allowDelete: false, viewAllRecords: true, modifyAllRecords: false },
+    // Read-only reference: knowledge articles for campaign copy
+    // (public_read catalog).
     crm_knowledge_article: { allowCreate: false, allowRead: true, allowEdit: false, allowDelete: false, viewAllRecords: true, modifyAllRecords: false },
   },
   fields: {

--- a/src/profiles/sales-manager.profile.ts
+++ b/src/profiles/sales-manager.profile.ts
@@ -20,8 +20,6 @@ export const SalesManagerProfile = {
     crm_campaign:    { allowCreate: true,  allowRead: true, allowEdit: true,  allowDelete: false, viewAllRecords: true,  modifyAllRecords: false },
     crm_case:        { allowCreate: false, allowRead: true, allowEdit: false, allowDelete: false, viewAllRecords: true,  modifyAllRecords: false },
     crm_task:        { allowCreate: true,  allowRead: true, allowEdit: true,  allowDelete: true,  viewAllRecords: true,  modifyAllRecords: true },
-    // Competitive-intel catalog (public_read OWD): managers curate battlecards.
-    crm_competitor:  { allowCreate: true,  allowRead: true, allowEdit: true,  allowDelete: false, viewAllRecords: true,  modifyAllRecords: false },
     // The forecast IS the manager's job: they read every rep's snapshot and
     // adjust the committed number, so this is org-wide read AND write on a
     // private object (#488 — the object had no grant at all).

--- a/src/profiles/sales-rep.profile.ts
+++ b/src/profiles/sales-rep.profile.ts
@@ -28,10 +28,8 @@ export const SalesRepProfile = {
     crm_campaign:    { allowCreate: false, allowRead: true,  allowEdit: false, allowDelete: false, viewAllRecords: true,  modifyAllRecords: false },
     crm_case:        { allowCreate: false, allowRead: true,  allowEdit: false, allowDelete: false, viewAllRecords: false, modifyAllRecords: false, readScope: 'own' as const },
     crm_task:        { allowCreate: true,  allowRead: true,  allowEdit: true,  allowDelete: true,  viewAllRecords: false, modifyAllRecords: false, readScope: 'own' as const },
-    // Reference catalogs (public_read OWD): reps read battlecards and knowledge
-    // articles, and may file a new competitor they ran into in a deal, but the
-    // battlecard content itself is curated by managers.
-    crm_competitor:        { allowCreate: true,  allowRead: true, allowEdit: false, allowDelete: false, viewAllRecords: true,  modifyAllRecords: false },
+    // Reference catalog (public_read OWD): reps read knowledge articles, which
+    // are authored by service.
     crm_knowledge_article: { allowCreate: false, allowRead: true, allowEdit: false, allowDelete: false, viewAllRecords: true,  modifyAllRecords: false },
     // Forecast snapshots are written by the nightly `forecast.hook` job and the
     // `revenue_forecasting` skill, never by hand — read-only, and only the rep's

--- a/src/profiles/system-admin.profile.ts
+++ b/src/profiles/system-admin.profile.ts
@@ -24,11 +24,9 @@ export const SystemAdminProfile = {
     crm_campaign:    { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: true, modifyAllRecords: true },
     crm_case:        { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: true, modifyAllRecords: true },
     crm_task:        { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: true, modifyAllRecords: true },
-    // The six objects below shipped with navigation, views, hooks and seed
-    // data but no grant in ANY permission set (#488): "Knowledge" and
-    // "Forecasts" were permission-denied nav items for every user, admins
-    // included, and `crm_competitor` was the same story behind the Sales group.
-    crm_competitor:            { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: true, modifyAllRecords: true },
+    // The objects below shipped with navigation, views, hooks and seed data
+    // but no grant in ANY permission set (#488): "Knowledge" and "Forecasts"
+    // were permission-denied nav items for every user, admins included.
     crm_forecast:              { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: true, modifyAllRecords: true },
     crm_knowledge_article:     { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: true, modifyAllRecords: true },
     // Detail rows. Their RECORD-level access derives from the master


### PR DESCRIPTION
## Description

`main` is currently failing `pnpm validate` with four cross-reference errors — every profile that grants CRUD on `crm_competitor` points at an object that no longer exists:

```
✗ Permission 'marketing_user' grants on object 'crm_competitor' which is not defined in objects.
✗ Permission 'sales_manager' grants on object 'crm_competitor' which is not defined in objects.
✗ Permission 'sales_rep'     grants on object 'crm_competitor' which is not defined in objects.
✗ Permission 'system_admin'  grants on object 'crm_competitor' which is not defined in objects.
```

Reproduced on a clean checkout of `main` at `7f0b3ef4`, so this is not specific to any open PR — but it turns every open PR's `Build and Test` red until it is fixed.

## Root cause — a semantic conflict git could not see

Two merges disagreed on meaning while merging cleanly on text:

| Time (UTC) | Event |
| --- | --- |
| 01:50 | #547 opened. `crm_competitor` existed on its base, so granting CRUD on it was correct. |
| 06:50 | #551 merged, reverting the demo-only competitor module and removing the `crm_competitor` object. |
| 07:57 | #547 merged — an hour after the object was gone, still carrying the grants. |

#551 touched objects, views, navigation and seed data; #547 touched `src/profiles/`. No file overlapped, so git had nothing to conflict on and GitHub's mergeability check — which is textual — stayed green for both. Neither PR was wrong on its own; only their merge order was.

## Changes

- Drop the `crm_competitor` grant from `sales_rep`, `sales_manager`, `marketing_user` and `system_admin`, and reword the surrounding comments that described the competitor catalog.
- The `crm_opportunity.competitors` **picklist** field is unrelated and stays — it never referenced the removed object. (#551 deliberately restored it as the hardcoded select.)

## Verification

On a clean checkout with this fix applied:

- `pnpm validate` — clean: 15 Objects / 309 Fields, 6 Permissions, 12 Positions. The only remaining output is the two pre-existing `campaign_enrollment` flow-variable warnings, which are expected and documented as safe to ignore.
- `pnpm typecheck` — clean.
- `pnpm test` — **128/128 passing** (11 files).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm validate` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] Changeset added

Refs #547, refs #551. No new issue filed: this is the mechanical consequence of the two merges above, not a product defect. The removed demo module itself is archived at tag `demo-series-2026-07` if it is ever needed again.
