### PR TITLE
fix(app): bind ambient chat to the platform `ask` agent

### DIFF
--- a/.changeset/app-default-agent-platform-binding.md
+++ b/.changeset/app-default-agent-platform-binding.md
@@ -1,0 +1,17 @@
+---
+'hotcrm': patch
+---
+
+Bind the CRM app's ambient chat to the platform `ask` agent. `crm_enterprise`
+still declared `defaultAgent: 'sales_copilot'`, an app-authored agent retired in
+#512 — per ADR-0063 §1/§2 the key is a surface binding whose only resolvable
+values are the two platform agents (`ask` for data surfaces, `build` for
+authoring surfaces), so the runtime's `loadAgent()` refused the record and the
+floating chatbot resolved to nothing. Nothing caught it: `defaultAgent` accepts
+any well-formed snake_case name, and the platform's agent lint only walks
+authored agents. HotCRM's six shipped skills already attach to `ask` by
+`surface` affinity, so the assistant now answers with its full skill set.
+Adds a guard to `test/metadata-references.test.ts` that pins every app's
+`defaultAgent` against the platform agent set read straight off the spec's
+`AgentSchema`, so the next dangling binding fails locally instead of in a demo.
+Refs #586.

--- a/src/apps/crm.app.ts
+++ b/src/apps/crm.app.ts
@@ -15,7 +15,13 @@ export const CrmApp = App.create({
   name: 'crm_enterprise',
   label: 'HotCRM',
   icon: 'briefcase',
-  defaultAgent: 'sales_copilot',
+  // ADR-0063 §1/§2 — `defaultAgent` is a surface binding, not a custom-agent
+  // slot: the only resolvable values are the two PLATFORM agents, `ask` (data
+  // surface) and `build` (authoring surface). HotCRM is a data surface, so it
+  // binds `ask`; the app's own AI capability ships as skills (`src/skills/`),
+  // which attach to the platform agents by `surface` affinity. The app-authored
+  // agents this key used to name were retired in #512.
+  defaultAgent: 'ask',
   branding: {
     primaryColor: '#4169E1',
     logo: '/assets/crm-logo.png',

--- a/src/pages/account_detail.page.ts
+++ b/src/pages/account_detail.page.ts
@@ -22,8 +22,8 @@ import type { Page } from '@objectstack/spec/ui';
  * Why not embed an inline chat panel? `ai:chat_window` was dropped
  * from objectui (see @object-ui/layout CHANGELOG 5.x). The supported
  * surface is the global floating chatbot mounted by app-shell, which
- * picks up `defaultAgent: 'sales_copilot'` from this app and is
- * launched from the FAB at the bottom-right.
+ * picks up `defaultAgent: 'ask'` from this app and is launched from
+ * the FAB at the bottom-right.
  */
 export const AccountDetailPage = {
   name: 'account_detail_page',

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { isDateMacroToken } from '@objectstack/spec/data';
+import { AgentSchema } from '@objectstack/spec/ai';
 import stack from '../objectstack.config';
 
 /**
@@ -1281,5 +1282,71 @@ describe('form views do not declare a dead data provider', () => {
       .filter((v) => !(v.list?.data?.object ?? v.object))
       .map((v) => v.list?.name ?? v.form?.type ?? '(unnamed view)');
     expect(unresolved, `views whose object no longer resolves:\n  ${unresolved.join('\n  ')}`).toEqual([]);
+  });
+});
+
+/**
+ * `App.defaultAgent` is a SURFACE BINDING, not a custom-agent slot.
+ *
+ * ADR-0063 §1/§2: the kernel ships exactly two agents — `ask` (the data
+ * surface, the implicit default) and `build` (authoring surfaces such as
+ * Studio). Tenant/app-package custom agents were withdrawn, and HotCRM's own
+ * app-authored agents were retired in #512; the app's AI capability now ships
+ * as skills, which attach to a platform agent by `surface` affinity.
+ *
+ * Nothing caught the dangling binding this replaces. `App.defaultAgent` is
+ * typed `SnakeCaseIdentifierSchema` — any well-formed snake_case name parses —
+ * so `os validate`, `pnpm build` and the platform's agent lint (which only
+ * walks `stack.agents`) all stayed green while `defaultAgent: 'sales_copilot'`
+ * pointed at an agent that had not existed for months. The failure is silent
+ * and late: `loadAgent()` refuses the non-platform record at chat time, so the
+ * only symptom is the ambient chatbot not answering in a demo.
+ *
+ * The platform set is READ FROM THE SPEC (`AgentSchema.shape.surface`), not
+ * transcribed here — the agent names and the surface names are the same two
+ * tokens, so this guard tracks the contract instead of drifting from it.
+ */
+describe('app AI bindings resolve to a platform agent', () => {
+  const apps: AnyRec[] = (stack as any).apps ?? [];
+
+  /** `['ask', 'build']` — straight off the spec's own surface enum. */
+  const PLATFORM_AGENTS: string[] = (() => {
+    const surface = (AgentSchema as AnyRec).shape.surface;
+    const enumSchema = typeof surface.removeDefault === 'function' ? surface.removeDefault() : surface;
+    return enumSchema.options as string[];
+  })();
+
+  it('the spec still exposes exactly the two platform agents', () => {
+    // Guard the guard: if this introspection ever returns [] the checks below
+    // would pass by asserting nothing (or fail for the wrong reason).
+    expect(PLATFORM_AGENTS).toEqual(['ask', 'build']);
+  });
+
+  it('every app defaultAgent names a platform agent', () => {
+    expect(apps.length, 'no apps found in the stack — the guard is vacuous').toBeGreaterThan(0);
+    const bad: string[] = [];
+    for (const app of apps) {
+      const agent = app.defaultAgent;
+      if (agent === undefined) continue; // omitting the key is legal — `ask` is implicit
+      if (!PLATFORM_AGENTS.includes(agent)) {
+        bad.push(
+          `${app.name}: defaultAgent "${agent}" is not a platform agent ` +
+            `(${PLATFORM_AGENTS.join(' | ')}) — it will not resolve at chat time`,
+        );
+      }
+    }
+    expect(bad, `dangling app agent bindings:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('the app authors no agents of its own — the surface is skills-only', () => {
+    // ADR-0063 §2. Re-introducing an app agent is what makes a name like
+    // `sales_copilot` look plausible in `defaultAgent` again; skills are the
+    // supported way to deepen an app's AI capability.
+    const agents: AnyRec[] = (stack as any).agents ?? [];
+    expect(
+      agents.map((a) => a.name),
+      'app-authored agents were retired in #512 — author skills instead (ADR-0063 §2)',
+    ).toEqual([]);
+    expect(((stack as any).skills ?? []).length, 'no skills registered').toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Fixes #586

## Description

`crm_enterprise` 仍然声明 `defaultAgent: 'sales_copilot'` —— 这个 app 自建 agent 早在 #512 就随「skills-only surface」（ADR-0063 §2）一起退役了。

按 ADR-0063 §1/§2，`defaultAgent` 是一个 **surface 绑定**，不是自定义 agent 的插槽：可解析的取值只有两个平台 agent —— `ask`（数据面，隐式默认）与 `build`（Studio 这类编排面）。运行时 `loadAgent()` 会拒绝非平台记录，所以这条绑定是死元数据：app-shell 挂载的悬浮 chatbot 解析不到 agent。

**为什么没人发现**：`App.defaultAgent` 的类型是 `SnakeCaseIdentifierSchema`，任何合法 snake_case 都能通过校验；而平台的 agent authoring lint 只遍历 `stack.agents`，从不看 `app.defaultAgent`。于是 `os validate`、`pnpm build`、`pnpm lint` 全绿，缺陷一直沉默到 demo 现场才暴露。

HotCRM 是数据面，因此绑定 `ask`。app 自身的 AI 能力以 skills 形式交付（`src/skills/`，共 6 个），它们本来就通过 `surface` 亲和挂到平台 agent 上 —— 修好绑定后助手即可带着完整技能集回答。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #586
Related to #512

## Changes Made

- `src/apps/crm.app.ts` — `defaultAgent: 'sales_copilot'` → `'ask'`，并补注释说明这是 surface 绑定而非自定义 agent 插槽（避免下一个作者再填一个"业务味"的名字）。
- `src/pages/account_detail.page.ts` — 清理注释里同样过期的 `sales_copilot` 引用。
- `test/metadata-references.test.ts` — 新增 `app AI bindings resolve to a platform agent` 守卫（3 条断言）。
- `.changeset/app-default-agent-platform-binding.md` — patch。

### 守卫为什么这样写

平台 agent 集合**从 spec 自身读出**，不在测试里再抄一份：

```ts
const surface = ( AgentSchema as AnyRec ).shape.surface;
const enumSchema = typeof surface.removeDefault === 'function' ? surface.removeDefault() : surface;
return enumSchema.options as string[]; // ['ask', 'build']
```

agent 名与 surface 名是同两个 token（`AgentSchema.surface` 即 `z.enum(['ask','build'])`），所以这个集合跟着契约走，不会随平台演进而在 app 侧腐化。这是刻意的 contract-first 选择：与其在消费侧写宽容回退，不如让约束在写元数据时就咬人。

三条断言：

1. `the spec still exposes exactly the two platform agents` —— guard the guard，内省一旦返回 `[]`，下面的检查会变成空断言而假绿。
2. `every app defaultAgent names a platform agent` —— 本 issue 的核心。缺省 key 是合法的（`ask` 是隐式默认），只校验显式取值。
3. `the app authors no agents of its own` —— ADR-0063 §2。重新引入 app agent 正是让 `sales_copilot` 这类名字"看起来合理"的前提；同时断言 skills 非空，避免这条退化成永真。

## Testing

- [x] Unit tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [x] New tests added

```
pnpm validate  → ✓ Validation passed (3053ms)
pnpm typecheck → ✓ (no errors)
pnpm lint      → 1 warning(s), 13 suggestion(s) — exit 0，均为既有项，与本次改动无关
pnpm build     → ✓ Build complete · Artifact: dist/objectstack.json (1015.8 KB)
pnpm test      → Test Files 34 passed (34) · Tests 649 passed | 1 skipped (650)
```

**反向验证**（证明守卫真的会咬，而不是恰好全绿）：把 `defaultAgent` 临时改回 `'sales_copilot'` 后单跑该用例 ——

```
× app AI bindings resolve to a platform agent > every app defaultAgent names a platform agent
  → dangling app agent bindings:
      crm_enterprise: defaultAgent "sales_copilot" is not a platform agent
      (ask | build) — it will not resolve at chat time
```

改回 `'ask'` 后恢复绿色。

## Checklist

- [x] **I have added a changeset**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**范围外发现，已另行开单 #606**：`sales_copilot` 在 `src/` 之外还有 4 处存活引用 —— `scripts/wow1-live-schema.sh:82` 与三个语种的 `content/docs/ai-copilot/live-schema*.mdx`，都是 Wow #1 demo 里 `POST /api/v1/ai/chat` 的请求体。那不是过期注释而是会真的失败的可执行路径（脚本用 `curl -fsS`，第二步直接中止）。本 PR 未改动它们，因为 #586 的验收明确限定在 `src/`。#606 里也一并记了 `objectstack.config.ts:76` 那句「the two agents + skills」的过期注释。

**上游缺口**（属 objectstack 侧，本 PR 不涉及）：agent authoring lint 只走 `stack.agents`，不校验 `app.defaultAgent` 的引用完整性。本 PR 的守卫是 app 侧的补位，不应替代上游修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf

---
_Generated by [Claude Code](https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf)_