### PR TITLE
fix(task): drop the shadowed assignment field group

### DIFF
--- a/.changeset/task-shadowed-field-group.md
+++ b/.changeset/task-shadowed-field-group.md
@@ -1,0 +1,10 @@
+---
+'hotcrm': patch
+---
+
+Drop the shadowed `assignment` field group on `crm_task`. #577 added the group
+with `owner` as its only member, but the synthesized detail page hoists `owner`
+into the highlight strip, so the group rendered on forms and never on detail
+pages (`field-group-shadowed`). `owner` moves to `basic`, next to
+subject/status/priority. Clears the warning #577 introduced; validate goes from
+5 warnings to 4.

--- a/src/objects/task.object.ts
+++ b/src/objects/task.object.ts
@@ -23,7 +23,10 @@ export const Task = ObjectSchema.create({
   fieldGroups: [
     { key: 'basic',      label: 'Task Information', icon: 'info' },
     { key: 'scheduling', label: 'Scheduling',       icon: 'calendar' },
-    { key: 'assignment', label: 'Assignment',       icon: 'user' },
+    // No 'assignment' group: `owner` was its only member, and the synthesized
+    // detail page hoists `owner` into the highlight strip — so the group
+    // rendered on forms and never on detail pages (`field-group-shadowed`).
+    // It lives in `basic` alongside subject/status/priority instead.
     { key: 'related',    label: 'Related Records',  icon: 'link' },
     { key: 'recurrence', label: 'Recurrence',       icon: 'refresh-ccw', defaultExpanded: false },
     { key: 'effort',     label: 'Progress & Effort', icon: 'activity',   defaultExpanded: false },
@@ -123,7 +126,7 @@ export const Task = ObjectSchema.create({
     
     // Assignment
     owner: Field.lookup('sys_user', {
-      group: 'assignment',
+      group: 'basic',
       defaultValue: cel`os.user.id`,
       label: 'Assigned To',
       trackHistory: true,


### PR DESCRIPTION
## Description

#577 (issue #575, item A3) gave `crm_task` a `fieldGroups` list. One entry — `assignment` — has `owner` as its only member, and the synthesized detail page hoists `owner` into the highlight strip. The group therefore renders on forms and **never** on detail pages, which `os validate` reports as:

```
⚠ object "crm_task": every field in group "assignment" (owner) is hoisted into the
  detail highlight strip (or is the record title) — the group renders on forms but
  never on detail pages
  rule: field-group-shadowed  at objects[14].fieldGroups
```

`main` went from 4 warnings to 5 when #577 landed. This clears it.

## Changes

- Removed the `assignment` group; `owner` moves to `basic`, alongside `subject` / `status` / `priority` — where a task's assignee reads naturally anyway.
- Left a comment recording *why* the group is absent, so the next person adding groups to this object doesn't reintroduce it.

`crm_campaign` also has an `assignment` group — untouched, it is a different object with several members.

## Not fixed here

`crm_campaign_member` still trips the same rule (its entire `basic` group is hoisted). That one is pre-existing, predates #577, and has a different shape — the object also has no name/title field, so it needs its own think rather than being swept into this PR.

## Verification

`pnpm verify` on a clean checkout:

- **exit code 0**, 0 errors
- warnings **5 → 4**; the remaining `field-group-shadowed` is the `crm_campaign_member` one described above
- **630 passed | 2 skipped** (33 files) — unchanged

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm verify` passes
- [x] Changeset added

Refs #575.
