### PR TITLE
chore(repo): labels-as-code — taxonomy manifest + sync workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,72 @@
+# Label taxonomy — the single source of truth for this repository's labels.
+#
+# Governance (no ad-hoc labels):
+#   - Every label this repo uses is declared here with a color and description.
+#     Add or change a label by PR-ing this file; the `label-sync` workflow
+#     applies the manifest when it lands on main (or via manual dispatch).
+#   - `.github/labeler.yml` (the path-based PR labeler) may only reference
+#     labels declared here — actions/labeler does not create labels.
+#   - Sync is non-destructive (skip-delete): labels absent from this manifest
+#     are left untouched. Retire a label by removing it here AND deleting it in
+#     repo settings in the same change, so manifest and reality stay aligned.
+#
+# Taxonomy:
+#   type        bug / enhancement / documentation / dependencies
+#   area        metadata / backend / ci/cd / configuration
+#   priority    prio:p0 — blocking the current release goal
+#               prio:p1 — next in line once P0s clear
+#               prio:p2 — triaged backlog, no near-term schedule
+#   provenance  upstream:objectstack — blocked on / caused by the platform
+#   workflow    needs-user-decision / skip-changeset
+
+# --- type ---
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+- name: dependencies
+  color: 0366d6
+  description: Dependency bumps and lockfile changes
+
+# --- area (mirrors .github/labeler.yml path rules) ---
+- name: metadata
+  color: c5def5
+  description: Declarative metadata — schema, security posture, UI surfaces
+- name: backend
+  color: c2e0c6
+  description: Server-side behaviour — hooks, flows, actions
+- name: ci/cd
+  color: 6e5494
+  description: CI plumbing and the verification pipeline
+- name: configuration
+  color: bfd4f2
+  description: Build and app configuration files
+
+# --- priority ---
+- name: "prio:p0"
+  color: b60205
+  description: Blocking the current release goal — do first
+- name: "prio:p1"
+  color: d93f0b
+  description: Next in line once P0s clear
+- name: "prio:p2"
+  color: fef2c0
+  description: Triaged backlog — no near-term schedule
+
+# --- provenance ---
+- name: "upstream:objectstack"
+  color: 5319e7
+  description: Blocked on / caused by the ObjectStack platform — tracked upstream
+
+# --- workflow ---
+- name: needs-user-decision
+  color: fbca04
+  description: Needs the maintainer's call before work proceeds
+- name: skip-changeset
+  color: cccccc
+  description: PR ships nothing to users (pure CI/docs chore) — changeset gate waived

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,29 @@
+name: Label Sync
+
+# Applies .github/labels.yml — the label taxonomy manifest — to the repository,
+# creating missing labels and updating colors/descriptions of declared ones.
+# Non-destructive by design (skip-delete): labels not in the manifest are left
+# alone, so GitHub defaults and any not-yet-inventoried labels survive. Retire
+# a label by removing it from the manifest AND deleting it in repo settings.
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/labels.yml']
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: Sync labels from manifest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          skip-delete: true
+          dry-run: false


### PR DESCRIPTION
## Description

Labels were being created ad hoc through the issues API — bare gray, no description — and half the repo's pre-existing labels (`metadata`, `backend`) were in the same state. This PR makes the label taxonomy a governed, reviewable asset:

- **`.github/labels.yml`** — single source of truth for every label: type (`bug`/`enhancement`/`documentation`/`dependencies`), area (`metadata`/`backend`/`ci/cd`/`configuration`), priority (`prio:p0/p1/p2`), provenance (`upstream:objectstack`), workflow (`needs-user-decision`/`skip-changeset`). Colors + descriptions for all, including the previously bare ones.
- **`.github/workflows/label-sync.yml`** — applies the manifest on merge to `main` (or manual dispatch) via `crazy-max/ghaction-github-labeler@v5`. Non-destructive (`skip-delete: true`): unlisted labels survive, so nothing not yet inventoried gets wiped.

Governance going forward: new labels land via PR to `labels.yml`, never ad hoc. `.github/labeler.yml` (path-based PR labeler) may only reference labels declared here — consistent with the invariant its own comments already state.

Manual follow-up after merge (one-time): delete the two stray bare labels `preview-1` and `post-preview` in repo settings — already removed from all issues, superseded by `prio:*`.

## Type of Change

- [x] CI/CD update

## Related Issues

Related to the 2026-08-02 backlog triage (`prio:p0/p1/p2` + `upstream:objectstack` labeling across #494–#603).

## Changes Made

- Add `.github/labels.yml` label taxonomy manifest (14 labels, 5 families) with governance header
- Add `.github/workflows/label-sync.yml` sync workflow (push-to-main on manifest change + workflow_dispatch)

## Testing

- YAML syntax validated; no application code paths affected
- `test/labeler-config.test.ts` invariants unaffected (labeler.yml untouched; all labels it references are declared in the manifest)
- First real sync run happens on merge (workflow is also manually dispatchable for a dry verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf

---
_Generated by [Claude Code](https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf)_