### PR TITLE
fix(dashboards): remove fabricated trend deltas from CRM/Sales/Service tiles

### DIFF
--- a/.changeset/no-fabricated-dashboard-trends.md
+++ b/.changeset/no-fabricated-dashboard-trends.md
@@ -1,0 +1,22 @@
+---
+'hotcrm': patch
+---
+
+Stop the CRM, Sales and Service dashboards showing invented period-over-period
+trends. Twelve KPI tiles across those three dashboards carried a hardcoded
+delta — `trend: { value: 12.5, direction: 'up', label: 'vs last month' }` and
+eleven more like it — that no query ever produced and nothing ever recomputed.
+They rendered the same "+12.5% vs last month" against every dataset, on every
+tenant, including a freshly seeded database where the claim was provably false,
+and they moved in the wrong direction as often as the right one.
+
+A period-over-period delta is a measurement: it can only come from comparing
+this period's result against the previous period's. Until the console can run
+that comparison for dataset metrics (widget `compareTo`), a tile now shows the
+number it actually measured and nothing else. This is the rule the Executive
+dashboard already followed — its own fabricated percentages were removed in
+#500 — so all four dashboards are finally honest in the same way.
+
+A new guard in `test/analytics-integrity.test.ts` walks every dashboard widget
+and fails on any `trend` carrying a literal number, at any nesting depth, so
+hand-typed deltas cannot reappear in metadata. Fixes #587.

--- a/src/dashboards/crm.dashboard.ts
+++ b/src/dashboards/crm.dashboard.ts
@@ -9,12 +9,19 @@ import { avgDealSizeMetricWidget, pipelineByStageFunnelWidget } from './shared-w
  * Single-page snapshot of revenue, pipeline, and customer activity. Designed
  * to mirror the polished CRM dashboard reference at
  * https://github.com/objectstack-ai/objectui/tree/main/examples/crm/src/dashboards
- * — KPI tiles with trend indicators and icons, an area-chart revenue trend, a
- * lead-source donut, a pipeline funnel, and a recent-deals table.
+ * — KPI tiles with icons, an area-chart revenue trend, a lead-source donut, a
+ * pipeline funnel, and a recent-deals table.
  *
  * This dashboard intentionally uses the framework's first-class metadata fields
  * (colorVariant, chartConfig, header, dateRange, descriptions, action buttons)
  * rather than ad-hoc hex strings stuffed into `options.color`.
+ *
+ * No KPI tile declares a `trend`. A period-over-period delta is a measurement,
+ * so it has to come from a real comparison query (widget `compareTo`) once the
+ * renderer supports it for dataset metrics — the percentages this file used to
+ * carry were typed by hand and recomputed by nothing, so they kept asserting
+ * the same "+12.5% vs last month" on any data, including an empty database.
+ * Same rule as the executive dashboard (#500, #587).
  */
 export const CrmOverviewDashboard: Dashboard = {
   name: 'crm_overview_dashboard',
@@ -60,10 +67,7 @@ export const CrmOverviewDashboard: Dashboard = {
       colorVariant: 'success',
       dataset: 'opportunity_metrics', values: ['total_amount'],
       layout: { x: 0, y: 0, w: 3, h: 2 },
-      options: {
-        icon: 'DollarSign',
-        trend: { value: 12.5, direction: 'up', label: 'vs last month' },
-      },
+      options: { icon: 'DollarSign' },
     },
     {
       id: 'active_deals',
@@ -77,7 +81,6 @@ export const CrmOverviewDashboard: Dashboard = {
       options: {
         icon: 'Briefcase',
         format: '0,0',
-        trend: { value: 2.1, direction: 'down', label: 'vs last month' },
       },
     },
     {
@@ -92,15 +95,11 @@ export const CrmOverviewDashboard: Dashboard = {
       options: {
         icon: 'Trophy',
         format: '0,0',
-        trend: { value: 4.3, direction: 'up', label: 'vs last month' },
       },
     },
-    avgDealSizeMetricWidget({ x: 9, y: 0, w: 3, h: 2 }, {
-      options: {
-        icon: 'bar-chart',
-        trend: { value: 1.2, direction: 'up', label: 'vs last month' },
-      },
-    }),
+    // No overrides left once the fabricated trend is gone: the factory already
+    // declares `options: { icon: 'bar-chart' }`, so re-passing it said nothing.
+    avgDealSizeMetricWidget({ x: 9, y: 0, w: 3, h: 2 }),
 
     // ─── Charts Row 1 ─────────────────────────────────────────────────
     {

--- a/src/dashboards/sales.dashboard.ts
+++ b/src/dashboards/sales.dashboard.ts
@@ -9,6 +9,13 @@ import { avgDealSizeMetricWidget, pipelineByStageFunnelWidget } from './shared-w
  * Pipeline analytics, win rate trends, and rep performance for the sales team.
  * Modeled after the polished CRM dashboard reference at
  * https://github.com/objectstack-ai/objectui/tree/main/examples/crm.
+ *
+ * No KPI tile declares a `trend`. A period-over-period delta is a measurement,
+ * so it has to come from a real comparison query (widget `compareTo`) once the
+ * renderer supports it for dataset metrics — the percentages this file used to
+ * carry were typed by hand and recomputed by nothing, so they kept asserting
+ * the same "+8.4% vs last quarter" on any data, including an empty database.
+ * Same rule as the executive dashboard (#500, #587).
  */
 export const SalesDashboard: Dashboard = {
   name: 'sales_dashboard',
@@ -71,7 +78,6 @@ export const SalesDashboard: Dashboard = {
       options: {
         icon: 'DollarSign',
         format: '0,0',
-        trend: { value: 8.4, direction: 'up', label: 'vs last quarter' },
       },
     },
     {
@@ -87,7 +93,6 @@ export const SalesDashboard: Dashboard = {
       options: {
         icon: 'Trophy',
         format: '0,0',
-        trend: { value: 14.7, direction: 'up', label: 'vs last quarter' },
       },
     },
     {
@@ -102,7 +107,6 @@ export const SalesDashboard: Dashboard = {
       options: {
         icon: 'Briefcase',
         format: '0,0',
-        trend: { value: 2.1, direction: 'down', label: 'vs last quarter' },
       },
     },
     avgDealSizeMetricWidget({ x: 9, y: 0, w: 3, h: 2 }, {
@@ -113,7 +117,6 @@ export const SalesDashboard: Dashboard = {
       options: {
         icon: 'bar-chart',
         format: '0,0',
-        trend: { value: 4.3, direction: 'up', label: 'vs last quarter' },
       },
     }),
 

--- a/src/dashboards/service.dashboard.ts
+++ b/src/dashboards/service.dashboard.ts
@@ -9,6 +9,13 @@ import type { Dashboard } from '@objectstack/spec/ui';
  * Uses semantic colorVariant tokens (warning/danger/success) and chartConfig
  * palettes instead of raw hex values, mirroring the polished CRM dashboard
  * reference at https://github.com/objectstack-ai/objectui/tree/main/examples/crm.
+ *
+ * No KPI tile declares a `trend`. A period-over-period delta is a measurement,
+ * so it has to come from a real comparison query (widget `compareTo`) once the
+ * renderer supports it for dataset metrics — the percentages this file used to
+ * carry were typed by hand and recomputed by nothing, so they kept asserting
+ * the same "-6.2% vs last week" on any data, including an empty database.
+ * Same rule as the executive dashboard (#500, #587).
  */
 export const ServiceDashboard: Dashboard = {
   name: 'service_dashboard',
@@ -102,7 +109,6 @@ export const ServiceDashboard: Dashboard = {
       options: {
         icon: 'Inbox',
         format: '0,0',
-        trend: { value: 6.2, direction: 'down', label: 'vs last week' },
       },
     },
     {
@@ -117,7 +123,6 @@ export const ServiceDashboard: Dashboard = {
       options: {
         icon: 'AlertTriangle',
         format: '0,0',
-        trend: { value: 1.0, direction: 'up', label: 'vs last week' },
       },
     },
     {
@@ -133,7 +138,6 @@ export const ServiceDashboard: Dashboard = {
         icon: 'Clock',
         format: '0.0',
         suffix: 'h',
-        trend: { value: 9.8, direction: 'down', label: 'vs last week' },
       },
     },
     {
@@ -148,7 +152,6 @@ export const ServiceDashboard: Dashboard = {
       options: {
         icon: 'ShieldAlert',
         format: '0,0',
-        trend: { value: 2.4, direction: 'down', label: 'vs last week' },
       },
     },
 

--- a/test/analytics-integrity.test.ts
+++ b/test/analytics-integrity.test.ts
@@ -111,6 +111,62 @@ describe('dashboard widget bindings resolve', () => {
   });
 });
 
+describe('metric tiles carry no fabricated trend deltas', () => {
+  /**
+   * A period-over-period delta is a MEASUREMENT: it can only come from
+   * comparing this period's query result against the previous period's. A
+   * number sitting in static metadata was, by construction, typed by hand — no
+   * query produced it, nothing recomputes it, and it keeps asserting "+12.5% vs
+   * last month" forever, including on a freshly seeded database where it is
+   * provably false. The executive dashboard dropped its own on exactly this
+   * reasoning (#500); the CRM, Sales and Service tiles kept theirs until #587.
+   *
+   * The honest source of a delta is a real comparison query (widget
+   * `compareTo`) once the renderer supports it for dataset metrics. Until then
+   * a tile shows the number it actually measured and nothing else, so this
+   * guard rejects the literal — anywhere in a widget, under any nesting, since
+   * the console reads `options` as a free-form bag and a hand-written trend can
+   * reappear at any depth.
+   */
+
+  /** Every `[path, value]` pair whose key is `trend`, at any depth. */
+  function* trendDeclarations(node: unknown, path: string): Generator<[string, unknown]> {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      for (const [i, item] of node.entries()) yield* trendDeclarations(item, `${path}[${i}]`);
+      return;
+    }
+    for (const [k, v] of Object.entries(node)) {
+      if (k === 'trend') yield [`${path}.${k}`, v];
+      yield* trendDeclarations(v, `${path}.${k}`);
+    }
+  }
+
+  /** `trend: 12.5` and `trend: { value: 12.5, … }` are both hand-typed deltas. */
+  const carriesLiteralNumber = (trend: unknown): boolean =>
+    typeof trend === 'number' ||
+    (!!trend && typeof trend === 'object' &&
+      Object.values(trend as AnyRec).some((v) => typeof v === 'number'));
+
+  it('no dashboard widget declares a literal trend value', () => {
+    const bad: string[] = [];
+    for (const d of dashboards) {
+      for (const w of d.widgets ?? []) {
+        for (const [path, trend] of trendDeclarations(w, `${d.name}/${w.id}`)) {
+          if (carriesLiteralNumber(trend)) {
+            bad.push(`${path} = ${JSON.stringify(trend)}`);
+          }
+        }
+      }
+    }
+    expect(
+      bad,
+      'hardcoded period-over-period deltas — a trend must be measured by a '
+        + `comparison query, not typed into metadata:\n  ${bad.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});
+
 describe('time windows stay relative at runtime', () => {
   /**
    * A filter value like `2026-06-29` in the metadata means someone computed


### PR DESCRIPTION
Fixes #587

## Description

CRM、Sales、Service 三个看板的 12 个 KPI 卡片各自携带一个写死的环比涨跌幅，例如
`trend: { value: 12.5, direction: 'up', label: 'vs last month' }`。这些数字不是任何查询算出来的，
也没有任何东西会重算它们：无论哪个租户、哪份数据集，哪怕是一个刚初始化、一条记录都没有的数据库，
卡片都照样宣称 “+12.5% vs last month”，方向朝上还是朝下也纯属手写时的选择。

环比涨跌幅本质上是一次**测量**——它只能来自“本期结果对比上期结果”的真实比较查询。在控制台能为
dataset metric 跑这个比较（widget `compareTo`）之前，卡片只展示它真正测到的那个数字，不多展示任何东西。
Executive 看板在 #500 已经按同样的理由删掉了自己那批伪造百分比，本 PR 让其余三个看板与它保持一致，
不再是“一个诚实、三个编造”的半吊子修复。

顺带删掉了 CRM 看板上 `avgDealSizeMetricWidget` 已经空掉的 override：trend 去掉之后，它只是把工厂
自己声明的 `options: { icon: 'bar-chart' }` 原样再传一遍，什么也没说。

三个看板的文件头注释各补了一段说明，写清楚“为什么这里没有 trend”以及未来重新引入时的正确来源，
避免下一个作者（或下一个 AI）把它当成遗漏再补回来。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] CI/CD update

## Related Issues

Fixes #587
Related to #500

## Changes Made

- `src/dashboards/crm.dashboard.ts`：删除 4 处写死的 `trend`；`avgDealSizeMetricWidget` 的空 override 一并删除；文件头注释更新。
- `src/dashboards/sales.dashboard.ts`：删除 4 处写死的 `trend`；文件头注释补充理由。
- `src/dashboards/service.dashboard.ts`：删除 4 处写死的 `trend`；文件头注释补充理由。
- `test/analytics-integrity.test.ts`：新增 pin test —— 遍历每个看板 widget，任意嵌套层级下只要出现携带字面数字的 `trend`（`trend: 12.5` 或 `trend: { value: 12.5, … }`）即失败。先在修复前跑过，确认它准确抓出全部 12 处；修复后转绿。
- `.changeset/no-fabricated-dashboard-trends.md`：patch 版本变更说明。

验收条件已满足：`grep -rn "trend:" src/dashboards/` 现在**零命中**。

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual testing completed
- [x] New tests added (if applicable)

```
pnpm validate   → exit 0
pnpm typecheck  → exit 0
pnpm lint       → exit 0
pnpm hygiene    → ✓ source hygiene clean
pnpm build      → exit 0
pnpm test       → Test Files  34 passed (34)
                  Tests  647 passed | 1 skipped (648)
```

pin test 在修复**之前**的输出（证明它确实咬得住，而不是空转）：

```
- Expected  []
+ Received
+   "crm_overview_dashboard/total_revenue.options.trend = {"value":12.5,"direction":"up","label":"vs last month"}",
+   "sales_dashboard/total_pipeline_value.options.trend = {"value":8.4,"direction":"up","label":"vs last quarter"}",
+   "service_dashboard/open_cases.options.trend = {"value":6.2,"direction":"down","label":"vs last week"}",
+   … 12 条全部命中
```

## Screenshots

无 UI 截图：本 PR 只做删除。受影响的卡片仍然渲染同一个实测数值，只是下方那行伪造的涨跌幅消失了。

## Checklist

- [x] **I have added a changeset** (`pnpm changeset`) — required on every PR, or the `skip-changeset` label is applied
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**为什么 guard 放在元数据层而不是源码 grep。** 验收里写的是 `grep -rn "trend:" src/dashboards/`，
但 pin test 遍历的是 `objectstack.config.ts` 注册后的看板对象树。这样更严格：它不关心写法（对象字面量、
工厂函数、spread、helper 拼装都一样抓），只关心**最终发布出去的元数据里有没有这个字面数字**——
“声明即生效”的那一面。同时它对嵌套深度不敏感，因为控制台把 `options` 当自由字段包读，
手写的 trend 可以从任意深度冒出来。

**文档漂移（不在本 PR 范围）。** `content/docs/analytics/dashboards.mdx` 描述的看板卡片与实际元数据
大面积对不上，已按 Prime Directive #10 另开 issue #610 记录，未在本 PR 内顺手改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf
