### PR TITLE
test: drop the now-stale unguarded-predicate exemption (unbreaks main)

### DIFF
--- a/.changeset/stale-unguarded-exemption.md
+++ b/.changeset/stale-unguarded-exemption.md
@@ -1,0 +1,9 @@
+---
+---
+
+Empty the `KNOWN_UNGUARDED` exemption map. #570 and #571 were each green on
+their own branch; #571 carved `crm_opportunity_line_item.unit_price_positive`
+out as a documented exemption while #570 landed that very guard in parallel, so
+the entry went stale the moment both merged and #571's own staleness check
+turned `main` red. Removing the entry is the fix the check was written to force.
+Tooling only — releases nothing.

--- a/test/object-validation-predicates.test.ts
+++ b/test/object-validation-predicates.test.ts
@@ -91,15 +91,15 @@ function unguardedFields(source: string): string[] {
 /**
  * Rules still shipping an unguarded comparison, with the reason.
  *
- * This is a shrinking list, not a permanent exemption: the entry below is the
- * remaining half of #514 item 3, carved into its own change because it touches
- * a different object family. The "no stale entries" test keeps this honest —
- * once that rule grows its guard, this map must be emptied or CI fails.
+ * Empty, and the "no stale entries" test below keeps it that way. It held one
+ * entry — `crm_opportunity_line_item.unit_price_positive`, the half of #514
+ * item 3 that was carved out of #571 because it touches a different object
+ * family. #570 landed that guard in parallel, so the exemption went stale the
+ * moment both merged and this file's own staleness check turned main red. That
+ * is the mechanism working: an exemption may outlive its fix by exactly one
+ * merge, never longer.
  */
-const KNOWN_UNGUARDED: Record<string, string> = {
-  'crm_opportunity_line_item.unit_price_positive':
-    '#514 item 3, opportunity_line_item half — tracked separately',
-};
+const KNOWN_UNGUARDED: Record<string, string> = {};
 
 describe('validation predicates are null-guarded', () => {
   it('finds script validations to check at all', () => {


### PR DESCRIPTION
## Description

`main` is red. `test/object-validation-predicates.test.ts` › *keeps no stale entries in the known-unguarded list* fails:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+ [ "crm_opportunity_line_item.unit_price_positive" ]
```

**Nothing is broken — the guard fired exactly as designed.**

## What happened

#571 could not fix `crm_opportunity_line_item.unit_price_positive` (it belongs to a different object family than that PR's scope), so it recorded the rule as a documented exemption **and paired it with a staleness check**, precisely so the exemption could not quietly outlive its fix.

#570, running in parallel, added the guard to that very rule.

Both PRs were green on their own branch. The collision exists only on `main`, where the exemption is now stale — which is the exact condition #571's check was written to detect. Emptying the map is the fix it was asking for.

This is the **third** instance today of "individually green, red after merge" (the others: #547's dangling `crm_competitor` grants, #439's stale StackBlitz lockfile). Worth noting that this one is the only one a test caught automatically — the other two had to be found by hand.

## Changes

- `KNOWN_UNGUARDED` is now empty, with a comment recording why the entry existed and how it died, so the next reader understands the mechanism rather than just seeing an empty object.

## Verification

`pnpm verify` on a clean checkout:

- **exit code 0**, 0 errors
- **436 passed | 2 skipped** (24 files) — the 2 skips are the version-gated `@objectstack 17+` bucket assertions
- 4 warnings, all pre-existing and benign

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm verify` passes
- [x] Changeset added (empty frontmatter — releases nothing)

Refs #514.
