### PR TITLE
fix(views): un-wire the dead mass_update_stage bulk button until #508 lands

### DIFF
--- a/.changeset/unwire-dead-mass-update-stage-bulk-button.md
+++ b/.changeset/unwire-dead-mass-update-stage-bulk-button.md
@@ -1,0 +1,17 @@
+---
+'hotcrm': patch
+---
+
+Stop shipping the dead "Update Stage" bulk button on the Opportunity list.
+Selecting deals and clicking it did nothing at all — no records were written,
+no request was even sent, and the console still reported "Action completed
+successfully" — so a rep watched a stage move succeed and then found the
+pipeline unchanged, which reads as lost data rather than as a feature that
+isn't ready. The button is now simply absent: stage moves happen on the
+pipeline kanban board (drag a card between columns), by editing the Stage cell
+inline in the grid, or on the deal record itself, all of which save correctly.
+
+Nothing else about the action changed — its definition, labels and translations
+stay in place, so the button returns in the release that fixes the underlying
+bulk-selection defect (#508). A metadata test now fails the build if the button
+is re-listed before that fix lands.

--- a/src/actions/opportunity.actions.ts
+++ b/src/actions/opportunity.actions.ts
@@ -62,15 +62,23 @@ export const CloneOpportunityAction: Action = {
 /**
  * Mass Update Opportunity Stage.
  *
- * KNOWN-BROKEN in console 16.1.0 — kept wired and tracked in issue #508.
- * No invocation path currently executes it: modal submits resolve `target`
- * as an object name (400), the selection-bar bulk button is a client-side
- * no-op (zero network requests), and the header toolbar path rejects
- * multi-row selections, so `input.selectedIds` never arrives. Script-typed
- * (modal is provably dead) with a recordId fallback so a single-row
- * invocation works the moment the toolbar delivers it. Until upstream ships
- * bulk-selection delivery, stage moves happen via the pipeline kanban
- * drag-and-drop, inline grid editing, or the record form.
+ * KNOWN-BROKEN in console 16.1.0 — kept DEFINED, no longer wired, tracked in
+ * issue #508. No invocation path currently executes it: modal submits resolve
+ * `target` as an object name (400), the selection-bar bulk button is a
+ * client-side no-op (zero network requests), and the header toolbar path
+ * rejects multi-row selections, so `input.selectedIds` never arrives.
+ * Script-typed (modal is provably dead) with a recordId fallback so a
+ * single-row invocation works the moment the toolbar delivers it.
+ *
+ * The list view no longer lists it in `bulkActions` (#588): that button was
+ * the one path that failed *silently* — success toast, nothing written — so it
+ * read as data loss rather than as a tracked gap. This definition stays put so
+ * the restore is a one-line edit in `src/views/opportunity.view.ts`; do it in
+ * the PR that closes #508, and fix the `ctx.api...update(id, {...})` call
+ * pinned in `test/action-sandbox.test.ts` at the same time.
+ *
+ * Until upstream ships bulk-selection delivery, stage moves happen via the
+ * pipeline kanban drag-and-drop, inline grid editing, or the record form.
  */
 export const MassUpdateStageAction: Action = {
   name: 'mass_update_stage',

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -69,11 +69,31 @@ export const OpportunityViews = defineView({
       { name: 'closing', label: 'Closing Soon', icon: 'calendar-check', view: 'closing_this_quarter' },
     ],
     // List-level entry points: generate_quote reaches the row menu via its
-    // own `locations: ['list_item']`. mass_update_stage stays wired even
-    // though console 16.1.0 cannot deliver bulk selections yet (tracked in
-    // issue #508 — see the note in opportunity.actions.ts). Built-in
-    // `exportOptions` covers CSV export.
-    bulkActions: ['mass_update_stage'],
+    // own `locations: ['list_item']`. Built-in `exportOptions` covers CSV
+    // export.
+    //
+    // There is deliberately NO `bulkActions` here.
+    //
+    // `mass_update_stage` used to be listed, and the selection-bar button that
+    // produced is a pure client-side no-op in this console: selecting rows and
+    // clicking it fires ZERO network requests and then raises a generic
+    // "Action completed successfully" toast (#508, path 2). A rep therefore
+    // watches a stage move report success and never happen — which reads as
+    // silent data loss, not as a tracked platform gap. Not shipping the
+    // control is the honest state until the platform can deliver the
+    // selection.
+    //
+    // The action DEFINITION stays in `src/actions/opportunity.actions.ts`
+    // (with its KNOWN-BROKEN note), so restoring the button is one line:
+    //
+    //     bulkActions: ['mass_update_stage'],
+    //
+    // Re-add it in the same PR that closes #508 — i.e. once the selection bar
+    // is verified to POST /api/v1/actions/crm_opportunity/mass_update_stage
+    // with `selectedIds`, and the action body has been fixed to match the
+    // engine facade (pinned in `test/action-sandbox.test.ts`). Until then reps
+    // move stages via the pipeline kanban drag-and-drop, inline grid editing,
+    // or the record form.
   },
 
   listViews: {

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -774,6 +774,53 @@ describe('list-level action references resolve', () => {
     }
     expect(bad, `redundant string rowActions:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
+
+  /**
+   * No view may wire an action whose bulk invocation path is known dead (#588).
+   *
+   * `bulkActions` renders a selection-bar button. For `mass_update_stage` that
+   * button fires ZERO network requests and then toasts "Action completed
+   * successfully" (#508, path 2, verified live against the dev console) — the
+   * worst possible failure mode, because a rep sees a stage move confirmed and
+   * silently not applied. Neither `os validate` nor the dangling-reference
+   * guard above can see this: the action IS defined, so the reference resolves
+   * and the metadata is shape-valid. Only this list knows the button is dead.
+   *
+   * Retire an entry here in the SAME PR that proves its path works — for
+   * `mass_update_stage` that means #508: the selection bar POSTing
+   * /api/v1/actions/crm_opportunity/mass_update_stage with `selectedIds`, and
+   * the body fixed to match the engine facade (see `action-sandbox.test.ts`).
+   */
+  const BULK_INVOCATION_DEAD: Record<string, string> = {
+    mass_update_stage: '#508 — selection-bar button is a client-side no-op in console 16.1.0',
+  };
+
+  it('no view wires an action whose bulk path is known dead', () => {
+    const wired: string[] = [];
+    for (const v of views) {
+      const lists = [v.list, ...Object.values(v.listViews ?? {})].filter(Boolean) as AnyRec[];
+      for (const list of lists) {
+        for (const name of list.bulkActions ?? []) {
+          const why = typeof name === 'string' ? BULK_INVOCATION_DEAD[name] : undefined;
+          if (why) wired.push(`view "${list.name ?? 'default'}": "${name}" — ${why}`);
+        }
+      }
+    }
+    expect(wired, `dead bulk buttons back on a list view:\n  ${wired.join('\n  ')}`).toEqual([]);
+  });
+
+  /**
+   * …and the counterpart: un-wiring must not become deletion.
+   *
+   * The definition is what makes the #508 restore a one-line edit, and what
+   * keeps the KNOWN-BROKEN note, the translations and the sandbox pin alive. A
+   * future cleanup pass that "removes the unused action" would throw all of
+   * that away and quietly close the paper trail.
+   */
+  it('keeps the definition of every un-wired action so the restore stays one line', () => {
+    const missing = Object.keys(BULK_INVOCATION_DEAD).filter((n) => !actionNames.has(n));
+    expect(missing, `un-wired but also deleted:\n  ${missing.join('\n  ')}`).toEqual([]);
+  });
 });
 
 describe('row colors and kanban groups key off real option values', () => {


### PR DESCRIPTION
Fixes #588
Related to #508

## Description

商机列表的 `bulkActions` 里挂着 `mass_update_stage`，而这个 action 在源码里早已被标注为 KNOWN-BROKEN。结果是：销售勾选若干商机、点下 "Update Stage"，控制台**一个网络请求都不会发**，随后弹出一句 "Action completed successfully"（#508 记录的第 2 条路径）。用户看到的是"阶段已更新成功"，回到列表却什么都没变——这被读成数据丢失，比按钮根本不存在要糟糕得多。

本 PR 只做一件事：把这个按钮从列表上摘掉，并在摘除的位置留下指向 #508 的说明。action 的**定义原样保留**（含参数、i18n 文案、KNOWN-BROKEN 注释与 sandbox 回归断言），所以等 #508 修好时，恢复按钮就是加回一行。

关于 `locations: ['list_toolbar']`（工具栏那个入口）**刻意不动**：按 #508 第 3 条路径，它是有明确反馈的（"This action runs on a single record — select exactly one row"），不属于本 issue 要治的"静默失败"，仍归 #508 跟踪。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] CI/CD update

## Related Issues

Fixes #588
Related to #508

## Changes Made

- `src/views/opportunity.view.ts`：删除 `bulkActions: ['mass_update_stage']`，原地留下说明注释——为什么不发这个按钮、恢复它需要哪一行、以及必须在关闭 #508 的那个 PR 里连同校验一起恢复。
- `src/actions/opportunity.actions.ts`：action 定义**不动**，只把注释里已经失真的 "kept wired" 改成 "kept DEFINED, no longer wired"，并补上指向 #588 与 view 的回指，避免注释开始说谎。
- `test/metadata-references.test.ts`：新增 `BULK_INVOCATION_DEAD` 登记表与两条断言——
  - 任何 view 都不得把登记表里的 action 列进 `bulkActions`（按钮不能悄悄回来）；
  - 登记表里的 action 必须仍然有定义（"未挂载"不能被后续清理误当成"没用了，删掉"）。

  这一类缺陷是 `os validate` 和现有 dangling-reference 守卫都看不见的：action 确实存在、引用能解析、元数据形状合法，只有这张表知道那个按钮是死的。

- `.changeset/unwire-dead-mass-update-stage-bulk-button.md`：patch，面向 release notes 读者说明按钮消失以及现有的三条可用替代路径。

## Testing

- [x] Unit tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing completed
- [x] New tests added (if applicable)

```
pnpm validate && pnpm typecheck && pnpm lint   → 通过（仅既有 1 warning / 13 suggestions）
pnpm hygiene                                   → ✓ source hygiene clean
pnpm build                                     → ✓ Build complete，13 Actions（定义仍在）
pnpm test                                      → Test Files 34 passed (34)
                                                 Tests 648 passed | 1 skipped (649)
```

新守卫做过反证：临时把 `bulkActions: ['mass_update_stage']` 加回去后，

```
× no view wires an action whose bulk path is known dead
AssertionError: dead bulk buttons back on a list view:
  view "open_opportunities": "mass_update_stage" — #508 — selection-bar button is a client-side no-op in console 16.1.0
```

改动已还原，最终全量再跑一次仍为 648 passed。

## Screenshots

无（本次为移除一个渲染出来但不可用的控件，没有新增可截图的界面）。

## Checklist

- [x] **I have added a changeset** (`pnpm changeset`) — required on every PR, or the `skip-changeset` label is applied
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`content/docs/` 无需改动——全库检索 "Update Stage" / "mass update" / "mass_update" 在产品文档中零命中，这个按钮从未被写进用户文档。四个语言包里的 `mass_update_stage` 文案也全部保留，因为 action 定义还在，i18n 覆盖率断言仍然依赖它们。

#508 依旧是底层 bulk 调用链路的跟踪 issue；本 PR 只处理"不要把一个死控件发给用户"这件事。


---
_Generated by [Claude Code](https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf)_