### PR TITLE
fix(i18n): translate every action label in all four locales; guard the class (#494)

### DIFF
--- a/.changeset/action-label-i18n-coverage.md
+++ b/.changeset/action-label-i18n-coverage.md
@@ -1,0 +1,13 @@
+---
+'hotcrm': patch
+---
+
+Translate every action label in all four locales, and guard the class with a
+test. Three actions (`enroll_leads`, `schedule_followup`, `generate_quote`) had
+no label entry in any locale pack, so they rendered their English code label in
+zh-CN / ja-JP / es-ES; `log_meeting`'s zh-CN translation sat in a dead top-level
+`globalActions` block instead of under `crm_case._actions`, where the action's
+`objectName` puts it. Adds two assertions to
+`test/metadata-references.test.ts` — every action needs a label in every locale,
+and `confirmText` / `successMessage` must be translated wherever the action
+declares them — so this class fails in CI instead of in a demo. Refs #494.

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -265,6 +265,10 @@ export const en: TranslationData = {
           label: 'Add to Campaign',
           successMessage: 'Leads added to campaign!',
         },
+        schedule_followup: {
+          label: 'Schedule Follow-up',
+          successMessage: 'Follow-up scheduled.',
+        },
       },
     },
 
@@ -359,6 +363,10 @@ export const en: TranslationData = {
           label: 'Update Stage',
           successMessage: 'Opportunities updated successfully!',
         },
+        generate_quote: {
+          label: 'Generate Quote',
+          successMessage: 'Quote created from opportunity!',
+        },
       },
     },
 
@@ -406,6 +414,16 @@ export const en: TranslationData = {
         log_call: {
           label: 'Log a Call',
           successMessage: 'Call logged successfully!',
+        },
+        log_meeting: {
+          label: 'Log a Meeting',
+          successMessage: 'Meeting logged successfully!',
+          params: {
+            subject: { label: 'Meeting Subject' },
+            duration: { label: 'Duration (minutes)' },
+            attendees: { label: 'Attendees' },
+            notes: { label: 'Meeting Notes' },
+          },
         },
         escalate_case: {
           label: 'Escalate Case',
@@ -588,6 +606,12 @@ export const en: TranslationData = {
         campaign_gantt: { label: 'Campaign Schedule' },
         campaign_calendar: { label: 'Launch Calendar' },
         campaign_timeline: { label: 'Marketing Timeline' },
+      },
+      _actions: {
+        enroll_leads: {
+          label: 'Enroll Leads',
+          successMessage: 'Eligible leads enrolled in campaign.',
+        },
       },
     },
 

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -243,6 +243,10 @@ export const esES: TranslationData = {
           label: 'Agregar a Campaña',
           successMessage: '¡Prospecto agregado a la campaña!',
         },
+        schedule_followup: {
+          label: 'Programar Seguimiento',
+          successMessage: 'Seguimiento programado.',
+        },
       },
     },
 
@@ -317,6 +321,10 @@ export const esES: TranslationData = {
           label: 'Actualizar Etapa',
           successMessage: '¡Etapa de oportunidad actualizada!',
         },
+        generate_quote: {
+          label: 'Generar Presupuesto',
+          successMessage: '¡Presupuesto creado desde la oportunidad!',
+        },
       },
     },
 
@@ -364,6 +372,16 @@ export const esES: TranslationData = {
         log_call: {
           label: 'Registrar Llamada',
           successMessage: '¡Llamada registrada con éxito!',
+        },
+        log_meeting: {
+          label: 'Registrar Reunión',
+          successMessage: '¡Reunión registrada con éxito!',
+          params: {
+            subject: { label: 'Asunto de la Reunión' },
+            duration: { label: 'Duración (minutos)' },
+            attendees: { label: 'Asistentes' },
+            notes: { label: 'Notas de la Reunión' },
+          },
         },
         escalate_case: {
           label: 'Escalar Caso',
@@ -546,6 +564,12 @@ export const esES: TranslationData = {
         campaign_gantt: { label: 'Programación de Campañas' },
         campaign_calendar: { label: 'Calendario de Campañas' },
         campaign_timeline: { label: 'Línea de Tiempo de Marketing' },
+      },
+      _actions: {
+        enroll_leads: {
+          label: 'Inscribir Prospectos',
+          successMessage: 'Prospectos elegibles inscritos en la campaña.',
+        },
       },
     },
 

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -243,6 +243,10 @@ export const jaJP: TranslationData = {
           label: 'キャンペーンに追加',
           successMessage: 'キャンペーンに追加しました！',
         },
+        schedule_followup: {
+          label: 'フォローアップを設定',
+          successMessage: 'フォローアップを設定しました。',
+        },
       },
     },
 
@@ -317,6 +321,10 @@ export const jaJP: TranslationData = {
           label: 'ステージ更新',
           successMessage: '商談ステージを更新しました！',
         },
+        generate_quote: {
+          label: '見積を作成',
+          successMessage: '商談から見積を作成しました！',
+        },
       },
     },
 
@@ -364,6 +372,16 @@ export const jaJP: TranslationData = {
         log_call: {
           label: '通話を記録',
           successMessage: '通話を記録しました！',
+        },
+        log_meeting: {
+          label: '会議を記録',
+          successMessage: '会議を記録しました！',
+          params: {
+            subject: { label: '会議の件名' },
+            duration: { label: '所要時間（分）' },
+            attendees: { label: '参加者' },
+            notes: { label: '議事メモ' },
+          },
         },
         escalate_case: {
           label: 'ケースをエスカレート',
@@ -546,6 +564,12 @@ export const jaJP: TranslationData = {
         campaign_gantt: { label: 'キャンペーン日程' },
         campaign_calendar: { label: 'キャンペーンカレンダー' },
         campaign_timeline: { label: 'マーケティングタイムライン' },
+      },
+      _actions: {
+        enroll_leads: {
+          label: 'リードを一括登録',
+          successMessage: '対象リードをキャンペーンに登録しました。',
+        },
       },
     },
 

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -331,6 +331,10 @@ export const zhCN: TranslationData = {
           label: '加入营销活动',
           successMessage: '已将线索加入营销活动！',
         },
+        schedule_followup: {
+          label: '安排跟进',
+          successMessage: '跟进任务已创建。',
+        },
       },
     },
 
@@ -486,9 +490,19 @@ export const zhCN: TranslationData = {
           label: '记录通话',
           successMessage: '通话记录成功！',
           params: {
-          subject: { label: '通话主题' },
-          duration: { label: '时长（分钟）' },
-          notes: { label: '通话记录' },
+            subject: { label: '通话主题' },
+            duration: { label: '时长（分钟）' },
+            notes: { label: '通话记录' },
+          },
+        },
+        log_meeting: {
+          label: '记录会议',
+          successMessage: '会议记录成功！',
+          params: {
+            subject: { label: '会议主题' },
+            duration: { label: '时长（分钟）' },
+            attendees: { label: '参会人' },
+            notes: { label: '会议纪要' },
           },
         },
         escalate_case: {
@@ -624,6 +638,12 @@ export const zhCN: TranslationData = {
         campaign_gantt: { label: '活动排期' },
         campaign_calendar: { label: '活动日历' },
         campaign_timeline: { label: '营销时间线' },
+      },
+      _actions: {
+        enroll_leads: {
+          label: '批量加入线索',
+          successMessage: '符合条件的线索已加入营销活动。',
+        },
       },
     },
 
@@ -767,6 +787,10 @@ export const zhCN: TranslationData = {
           label: '克隆商机',
           successMessage: '商机克隆成功！',
         },
+        generate_quote: {
+          label: '生成报价单',
+          successMessage: '已根据商机创建报价单！',
+        },
         mass_update_stage: {
           label: '更新阶段',
           successMessage: '商机阶段已更新！',
@@ -846,19 +870,6 @@ export const zhCN: TranslationData = {
         tax_rate: { label: '税率（%）' },
         total_price: { label: '总计' },
         line_number: { label: '行号' },
-      },
-    },
-  },
-
-  globalActions: {
-    log_meeting: {
-      label: '记录会议',
-      successMessage: '会议记录成功！',
-      params: {
-        subject: { label: '会议主题' },
-        duration: { label: '时长（分钟）' },
-        attendees: { label: '参会人' },
-        notes: { label: '会议纪要' },
       },
     },
   },

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -23,6 +23,7 @@ const objects: AnyRec[] = (stack as any).objects ?? [];
 const pages: AnyRec[] = (stack as any).pages ?? [];
 const views: AnyRec[] = (stack as any).views ?? [];
 const profiles: AnyRec[] = (stack as any).permissions ?? [];
+const stackActions: AnyRec[] = (stack as any).actions ?? [];
 
 const objectNames = new Set(objects.map((o) => o.name));
 const profileNames = new Set(profiles.map((p) => p.name));
@@ -954,5 +955,54 @@ describe('dashboard date ranges window a field the query layer can actually comp
       }
     }
     expect(bad, `dangling dashboard date-range fields:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});
+
+/**
+ * Action labels are the most visible strings in the app — they render in row
+ * menus, on detail-page headers and in list toolbars. They also had no guard,
+ * so #494's i18n audit missed the whole class: three actions
+ * (`enroll_leads`, `schedule_followup`, `generate_quote`) shipped with no label
+ * entry in ANY locale pack, and `log_meeting` had one only in zh-CN.
+ *
+ * The gap only became visible as recent PRs surfaced those actions:
+ * `generate_quote` moved onto the opportunity header (#515), `enroll_leads`
+ * was introduced with the campaign-enrollment screen flow (#536), and
+ * `schedule_followup` became the row menu's sole remaining entry once the dead
+ * duplicate was removed (#537). A missing entry is not an error — it silently
+ * falls back to the English `label` in code — which is exactly why it needs a
+ * test rather than a warning.
+ */
+describe('action labels are translated in every locale', () => {
+  it('every action has a label entry in every locale pack', () => {
+    expect(localePacks.length, 'no locale packs found in stack.translations').toBeGreaterThan(0);
+    const bad: string[] = [];
+    for (const action of stackActions) {
+      const { name, objectName } = action;
+      if (!name || !objectName) continue;
+      for (const [locale, pack] of localePacks) {
+        const label = pack?.objects?.[objectName]?._actions?.[name]?.label;
+        if (!label) bad.push(`${locale}: ${objectName}._actions.${name}.label`);
+      }
+    }
+    expect(bad, `actions with no translated label:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('confirmText and successMessage are translated wherever the action declares them', () => {
+    // A half-translated action is worse than an untranslated one: the menu item
+    // reads Chinese and then the confirm dialog answers in English.
+    const bad: string[] = [];
+    for (const action of stackActions) {
+      const { name, objectName } = action;
+      if (!name || !objectName) continue;
+      for (const key of ['confirmText', 'successMessage'] as const) {
+        if (!action[key]) continue;
+        for (const [locale, pack] of localePacks) {
+          const entry = pack?.objects?.[objectName]?._actions?.[name];
+          if (entry && !entry[key]) bad.push(`${locale}: ${objectName}._actions.${name}.${key}`);
+        }
+      }
+    }
+    expect(bad, `action strings declared in code but not translated:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 });


### PR DESCRIPTION
## Description

Closes the **action-label** gap in #494's i18n audit, and adds a guard so the class cannot silently reopen.

Action labels are the most visible strings in the app — they render in row menus, on detail-page headers and in list toolbars — but #494's audit covered objects, fields, options, navigation and `_sections`, not `_actions.*.label`. Found by testing on 16.1.0 after #537 merged: the lead row menu rendered 「转化线索」and 「加入营销活动」in Chinese, but 「Schedule Follow-up」in English.

Comparing all 13 declared actions in `src/actions/*.ts` against the four locale packs:

| Action | Object | en | zh-CN | ja-JP | es-ES |
| --- | --- | :-: | :-: | :-: | :-: |
| `enroll_leads` | crm_campaign | ✗ | ✗ | ✗ | ✗ |
| `schedule_followup` | crm_lead | ✗ | ✗ | ✗ | ✗ |
| `generate_quote` | crm_opportunity | ✗ | ✗ | ✗ | ✗ |
| `log_meeting` | crm_case | ✗ | ✗* | ✗ | ✗ |

\* zh-CN *had* a `log_meeting` translation, but in a dead top-level `globalActions` block. The action declares `objectName: 'crm_case'`, so the consumed path is `objects.crm_case._actions.log_meeting` — exactly where its twin `log_call` already lived. The block was left behind when #515 scoped these two actions to `crm_case`; it is now moved into place and the dead block removed. This is the same "translation keyed to nothing" class #494 catalogues elsewhere.

### Why it surfaced now

These three are precisely the actions that recent PRs pushed into the UI: `generate_quote` moved onto the opportunity header and row actions (#515), `enroll_leads` arrived with the campaign-enrollment screen flow (#536), and `schedule_followup` became the row menu's sole remaining entry once #537 removed the dead duplicate. As more actions get surfaced correctly, this class keeps becoming visible — hence the guard rather than four one-off fixes.

## Changes

- **Translations** — added `enroll_leads`, `schedule_followup`, `generate_quote` and `log_meeting` (with its four params) to `en`, `zh-CN`, `ja-JP`, `es-ES`, keyed under the object each action declares. Removed zh-CN's dead `globalActions` block; also fixed the stray indentation in `log_call`'s params while in that block.
- **Guard** (`test/metadata-references.test.ts`, 2 new assertions):
  - every declared action has `_actions.<name>.label` in **every** locale pack;
  - `confirmText` / `successMessage` are translated wherever the action declares them — a half-translated action is worse than an untranslated one, since the menu item reads Chinese and the confirm dialog then answers in English.

A missing entry is not an error at runtime — it silently falls back to the English `label` in code — which is why this needs a test rather than a lint warning.

## Verification

**Red → green.** The first guard, run against `main` before these translations, failed with exactly the 16 expected misses (4 actions × 4 locales):

```
en: crm_campaign._actions.enroll_leads.label
zh-CN: crm_campaign._actions.enroll_leads.label
... (16 total)
```

After the translations, on a clean checkout:

- `pnpm validate` — clean (16 objects / 6 permissions). Only the two pre-existing `campaign_enrollment` flow-variable warnings remain, documented as safe to ignore.
- `pnpm typecheck` — clean.
- `pnpm test` — **136/136 passing** (11 files; was 128 before the 8 new assertions).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm validate` / `typecheck` / `test` pass
- [x] Tests added that prove the fix (guard fails before, passes after)
- [x] Changeset added

Refs #494 — that issue stays open for its remaining scope (option keys keyed by display label, navigation coverage in en/ja-JP/es-ES, the 40 keys missing from ja-JP and es-ES, translations pointing at renamed fields).
