### PR TITLE
feat(forecast): add the forecast_snapshot nightly writer (#590)

### DIFF
--- a/.changeset/forecast-snapshot-writer.md
+++ b/.changeset/forecast-snapshot-writer.md
@@ -1,0 +1,28 @@
+---
+"hotcrm": minor
+---
+
+Forecasting now produces real data. HotCRM documented a nightly forecast job for
+several releases, but nothing anywhere actually created a forecast snapshot — the
+Forecast object, the attainment and coverage formulas, the Forecast Metrics
+dataset and the dashboard's "Quota Attainment by Rep" table all ran on three
+hand-seeded demo rows, so on a live org the whole forecasting story was empty.
+
+The new **Forecast Snapshot** scheduled flow runs nightly at 03:00 and writes one
+current-quarter snapshot per active opportunity owner: open pipeline, best case,
+commit and closed-won totals, aggregated from that owner's opportunities closing
+inside the quarter. Re-runs refresh the same row rather than adding another, so a
+snapshot tracks the pipeline down as well as up, and `quota` is never touched —
+it stays hand-maintained until a quota model exists.
+
+Two supporting changes make that possible and honest:
+
+- The Forecast object now derives `period_start` (alongside the `period_end` and
+  `period_label` it already derived), so any writer can ask for "this quarter"
+  and get a calendar-true window instead of hand-computing a boundary and
+  drifting off it.
+- `best_case_amount` and `commit_amount` are documented as what they now
+  measure: the deal's stored **Forecast Category**, the same boundary the
+  "Closing This Quarter" list view and the pipeline-by-category chart use. The
+  old field descriptions named probability thresholds that no writer applied and
+  that disagreed with how deals are actually categorised.

--- a/content/docs/administration/automation.mdx
+++ b/content/docs/administration/automation.mdx
@@ -66,7 +66,7 @@ A flow fires one of three ways, set by its start node:
 
 > **Auto-launch needs the `triggers` capability.** Record-change and scheduled flows only fire when the stack's `requires` list includes `triggers` — it installs the record-change + schedule trigger providers (schedule triggers also use the job service). Screen flows are always launched manually.
 
-**Built-in flows in HotCRM** (10):
+**Built-in flows in HotCRM** (11):
 
 | Flow | Trigger | What it does |
 | --- | --- | --- |
@@ -80,6 +80,7 @@ A flow fires one of three ways, set by its start node:
 | **Contract Renewal Reminder** | Schedule (daily 8 AM) | Open renewal tasks/opportunities for contracts nearing their `end_date` |
 | **Case SLA Monitor** | Schedule (hourly) | Flag and escalate open cases past their SLA due date |
 | **Stalled Deal Alert** | Schedule (daily 7:30 AM) | Nudge owners about open opportunities stuck in a stage too long |
+| **Forecast Snapshot** | Schedule (daily 3 AM) | Upsert a current-quarter forecast row per active opportunity owner — pipeline, best case, commit and closed-won totals |
 
 Notifications inside flows are delivered by the **`notify` node** (inbox + email via the messaging service) — not the legacy `script`/email step, which is a no-op in 7.4.
 
@@ -87,9 +88,11 @@ See [Customization › Extending Objects](/docs/customization/extending-objects)
 
 ## Scheduled automation
 
-Time-based automation is implemented as **scheduled flows** — flows whose start node carries a cron schedule. See the four `Schedule` rows above (campaign enrollment, contract renewal, SLA monitor, stalled-deal alert). They run via the job service, so the `triggers` capability is paired with `job` (both ship in the default slate).
+Time-based automation is implemented as **scheduled flows** — flows whose start node carries a cron schedule. See the five `Schedule` rows above (campaign enrollment, contract renewal, SLA monitor, stalled-deal alert, forecast snapshot). They run via the job service, so the `triggers` capability is paired with `job` (both ship in the default slate).
 
 Date-driven field logic that needs no orchestration — defaulting a quote's expiration date, freezing an expired/accepted quote, deriving a forecast period — lives in lightweight **object hooks** (`beforeInsert` / `beforeUpdate`) rather than a scheduled sweep.
+
+The division of labour on forecasts is worth calling out, because it is the pattern to copy: the **Forecast Snapshot** flow decides *who* gets a snapshot and *what the totals are*, while the forecast object's hook decides *which calendar period the snapshot belongs to*. A cron expression can say "every night"; it cannot say "the first day of this quarter", so that boundary is derived once, by the object, for every writer.
 
 ## Approvals
 

--- a/content/docs/sales/forecasting.mdx
+++ b/content/docs/sales/forecasting.mdx
@@ -13,24 +13,29 @@ This page is about the **forecast object** that stores those snapshots. For the 
 
 | Section | Fields |
 | --- | --- |
-| **Period** | Owner, period (`month` / `quarter`), period start. Period end and the friendly label (e.g. **Q3 2026**) are derived. |
+| **Period** | Owner and period (`month` / `quarter`). The period start, the period end and the friendly label (e.g. **Q3 2026**) are all derived. |
 | **Numbers** | Quota, pipeline amount, best-case amount, commit amount, closed amount. |
 | **Source** | `scheduled` (nightly job), `ai` (Copilot-generated), `manual` (rep entry). |
 | **Narrative** | Optional commentary — what changed, what's at risk, what to ask in the next 1:1. |
 
-Pipeline, best-case, commit and closed are independent buckets — they answer different questions:
+Pipeline, best case and commit are **nested**, not independent — each is a subset of the one above it, so you read them as a ladder of confidence rather than as slices of a pie:
 
-- **Pipeline** — every open deal in this period, regardless of confidence.
-- **Best case** — deals the rep believes are winnable with a stretch effort.
-- **Commit** — deals the rep is willing to put their name on (≥ 80% probability by convention).
-- **Closed** — already won; cannot move.
+- **Pipeline** — every open deal closing in this period, regardless of confidence.
+- **Best case** — the subset a rep believes is winnable: deals whose **Forecast Category** is *Best Case* or *Commit*.
+- **Commit** — the subset a rep will put their name on: **Forecast Category** *Commit*.
+- **Closed** — already won in this period; cannot move, and sits outside the three open buckets.
+
+A deal's Forecast Category is set automatically from its **Stage**, so the same boundary decides what shows up in the *Closing This Quarter* opportunity view, in the *Pipeline by Forecast Category* chart, and in the snapshot. There is nothing separate to maintain.
 
 ## How periods are derived
 
-You enter `period` and `period_start`; the system computes the rest. For a quarterly forecast starting 2026-07-01:
+You choose a `period`; the system computes the rest. Supply a `period_start` to snapshot a specific quarter or month, or leave it out and the snapshot lands on the calendar period containing its snapshot date. For a quarterly forecast taken on 2026-08-02:
 
+- `period_start` → 2026-07-01
 - `period_end` → 2026-09-30
 - `period_label` → **Q3 2026**
+
+Because the boundary is always computed, never typed, every snapshot for the same quarter lines up exactly — which is what makes “this quarter” filters and quarter-over-quarter trends work at all.
 
 So you'll never see a record labelled “2026-07-01 through ???” — only the human label. The list view and dashboards group by `period_label` directly.
 
@@ -38,7 +43,7 @@ So you'll never see a record labelled “2026-07-01 through ???” — only the 
 
 There are three sources, recorded in the `source` field:
 
-1. **Scheduled** — a nightly job (built on the platform's flow engine) snapshots every rep's pipeline. This is the spine of the historical trend.
+1. **Scheduled** — the **Forecast Snapshot** flow runs nightly at 3 AM and snapshots the current quarter for every rep who owns at least one live deal. This is the spine of the historical trend. Re-running it refreshes the same row, so numbers move down as well as up; it never writes **Quota**, which stays whatever a manager set.
 2. **AI** — the Copilot skill generates a forecast from current pipeline + recent stage moves + similar past deals. The conversation transcript is stored alongside the record.
 3. **Manual** — a manager enters a number directly. Used for adjustments and overrides.
 

--- a/src/flows/forecast-snapshot.flow.ts
+++ b/src/flows/forecast-snapshot.flow.ts
@@ -1,0 +1,334 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { P } from '@objectstack/spec';
+import type * as Automation from '@objectstack/spec/automation';
+type Flow = Automation.Flow;
+
+/**
+ * Forecast Snapshot — nightly per-owner pipeline snapshot into `crm_forecast`.
+ *
+ * The gap this closes: `crm_forecast` documented a nightly writer that did not
+ * exist. `forecast.hook.ts` only DERIVES fields on a row someone else creates,
+ * and nothing in `src/` ever created one — so the forecast object, its
+ * `attainment_pct` / `coverage_ratio` formulas, the `forecast_metrics` dataset
+ * and the dashboard's quota-attainment table all ran on the three hand-seeded
+ * demo rows. On any live install the whole forecasting story was an empty
+ * shell (#590).
+ *
+ * ## Buckets
+ *
+ * Amounts are aggregated from `crm_opportunity` by `forecast_category` — the
+ * stored, indexed column the opportunity lifecycle hook derives from `stage`,
+ * and the same column the "Commit & Best Case" list view and the
+ * `pipeline_by_forecast_category` dashboard widget already group on. Reading
+ * the snapshot off `probability` instead would create a SECOND definition of
+ * "commit" that silently disagrees with those surfaces.
+ *
+ * The buckets are CUMULATIVE, the standard forecast ladder — and the shape the
+ * object's own fields already assume (`pipeline` is "all open opportunities",
+ * so it necessarily contains the other two), the seeded magnitudes show
+ * (pipeline > best case > commit), and the opportunity `closing_this_quarter`
+ * view spells out by treating `['commit', 'best_case']` as one bucket:
+ *
+ *   pipeline_amount  → every OPEN opportunity closing in the period
+ *   best_case_amount → open, forecast_category ∈ { best_case, commit }
+ *   commit_amount    → open, forecast_category = commit
+ *   closed_amount    → stage = closed_won, closing in the period
+ *
+ * `quota` is deliberately never written: it is maintained by hand until a
+ * quota model exists, and a sweep that reset it every night would erase the
+ * denominator of `attainment_pct`.
+ *
+ * ## Shape
+ *
+ * Per owner: ensure the current-period row exists, re-read it, then sum four
+ * scoped queries into it. Two things force that ordering.
+ *
+ * 1. The period window is DATA, not arithmetic. A flow template resolves
+ *    `{TODAY()}` and day offsets only — it cannot say "the first day of this
+ *    calendar quarter". So the flow selects the row whose window CONTAINS
+ *    today (`period_start <= today <= period_end`), lets `forecast.hook.ts`
+ *    derive a calendar-true window on create, and then reads the boundaries
+ *    back off the row to scope the opportunity queries. One definition of "the
+ *    current period", owned by the object.
+ * 2. Sums come from four separate `get_record` + `loop` pairs rather than one
+ *    query with in-loop branching. A filter is plain metadata, so the bucket
+ *    definitions stay declarative and greppable; the accumulator templates
+ *    stay pure arithmetic (`* 1` coerces a currency that arrives as a string
+ *    and maps null to 0).
+ *
+ * Idempotency: the row is keyed by (owner, period, containing window), so a
+ * re-run finds it and OVERWRITES the amounts instead of inserting a second
+ * row — the same upsert discipline as `contract_renewal` /
+ * `opportunity_stagnation`. Re-running is how a snapshot stays current, and it
+ * is the only way an amount ever decreases.
+ *
+ * Scope: an "active opportunity owner" is a user owning at least one
+ * opportunity that is not `closed_lost`. Users with none are skipped entirely,
+ * so a fresh install does not litter a zero row per employee.
+ */
+
+/**
+ * The period this sweep snapshots. `quarter` because that is what every
+ * consumer reads: the `this_quarter_forecasts` view filters `period: 'quarter'`
+ * and the quota-attainment table is a quarterly scoreboard. A monthly cadence
+ * would be a second flow, not a flag — the upsert key is (owner, period).
+ */
+const SNAPSHOT_PERIOD = 'quarter';
+
+/** Open = not yet resolved either way. Both closed stages leave the pipeline. */
+const OPEN_STAGES = { $nin: ['closed_won', 'closed_lost'] };
+
+/** Window the current-period row: `period_start <= today <= period_end`. */
+const CURRENT_PERIOD_FILTER = {
+  owner: '{currentOwner.id}',
+  period: SNAPSHOT_PERIOD,
+  period_start: { $lte: '{TODAY()}' },
+  period_end: { $gte: '{TODAY()}' },
+};
+
+/** Opportunities of the owner in flight during the snapshot window. */
+const inPeriod = (extra: Record<string, unknown>) => ({
+  owner: '{currentOwner.id}',
+  close_date: {
+    $gte: '{currentForecast.period_start}',
+    $lte: '{currentForecast.period_end}',
+  },
+  ...extra,
+});
+
+/**
+ * One `get_record` + `loop` pair that sums `amount` into `total`.
+ *
+ * `amount * 1` rather than a bare `amount`: the accumulator runs through the
+ * template evaluator, which stringifies non-numeric values — a currency that
+ * comes back from the driver as `"90000"` would CONCATENATE instead of add.
+ * `* 1` coerces it, and maps a null/absent amount to 0.
+ */
+const sumBucket = (key: string, label: string, filter: Record<string, unknown>, total: string) => ({
+  find: {
+    id: `find_${key}`,
+    type: 'get_record' as const,
+    label: `Find ${label}`,
+    config: {
+      objectName: 'crm_opportunity',
+      filter,
+      limit: 500,
+      outputVariable: `${key}Opps`,
+    },
+  },
+  sum: {
+    id: `sum_${key}`,
+    type: 'loop' as const,
+    label: `Sum ${label}`,
+    config: {
+      collection: `{${key}Opps}`,
+      iteratorVariable: `current_${key}`,
+      body: {
+        nodes: [
+          {
+            id: `add_${key}`,
+            type: 'assignment' as const,
+            label: `Add to ${label}`,
+            config: { assignments: { [total]: `{${total} + current_${key}.amount * 1}` } },
+          },
+        ],
+        edges: [],
+      },
+    },
+  },
+});
+
+const BUCKETS = [
+  sumBucket('pipeline', 'Open Pipeline', inPeriod({ stage: OPEN_STAGES }), 'pipelineTotal'),
+  sumBucket(
+    'best_case',
+    'Best Case',
+    inPeriod({ stage: OPEN_STAGES, forecast_category: { $in: ['best_case', 'commit'] } }),
+    'bestCaseTotal',
+  ),
+  sumBucket(
+    'commit',
+    'Commit',
+    inPeriod({ stage: OPEN_STAGES, forecast_category: 'commit' }),
+    'commitTotal',
+  ),
+  sumBucket('won', 'Closed Won', inPeriod({ stage: 'closed_won' }), 'closedTotal'),
+];
+
+/**
+ * The per-owner body runs as one straight line once the two gates pass:
+ * reload → reset → (find/sum) × 4 → write.
+ */
+const OWNER_CHAIN = [
+  'reload_forecast',
+  'reset_totals',
+  ...BUCKETS.flatMap((b) => [b.find.id, b.sum.id]),
+  'write_snapshot',
+];
+
+export const ForecastSnapshotFlow: Flow = {
+  name: 'forecast_snapshot',
+  label: 'Forecast Snapshot',
+  description:
+    'Nightly sweep: upsert a current-quarter crm_forecast row per active opportunity owner with pipeline, best-case, commit and closed-won totals.',
+  type: 'schedule',
+  status: 'active',
+  // Scheduled runs have no trigger user, so under the default runAs:'user' the
+  // data nodes execute UNSCOPED anyway. Declare runAs:'system' to make that
+  // RLS-bypassing elevation explicit and intended (ADR-0049, #1888) — and it
+  // is load-bearing here: `crm_forecast` is `sharingModel: 'private'`, so a
+  // user-scoped sweep could only ever see its own rows.
+  runAs: 'system',
+
+  variables: [],
+
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start (daily 03:00)', config: { schedule: '0 3 * * *' } },
+    {
+      // Every user is a candidate; the `has_deals` gate below decides who is
+      // actually an opportunity owner. Filtering `sys_user` here instead would
+      // hard-code an activity flag this app does not own.
+      id: 'query_owners', type: 'get_record', label: 'Find Users',
+      config: { objectName: 'sys_user', filter: {}, limit: 500, outputVariable: 'ownerList' },
+    },
+    {
+      id: 'loop_owners', type: 'loop', label: 'For Each Owner',
+      config: {
+        collection: '{ownerList}',
+        iteratorVariable: 'currentOwner',
+        body: {
+          nodes: [
+            {
+              // Cheap findOne gate: a user with no live opportunity is not a
+              // forecast owner, and must not get a row (a fresh install would
+              // otherwise gain one empty snapshot per employee).
+              id: 'find_any_deal', type: 'get_record', label: 'Owns Any Live Deal?',
+              config: {
+                objectName: 'crm_opportunity',
+                filter: { owner: '{currentOwner.id}', stage: { $nin: ['closed_lost'] } },
+                outputVariable: 'ownerAnyDeal',
+              },
+            },
+            {
+              id: 'has_deals', type: 'decision', label: 'Active Owner?',
+              config: { condition: P`ownerAnyDeal != null` },
+            },
+            {
+              // Idempotency gate AND period lookup in one read: the row whose
+              // window contains today IS this owner's current-period snapshot.
+              id: 'find_forecast', type: 'get_record', label: 'Current-Period Snapshot?',
+              config: {
+                objectName: 'crm_forecast',
+                filter: CURRENT_PERIOD_FILTER,
+                outputVariable: 'existingForecast',
+              },
+            },
+            {
+              id: 'check_missing', type: 'decision', label: 'First Snapshot This Period?',
+              config: { condition: P`existingForecast == null` },
+            },
+            {
+              // Only `period` is supplied: `forecast.hook.ts` derives
+              // period_start/period_end/period_label so the boundaries are
+              // calendar-true (#530) without the flow doing date arithmetic it
+              // cannot do. `quota` is omitted on purpose — see the header.
+              // A leaf node: the two mutually-exclusive edges out of
+              // `check_missing` both converge on `reload_forecast`, so the
+              // chain below runs exactly once on either path.
+              id: 'create_forecast', type: 'create_record', label: 'Open Snapshot Row',
+              config: {
+                objectName: 'crm_forecast',
+                fields: {
+                  owner: '{currentOwner.id}',
+                  period: SNAPSHOT_PERIOD,
+                  snapshot_date: '{TODAY()}',
+                  source: 'scheduled',
+                  pipeline_amount: 0,
+                  best_case_amount: 0,
+                  commit_amount: 0,
+                  closed_amount: 0,
+                },
+              },
+            },
+            {
+              // Re-read rather than reuse the create output, so both paths
+              // (row already existed / row just created) hand the rest of the
+              // body ONE variable carrying the hook-derived period window.
+              id: 'reload_forecast', type: 'get_record', label: 'Load Snapshot Row',
+              config: {
+                objectName: 'crm_forecast',
+                filter: CURRENT_PERIOD_FILTER,
+                outputVariable: 'currentForecast',
+              },
+            },
+            {
+              // Accumulators live in the flow-wide variable map (a loop body
+              // shares the enclosing scope), so they MUST be zeroed per owner
+              // or every rep inherits the previous rep's totals.
+              id: 'reset_totals', type: 'assignment', label: 'Reset Totals',
+              config: {
+                assignments: {
+                  pipelineTotal: 0,
+                  bestCaseTotal: 0,
+                  commitTotal: 0,
+                  closedTotal: 0,
+                },
+              },
+            },
+            ...BUCKETS.flatMap((b) => [b.find, b.sum]),
+            {
+              // Filter by id: `update_record` calls `data.update` without
+              // `options.multi`, so a filter matching more than one row fails
+              // (same constraint as demo_bootstrap / case_sla_monitor).
+              id: 'write_snapshot', type: 'update_record', label: 'Write Snapshot',
+              config: {
+                objectName: 'crm_forecast',
+                filter: { id: '{currentForecast.id}' },
+                fields: {
+                  pipeline_amount: '{pipelineTotal}',
+                  best_case_amount: '{bestCaseTotal}',
+                  commit_amount: '{commitTotal}',
+                  closed_amount: '{closedTotal}',
+                  snapshot_date: '{TODAY()}',
+                  source: 'scheduled',
+                },
+              },
+            },
+          ],
+          edges: [
+            // Loop-nested conditions are explicit CEL envelopes (`P`): the
+            // conversion pass that wraps bare strings only walks a flow's
+            // TOP-LEVEL edges, so a bare string in here would fall through to
+            // the legacy template path and compare as text — a gate that never
+            // opens, silently (#567 / upstream #4347).
+            { id: 'b1', source: 'find_any_deal', target: 'has_deals', type: 'default' },
+            // No matching edge simply ends this iteration, so a user with no
+            // live deal is skipped without a snapshot row.
+            { id: 'b2', source: 'has_deals', target: 'find_forecast', type: 'conditional', condition: P`ownerAnyDeal != null`, label: 'Active owner' },
+            { id: 'b3', source: 'find_forecast', target: 'check_missing', type: 'default' },
+            // Mutually exclusive, and both reach `reload_forecast` — never a
+            // default edge alongside a conditional one, which would traverse
+            // BOTH and double-count the whole chain.
+            { id: 'b4', source: 'check_missing', target: 'create_forecast', type: 'conditional', condition: P`existingForecast == null`, label: 'Open new row' },
+            { id: 'b5', source: 'check_missing', target: 'reload_forecast', type: 'conditional', condition: P`existingForecast != null`, label: 'Refresh existing row' },
+            { id: 'b6', source: 'create_forecast', target: 'reload_forecast', type: 'default' },
+            ...OWNER_CHAIN.slice(0, -1).map((source, i) => ({
+              id: `c${i}`,
+              source,
+              target: OWNER_CHAIN[i + 1],
+              type: 'default' as const,
+            })),
+          ],
+        },
+      },
+    },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+
+  edges: [
+    { id: 'e1', source: 'start', target: 'query_owners', type: 'default' },
+    { id: 'e2', source: 'query_owners', target: 'loop_owners', type: 'default' },
+    { id: 'e3', source: 'loop_owners', target: 'end', type: 'default' },
+  ],
+};

--- a/src/flows/index.ts
+++ b/src/flows/index.ts
@@ -17,6 +17,7 @@ export { QuoteGenerationFlow } from './quote-generation.flow';
 export { ContractRenewalFlow } from './contract-renewal.flow';
 export { CaseSlaMonitorFlow } from './case-sla-monitor.flow';
 export { OpportunityStagnationFlow } from './opportunity-stagnation.flow';
+export { ForecastSnapshotFlow } from './forecast-snapshot.flow';
 export { LeadAssignmentFlow } from './lead-assignment.flow';
 export { CaseCsatFollowupFlow } from './case-csat-followup.flow';
 // Migrated from object workflows[] (removed in 7.7): scheduled status-flips + notifications
@@ -39,6 +40,7 @@ import { QuoteGenerationFlow } from './quote-generation.flow';
 import { ContractRenewalFlow } from './contract-renewal.flow';
 import { CaseSlaMonitorFlow } from './case-sla-monitor.flow';
 import { OpportunityStagnationFlow } from './opportunity-stagnation.flow';
+import { ForecastSnapshotFlow } from './forecast-snapshot.flow';
 import { LeadAssignmentFlow } from './lead-assignment.flow';
 import { CaseCsatFollowupFlow } from './case-csat-followup.flow';
 import { CampaignCompletionFlow } from './campaign-completion.flow';
@@ -67,6 +69,7 @@ export const allFlows: Flow[] = [
   ContractRenewalFlow,
   CaseSlaMonitorFlow,
   OpportunityStagnationFlow,
+  ForecastSnapshotFlow,
   LeadAssignmentFlow,
   CaseCsatFollowupFlow,
   // Migrated from object workflows[] (removed in 7.7)

--- a/src/objects/forecast.hook.ts
+++ b/src/objects/forecast.hook.ts
@@ -5,9 +5,19 @@ import type { Hook, HookContext } from '@objectstack/spec/data';
 /**
  * Forecast lifecycle hook.
  *
- * Auto-derives `period_end` and `period_label` from `period` + `period_start`
- * so callers (UI, AI skill, scheduled snapshot job) don't have to compute
- * them. Also stamps `snapshot_date` to today on insert if unset.
+ * Auto-derives the whole period family — `period_start`, `period_end` and
+ * `period_label` — from `period` (+ `period_start`, when the caller supplies
+ * one) so callers (UI, AI skill, the `forecast_snapshot` scheduled flow) don't
+ * have to compute them. Also stamps `snapshot_date` to today on insert if
+ * unset.
+ *
+ * Why `period_start` is derived here and nowhere else: a flow template can
+ * express `{TODAY()}` and day offsets, but it has no way to say "the first day
+ * of the calendar quarter containing today". If each writer computed its own
+ * boundary we would get exactly the drift #530 pinned in the seeds — snapshots
+ * labelled 'Q3 2026' whose `period_start` is some mid-quarter date, so every
+ * "this quarter" equals-filter misses. One derivation, one definition: give
+ * the object a `period` and it lands on a calendar-true boundary or not at all.
  *
  * NOTE: all helpers are inlined into `handler` because the build pipeline
  * lowers inline handlers — module-scope helpers would not survive lowering.
@@ -17,7 +27,7 @@ const forecastDerive: Hook = {
   object: 'crm_forecast',
   events: ['beforeInsert', 'beforeUpdate'],
   priority: 200,
-  description: 'Derive period_end and period_label from period + period_start.',
+  description: 'Derive period_start, period_end and period_label from period (+ snapshot_date).',
   handler: async (ctx: HookContext) => {
     const pad = (n: number) => String(n).padStart(2, '0');
     const isoDate = (d: Date) =>
@@ -27,6 +37,14 @@ const forecastDerive: Hook = {
       new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 0));
     const endOfQuarter = (start: Date) =>
       new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 3, 0));
+    // First day of the calendar period CONTAINING `d` — the inverse of the
+    // two helpers above, and the piece a flow template cannot express.
+    const startOfPeriod = (period: string, d: Date) =>
+      new Date(Date.UTC(
+        d.getUTCFullYear(),
+        period === 'quarter' ? Math.floor(d.getUTCMonth() / 3) * 3 : d.getUTCMonth(),
+        1,
+      ));
     const labelFor = (period: string, start: Date) => {
       if (period === 'quarter') {
         const q = Math.floor(start.getUTCMonth() / 3) + 1;
@@ -41,10 +59,27 @@ const forecastDerive: Hook = {
       (typeof input.period === 'string' && input.period) ||
       (typeof previous?.period === 'string' && (previous.period as string)) ||
       'month';
-    const startStr =
+    let startStr =
       (typeof input.period_start === 'string' && input.period_start) ||
       (typeof previous?.period_start === 'string' && (previous.period_start as string)) ||
       undefined;
+
+    // No period_start anywhere ⇒ snapshot the period that contains the
+    // snapshot day (falling back to today). `period_start` is required +
+    // notNull, so before this the write simply failed; deriving it is what
+    // makes `{ period: 'quarter' }` a complete, calendar-true snapshot
+    // request — the only shape an automated writer can express.
+    if (!startStr) {
+      const anchorStr =
+        (typeof input.snapshot_date === 'string' && input.snapshot_date) ||
+        (typeof previous?.snapshot_date === 'string' && (previous.snapshot_date as string)) ||
+        isoDate(new Date());
+      const anchor = new Date(`${anchorStr.slice(0, 10)}T00:00:00Z`);
+      if (!Number.isNaN(anchor.getTime())) {
+        startStr = isoDate(startOfPeriod(period, anchor));
+        input.period_start = startStr;
+      }
+    }
 
     if (startStr) {
       const start = new Date(`${startStr}T00:00:00Z`);

--- a/src/objects/forecast.object.ts
+++ b/src/objects/forecast.object.ts
@@ -12,14 +12,24 @@ import { F, P, cel } from '@objectstack/spec';
  * without re-aggregating opportunity history.
  *
  * Written by:
- *   • `forecast.hook.ts` scheduled job (default: nightly)
+ *   • `src/flows/forecast-snapshot.flow.ts` — the `forecast_snapshot`
+ *     scheduled flow, nightly at 03:00, one current-quarter row per active
+ *     opportunity owner (#590). It never touches `quota`.
  *   • `revenue_forecasting` AI skill on demand
+ *   • `forecast.hook.ts` derives the period family + `snapshot_date` on every
+ *     write; it creates nothing on its own.
  *
- * Forecast categories follow the standard Salesforce model:
- *   pipeline  → all open opps
- *   best_case → high-confidence opps (>= 60%)
- *   commit    → owner-committed opps (>= 80%)
- *   closed    → already-won amount
+ * Forecast categories follow the standard Salesforce ladder, and the buckets
+ * are CUMULATIVE — each is a subset of the one above it:
+ *   pipeline  → all open opps closing in the period
+ *   best_case → open opps whose forecast_category is best_case OR commit
+ *   commit    → open opps whose forecast_category is commit
+ *   closed    → already-won amount in the period
+ *
+ * The bucket boundary is the stored `forecast_category` column (derived from
+ * `stage` by the opportunity lifecycle hook), NOT a probability threshold —
+ * one definition, shared with the "Commit & Best Case" opportunity view and
+ * the `pipeline_by_forecast_category` dashboard widget.
  */
 export const Forecast = ObjectSchema.create({
   name: 'crm_forecast',
@@ -118,7 +128,7 @@ export const Forecast = ObjectSchema.create({
 
     pipeline_amount: Field.currency({
       label: 'Pipeline',
-      description: 'Sum of all open opportunities (any stage).',
+      description: 'Sum of all open opportunities closing in this period (any stage).',
       scale: 2,
       min: 0,
       group: 'amounts',
@@ -126,7 +136,11 @@ export const Forecast = ObjectSchema.create({
 
     best_case_amount: Field.currency({
       label: 'Best Case',
-      description: 'Open opportunities with probability >= 60%.',
+      // Was "probability >= 60%", which named a threshold no writer applied
+      // and which disagreed with the stage → forecast_category map that
+      // actually classifies deals (proposal is 60% but lands in `commit`).
+      // The stored category is the single boundary (#590).
+      description: 'Open opportunities in the best_case or commit forecast category.',
       scale: 2,
       min: 0,
       group: 'amounts',
@@ -134,7 +148,7 @@ export const Forecast = ObjectSchema.create({
 
     commit_amount: Field.currency({
       label: 'Commit',
-      description: 'Open opportunities with probability >= 80% (owner-committed).',
+      description: 'Open opportunities in the commit forecast category (owner-committed).',
       scale: 2,
       min: 0,
       group: 'amounts',

--- a/test/flow-scheduled.test.ts
+++ b/test/flow-scheduled.test.ts
@@ -5,8 +5,10 @@ import { CampaignCompletionFlow } from '../src/flows/campaign-completion.flow';
 import { CaseSlaMonitorFlow } from '../src/flows/case-sla-monitor.flow';
 import { ContractExpirationFlow } from '../src/flows/contract-expiration.flow';
 import { ContractRenewalFlow } from '../src/flows/contract-renewal.flow';
+import { ForecastSnapshotFlow } from '../src/flows/forecast-snapshot.flow';
 import { OpportunityStagnationFlow } from '../src/flows/opportunity-stagnation.flow';
 import { QuoteExpirationFlow } from '../src/flows/quote-expiration.flow';
+import forecastDerive from '../src/objects/forecast.hook';
 import { TaskDueReminderFlow } from '../src/flows/task-due-reminder.flow';
 import * as allFlows from '../src/flows';
 import { makeFlowHarness, type Rec } from './helpers/flow-harness';
@@ -463,6 +465,200 @@ describe('contract_renewal — daily notice-window sweep', () => {
     ]);
     expect(h.store.crm_task).toHaveLength(0);
     expect(h.notifications).toHaveLength(0);
+  });
+});
+
+describe('forecast_snapshot — nightly per-owner pipeline snapshot', () => {
+  // Calendar-quarter maths in UTC, mirroring forecast.hook.ts and the seed
+  // module. The flow itself does none of this — that is the point: a flow
+  // template cannot express a quarter boundary, so the hook owns it and the
+  // flow reads the window back off the row it created.
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const isoUtc = (d: Date) => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+  const nowUtc = new Date();
+  const qStart = new Date(Date.UTC(nowUtc.getUTCFullYear(), Math.floor(nowUtc.getUTCMonth() / 3) * 3, 1));
+  const qEnd = new Date(Date.UTC(qStart.getUTCFullYear(), qStart.getUTCMonth() + 3, 0));
+  const inPeriod = isoUtc(qStart);
+  const beforePeriod = isoUtc(new Date(qStart.getTime() - 86_400_000));
+  const quarterLabel = `Q${Math.floor(qStart.getUTCMonth() / 3) + 1} ${qStart.getUTCFullYear()}`;
+
+  const users = (): Rec[] => [
+    { id: 'rep1', name: 'Rep One' },
+    { id: 'rep2', name: 'Rep Two' },
+    { id: 'rep3', name: 'No Deals At All' },
+    { id: 'rep4', name: 'Only Lost Deals' },
+  ];
+
+  // Both rows that MUST be counted and rows that must be left out — a sweep
+  // whose window or bucket filter silently matches everything looks identical
+  // to a correct one otherwise.
+  const opps = (): Rec[] => [
+    // rep1 — one deal per bucket, plus two that must not count.
+    { id: 'o1', owner: 'rep1', stage: 'qualification',  forecast_category: 'pipeline',  amount: 100_000, close_date: inPeriod },
+    { id: 'o2', owner: 'rep1', stage: 'needs_analysis', forecast_category: 'best_case', amount: 50_000,  close_date: inPeriod },
+    { id: 'o3', owner: 'rep1', stage: 'negotiation',    forecast_category: 'commit',    amount: 30_000,  close_date: inPeriod },
+    { id: 'o4', owner: 'rep1', stage: 'closed_won',     forecast_category: 'closed',    amount: 70_000,  close_date: inPeriod },
+    // Closes in the PREVIOUS quarter — outside every bucket, but still makes
+    // rep1 an active owner.
+    { id: 'o5', owner: 'rep1', stage: 'proposal',       forecast_category: 'commit',    amount: 999_999, close_date: beforePeriod },
+    // Lost deals are neither open nor won.
+    { id: 'o6', owner: 'rep1', stage: 'closed_lost',    forecast_category: 'omitted',   amount: 12_345,  close_date: inPeriod },
+    // rep2 — the second amount arrives as a STRING, the shape a currency
+    // column takes coming back from some drivers. Without the `* 1` coercion
+    // in the accumulator the template CONCATENATES and pipeline reads
+    // "020000" + "25000" instead of 45000.
+    { id: 'o7', owner: 'rep2', stage: 'proposal',       forecast_category: 'commit',    amount: 20_000,  close_date: inPeriod },
+    { id: 'o8', owner: 'rep2', stage: 'qualification',  forecast_category: 'pipeline',  amount: '25000', close_date: inPeriod },
+    // rep4 owns nothing but a lost deal — not a forecast owner.
+    { id: 'o9', owner: 'rep4', stage: 'closed_lost',    forecast_category: 'omitted',   amount: 88_000,  close_date: inPeriod },
+  ];
+
+  const harness = (forecasts: Rec[] = []) =>
+    makeFlowHarness(
+      { forecast_snapshot: ForecastSnapshotFlow },
+      { sys_user: users(), crm_opportunity: opps(), crm_forecast: forecasts },
+      { hooks: [forecastDerive] },
+    );
+
+  const run = async (forecasts: Rec[] = []) => {
+    const h = harness(forecasts);
+    await h.run('forecast_snapshot', {}, { event: 'schedule' });
+    return h;
+  };
+
+  const byOwner = (h: ReturnType<typeof harness>) =>
+    Object.fromEntries(h.store.crm_forecast.map((f) => [f.owner, f]));
+
+  it('opens a current-period row for every active opportunity owner, and only for them', async () => {
+    const h = await run();
+
+    expect(h.store.crm_forecast).toHaveLength(2);
+    const owners = h.store.crm_forecast.map((f) => f.owner).sort();
+    expect(owners).toEqual(['rep1', 'rep2']);
+    // A user with no opportunities at all, and one whose only deal is lost,
+    // must not collect an empty snapshot row.
+    expect(owners, 'rep3 owns nothing').not.toContain('rep3');
+    expect(owners, 'rep4 owns only a lost deal').not.toContain('rep4');
+  });
+
+  it('lands on a calendar-true quarter, derived by the hook rather than the flow', async () => {
+    const h = await run();
+    const snap = byOwner(h).rep1;
+
+    expect(snap.period).toBe('quarter');
+    // The invariant #530 pinned for the seeds now also holds for every
+    // runtime snapshot: exact boundaries, and the label dialect the hook and
+    // the seeds both speak.
+    expect(snap.period_start).toBe(isoUtc(qStart));
+    expect(snap.period_end).toBe(isoUtc(qEnd));
+    expect(snap.period_label).toBe(quarterLabel);
+    expect(snap.snapshot_date).toBe(isoUtc(nowUtc));
+    expect(snap.source).toBe('scheduled');
+  });
+
+  it('sums the cumulative buckets from forecast_category', async () => {
+    const h = await run();
+    const snap = byOwner(h).rep1;
+
+    // pipeline = every open deal in the window: 100k + 50k + 30k.
+    expect(Number(snap.pipeline_amount)).toBe(180_000);
+    // best case = best_case ∪ commit: 50k + 30k. A strict partition would
+    // read 50k here, so this pins the ladder, not just "some sum happened".
+    expect(Number(snap.best_case_amount)).toBe(80_000);
+    expect(Number(snap.commit_amount)).toBe(30_000);
+    expect(Number(snap.closed_amount)).toBe(70_000);
+  });
+
+  it('excludes deals closing outside the period, and lost deals', async () => {
+    const h = await run();
+    const snap = byOwner(h).rep1;
+    // The 999,999 last-quarter deal and the 12,345 lost deal are the only way
+    // any total could exceed these.
+    for (const field of ['pipeline_amount', 'best_case_amount', 'commit_amount', 'closed_amount']) {
+      expect(Number(snap[field]), `${field} swallowed an out-of-scope deal`).toBeLessThan(200_000);
+    }
+  });
+
+  it('coerces a string amount instead of concatenating it', async () => {
+    const h = await run();
+    const snap = byOwner(h).rep2;
+    expect(Number(snap.pipeline_amount)).toBe(45_000);
+    expect(typeof snap.pipeline_amount, 'the accumulator produced a string').toBe('number');
+  });
+
+  it('is idempotent: a second sweep refreshes the row instead of duplicating it', async () => {
+    const h = harness();
+    await h.run('forecast_snapshot', {}, { event: 'schedule' });
+    await h.run('forecast_snapshot', {}, { event: 'schedule' });
+
+    expect(h.store.crm_forecast, 'the sweep inserted a second row for the same period').toHaveLength(2);
+    const snap = byOwner(h).rep1;
+    // Re-running must RECOMPUTE, not accumulate: a sweep that added to the
+    // stored totals would read 360,000 here.
+    expect(Number(snap.pipeline_amount)).toBe(180_000);
+  });
+
+  it('overwrites stale amounts when the pipeline moves', async () => {
+    // A pre-existing row from an earlier night, carrying numbers that no
+    // longer reflect the pipeline. The whole point of a nightly upsert is
+    // that amounts can go DOWN, which a create-once writer never achieves.
+    const h = await run([{
+      id: 'f_rep1', owner: 'rep1', period: 'quarter',
+      period_start: isoUtc(qStart), period_end: isoUtc(qEnd), period_label: quarterLabel,
+      snapshot_date: beforePeriod, source: 'scheduled',
+      pipeline_amount: 9_999_999, best_case_amount: 9_999_999,
+      commit_amount: 9_999_999, closed_amount: 9_999_999,
+    }]);
+
+    expect(h.store.crm_forecast).toHaveLength(2);
+    const snap = byOwner(h).rep1;
+    expect(snap.id, 'the existing row was replaced rather than refreshed').toBe('f_rep1');
+    expect(Number(snap.pipeline_amount)).toBe(180_000);
+    expect(Number(snap.closed_amount)).toBe(70_000);
+    expect(snap.snapshot_date).toBe(isoUtc(nowUtc));
+  });
+
+  it('never writes quota — the manually-maintained attainment denominator', async () => {
+    const h = await run([{
+      id: 'f_rep1', owner: 'rep1', period: 'quarter',
+      period_start: isoUtc(qStart), period_end: isoUtc(qEnd), period_label: quarterLabel,
+      snapshot_date: beforePeriod, source: 'scheduled', quota: 1_500_000,
+    }]);
+
+    const snap = byOwner(h).rep1;
+    expect(Number(snap.quota), 'the sweep clobbered a hand-maintained quota').toBe(1_500_000);
+    // And a freshly opened row leaves quota unset rather than zeroing it,
+    // so `attainment_pct` guards on quota > 0 instead of dividing by a lie.
+    expect(byOwner(h).rep2.quota).toBeUndefined();
+  });
+
+  it('does not touch a snapshot belonging to a different period', async () => {
+    const previousQuarterEnd = isoUtc(new Date(qStart.getTime() - 86_400_000));
+    const h = await run([{
+      id: 'f_old', owner: 'rep1', period: 'quarter',
+      period_start: isoUtc(new Date(Date.UTC(qStart.getUTCFullYear(), qStart.getUTCMonth() - 3, 1))),
+      period_end: previousQuarterEnd, period_label: 'previous',
+      snapshot_date: previousQuarterEnd, source: 'scheduled', closed_amount: 1_485_000,
+    }]);
+
+    const old = h.store.crm_forecast.find((f) => f.id === 'f_old')!;
+    expect(Number(old.closed_amount), 'a closed period was rewritten').toBe(1_485_000);
+    // rep1 still gets a NEW row for the current quarter.
+    expect(h.store.crm_forecast).toHaveLength(3);
+  });
+
+  it('is a clean no-op when nobody owns a live deal', async () => {
+    const h = makeFlowHarness(
+      { forecast_snapshot: ForecastSnapshotFlow },
+      {
+        sys_user: [{ id: 'rep9', name: 'Idle' }],
+        crm_opportunity: [{ id: 'ox', owner: 'rep9', stage: 'closed_lost', amount: 10, close_date: inPeriod }],
+        crm_forecast: [],
+      },
+      { hooks: [forecastDerive] },
+    );
+    await h.run('forecast_snapshot', {}, { event: 'schedule' });
+    expect(h.store.crm_forecast).toHaveLength(0);
   });
 });
 

--- a/test/helpers/flow-harness.ts
+++ b/test/helpers/flow-harness.ts
@@ -2,6 +2,7 @@
 
 import { AutomationEngine, installBuiltinNodes } from '@objectstack/service-automation';
 import type * as Automation from '@objectstack/spec/automation';
+import type { Hook } from '@objectstack/spec/data';
 
 type Flow = Automation.Flow;
 
@@ -111,6 +112,47 @@ export function makeDataEngine(seed: Record<string, Rec[]> = {}): DataEngine {
 }
 
 /**
+ * Wrap a data engine so registered `beforeInsert` / `beforeUpdate` hooks run
+ * against the mutating payload, exactly as the real runtime does before a
+ * write reaches the driver.
+ *
+ * `previous` for an update is the first matching row — the flows here update
+ * by `id`, and `update_record` cannot fan out anyway (no `options.multi`).
+ */
+function withHooks(engine: DataEngine, hooks: Hook[]): DataEngine {
+  const run = async (
+    object: string,
+    event: 'beforeInsert' | 'beforeUpdate',
+    input: Rec,
+    previous?: Rec,
+  ) => {
+    for (const hook of hooks) {
+      if (hook.object !== object) continue;
+      if (!(hook.events ?? []).includes(event as never)) continue;
+      await (hook.handler as (ctx: Rec) => unknown)({
+        event, object, input, previous, user: undefined, logger: silentLogger,
+      });
+    }
+  };
+
+  return {
+    ...engine,
+    store: engine.store,
+    async insert(object, data) {
+      const input = { ...data };
+      await run(object, 'beforeInsert', input);
+      return engine.insert(object, input);
+    },
+    async update(object, data, opts = {}) {
+      const input = { ...data };
+      const previous = await engine.findOne(object, opts);
+      await run(object, 'beforeUpdate', input, previous ?? undefined);
+      return engine.update(object, input, opts);
+    },
+  };
+}
+
+/**
  * A notification captured from a `notify` node.
  *
  * The builtin notify node calls `messaging.emit({ topic, audience, payload,
@@ -188,11 +230,31 @@ export interface FlowHarness {
  * recipient/severity/template contract (the class of bug where a notify targets
  * `{record.owner.manager}` and silently interpolates to "undefined").
  */
+export interface FlowHarnessOptions {
+  /**
+   * Object hooks to run around the data engine's writes.
+   *
+   * Off by default, because most flow tests want to assert exactly what the
+   * FLOW wrote. But a flow that relies on a `beforeInsert` hook to complete
+   * the record it creates — `forecast_snapshot` hands `crm_forecast` a bare
+   * `period` and lets `forecast_derive_period` compute the calendar window —
+   * is only half-tested without them: the flow would look fine while writing a
+   * row no consumer can find.
+   *
+   * `beforeInsert` / `beforeUpdate` only; the flows under test have no
+   * after-hook dependencies.
+   */
+  hooks?: Hook[];
+}
+
 export function makeFlowHarness(
   flows: Record<string, Flow>,
   seed: Record<string, Rec[]> = {},
+  options: FlowHarnessOptions = {},
 ): FlowHarness {
-  const raw = makeDataEngine(seed);
+  const base = makeDataEngine(seed);
+  const hooks = options.hooks ?? [];
+  const raw: DataEngine = hooks.length === 0 ? base : withHooks(base, hooks);
   const notifications: SentNotification[] = [];
   const queries: RecordedQuery[] = [];
 


### PR DESCRIPTION
Fixes #590

## Description

`crm_forecast` 的文档承诺了一个 nightly 快照任务，但这个任务从来不存在：`forecast.hook.ts` 只做字段派生，`src/` 里没有任何 flow / hook / job 创建过 `crm_forecast` 行。结果是整条预测链路——forecast 对象、`attainment_pct` / `coverage_ratio` 公式、`forecast_metrics` 数据集、仪表盘的配额达成表——全部跑在 `src/data/index.ts` 里手写的 3 条种子数据上。在任何真实环境里，这个功能都是一个空壳。

本 PR 新增 `forecast_snapshot` 调度 flow（每晚 03:00，`runAs: 'system'`），为每一位**活跃商机负责人**写入一条当季快照。

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

Fixes #590
Related to #530 (期间边界必须是日历对齐的), #567 (loop 内条件必须是显式 CEL envelope)

发现但**未在本 PR 修复**的问题，已另开 unassigned issue：#613（forecast 种子的 `externalId: 'period_label'` 不再是唯一键）、#614（`quota_attainment_by_rep` 跨期间求和导致重复计数）。

## Changes Made

- **`src/flows/forecast-snapshot.flow.ts`（新增）** — 每晚 03:00 扫描：遍历用户 → 用一次 findOne 判断其是否拥有非 `closed_lost` 商机（不是负责人就完全跳过，不留空行）→ 定位/创建"窗口包含今天"的当季快照行 → 重新读回该行 → 用 4 组 `get_record` + `loop` 把金额累加进去 → `update_record` 写回。
- **金额口径**：按存储列 `forecast_category` 分桶，且是**累进**的（`pipeline ⊇ best_case ⊇ commit`）。这与对象自身字段的语义（pipeline 是"所有开放商机"）、种子数据的量级关系、以及已有的 `closing_this_quarter` 视图（把 `['commit', 'best_case']` 当作一个桶）三者一致。改用 `probability` 阈值会凭空造出第二套 "commit" 定义，和列表视图、`pipeline_by_forecast_category` 图表悄悄打架。
- **`quota` 永不写入** —— 它是 `attainment_pct` 的分母，在配额模型出现之前由人工维护。
- **`src/objects/forecast.hook.ts`** — 现在除了 `period_end` / `period_label`，也派生 `period_start`。flow 模板只能解析 `{TODAY()}` 和天偏移，**无法**表达"本日历季度的第一天"；把这个边界交给对象派生，等于让 #530 为种子数据钉住的日历对齐不变式，对运行期快照同样成立。这也是"声明即强制"：调用方只要给出 `period`，就不可能写出一个边界歪掉的快照。
- **`src/objects/forecast.object.ts`** — 文档注释指向真实的 writer 与调度；`best_case_amount` / `commit_amount` 的描述改为它们真正度量的东西（存储的 forecast category），原先写的概率阈值没有任何 writer 执行，而且和 stage → category 映射本身就矛盾（proposal 是 60% 却落在 `commit`）。
- **`test/helpers/flow-harness.ts`** — 新增可选的 `hooks` 参数（默认关闭，不影响既有测试），让 runtime 测试能把 flow 和 hook 放在一起验证。`forecast_snapshot` 只交给 `crm_forecast` 一个 `period`，如果不跑 hook，测试会"通过"，却写出一条没有任何消费方能查到的行。
- **文档** — `content/docs/administration/automation.mdx` 补上 flow 表格行与计数；`content/docs/sales/forecasting.mdx` 把"三个桶互相独立"更正为"累进阶梯"，并说明期间边界是算出来的、不是填出来的。

## Testing

- [x] Unit tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [x] New tests added

`test/flow-scheduled.test.ts` 新增 10 个 runtime 用例，跑真实的 `AutomationEngine`（不是 PENDING_FLOWS 豁免）：

- 只为活跃负责人开行；`rep3`（没有任何商机）和 `rep4`（只有 lost 单）不得到行
- 期间字段日历对齐（`period_start` / `period_end` / `period_label` / `snapshot_date`），由 hook 派生
- 累进分桶金额精确断言（`best_case` 断言 80,000 而非 50,000，专门钉住"累进"而不是"求和发生了"）
- 排除跨期间与 lost 单
- 字符串金额被强制转数（`amount: '25000'`），防止模板拼接成 `"020000"`
- 幂等：第二次扫描刷新同一行而不新增；也不会把金额累加成两倍
- 覆盖过期数字（金额可以变小，这正是 create-once writer 做不到的）
- 从不写 `quota`
- 不碰属于其它期间的快照
- 无人拥有活跃商机时干净空跑

反向验证（mutation check）：把 best-case 过滤器从 `{ $in: ['best_case', 'commit'] }` 改成 `'best_case'`，测试如预期失败（`- 80000 / + 50000`），确认断言不是空转。

```
 Test Files  34 passed (34)
      Tests  662 passed | 1 skipped (663)
```

```
✓ Validation passed (946ms)   Logic: 24 Flows
✓ Build complete              → Skipping legacy runtime bundle (all 24 callables are body-only)
✓ source hygiene clean
tsc --noEmit                  (clean)
pnpm lint                     1 warning, 13 suggestions — 全部为既有项，无新增
```

## Additional Notes

**为什么没有用 `script` 节点做聚合。** 这条路看起来最直接，但 `script` 的 `config.script` 是 no-op，真正执行需要 `defineStack({ functions })`。而顶层 `functions` 不参与 body 提取（见 `@objectstack/cli` 的 `lower-callables`），一旦声明，`objectstack build` 就会开始产出 `objectstack-runtime.{hash}.mjs`，并在 artifact 里写下 `runtimeModule`。而 `scripts/publish-marketplace.mjs` **只上传 `dist/objectstack.json`** —— 发布到 marketplace 的 app 会引用一个根本没随行的模块，扫描在真实部署里直接报 "no function named … is registered"。本 PR 构建后 `runtimeModule` 仍为 `(none)`，发布形态未变。

**为什么 flow 里是"先建行、再读回、最后写数"。** 期间窗口是**数据**，不是算术。flow 选出"窗口包含今天"的那一行（`period_start <= today` 且 `period_end >= today`，不需要任何日历运算），由 hook 在创建时给出日历对齐的窗口，再把边界读回来用于圈定商机。全流程只有一处定义"当前期间"，且归对象所有。

**`check_missing` 的两条出边都是 conditional 且互斥**，共同汇入 `reload_forecast`。这里刻意不用"conditional + default"的组合：`traverseNext` 会把两类边都走一遍，那样整条链路会被执行两次、金额翻倍。


---
_Generated by [Claude Code](https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf)_