### PR TITLE
fix(analytics): pin the quota attainment table to one forecast period (#614)

### DIFF
--- a/.changeset/quota-attainment-single-period.md
+++ b/.changeset/quota-attainment-single-period.md
@@ -1,0 +1,29 @@
+---
+'hotcrm': patch
+---
+
+Fix the Sales dashboard's **Quota Attainment by Rep** table, which showed every
+rep a quota several times larger than their real one. `crm_forecast` stores one
+snapshot per owner **per period** — a current quarter, a current month and every
+settled period before them — and the table aggregated all of them at once, so it
+added a quarter's quota to a month's quota to last quarter's quota and labelled
+the total "Quota". On the shipped seed data a rep with a real 1,500,000 quarterly
+quota was shown 7,940,000, and attainment read 90% where the truth was 55%.
+
+The table is now pinned to the current quarter
+(`period` = `quarter` **and** `period_start` = the current quarter's first day),
+so Quota, Closed and Attainment are the numbers for the quarter in progress. Both
+halves of that key are needed: the period type alone still sums every quarter
+ever snapshotted, and the start date alone still merges the quarter row with the
+month row that opens the same quarter. Its description now says "current-quarter"
+in all four locales, and the Forecasting guide spells out the rule for anyone
+building their own roll-up.
+
+For the few hours between a quarter boundary and the 03:00 snapshot sweep that
+opens the new quarter's row, the table is empty rather than showing the previous
+quarter's attainment under a header that says this one.
+
+A new guard (`test/forecast-period-scope.test.ts`) fails the build for any widget
+or report that aggregates `forecast_metrics` without either grouping by period or
+filtering to a single one, and runs the shipped widget through the real analytics
+path to check the number it produces. Fixes #614.

--- a/content/docs/sales/forecasting.mdx
+++ b/content/docs/sales/forecasting.mdx
@@ -51,10 +51,12 @@ You can have all three for the same owner/period — they sit next to each other
 
 ## What you do with them
 
-- **Roll-up dashboards** — Sales dashboard groups by `period_label` and sums `commit_amount` across the team.
+- **Roll-up dashboards** — the Sales dashboard's *Quota Attainment by Rep* table shows each rep's **current-quarter** quota, closed revenue and attainment.
 - **Trend** — pick an owner and a period and chart `commit_amount` over the `created_at` of every snapshot. Sudden drops trigger the *“why did commit fall ¥800k this week?”* conversation.
 - **Attainment** — `closed_amount / quota` is computed in the report layer; no dedicated field.
 - **AI grounding** — the AI agent reads recent snapshots to ground its narrative in real movement, not imagined deals.
+
+> **Always scope a roll-up to one period.** A forecast number is only meaningful *inside* its period. Because the object stores one row per owner **per period** — this quarter, this month, and every settled period before them — a chart or table that adds up **Quota** or **Closed Won** without saying which period it means will stack a quarter's quota on top of a month's on top of last quarter's. Scope every roll-up either by grouping on the period label (**Q3 2026**, **Aug 2026**), or by filtering to a single period type *and* period start.
 
 ## Who can edit
 

--- a/src/dashboards/sales.dashboard.ts
+++ b/src/dashboards/sales.dashboard.ts
@@ -223,13 +223,43 @@ export const SalesDashboard: Dashboard = {
     {
       id: 'quota_attainment_by_rep',
       title: 'Quota Attainment by Rep',
-      description: 'Quota, closed revenue and attainment per rep, from forecast snapshots',
+      description: 'Current-quarter quota, closed revenue and attainment per rep, from forecast snapshots',
       type: 'table',
       colorVariant: 'default',
       // crm_forecast has neither `close_date` nor `type`; opt out of the
       // dashboard filters bound to those fields (framework#2501 injects every
       // dashboard filter into each widget query). `owner` exists and applies.
       filterBindings: { dateRange: false, type: false },
+      // ONE period, or the numbers are nonsense (#614). `crm_forecast` holds a
+      // row per owner PER PERIOD, and `quota_sum` / `closed_sum` are plain
+      // `sum` measures — so an unpinned query adds this quarter's quota to this
+      // month's quota to every settled quarter's quota and labels the total
+      // "Quota". On the shipped seeds that turned a rep's real 1,500,000
+      // quarterly quota into 7,940,000, with attainment wrong by the same
+      // construction (89% instead of 55%).
+      //
+      // Both halves of the key are needed. `period: 'quarter'` alone still sums
+      // every quarter ever snapshotted; `period_start` alone still merges the
+      // quarter row with the month row that opens the same quarter (Q3 and July
+      // both start on the 1st). Together they name exactly one snapshot per
+      // owner — the same (owner, period, period_start) tuple the snapshot sweep
+      // upserts on and the object indexes.
+      //
+      // `{current_quarter_start}` is resolved by the ANALYTICS path, verified
+      // rather than assumed: `queryDataset` runs both the dataset filter and the
+      // widget's `runtimeFilter` through `resolveFilterTokens`, which
+      // understands `{(current|last|next)_(week|month|quarter|year)_(start|end)}`
+      // and throws `FILTER_TOKEN_UNKNOWN` on anything else. This is NOT true of
+      // the list-view path — see the comment on `this_quarter_forecasts` in
+      // `src/views/forecast.view.ts`, where the same macro would ship to the
+      // driver as a literal string. Do not generalise from one path to the other.
+      //
+      // Cost of pinning to the CURRENT quarter rather than the latest one: for
+      // the few hours between a quarter boundary and the 03:00 sweep that opens
+      // the new row, the table is empty. Empty is the honest state — the
+      // alternative renders last quarter's attainment under a header that says
+      // this one.
+      filter: { period: 'quarter', period_start: '{current_quarter_start}' },
       dataset: 'forecast_metrics', dimensions: ['owner'], values: ['quota_sum', 'closed_sum', 'attainment'],
       layout: { x: 0, y: 14, w: 12, h: 4 },
       options: {

--- a/src/datasets/forecast.dataset.ts
+++ b/src/datasets/forecast.dataset.ts
@@ -10,6 +10,33 @@ import { defineDataset } from '@objectstack/spec/ui';
  * ended up annotating its revenue chart with a hardcoded quota of 100000
  * while the seeded quotas run 500k–1.5M. Widgets that talk about quota must
  * bind here instead of inventing numbers.
+ *
+ * ## The measures are NOT additive across periods (#614)
+ *
+ * One row per owner per period, and the table deliberately holds several
+ * periods at once (a current quarter, a current month, several settled ones).
+ * `quota_sum` and friends are plain `sum`s, so a query that does not pin the
+ * period adds a quarter's quota to a month's quota to last quarter's quota and
+ * calls the result "Quota" — the defect that shipped on
+ * `quota_attainment_by_rep` until #614.
+ *
+ * Every consumer must therefore make the period unambiguous, one of two ways:
+ *
+ *   • group by `period_label` (unique per period, so each row IS one period) —
+ *     the shape a quota-over-time trend wants; or
+ *   • filter to a single snapshot with `period` + `period_start`
+ *     (`{ period: 'quarter', period_start: '{current_quarter_start}' }`) —
+ *     the shape a "where do we stand right now" scoreboard wants.
+ *
+ * `test/forecast-period-scope.test.ts` fails the build for any widget or report
+ * that does neither, so the trap cannot be walked into twice.
+ *
+ * This constraint is deliberately NOT a dataset-level `filter` pinning the
+ * latest quarter. A dataset filter is invisible at the call site: it would make
+ * the very trend the `period` / `period_label` dimensions exist to serve return
+ * a single row, with nothing on the widget to explain why. The failure mode of
+ * a missing widget filter is a loud test; the failure mode of a hidden dataset
+ * filter is silently missing data.
  */
 export const ForecastDataset = defineDataset({
   name: 'forecast_metrics',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -767,7 +767,7 @@ export const en: TranslationData = {
         pipeline_by_forecast_category: { title: 'Pipeline by Forecast Category', description: 'Open pipeline grouped by sales forecast category' },
         lead_source_breakdown: { title: 'Lead Source', description: 'Where our pipeline is coming from' },
         open_pipeline_by_owner: { title: 'Open Pipeline by Owner', description: 'In-flight pipeline value, deal count and avg win probability per rep' },
-        quota_attainment_by_rep: { title: 'Quota Attainment by Rep', description: 'Quota, closed revenue and attainment per rep, from forecast snapshots' },
+        quota_attainment_by_rep: { title: 'Quota Attainment by Rep', description: 'Current-quarter quota, closed revenue and attainment per rep, from forecast snapshots' },
         pipeline_stage_by_source: { title: 'Pipeline by Stage × Lead Source', description: 'Cross-tab of open opportunity amount by stage and source' },
       },
     },

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -725,7 +725,7 @@ export const esES: TranslationData = {
         pipeline_by_forecast_category: { title: 'Pipeline por categoría de pronóstico', description: 'Pipeline abierto agrupado por categoría de pronóstico de ventas' },
         lead_source_breakdown: { title: 'Origen del prospecto', description: 'De dónde proviene nuestro pipeline' },
         open_pipeline_by_owner: { title: 'Pipeline abierto por responsable', description: 'Valor del pipeline en curso, número de negocios y probabilidad media de cierre por comercial' },
-        quota_attainment_by_rep: { title: 'Cumplimiento de cuota por representante', description: 'Cuota, ingresos cerrados y cumplimiento por representante, según instantáneas de pronóstico' },
+        quota_attainment_by_rep: { title: 'Cumplimiento de cuota por representante', description: 'Cuota del trimestre actual, ingresos cerrados y cumplimiento por representante, según instantáneas de pronóstico' },
         pipeline_stage_by_source: { title: 'Pipeline por Etapa × Origen', description: 'Tabla cruzada del importe de oportunidades abiertas por etapa y origen' },
       },
     },

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -725,7 +725,7 @@ export const jaJP: TranslationData = {
         pipeline_by_forecast_category: { title: '予測カテゴリ別パイプライン', description: '売上予測カテゴリ別のオープンパイプライン金額' },
         lead_source_breakdown: { title: 'リードソース', description: 'パイプラインの流入元' },
         open_pipeline_by_owner: { title: '担当者別オープンパイプライン', description: '営業担当者ごとの進行中パイプライン金額・商談数・平均勝率' },
-        quota_attainment_by_rep: { title: '担当者別ノルマ達成状況', description: '予測スナップショットに基づく担当者別のノルマ・成約収益・達成率' },
+        quota_attainment_by_rep: { title: '担当者別ノルマ達成状況', description: '予測スナップショットに基づく担当者別の今四半期ノルマ・成約収益・達成率' },
         pipeline_stage_by_source: { title: 'ステージ × リードソース', description: 'ステージとソース別の進行中商談金額のクロス集計' },
       },
     },

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -999,7 +999,7 @@ export const zhCN: TranslationData = {
         pipeline_by_forecast_category: { title: '预测类别管道分布', description: '按预测类别统计的进行中管道金额' },
         lead_source_breakdown: { title: '线索来源分布', description: '按来源统计的线索数量' },
         open_pipeline_by_owner: { title: '按负责人统计进行中管道', description: '各销售负责人的进行中管道金额、商机数与平均赢单概率' },
-        quota_attainment_by_rep: { title: '按销售代表统计配额达成', description: '来自预测快照的各销售代表配额、已成交收入与达成率' },
+        quota_attainment_by_rep: { title: '按销售代表统计配额达成', description: '来自预测快照的各销售代表本季度配额、已成交收入与达成率' },
         pipeline_stage_by_source: { title: '阶段 × 线索来源', description: '按阶段和来源交叉统计进行中商机金额' },
       },
     },

--- a/test/forecast-period-scope.test.ts
+++ b/test/forecast-period-scope.test.ts
@@ -1,0 +1,339 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import { AnalyticsService } from '@objectstack/service-analytics';
+import stack from '../objectstack.config';
+import { ForecastDataset } from '../src/datasets/forecast.dataset';
+import { CrmSeedData } from '../src/data/index';
+
+/**
+ * `forecast_metrics` is per-period; aggregating it without pinning a period is
+ * a double count (#614).
+ *
+ * `crm_forecast` holds one row per owner PER PERIOD and deliberately holds
+ * several periods at once — a current quarter, a current month, and every
+ * settled period the seeds ship. `quota_sum` / `closed_sum` / `pipeline_sum` /
+ * `commit_sum` are plain `sum` measures, so a query that does not pin the
+ * period adds a quarter's quota to a month's quota to last quarter's quota and
+ * presents the total as "Quota". That is what `quota_attainment_by_rep` did:
+ * on the shipped seeds a rep whose real quarterly quota is 1,500,000 was shown
+ * 7,940,000, with attainment inflated from 55% to 89%.
+ *
+ * Two independent guards, because the two failure modes are different:
+ *
+ *   • the STRUCTURAL guard reads metadata and fails any surface that leaves the
+ *     period ambiguous — that is the one that stops the next widget author (or
+ *     the next agent) from re-introducing the bug;
+ *   • the RUNTIME guard executes the shipped widget binding through the real
+ *     dataset compiler, the real filter-token resolver and a real engine, so
+ *     "the filter is present" is backed by "the number that comes back is the
+ *     rep's quarterly quota".
+ */
+
+type AnyRec = Record<string, any>;
+
+const datasets: AnyRec[] = (stack as any).datasets ?? [];
+const reports: AnyRec[] = (stack as any).reports ?? [];
+const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
+
+const DATASET = 'forecast_metrics';
+
+/**
+ * Measures whose value is only meaningful within ONE period. Derived from the
+ * dataset rather than listed by hand, so a measure added later is covered on
+ * the day it lands: every `sum` is per-period by construction, and a derived
+ * measure inherits the property from its inputs (`attainment` is
+ * `closed_sum / quota_sum` — both per-period, so the ratio is too).
+ */
+const perPeriodMeasures = (() => {
+  const ds = datasets.find((d) => d.name === DATASET);
+  const measures: AnyRec[] = ds?.measures ?? [];
+  const additive = new Set(measures.filter((m) => m.aggregate === 'sum').map((m) => m.name));
+  // Fixed-point pass: a derived measure over per-period inputs is per-period.
+  for (let changed = true; changed; ) {
+    changed = false;
+    for (const m of measures) {
+      if (additive.has(m.name) || !m.derived) continue;
+      if ((m.derived.of ?? []).some((of: string) => additive.has(of))) {
+        additive.add(m.name);
+        changed = true;
+      }
+    }
+  }
+  return additive;
+})();
+
+/**
+ * Does this binding name exactly one snapshot per group?
+ *
+ * Two accepted shapes, and neither is negotiable in half:
+ *
+ *   • GROUPED — `period_label` is on the axis. It is the only single dimension
+ *     that is unique per period ("Q3 2026" vs "Aug 2026"), so each output row
+ *     is one snapshot. `period` + `period_start` together do the same job.
+ *   • PINNED  — the filter fixes `period` AND `period_start` to a single value.
+ *     `period` alone still sums every quarter ever snapshotted; `period_start`
+ *     alone still merges the quarter row with the month row that opens the same
+ *     quarter (Q3 and July both start on the 1st). Only the pair is one row.
+ *
+ * A range (`$gte` / `$lte` / `$in`) on `period_start` is NOT a pin: it spans
+ * periods again, which is the whole defect.
+ */
+function periodScope(binding: AnyRec): { ok: boolean; why: string } {
+  const axis = new Set<string>([
+    ...(binding.dimensions ?? []),
+    ...(binding.rows ?? []),
+    ...(binding.columns ?? []),
+  ]);
+  if (axis.has('period_label')) return { ok: true, why: 'grouped by period_label' };
+  if (axis.has('period') && axis.has('period_start')) {
+    return { ok: true, why: 'grouped by period + period_start' };
+  }
+
+  const filter: AnyRec = binding.filter ?? binding.runtimeFilter ?? {};
+  const isScalarPin = (v: unknown) => v != null && (typeof v === 'string' || typeof v === 'number');
+  if (isScalarPin(filter.period) && isScalarPin(filter.period_start)) {
+    return { ok: true, why: 'filtered to one period + period_start' };
+  }
+  return {
+    ok: false,
+    why:
+      'neither grouped by a period dimension nor filtered to a single '
+      + `(period, period_start) — got dimensions [${[...axis].join(', ') || '—'}] `
+      + `and filter ${JSON.stringify(filter)}`,
+  };
+}
+
+/** Every dataset-bound surface in the app, flattened to one shape. */
+const bindings: Array<{ where: string; binding: AnyRec }> = [
+  ...reports.flatMap((r) =>
+    r.type === 'joined' && Array.isArray(r.blocks)
+      ? r.blocks.map((b: AnyRec) => ({ where: `report ${r.name}/${b.name}`, binding: b }))
+      : [{ where: `report ${r.name}`, binding: r }],
+  ),
+  ...dashboards.flatMap((d) =>
+    (d.widgets ?? []).map((w: AnyRec) => ({ where: `widget ${d.name}/${w.id}`, binding: w })),
+  ),
+];
+
+describe('every forecast_metrics consumer pins a single period (#614)', () => {
+  const forecastBindings = bindings.filter(
+    ({ binding }) =>
+      binding.dataset === DATASET
+      && [...(binding.values ?? [])].some((v: string) => perPeriodMeasures.has(v)),
+  );
+
+  it('the dataset still declares the per-period measures this guard protects', () => {
+    // A guard that silently matches nothing is worse than no guard. If the
+    // measures are renamed, this fails instead of quietly passing forever.
+    expect([...perPeriodMeasures].sort()).toEqual(
+      ['attainment', 'closed_sum', 'commit_sum', 'pipeline_sum', 'quota_sum'],
+    );
+  });
+
+  it('the sales quota table is one of the surfaces under guard', () => {
+    expect(forecastBindings.map((b) => b.where)).toContain(
+      'widget sales_dashboard/quota_attainment_by_rep',
+    );
+  });
+
+  it('no surface sums forecast measures across periods', () => {
+    const bad = forecastBindings
+      .map(({ where, binding }) => ({ where, ...periodScope(binding) }))
+      .filter((r) => !r.ok)
+      .map((r) => `${r.where}: ${r.why}`);
+    expect(
+      bad,
+      'these surfaces add one period\'s snapshot to another\'s — group by '
+        + `period_label, or filter to one (period, period_start):\n  ${bad.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});
+
+// ─── Runtime: the numbers the widget actually produces ──────────────────
+
+/** The shipped widget, read from metadata so the test cannot drift from it. */
+const quotaWidget: AnyRec = (dashboards.find((d) => d.name === 'sales_dashboard')?.widgets ?? [])
+  .find((w: AnyRec) => w.id === 'quota_attainment_by_rep');
+
+const forecastSeed = CrmSeedData.find((s: any) => s.object === 'crm_forecast') as
+  | { records: AnyRec[] }
+  | undefined;
+
+const pad = (n: number) => String(n).padStart(2, '0');
+const isoDate = (d: Date) => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+const now = new Date();
+const currentQuarterStart = isoDate(
+  new Date(Date.UTC(now.getUTCFullYear(), Math.floor(now.getUTCMonth() / 3) * 3, 1)),
+);
+
+/**
+ * Only the columns the dataset reads. `crm_forecast`'s real schema carries
+ * formulas and CEL-valued seed columns (`snapshot_date: cel\`today()\``) that
+ * belong to the object suite, not to this one; the analytics contract under
+ * test is "which rows does the filter select and what do they sum to".
+ */
+const ANALYTICS_COLUMNS = [
+  'period', 'period_label', 'period_start', 'quota',
+  'closed_amount', 'pipeline_amount', 'commit_amount',
+] as const;
+
+const makeEngine = () =>
+  ObjectQL.create({
+    datasources: { default: new InMemoryDriver({ persistence: false }) },
+    objects: {
+      crm_forecast: {
+        name: 'crm_forecast',
+        fields: {
+          id: { type: 'text' },
+          owner: { type: 'text' },
+          period: { type: 'text' },
+          period_label: { type: 'text' },
+          period_start: { type: 'date' },
+          quota: { type: 'number' },
+          closed_amount: { type: 'number' },
+          pipeline_amount: { type: 'number' },
+          commit_amount: { type: 'number' },
+        },
+      },
+    } as never,
+  });
+
+describe('quota_attainment_by_rep over the real seeds (#614)', () => {
+  let ql: Awaited<ReturnType<typeof makeEngine>>;
+  let analytics: AnalyticsService;
+  /** Every filter the analytics service handed the engine, in order. */
+  let filtersSeen: unknown[];
+
+  /** The two reps the seeds are replayed for. */
+  const REPS = ['rep_alice', 'rep_bob'] as const;
+
+  beforeAll(async () => {
+    ql = await makeEngine();
+    const api = ql.createContext({ isSystem: true });
+
+    // The seed file ships ONE unowned set of snapshots (owner is backfilled to
+    // the active user at runtime). Replaying it per rep is what the live table
+    // holds: the same period ladder, once per owner.
+    for (const rep of REPS) {
+      for (const rec of forecastSeed?.records ?? []) {
+        const row: AnyRec = { owner: rep };
+        for (const col of ANALYTICS_COLUMNS) row[col] = rec[col] ?? 0;
+        await api.object('crm_forecast').insert(row);
+      }
+    }
+
+    // "…plus one sweep run": `forecast_snapshot` upserts the CURRENT-period row
+    // and rewrites its amounts; it never writes `quota` (see the flow header).
+    // Modelled here as the write itself rather than by re-running the flow —
+    // `test/flow-scheduled.test.ts` owns the flow's behaviour; this file owns
+    // what the dashboard reads afterwards.
+    for (const rep of REPS) {
+      // `(document, options)` — the engine's real repo-facade shape (#616).
+      await api.object('crm_forecast').update(
+        { closed_amount: 900000, pipeline_amount: 2500000, commit_amount: 1200000 },
+        { where: { owner: rep, period: 'quarter', period_start: currentQuarterStart }, multi: true },
+      );
+    }
+
+    filtersSeen = [];
+    analytics = new AnalyticsService({
+      // The same bridge `AnalyticsServicePlugin` auto-wires to the "data"
+      // service at boot, so the filter this test observes is the filter the
+      // engine really receives in the app.
+      executeAggregate: async (objectName, { groupBy, aggregations, filter, timezone, context }) => {
+        filtersSeen.push(filter);
+        return (ql as any).aggregate(objectName, {
+          where: filter,
+          groupBy,
+          aggregations: aggregations?.map((a: AnyRec) => ({
+            function: a.method, field: a.field, alias: a.alias,
+          })),
+          timezone,
+          context,
+        });
+      },
+      queryCapabilities: () => ({ nativeSql: false, objectqlAggregate: true, inMemory: false }),
+    });
+  });
+
+  afterAll(async () => {
+    await ql?.close();
+  });
+
+  const runWidget = async (runtimeFilter?: AnyRec) =>
+    (await analytics.queryDataset(
+      ForecastDataset as never,
+      {
+        dimensions: quotaWidget.dimensions,
+        measures: quotaWidget.values,
+        ...(runtimeFilter ? { runtimeFilter: runtimeFilter as never } : {}),
+      },
+      { isSystem: true } as never,
+    )).rows as AnyRec[];
+
+  /** The seeds' own current-quarter numbers — the answer the table must show. */
+  const currentQuarterSeed = () =>
+    (forecastSeed?.records ?? []).find(
+      (r) => r.period === 'quarter' && r.period_start === currentQuarterStart,
+    );
+
+  it('the seeds really do hold several periods for one owner', () => {
+    // The premise of the whole issue. If the seeds ever ship a single period,
+    // the assertions below would pass for the wrong reason.
+    expect((forecastSeed?.records ?? []).length).toBeGreaterThan(1);
+    expect(currentQuarterSeed(), 'no current-quarter seed row').toBeDefined();
+  });
+
+  it('unpinned, the measures add every snapshot together — the #614 defect', async () => {
+    const rows = await runWidget();
+    const alice = rows.find((r) => r.owner === 'rep_alice')!;
+    const seededQuotaTotal = (forecastSeed?.records ?? [])
+      .reduce((sum, r) => sum + Number(r.quota ?? 0), 0);
+
+    expect(rows).toHaveLength(REPS.length);
+    expect(alice.quota_sum).toBe(seededQuotaTotal);
+    // Concretely, and this is the number the dashboard used to print: every
+    // period's quota stacked into one "Quota" cell.
+    expect(alice.quota_sum).toBeGreaterThan(Number(currentQuarterSeed()!.quota));
+  });
+
+  it('the shipped widget filter yields the rep\'s quarterly quota, not the sum of snapshots', async () => {
+    const seedRow = currentQuarterSeed()!;
+    const rows = await runWidget(quotaWidget.filter);
+
+    expect(rows).toHaveLength(REPS.length);
+    for (const rep of REPS) {
+      const row = rows.find((r) => r.owner === rep)!;
+      expect(row.quota_sum, `${rep} quota`).toBe(Number(seedRow.quota));
+      // The sweep's write, not the seeded placeholder — the widget reads the
+      // refreshed current-quarter row.
+      expect(row.closed_sum, `${rep} closed`).toBe(900000);
+      expect(row.attainment, `${rep} attainment`).toBeCloseTo(900000 / Number(seedRow.quota), 10);
+    }
+  });
+
+  it('the {current_quarter_start} macro is resolved before the filter reaches the engine', async () => {
+    filtersSeen = [];
+    await runWidget(quotaWidget.filter);
+
+    const leaves: string[] = [];
+    const walk = (n: unknown) => {
+      if (typeof n === 'string') leaves.push(n);
+      else if (Array.isArray(n)) n.forEach(walk);
+      else if (n && typeof n === 'object') Object.values(n).forEach(walk);
+    };
+    filtersSeen.forEach(walk);
+
+    expect(filtersSeen.length).toBeGreaterThan(0);
+    // An unresolved token would reach the driver as the literal string
+    // "{current_quarter_start}", compare as text and match nothing — an empty
+    // table indistinguishable from "no data yet". This is exactly what the
+    // LIST path does with the same macro (see src/views/forecast.view.ts), so
+    // the analytics path is asserted, never assumed.
+    expect(leaves.filter((v) => /^\{.+\}$/.test(v))).toEqual([]);
+    expect(leaves).toContain(currentQuarterStart);
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/hotcrm#614

## Description

销售仪表盘的 **Quota Attainment by Rep** 表把同一个人所有周期的快照加在一起当成"配额"。`crm_forecast` 是**每人每周期一行**,而 `quota_sum` / `closed_sum` 是普通的 `sum` 度量,所以这张表把本季度配额 + 本月配额 + 每一个已结束周期的配额全部相加。种子数据下,一个真实季度配额 1,500,000 的销售,表里显示 7,940,000,达成率 90%(真实值 55%)。

修复方式:给 widget 加上 `filter: { period: 'quarter', period_start: '{current_quarter_start}' }`,把它钉在当前季度这一行上。

**两个条件缺一不可**,这不是冗余:

| 过滤条件 | 种子数据下的 Quota | 为什么不够 |
| --- | --- | --- |
| 无 | **7,940,000** | 当前缺陷 |
| 只有 `period: 'quarter'` | 6,500,000 | 仍然把历史上每一个季度加起来 |
| 只有 `period_start` | 1,980,000 | Q3 2026 和 Jul 2026 的 `period_start` 都是 `2026-07-01`,季度行和月度行被合并 |
| 两者同时 | **1,500,000** ✅ | 唯一命中一行 |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Related Issues

Fixes #614
Related to #590 (让 `crm_forecast` 变成活表的那个 PR,本缺陷在其中被发现并留作 unassigned)

顺带发现、**未在本 PR 修复**、已单独立 issue:#627(预测文档称达成率"没有专属字段",但 `crm_forecast.attainment_pct` 就是)。

## Changes Made

- `src/dashboards/sales.dashboard.ts` — widget 加 `filter`,并把"为什么是这两个键、为什么是当前季度而不是最新季度"写进注释。
- `src/datasets/forecast.dataset.ts` — 在数据集头部写清"这些度量跨周期不可相加"的契约,以及**为什么没有**选择给数据集加 `defaultFilter`(见下)。
- `src/translations/{en,zh-CN,es-ES,ja-JP}.ts` — 描述改为"本季度",四种语言同步。
- `content/docs/sales/forecasting.mdx` — 修正一条描述不存在的 widget 的旧文案,并给管理员补上"任何汇总都必须限定周期"的说明。
- `test/forecast-period-scope.test.ts` — 新增守卫(见 Testing)。
- `.changeset/quota-attainment-single-period.md`

## 路线选择:为什么是方案 1

issue 给了三条路线,逐条实测后选方案 1。

**方案 2(加 `current_quarter` 布尔维度)——不可行。** 这个标记必须随时间变化,只能做成 formula 字段;而 formula 是引擎查完之后在 JS 里算的,数据引擎根本看不到这一列。同一个仓库里已经踩过这个坑:`forecast.view.ts` 里 `attainment_pct desc` 的排序键失效就是同样原因。这条路会做出一个"过滤不掉任何东西"的过滤器。

**方案 3(给 `forecast_metrics` 加 defaultFilter)——可行但不该做。** `DatasetSchema` 确实支持顶层 `filter`,而且**当前 `forecast_metrics` 只有一个消费方**(就是这个 widget;十个 report 一个都没绑它,已全量 grep 确认),所以影响面很小。不选它的理由是长期形状:`period` / `period_label` 这两个维度存在的意义就是做跨周期趋势,一旦数据集自带"只看最新季度",将来任何一张配额趋势图都会**静默地只返回一行**,而 widget 上没有任何东西能解释原因。缺 widget 过滤器的失败模式是一个会红的测试;藏在数据集里的过滤器的失败模式是悄悄少了数据。

**方案 1——实测可行。** PM 特别提醒"分析路径必须单独验证,不要从列表路径外推",所以这一条是跑出来的,不是推出来的:`queryDataset` 在任何 strategy 执行之前,就把 widget 的 `runtimeFilter` 过了一遍 `resolveFilterTokens`(它认识 `{(current|last|next)_(week|month|quarter|year)_(start|end)}`,不认识的直接抛 `FILTER_TOKEN_UNKNOWN`)。对真实跑起来的服务发一次查询,编译出来的 SQL 是:

```
SELECT owner, SUM(quota), SUM(closed_amount) FROM "crm_forecast"
WHERE (period = $1 AND period_start = $2) GROUP BY owner
```

宏被解析成绑定参数,SQLite 上 `Field.date` 存的就是 `YYYY-MM-DD` 文本,等值比较成立。列表路径确实一个宏都解析不了 —— 所以 `this_quarter_forecasts` 视图保持只用操作符过滤,两条路径的结论没有互相外推。

**已知代价(已写进注释和 changeset):** 季度切换到当晚 03:00 sweep 建出新行之间,表是空的。空表是诚实的状态 —— 另一个选择是在写着"本季度"的表头下显示上季度的达成率。

## Testing

- [x] Unit tests pass — `pnpm test`:`Test Files 39 passed (39)` / `Tests 798 passed | 1 skipped (799)`
- [x] Linting passes — `pnpm lint`:1 warning / 13 suggestions,全部是既有项,本次未新增
- [x] Build succeeds — `pnpm build` + `pnpm validate` + `pnpm typecheck` 全绿(validate 含 `Checking filter placeholders (#3574)`,新宏通过校验)
- [x] Manual testing completed — 见下
- [x] New tests added

### 新增守卫 `test/forecast-period-scope.test.ts`

两个互补的部分:

1. **结构守卫(读元数据)** —— 任何绑定 `forecast_metrics` 且选了"逐周期度量"的 widget/report,必须要么按 `period_label`(或 `period` + `period_start`)分组,要么过滤到唯一一个 `(period, period_start)`。"逐周期度量"的清单是从数据集**推导**的而不是手写的:所有 `sum` 度量,加上依赖它们的 derived 度量(`attainment` 因此自动在内),所以以后新增度量当天就被覆盖。
2. **运行时守卫(真跑一遍)** —— 用真实种子数据、真实 `compileDataset`、真实 token 解析器和真实引擎,执行**从元数据里读出来的**那个 widget 绑定,断言它算出来的数字;并且断言送到引擎的过滤器里不残留任何 `{...}` 字面量。

守卫本身做过变异验证:把 widget 的 `filter` 摘掉,3 个测试立刻变红,报错文案直接指出问题所在:

```
widget sales_dashboard/quota_attainment_by_rep: neither grouped by a period
dimension nor filtered to a single (period, period_start) — got dimensions
[owner] and filter {}
```

### 手工验证(真实服务 + 真实 SQLite,种子数据 + 一次 sweep)

按 issue 的验收原话,`pnpm start` 起真实应用,给种子快照回填 owner,再按 sweep 的写法刷新当前季度行的金额(sweep 从不写 `quota`),然后打 `POST /api/v1/analytics/dataset/query`:

**改前(无周期过滤):**
```json
{ "owner": "Probe 614", "quota_sum": 7940000, "closed_sum": 7148000, "attainment": 0.9002518891687658 }
```

**改后(本 PR 的 widget 过滤器):**
```json
{ "owner": "Probe 614", "quota_sum": 1500000, "closed_sum": 900000, "attainment": 0.6 }
```

`1,500,000` 正是这位销售 Q3 2026 的季度配额,`900,000` 正是那次 sweep 写进去的 closed 金额 —— 验收通过。(若不跑 sweep,只有种子数据,则是 `1,500,000 / 820,000 = 54.7%`。)

验证结束后已关闭该 dev server,未影响其他 agent 在跑的实例。

## Checklist

- [x] **I have added a changeset**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`forecast_metrics` 的消费方普查结果:**只有这一个 widget**。`src/reports/` 下 10 个 report 全部绑在 `opportunity_metrics` / `account_metrics` / `case_metrics` / `lead_metrics` 上,没有一个读 `forecast_metrics`。所以本 PR 不改变任何其他界面的数字。

未改动 `src/data/index.ts`(本轮归 #622),未改动 `content/docs/guides/index*.mdx` 与 `meta*.json`,未改动 `content/docs/releases/`。

---
_Generated by [Claude Code](https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf)_