### PR TITLE
chore(repo): add pm:queue / pm:dispatched to the label taxonomy

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -67,6 +67,12 @@
 - name: needs-user-decision
   color: fbca04
   description: Needs the maintainer's call before work proceeds
+- name: "pm:queue"
+  color: 0e8a16
+  description: Ready for the PM dispatch loop
+- name: "pm:dispatched"
+  color: 1d76db
+  description: Dispatched to a dev agent by /pm-dispatch
 - name: skip-changeset
   color: cccccc
   description: PR ships nothing to users (pure CI/docs chore) — changeset gate waived


### PR DESCRIPTION
## Description

Follow-up to #604 (merged): adds the `/pm-dispatch` loop's two state labels to the taxonomy manifest — through the labels-as-code channel that #604 established, not ad hoc via the issues API. `needs-user-decision` (the third pm-loop label) was already declared.

- `pm:queue` `0e8a16` — Ready for the PM dispatch loop
- `pm:dispatched` `1d76db` — Dispatched to a dev agent by /pm-dispatch

The PM dispatch loop for the hotcrm P0 backlog is starting now; `pm:dispatched` will be applied to in-flight issues (bare until this merges and label-sync restyles it).

## Type of Change

- [x] CI/CD update

## Related Issues

Related to #604.

## Changes Made

- Add `pm:queue` and `pm:dispatched` entries to `.github/labels.yml` (workflow family)

## Testing

- YAML-only change; label-sync workflow applies it on merge (also manually dispatchable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf

---
_Generated by [Claude Code](https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf)_