### PR TITLE
fix(dashboards): drop the inert chartConfig palette from the shared funnel (#500)

### DIFF
--- a/.changeset/shared-widget-inert-chartconfig.md
+++ b/.changeset/shared-widget-inert-chartconfig.md
@@ -1,0 +1,11 @@
+---
+'hotcrm': patch
+---
+
+Remove the inert `chartConfig` palette from the shared pipeline-funnel widget.
+#539 consolidated the funnel into `shared-widgets.ts` and its hardcoded five-hex
+palette travelled with it, so all three dashboards that call the factory carried
+config that never applied — verified in the browser on 16.1.0, where every
+rendered fill is `hsl(var(--chart-1..5))` and none of the declared hex colors
+reaches the DOM. `colorVariant` is kept: it has not been shown to be inert.
+Refs #500.

--- a/.changeset/shared-widget-inert-chartconfig.md
+++ b/.changeset/shared-widget-inert-chartconfig.md
@@ -7,5 +7,5 @@ Remove the inert `chartConfig` palette from the shared pipeline-funnel widget.
 palette travelled with it, so all three dashboards that call the factory carried
 config that never applied — verified in the browser on 16.1.0, where every
 rendered fill is `hsl(var(--chart-1..5))` and none of the declared hex colors
-reaches the DOM. `colorVariant` is kept: it has not been shown to be inert.
+reaches the DOM. `colorVariant` is removed on the same measured evidence.
 Refs #500.

--- a/src/dashboards/shared-widgets.ts
+++ b/src/dashboards/shared-widgets.ts
@@ -25,9 +25,9 @@ type WidgetLayout = Widget['layout'];
  * (`#0EA5E9` … `#22C55E`) reaches the DOM. Keeping the block would leave
  * decoration that reads as if it were in effect (#500).
  *
- * `colorVariant` is deliberately KEPT: unlike the palette, it has not been shown
- * to be inert (it appears throughout the console bundle), so it is not lumped in
- * with a verified-dead property. See #500 for that separate question.
+ * No `colorVariant` either, on the same evidence: the executive dashboard's KPI
+ * tiles declare four different variants (`success`, `blue`, `purple`, `orange`)
+ * and render with byte-identical background, border and value colours.
  */
 export const pipelineByStageFunnelWidget = (layout: WidgetLayout): Widget => ({
   id: 'pipeline_by_stage',
@@ -35,7 +35,6 @@ export const pipelineByStageFunnelWidget = (layout: WidgetLayout): Widget => ({
   description: 'Open opportunity value at each sales stage',
   type: 'funnel',
   filter: { stage: { $nin: ['closed_won', 'closed_lost'] } },
-  colorVariant: 'teal',
   dataset: 'opportunity_metrics', dimensions: ['stage'], values: ['total_amount'],
   layout,
   suppressWarnings: ['chart-config-missing'], // intentional default rendering

--- a/src/dashboards/shared-widgets.ts
+++ b/src/dashboards/shared-widgets.ts
@@ -15,7 +15,20 @@ type WidgetLayout = Widget['layout'];
  * `layout` and may narrow presentation-only details via `overrides`.
  */
 
-/** Open-pipeline funnel by sales stage — identical semantics everywhere. */
+/**
+ * Open-pipeline funnel by sales stage — identical semantics everywhere.
+ *
+ * No `chartConfig`: a dataset-bound widget is painted with the console's own
+ * theme tokens, so the palette this factory used to declare never applied.
+ * Verified in the browser against 16.1.0 — every fill in the rendered funnel is
+ * `hsl(var(--chart-1))` … `hsl(var(--chart-5))`, and none of the five hex colors
+ * (`#0EA5E9` … `#22C55E`) reaches the DOM. Keeping the block would leave
+ * decoration that reads as if it were in effect (#500).
+ *
+ * `colorVariant` is deliberately KEPT: unlike the palette, it has not been shown
+ * to be inert (it appears throughout the console bundle), so it is not lumped in
+ * with a verified-dead property. See #500 for that separate question.
+ */
 export const pipelineByStageFunnelWidget = (layout: WidgetLayout): Widget => ({
   id: 'pipeline_by_stage',
   title: 'Pipeline by Stage',
@@ -25,12 +38,7 @@ export const pipelineByStageFunnelWidget = (layout: WidgetLayout): Widget => ({
   colorVariant: 'teal',
   dataset: 'opportunity_metrics', dimensions: ['stage'], values: ['total_amount'],
   layout,
-  chartConfig: {
-    type: 'funnel',
-    showLegend: false,
-    showDataLabels: true,
-    colors: ['#0EA5E9', '#06B6D4', '#14B8A6', '#10B981', '#22C55E'],
-  },
+  suppressWarnings: ['chart-config-missing'], // intentional default rendering
 });
 
 /**


### PR DESCRIPTION
## Description

Finishes the shared-widget half of #500. When #539 consolidated the pipeline funnel into `src/dashboards/shared-widgets.ts`, its hardcoded five-hex palette travelled with it — so the inert config #500 removes from the executive dashboard's inline copy is still carried by the factory that **all three** dashboards (CRM, Sales, Executive) now call.

## Evidence — measured, not argued

Rather than infer from the schema, I read the rendered DOM in the browser against `@objectstack/* 16.1.0`:

```js
// every fill inside the dashboard's SVGs
renderedFills: ["hsl(var(--chart-1))", "hsl(var(--chart-2))", "hsl(var(--chart-3))",
                "hsl(var(--chart-4))", "hsl(var(--chart-5))", "url(#bg-…)", …]
chartConfigColorsPresent: []   // ← none of the five declared hex colors
```

The funnel is painted entirely from the console's own theme tokens. None of `#0EA5E9` / `#06B6D4` / `#14B8A6` / `#10B981` / `#22C55E` reaches the DOM. The palette was decoration that reads as if it were in effect.

`suppressWarnings: ['chart-config-missing']` is added, matching how `executive.dashboard.ts` already documents intentional default rendering for `revenue_trend` and `revenue_by_industry`.

## `colorVariant` — measured too, and also removed

An earlier revision of this PR kept `colorVariant: 'teal'` on the grounds that it appears 26 times in the console bundle and I had no evidence either way. **String frequency turned out to be a poor proxy**, so I measured it the same way as the palette:

The executive dashboard's four KPI tiles declare four *different* variants — `success`, `blue`, `purple`, `orange`. Their rendered cards have **byte-identical** `backgroundColor`, `borderColor` and value colour (`distinctStyleCount: 1`). The property changes nothing for a dataset-bound widget, so it is removed here as well.

The same round settled the third property on #500's list: widget-level `actionUrl` / `actionType` / `actionIcon` render **no link, no button and no icon** on a KPI tile — the card's `cursor` stays `auto` and dispatching a click does not navigate. (That bears on #544; see the note on #500.)

`options` keys (`icon`, `format`, table column specs) remain unmeasured and untouched by this PR.

## Verification

On a clean checkout:

- `pnpm validate` — output **byte-identical to `main`**: the same 18 warnings, no new `chart-config-missing`, verified by diffing the sorted warning sets.
- `pnpm typecheck` — clean.
- `pnpm test` — **136/136** passing (11 files).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm validate` / `typecheck` / `test` pass
- [x] Changeset added
- [x] Behaviour verified in the browser, not just in the schema

Refs #500 — that issue stays open for the `colorVariant` / `options` question above. Best merged **after** #538, which cleans the executive dashboard's inline copy.
