### PR TITLE
fix(demo): claim the platform owner_id on seeded records, not just the app owner lookup (#622)

### DIFF
--- a/.changeset/demo-bootstrap-platform-ownership.md
+++ b/.changeset/demo-bootstrap-platform-ownership.md
@@ -1,0 +1,26 @@
+---
+'hotcrm': patch
+---
+
+Demo bootstrap now claims the platform ownership column, so seeded records are editable
+
+On a freshly seeded demo org, every seeded contract was read-only for every user — the
+admin included. Opening a demo contract and changing a field answered
+`403 FORBIDDEN`, and uploading to its Attachments panel answered
+`403 ATTACHMENT_PARENT_ACCESS`, which read as "attachments are broken on contracts" when
+what was broken was the contract's ownership.
+
+Each of these objects carries two ownership columns: the app's own `owner` lookup, which
+drives the "My Leads" / "My Deals" / "My Cases" views and every owner-addressed
+notification, and the platform's `owner_id`, which is the only one record sharing reads.
+Under `sharingModel: 'private'` a record with no `owner_id` admits nobody, and a share can
+only widen access from an owner that isn't there. The `demo_bootstrap` sweep stamped the
+`owner` lookup alone, so a seeded row that arrived without a platform owner came out of
+bootstrap looking claimed everywhere a person would check while still being owned by
+nobody for access control — and because the sweep then selected on `owner`, it never
+looked at that row again. The state was permanent.
+
+`demo_bootstrap` now stamps both columns on every record it claims, and sweeps each object
+for rows missing either one, so an org already left in the half-claimed state repairs
+itself on the next pass rather than needing a database reset. No metadata, seed values or
+API shapes changed; only the bootstrap sweep.

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -2183,6 +2183,18 @@ connector instead. Retained for customers still on the legacy stack.`,
  * The `demo_bootstrap` scheduled flow (`src/flows/demo-bootstrap.flow.ts`)
  * does it at the only moment it can: once the first real user exists, its
  * periodic sweep claims every ownerless seeded record for that user.
+ *
+ * That sweep owns BOTH ownership columns, and it has to (#622). Seed writes
+ * run under `{ isSystem: true }`, which by the seeder's documented contract
+ * disables the security plugin's auto-injection of `organization_id` /
+ * `owner_id` — "seeds either declare those fields explicitly per record" — and
+ * per the paragraph above these seeds cannot declare it. So a seeded row can
+ * reach the database owned by nobody at the PLATFORM level (`owner_id` null)
+ * even though the app's own `owner` lookup later reads as claimed, and under
+ * `sharingModel: 'private'` such a row is editable by no one at all, admin
+ * included. Nothing here should grow an `owner` / `owner_id` seed value to
+ * paper over that: the sweep is the mechanism, and
+ * `test/flow-scheduled.test.ts` holds it to claiming both columns.
  */
 
 /** All CRM seed datasets */

--- a/src/flows/demo-bootstrap.flow.ts
+++ b/src/flows/demo-bootstrap.flow.ts
@@ -33,17 +33,69 @@ type Flow = Automation.Flow;
  * Scoped to a demo install by intent — it claims records for whoever the first
  * user is. A real deployment assigns ownership through import or territory
  * rules instead, and by then nothing is ownerless for this to pick up.
+ *
+ * ─── TWO ownership columns, not one (#622) ───────────────────────────────
+ *
+ * Every claimed object carries two:
+ *
+ *   - `owner`    — the app's own `lookup(sys_user)` field. Drives the "My …"
+ *                  views, the owner-addressed `notify` in every sweep, and the
+ *                  owner axis of the analytics datasets.
+ *   - `owner_id` — the PLATFORM ownership column ObjectQL injects into every
+ *                  user-owned object. This is the one — and the only one — the
+ *                  sharing service reads: under `sharingModel: 'private'` the
+ *                  OWD baseline admits the owner of `owner_id` and a share can
+ *                  only WIDEN from there.
+ *
+ * They are independent columns, so claiming one does not claim the other, and
+ * an app field that happens to be named `owner` is not the platform's owner.
+ * This flow used to stamp `owner` alone. A row that reached the platform
+ * ownerless therefore came out of the sweep looking claimed (`owner` = the dev
+ * admin) while still being owned by nobody as far as access control is
+ * concerned — `PATCH` answered 403 for EVERY user including the admin, and the
+ * attachment surface, which gates on `canEdit(parent)`, answered 403
+ * `ATTACHMENT_PARENT_ACCESS` on upload. Worse, the sweep's own filter then read
+ * `owner != null` and never looked at the row again: the state was terminal.
+ *
+ * Why rows reach the platform ownerless at all: seed writes run under
+ * `{ isSystem: true }`, which by the seeder's documented contract DISABLES the
+ * security plugin's auto-injection of `organization_id` / `owner_id` — "seeds
+ * either declare those fields explicitly per record". HotCRM's seeds cannot
+ * declare it: `cel\`os.user.id\`` does not resolve at seed time (boot logs
+ * "Unknown variable: os" for exactly these fields), which is why this flow
+ * exists in the first place. So ownership at the platform level is THIS flow's
+ * job, and nothing else's.
+ *
+ * Hence: every pass stamps BOTH columns, and each object is swept twice — once
+ * for rows missing `owner`, once for rows missing `owner_id`. Two single-field
+ * filters rather than one `$or`: `{ field: null }` is the only filter shape
+ * these sweeps have ever used against the real driver, and a half-claimed row
+ * (the state above) must still be reachable, which a single `owner`-keyed pass
+ * cannot do. On a healthy org both passes select nothing.
  */
 
-/** One find + loop + stamp-owner pass over an object. */
-const claim = (key: string, objectName: string, label: string) => ({
+/** The two ownership columns a claim pass stamps together. See the note above. */
+const OWNERSHIP_COLUMNS = ['owner', 'owner_id'] as const;
+type OwnershipColumn = (typeof OWNERSHIP_COLUMNS)[number];
+
+/** Both columns, pointed at the first user — the payload of every claim. */
+const CLAIM_FIELDS: Record<OwnershipColumn, string> = {
+  owner: '{firstUser.id}',
+  owner_id: '{firstUser.id}',
+};
+
+/**
+ * One find + loop + stamp-owner pass over an object, selecting the rows that
+ * are ownerless in `column` and stamping BOTH ownership columns on each.
+ */
+const claim = (key: string, objectName: string, label: string, column: OwnershipColumn) => ({
   find: {
     id: `find_${key}`,
     type: 'get_record' as const,
-    label: `Find ownerless ${label}`,
+    label: `Find ${label} with no ${column}`,
     config: {
       objectName,
-      filter: { owner: null },
+      filter: { [column]: null },
       limit: 500,
       outputVariable: `${key}List`,
     },
@@ -51,7 +103,7 @@ const claim = (key: string, objectName: string, label: string) => ({
   loop: {
     id: `loop_${key}`,
     type: 'loop' as const,
-    label: `Claim each ${label}`,
+    label: `Claim each ${label} with no ${column}`,
     config: {
       collection: `{${key}List}`,
       iteratorVariable: `current_${key}`,
@@ -60,11 +112,11 @@ const claim = (key: string, objectName: string, label: string) => ({
           {
             id: `stamp_${key}`,
             type: 'update_record' as const,
-            label: `Set owner on ${label}`,
+            label: `Set owner + owner_id on ${label}`,
             config: {
               objectName,
               filter: { id: `{current_${key}.id}` },
-              fields: { owner: '{firstUser.id}' },
+              fields: { ...CLAIM_FIELDS },
             },
           },
         ],
@@ -74,19 +126,35 @@ const claim = (key: string, objectName: string, label: string) => ({
   },
 });
 
-const TARGETS = [
-  claim('leads', 'crm_lead', 'Leads'),
-  claim('accounts', 'crm_account', 'Accounts'),
-  claim('contacts', 'crm_contact', 'Contacts'),
-  claim('opportunities', 'crm_opportunity', 'Opportunities'),
-  claim('cases', 'crm_case', 'Cases'),
-  claim('tasks', 'crm_task', 'Tasks'),
-  // Quotes and contracts are seeded ownerless too — without claiming them the
-  // contract_renewal / contract_expiration / quote_expiration notifies address
-  // a null owner and reach nobody (the exact failure this flow exists to fix).
-  claim('quotes', 'crm_quote', 'Quotes'),
-  claim('contracts', 'crm_contract', 'Contracts'),
+/**
+ * The objects whose seeded rows this flow claims.
+ *
+ * Quotes and contracts are in the list because they are seeded ownerless too —
+ * without claiming them the contract_renewal / contract_expiration /
+ * quote_expiration notifies address a null owner and reach nobody (the exact
+ * failure this flow exists to fix), and `crm_contract` additionally becomes
+ * uneditable for everyone (#622).
+ */
+const CLAIMED_OBJECTS: ReadonlyArray<[key: string, objectName: string, label: string]> = [
+  ['leads', 'crm_lead', 'Leads'],
+  ['accounts', 'crm_account', 'Accounts'],
+  ['contacts', 'crm_contact', 'Contacts'],
+  ['opportunities', 'crm_opportunity', 'Opportunities'],
+  ['cases', 'crm_case', 'Cases'],
+  ['tasks', 'crm_task', 'Tasks'],
+  ['quotes', 'crm_quote', 'Quotes'],
+  ['contracts', 'crm_contract', 'Contracts'],
 ];
+
+/**
+ * One pass per (object, ownership column). Ordered column-major so the whole
+ * `owner` sweep runs before the whole `owner_id` sweep — the `owner` pass
+ * stamps both columns, so by the time the `owner_id` sweep is reached it only
+ * has genuinely half-claimed rows left to repair.
+ */
+const TARGETS = OWNERSHIP_COLUMNS.flatMap((column) =>
+  CLAIMED_OBJECTS.map(([key, objectName, label]) => claim(`${key}_by_${column}`, objectName, label, column)),
+);
 
 /**
  * The whole flow is one straight line: check for a user, then find/loop each
@@ -103,7 +171,8 @@ const CHAIN = [
 export const DemoBootstrapFlow: Flow = {
   name: 'demo_bootstrap',
   label: 'Demo Bootstrap',
-  description: 'Claim ownerless seeded demo records for the first user so the "My …" views work.',
+  description:
+    'Claim ownerless seeded demo records for the first user — both the app `owner` lookup (the "My …" views) and the platform `owner_id` column (sharing / who may edit).',
   type: 'schedule',
   status: 'active',
   runAs: 'system',

--- a/test/flow-scheduled.test.ts
+++ b/test/flow-scheduled.test.ts
@@ -5,6 +5,7 @@ import { CampaignCompletionFlow } from '../src/flows/campaign-completion.flow';
 import { CaseSlaMonitorFlow } from '../src/flows/case-sla-monitor.flow';
 import { ContractExpirationFlow } from '../src/flows/contract-expiration.flow';
 import { ContractRenewalFlow } from '../src/flows/contract-renewal.flow';
+import { DemoBootstrapFlow } from '../src/flows/demo-bootstrap.flow';
 import { ForecastSnapshotFlow } from '../src/flows/forecast-snapshot.flow';
 import { OpportunityStagnationFlow } from '../src/flows/opportunity-stagnation.flow';
 import { QuoteExpirationFlow } from '../src/flows/quote-expiration.flow';
@@ -750,5 +751,157 @@ describe('loop-nested conditions must be explicit CEL envelopes', () => {
       'bare string condition(s) inside a loop body — these never evaluate.\n' +
         "Wrap as { dialect: 'cel', source: '…' }:\n  " + bare.join('\n  '),
     ).toEqual([]);
+  });
+});
+
+/**
+ * demo_bootstrap — the post-seed ownership claim (#622).
+ *
+ * The failure this guards against is silent by construction. A seeded row can
+ * reach the database with the PLATFORM ownership column (`owner_id`) empty:
+ * seed writes run `{ isSystem: true }`, which by the seeder's documented
+ * contract disables auto-injection of `owner_id`, and these seeds cannot
+ * declare one (`cel`os.user.id`` does not resolve at seed time — that is why
+ * this flow exists). `owner_id` is the only column the sharing service reads,
+ * so under `sharingModel: 'private'` such a row is editable by NOBODY, the
+ * admin included: `PATCH` answers 403, and the attachment surface — which
+ * gates on `canEdit(parent)` — answers 403 ATTACHMENT_PARENT_ACCESS.
+ *
+ * Stamping only the app-level `owner` lookup hid it perfectly: the record LOOKS
+ * claimed everywhere a human would check, the "My …" views fill up, and the
+ * sweep's own filter (`owner != null`) then excludes the row forever, so the
+ * broken state is terminal. Shipped that way, `crm_contract` was read-only for
+ * every user on every demo org.
+ *
+ * These cases therefore assert the OUTCOME — every claimed object comes out of
+ * bootstrap with a real platform owner — over the object list read from the
+ * flow itself, so a newly claimed object is covered the day it is added.
+ */
+describe('demo_bootstrap — post-seed ownership claim', () => {
+  const USER = 'usr_first';
+
+  /** The platform ownership column; injected by ObjectQL, read by sharing. */
+  const PLATFORM_OWNER = 'owner_id';
+  /** The app's own lookup; drives "My …" views and owner-addressed notify. */
+  const APP_OWNER = 'owner';
+
+  /** Every object the flow claims, read off the flow's own `get_record` nodes. */
+  const claimedObjects = (): string[] => {
+    const nodes = (DemoBootstrapFlow.nodes ?? []) as Rec[];
+    const names = nodes
+      .filter((n) => n.type === 'get_record' && n.config?.objectName !== 'sys_user')
+      .map((n) => String(n.config.objectName));
+    return [...new Set(names)];
+  };
+
+  /**
+   * One row per ownerless SHAPE, for each claimed object:
+   *  - `both`      — a fresh seed row, ownerless on both columns.
+   *  - `app_only`  — the platform stamp fired, the app lookup is still empty.
+   *  - `plat_only` — THE #622 STATE: the app lookup reads as claimed while the
+   *                  platform column is empty. A sweep keyed on `owner` alone
+   *                  can never see this row again.
+   * Plus `owned`, already claimed by a real rep — must be left alone.
+   */
+  const seedStore = (): Record<string, Rec[]> => {
+    const store: Record<string, Rec[]> = { sys_user: [{ id: USER, email: 'admin@objectos.ai' }] };
+    for (const object of claimedObjects()) {
+      store[object] = [
+        { id: `${object}_both`, [APP_OWNER]: null, [PLATFORM_OWNER]: null },
+        { id: `${object}_app_only`, [APP_OWNER]: null, [PLATFORM_OWNER]: USER },
+        { id: `${object}_plat_only`, [APP_OWNER]: USER, [PLATFORM_OWNER]: null },
+        { id: `${object}_owned`, [APP_OWNER]: 'rep_9', [PLATFORM_OWNER]: 'rep_9' },
+      ];
+    }
+    return store;
+  };
+
+  const runBootstrap = async (store: Record<string, Rec[]> = seedStore()) => {
+    const h = makeFlowHarness({ demo_bootstrap: DemoBootstrapFlow }, store);
+    await h.run('demo_bootstrap', {}, { event: 'schedule' });
+    return h;
+  };
+
+  it('claims every object the seed data ships an owner-scoped record for', () => {
+    // Guards the cases below: they iterate this list, so an empty or truncated
+    // one would make every assertion vacuous.
+    const claimed = claimedObjects();
+    for (const object of [
+      'crm_lead', 'crm_account', 'crm_contact', 'crm_opportunity',
+      'crm_case', 'crm_task', 'crm_quote', 'crm_contract',
+    ]) {
+      expect(claimed, `demo_bootstrap never claims ${object}`).toContain(object);
+    }
+  });
+
+  it('leaves no claimed object ownerless at the PLATFORM level', async () => {
+    const h = await runBootstrap();
+
+    const ownerless: string[] = [];
+    for (const object of claimedObjects()) {
+      for (const row of h.store[object] ?? []) {
+        if (row[PLATFORM_OWNER] == null) ownerless.push(`${object}/${row.id as string}`);
+      }
+    }
+    expect(
+      ownerless,
+      'these rows came out of demo_bootstrap owned by nobody at the platform level.\n' +
+        `Under sharingModel:'private' that makes them read-only for EVERY user, admin\n` +
+        'included, and blocks attachments on them:\n  ' + ownerless.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('claims BOTH ownership columns on every row it touches', async () => {
+    const h = await runBootstrap();
+
+    for (const object of claimedObjects()) {
+      const byId = Object.fromEntries((h.store[object] ?? []).map((r) => [r.id, r]));
+      for (const shape of ['both', 'app_only', 'plat_only']) {
+        const row = byId[`${object}_${shape}`];
+        expect(row, `${object}_${shape} vanished`).toBeTruthy();
+        expect(row[PLATFORM_OWNER], `${object}_${shape}: platform ${PLATFORM_OWNER} not claimed`).toBe(USER);
+        expect(row[APP_OWNER], `${object}_${shape}: app ${APP_OWNER} not claimed`).toBe(USER);
+      }
+    }
+  });
+
+  it('repairs a row the app lookup already calls claimed (the #622 state)', async () => {
+    // The regression in one case: `owner` set, `owner_id` empty. A sweep keyed
+    // on `owner` alone reports success and never touches the row again, which
+    // is why this shipped invisibly.
+    const h = await runBootstrap();
+    const contract = (h.store.crm_contract ?? []).find((r) => r.id === 'crm_contract_plat_only');
+    expect(contract?.[PLATFORM_OWNER], 'half-claimed contract still ownerless to sharing').toBe(USER);
+  });
+
+  it('never reassigns a record that already has a real owner', async () => {
+    const h = await runBootstrap();
+    for (const object of claimedObjects()) {
+      const owned = (h.store[object] ?? []).find((r) => r.id === `${object}_owned`);
+      expect(owned?.[APP_OWNER], `${object}: stole an owned record`).toBe('rep_9');
+      expect(owned?.[PLATFORM_OWNER], `${object}: overwrote a real platform owner`).toBe('rep_9');
+    }
+  });
+
+  it('is a no-op on a fully claimed org', async () => {
+    const first = await runBootstrap();
+    const settled = JSON.parse(JSON.stringify(first.store)) as Record<string, Rec[]>;
+
+    const second = await runBootstrap(JSON.parse(JSON.stringify(settled)) as Record<string, Rec[]>);
+    expect(second.store).toEqual(settled);
+  });
+
+  it('does nothing at all before the first user exists', async () => {
+    const store = seedStore();
+    store.sys_user = [];
+    const h = await runBootstrap(store);
+
+    // Every row keeps exactly the ownership it started with — in particular the
+    // sweep must not stamp the literal `{firstUser.id}` placeholder.
+    for (const object of claimedObjects()) {
+      const both = (h.store[object] ?? []).find((r) => r.id === `${object}_both`);
+      expect(both?.[APP_OWNER], `${object}: claimed with no user present`).toBeNull();
+      expect(both?.[PLATFORM_OWNER], `${object}: claimed with no user present`).toBeNull();
+    }
   });
 });

--- a/test/runtime-coverage.test.ts
+++ b/test/runtime-coverage.test.ts
@@ -52,9 +52,6 @@ const RUNTIME_TEST_FILES = [
 const PENDING_FLOWS = new Set([
   // Spans a 24h `wait` node; needs timer-resume support in the harness.
   'case_csat_followup',
-  // First-boot demo seeding. Exercised end to end every time the e2e suite
-  // boots a cold database (e2e/smoke.spec.ts asserts the seeded records).
-  'demo_bootstrap',
 ]);
 
 const testSource = (() => {


### PR DESCRIPTION
Fixes objectstack-ai/hotcrm#622

## Description

演示组织里每一条种子合同对所有人只读——管理员也不例外。打开一条 demo 合同改一个字段，`PATCH` 回 403；#602 刚开的附件面板在合同上传时回 403 `ATTACHMENT_PARENT_ACCESS`，看起来像"附件坏了"，实际坏的是合同的所有权。

这些对象身上有**两个**所有权列：

| 列 | 归属 | 作用 |
|---|---|---|
| `owner` | 应用自己的 `lookup(sys_user)` 字段 | "My Leads / My Deals / My Cases" 视图、所有面向 owner 的 `notify`、分析数据集的 owner 维度 |
| `owner_id` | ObjectQL 注入的**平台**所有权列 | 共享服务**唯一**读取的那一个：`sharingModel: 'private'` 下 OWD 基线只放行 `owner_id` 的持有者，share 只能从这个 owner 往外 **widen** |

`demo_bootstrap` 过去只盖 `owner`。于是一条到达数据库时平台层无主的记录，扫过之后在**人能看到的每个地方**都像是被认领了（`owner` = dev admin），而在访问控制眼里仍然属于任何人都不是；更糟的是扫描自己的过滤条件随后变成 `owner != null`，这条记录再也不会被看第二眼——**这是一个终态，产品内没有任何恢复路径**。

记录为什么会那样到达数据库：seed 写入跑在 `{ isSystem: true }` 下，按 seeder 自己的契约这会**关闭** `organization_id` / `owner_id` 的自动注入（"seeds either declare those fields explicitly per record"），而本仓库的 seed 无法声明它——`cel\`os.user.id\`` 在 seed 阶段不解析（启动日志对这些字段正好打 `Unknown variable: os`），这本来就是这个 flow 存在的理由。所以平台层所有权是**这个 flow 的职责，没有别人的**。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes objectstack-ai/hotcrm#622
Related to objectstack-ai/hotcrm#602 (附件面板是这个缺陷浮出水面的地方，它本身是对的)

## Changes Made

- `src/flows/demo-bootstrap.flow.ts` — 每一次认领同时盖 **两个** 列；每个对象扫**两遍**，一遍捞缺 `owner` 的、一遍捞缺 `owner_id` 的，所以已经处在半认领终态的组织会在下一次扫描时**自愈**，不需要重置数据库。用两个单字段过滤而不是一个 `$or`：`{ field: null }` 是这些 sweep 对真实 driver 用过的唯一过滤形状，健康组织下两遍都选不出任何行。
- `test/flow-scheduled.test.ts` — 新增 `demo_bootstrap` 的 runtime 用例，断言的是**结果**而不是形状：凡是 `demo_bootstrap` 认领的对象，出 bootstrap 后都不能在平台层无主。对象清单从 flow 自身读出，所以以后新增一个被认领的对象当天就自动被覆盖。同时覆盖三种无主形态（两列皆空 / 只缺 `owner` / **只缺 `owner_id`** 即 #622 状态）、已有真实 owner 的记录不得被抢、重复运行幂等、首个用户出现前不动任何行。
- `test/runtime-coverage.test.ts` — `demo_bootstrap` 因此离开 `PENDING_FLOWS`。
- `src/data/index.ts` — 只加注释：说明平台层所有权归 sweep 管，不要在 seed 里长出 `owner` / `owner_id` 值来掩盖。

## Testing

- [x] Unit tests pass (`pnpm test`) — `Test Files 38 passed (38) · Tests 798 passed | 1 skipped (799)`
- [x] Linting passes (`pnpm lint`) — `1 warning(s), 13 suggestion(s)`，均为既有项，无新增
- [x] Build succeeds (`pnpm build`) + `pnpm validate` + `pnpm typecheck` + `pnpm hygiene` 全绿
- [x] Manual testing completed（见下）
- [x] New tests added

新用例先做过**反向验证**：把 flow 临时改回只盖 `owner` 的旧行为，三个平台所有权断言如期失败（`expected null to be 'usr_first'`），确认它们不是空转。

真机验证（`objectstack dev --seed-admin`，`@objectstack/*` 17.0.0-rc.1，全新 DB）——按 issue 里的原话复现再修复：

```
# 人工造出 issue 报告的那个状态：owner 已认领、owner_id 为空
PATCH /api/v1/data/crm_contract/Hj5iX02U7wUVsttH   → 403
  {"error":"FORBIDDEN: insufficient privileges to update crm_contract Hj5iX02U7wUVsttH"}
POST  /api/v1/data/sys_attachment {parent_object: crm_contract, …} → 403 ATTACHMENT_PARENT_ACCESS

# 修复后的 demo_bootstrap 扫过一遍
crm_contract  owner_id 4/4   owner 4/4     ← 自愈，无需重置数据库

PATCH /api/v1/data/crm_contract/Hj5iX02U7wUVsttH   → 200
POST  /api/v1/data/sys_attachment {parent_object: crm_contract, …} → 400 "File is required"
                                                    ← 已过 canEdit(parent) 门禁，剩下的是缺文件体
PATCH /api/v1/data/crm_account/…                   → 200
PATCH /api/v1/data/crm_quote/…                     → 200
```

八个被认领对象全量：`crm_account 9/9 · crm_contact 9/9 · crm_opportunity 20/20 · crm_quote 5/5 · crm_case 38/38 · crm_task 7/7 · crm_lead 21/21 · crm_contract 4/4`。

## Checklist

- [x] **I have added a changeset** — `.changeset/demo-bootstrap-platform-ownership.md`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation（flow 与 seed 的内联说明；无面向用户的行为变化需要新文档页）
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**issue 里 `security/explain` 与写入路径互相矛盾的那一半：判定为平台侧，不在本 PR 内改。** 在同一个 principal、同一条无主记录上实测：

```
POST /api/v1/security/explain {object: crm_contract, operation: update, recordId: …}
  → allowed: true
     layers[vama_bypass].detail = "View/Modify All Data bypass held via [admin_full_access]
                                   — ownership and sharing checks are skipped"
     record = { visible: false, decidedBy: "sharing" }

PATCH /api/v1/data/crm_contract/<同一条>   → 403 FORBIDDEN
```

`vama_bypass` 这一层自己写着"ownership and sharing checks are skipped"，而引擎的写入路径并没有跳过——两者对同一个问题给出相反答案，且 `explain` 正是管理员会用来排查这个问题的工具。这段逻辑完全在 `@objectstack/plugin-security` 的 explain 与引擎写入路径之间，没有任何本仓库的元数据参与，本仓库也改不动它，因此另开 upstream issue 记录，不在这里动平台代码。本 PR 的修复与它无关：无论哪一侧是对的，种子记录都应该有一个真实的 owner。


---
_Generated by [Claude Code](https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf)_