### PR TITLE
fix(validations): make every validation predicate total so rules stop being silently skipped

### DIFF
--- a/.changeset/validation-predicate-totality.md
+++ b/.changeset/validation-predicate-totality.md
@@ -1,0 +1,29 @@
+---
+'hotcrm': patch
+---
+
+Make every validation predicate TOTAL, so a rule can no longer be silently
+skipped on update. A rule is evaluated against `{...previous, ...data}`, and the
+engine fills absent fields with `null` **only on insert** — on update, `previous`
+is whatever the driver returned. A driver that stores only the columns a row was
+actually written with hands back a record with the key **absent**, strict CEL
+aborts the whole predicate with `No such key`, and the engine's answer to a
+predicate that cannot answer is to skip the rule. No error, no failed save — just
+a rule that reads as enforced and requires nothing.
+
+23 of the app's 24 script validations were exposed, including
+`crm_lead.disqualification_reason_required`, `crm_task.completed_date_required`
+and `crm_case.escalation_reason_required`. Every `record.x` read now carries a
+`has(record.x)` guard, and `test/object-validation-predicates.test.ts` enforces
+the house rule two ways: a structural check that no predicate reads a field
+without a guard, and a run of every predicate through the engine's own
+`evaluateValidationRules` against a record with no keys at all, failing on any
+"predicate failed to evaluate" warning.
+
+Measured per driver: `driver-sql` and `driver-sqlite-wasm` are column-complete
+(`SELECT *` returns NULL for unset columns), so rules already fired there and
+their behaviour is unchanged. `driver-memory` and `driver-mongodb` return only
+what was written, so on those the affected rules now fire where they previously
+did nothing — a record that was accepted before may now be correctly rejected on
+update (for example, moving a task to Completed without a completed date).
+Refs #630.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,9 @@ Use the most specific `Field` type available from `@objectstack/spec/data`:
 - **i18n**: Every new object must have entries in all 4 locale files (`src/translations/{en,zh-CN,es-ES,ja-JP}.ts`) — label, pluralLabel, all field labels + option labels, view labels, navigation labels. No new feature ships without all 4 locales.
 - **Docs**: Every new object/feature requires user-facing documentation under `content/docs/` (e.g. `getting-started/`, `guides/`, `marketing/`, `analytics/`, `administration/`) written for business users + admins (not developers).
 - **Documentation**: All documentation MUST be in English.
+- **Validation predicates must be TOTAL**: every `record.x` read in an authored
+  CEL predicate — `validations[].condition`, `requiredWhen`, `readonlyWhen`,
+  `visibleWhen` — carries a `has(record.x)` guard. See below.
 - **No Engine Code**: Do not try to modify the core runtime code. Focus on the *usage* of the runtime.
 - **Dependencies**: HotCRM depends on the published `@objectstack/*` packages (runtime, spec, drivers, services) declared in `package.json`. Keep `specVersion` in `objectstack.manifest.json` aligned with the installed `@objectstack/spec`.
 - **Tone**: Act as a Senior 10x Engineer. Be concise, professional, and technically accurate.
@@ -166,6 +169,41 @@ Use the most specific `Field` type available from `@objectstack/spec/data`:
 > warning on non-object items (pages/flows/datasets/etc.) is advisory only; its
 > "fail at install" wording is stale. Don't mass-rename UI/automation items to
 > chase that warning.
+
+### Validation predicates must be TOTAL (#630)
+
+A validation rule is evaluated against `{...previous, ...data}`, and the engine
+fills absent fields with `null` **only on insert**. On update, `previous` is
+whatever the driver returned — and a driver that stores only the columns a row
+was actually written with (`driver-memory`, `driver-mongodb`) hands back a
+record with the key **absent**, not null. Strict CEL then aborts the whole
+predicate with `No such key`, and the engine's answer to a predicate that
+cannot answer is to **skip the rule**:
+
+```
+WARN Validation rule 'x' predicate failed to evaluate (type: No such key: y) — skipped
+```
+
+No error, no failed save — just a rule that reads as enforced and requires
+nothing. So **every `record.x` read carries a `has(record.x)` guard**:
+
+| intent | write this |
+| --- | --- |
+| `x` holds no value | `(!has(record.x) \|\| isBlank(record.x))` |
+| `x` holds a value | `has(record.x) && record.x <op> …` |
+
+`!= null` is **not** a substitute — measured on an absent key, `record.f != null`
+aborts exactly like `record.f < 0` does. It guards a different hazard
+(`dyn<null> < int`); numeric comparisons need both guards. `has()` is the only
+total accessor: `coalesce(record.f, "")` aborts too, because its argument is
+evaluated before the call.
+
+`test/object-validation-predicates.test.ts` enforces this two ways — a grep for
+the guard, and a run of every predicate through the engine's own
+`evaluateValidationRules` against a record with no keys at all. That file also
+carries the full measurement table, the driver-by-driver findings, and why this
+route was chosen over making the in-memory test driver column-complete. Read it
+before adding a rule.
 
 ## ⬆️ Platform Upgrades (ObjectStack version bumps)
 

--- a/src/objects/campaign.object.ts
+++ b/src/objects/campaign.object.ts
@@ -269,6 +269,11 @@ export const Campaign = ObjectSchema.create({
   },
   
   // Validation Rules
+  //
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'end_after_start',
@@ -278,14 +283,14 @@ export const Campaign = ObjectSchema.create({
       // `<=`, not `<`: the message promises "after", so a campaign that ends
       // the day it starts is a violation. Matches `crm_contract`'s twin rule
       // and `crm_forecast.period_end_after_start` (#514 item 12).
-      condition: P`record.end_date != null && record.start_date != null && record.end_date <= record.start_date`,
+      condition: P`has(record.end_date) && record.end_date != null && has(record.start_date) && record.start_date != null && record.end_date <= record.start_date`,
     },
     {
       name: 'actual_cost_within_budget',
       type: 'script',
       severity: 'warning',
       message: 'Actual Cost exceeds Budgeted Cost',
-      condition: P`record.actual_cost != null && record.budgeted_cost != null && record.actual_cost > record.budgeted_cost`,
+      condition: P`has(record.actual_cost) && record.actual_cost != null && has(record.budgeted_cost) && record.budgeted_cost != null && record.actual_cost > record.budgeted_cost`,
     },
   ],
   

--- a/src/objects/campaign_member.object.ts
+++ b/src/objects/campaign_member.object.ts
@@ -118,13 +118,17 @@ export const CampaignMember = ObjectSchema.create({
     }),
   },
 
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'lead_or_contact_required',
       type: 'script',
       severity: 'error',
       message: 'A campaign member must reference either a Lead or a Contact',
-      condition: P`isBlank(record.crm_lead) && isBlank(record.crm_contact)`,
+      condition: P`(!has(record.crm_lead) || isBlank(record.crm_lead)) && (!has(record.crm_contact) || isBlank(record.crm_contact))`,
     },
   ],
 });

--- a/src/objects/case.object.ts
+++ b/src/objects/case.object.ts
@@ -319,20 +319,24 @@ export const Case = ObjectSchema.create({
   
   // Removed: list_views and form_views belong in UI configuration, not object definition
   
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'resolution_required_for_closed',
       type: 'script',
       severity: 'error',
       message: 'Resolution is required when closing a case',
-      condition: P`record.status == "closed" && isBlank(record.resolution)`,
+      condition: P`has(record.status) && record.status == "closed" && (!has(record.resolution) || isBlank(record.resolution))`,
     },
     {
       name: 'escalation_reason_required',
       type: 'script',
       severity: 'error',
       message: 'Escalation reason is required when escalating a case',
-      condition: P`record.is_escalated == true && isBlank(record.escalation_reason)`,
+      condition: P`has(record.is_escalated) && record.is_escalated == true && (!has(record.escalation_reason) || isBlank(record.escalation_reason))`,
     },
     {
       name: 'case_status_progression',

--- a/src/objects/contract.object.ts
+++ b/src/objects/contract.object.ts
@@ -229,13 +229,18 @@ export const Contract = ObjectSchema.create({
   },
   
   // Validation Rules
+  //
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'end_after_start',
       type: 'script',
       severity: 'error',
       message: 'End Date must be after Start Date',
-      condition: P`record.end_date != null && record.start_date != null && record.end_date <= record.start_date`,
+      condition: P`has(record.end_date) && record.end_date != null && has(record.start_date) && record.start_date != null && record.end_date <= record.start_date`,
     },
     // NOTE: the `valid_contract_term` warning (months-between term check) was
     // dropped in the 9.8.0 upgrade — its CEL predicate used `monthsBetween()`,

--- a/src/objects/forecast.object.ts
+++ b/src/objects/forecast.object.ts
@@ -213,6 +213,10 @@ export const Forecast = ObjectSchema.create({
     apiMethods: ['get', 'list', 'create', 'update', 'delete'],
   },
 
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'period_end_after_start',
@@ -225,14 +229,14 @@ export const Forecast = ObjectSchema.create({
       // operator as the `end_after_start` twins on campaign/contract, which
       // this rule used to diverge from in both operator and wording
       // ("on or after") — #514 item 12.
-      condition: P`record.period_end != null && record.period_start != null && record.period_end <= record.period_start`,
+      condition: P`has(record.period_end) && record.period_end != null && has(record.period_start) && record.period_start != null && record.period_end <= record.period_start`,
     },
     {
       name: 'snapshot_amounts_non_negative',
       type: 'script',
       severity: 'error',
       message: 'Snapshot amounts cannot be negative.',
-      condition: P`(record.pipeline_amount != null && record.pipeline_amount < 0) || (record.best_case_amount != null && record.best_case_amount < 0) || (record.commit_amount != null && record.commit_amount < 0) || (record.closed_amount != null && record.closed_amount < 0)`,
+      condition: P`(has(record.pipeline_amount) && record.pipeline_amount != null && record.pipeline_amount < 0) || (has(record.best_case_amount) && record.best_case_amount != null && record.best_case_amount < 0) || (has(record.commit_amount) && record.commit_amount != null && record.commit_amount < 0) || (has(record.closed_amount) && record.closed_amount != null && record.closed_amount < 0)`,
     },
   ],
 });

--- a/src/objects/knowledge_article.object.ts
+++ b/src/objects/knowledge_article.object.ts
@@ -206,20 +206,24 @@ export const KnowledgeArticle = ObjectSchema.create({
     apiMethods: ['get', 'list', 'create', 'update', 'delete'],
   },
 
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'published_requires_body',
       type: 'script',
       severity: 'error',
       message: 'Articles cannot be published without a body.',
-      condition: P`record.status == "published" && (record.body == null || record.body == "")`,
+      condition: P`has(record.status) && record.status == "published" && (!has(record.body) || record.body == null || record.body == "")`,
     },
     {
       name: 'published_requires_summary',
       type: 'script',
       severity: 'warning',
       message: 'Published articles should have a summary for search results and AI citations.',
-      condition: P`record.status == "published" && (record.summary == null || record.summary == "")`,
+      condition: P`has(record.status) && record.status == "published" && (!has(record.summary) || record.summary == null || record.summary == "")`,
     },
   ],
 });

--- a/src/objects/lead.object.ts
+++ b/src/objects/lead.object.ts
@@ -393,13 +393,17 @@ export const Lead = ObjectSchema.create({
   
   // Removed: list_views and form_views belong in UI configuration, not object definition
   
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'email_required',
       type: 'script',
       severity: 'error',
       message: 'Email is required',
-      condition: P`isBlank(record.email)`,
+      condition: P`!has(record.email) || isBlank(record.email)`,
     },
     {
       // The field description has promised "Required when status is
@@ -412,7 +416,7 @@ export const Lead = ObjectSchema.create({
       type: 'script',
       severity: 'error',
       message: 'Disqualification reason is required when a lead is Unqualified',
-      condition: P`record.status == "unqualified" && isBlank(record.disqualification_reason)`,
+      condition: P`has(record.status) && record.status == "unqualified" && (!has(record.disqualification_reason) || isBlank(record.disqualification_reason))`,
     },
     {
       // "Disqualified as a duplicate" has to name the survivor (#598).

--- a/src/objects/opportunity.object.ts
+++ b/src/objects/opportunity.object.ts
@@ -335,20 +335,28 @@ export const Opportunity = ObjectSchema.create({
   // (see validations[] below). 7.7 removed the top-level `stateMachines` key.
 
   // Validation Rules
+  //
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'close_date_future',
       type: 'script',
       severity: 'warning',
       message: 'Close date should not be in the past unless opportunity is closed',
-      condition: P`record.close_date != null && record.close_date < today() && record.stage != "closed_won" && record.stage != "closed_lost"`,
+      // An absent `stage` key means "no stage recorded", which is not a closed
+      // stage — hence `!has(record.stage) || (…)` rather than a leading
+      // `has(record.stage) &&`, which would suppress the warning instead.
+      condition: P`has(record.close_date) && record.close_date != null && record.close_date < today() && (!has(record.stage) || (record.stage != "closed_won" && record.stage != "closed_lost"))`,
     },
     {
       name: 'amount_positive',
       type: 'script',
       severity: 'error',
       message: 'Amount must be greater than zero',
-      condition: P`record.amount != null && record.amount <= 0`,
+      condition: P`has(record.amount) && record.amount != null && record.amount <= 0`,
     },
     {
       // Migrated from the removed top-level `stateMachines` key (OpportunityStateMachine).

--- a/src/objects/opportunity_line_item.object.ts
+++ b/src/objects/opportunity_line_item.object.ts
@@ -102,19 +102,27 @@ export const OpportunityLineItem = ObjectSchema.create({
     }),
   },
 
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'unit_price_positive',
       type: 'script',
       severity: 'error',
       message: 'Sales price cannot be negative',
-      // The `!= null` guard is load-bearing, not defensive noise: strict CEL
+      // Both guards are load-bearing, not defensive noise. `has(...)` answers
+      // "is the key present at all": on update the predicate sees
+      // `{...previous, ...data}`, and a driver that stores only written columns
+      // returns no key, which aborts the whole predicate and silently skips the
+      // rule (#630). `!= null` answers "does it hold a value": strict CEL
       // ABORTS on `null < 0` instead of evaluating it false, so the unguarded
       // form left this rule inert on a blank price — it never fired at all,
-      // which is the opposite of what a validation is for. The hazard is
+      // which is the opposite of what a validation is for. The `null` hazard is
       // written up at `account.object.ts:244-245`; the same-named rule in
-      // `quote_line_item.object.ts` has carried the guard all along.
-      condition: P`record.unit_price != null && record.unit_price < 0`,
+      // `quote_line_item.object.ts` has carried that guard all along.
+      condition: P`has(record.unit_price) && record.unit_price != null && record.unit_price < 0`,
     },
   ],
 });

--- a/src/objects/product.object.ts
+++ b/src/objects/product.object.ts
@@ -223,26 +223,34 @@ export const Product = ObjectSchema.create({
   },
   
   // Validation Rules
+  //
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'price_positive',
       type: 'script',
       severity: 'error',
       message: 'List Price must be positive',
-      // Null-guard: strict CEL cannot compare dyn<null> < int, and an
-      // unguarded predicate aborts evaluation (rule silently skipped) — the
-      // hazard written up on `account.object.ts`. `list_price` is `required`,
-      // but the rule also runs on partial updates that omit it.
-      condition: P`record.list_price != null && record.list_price < 0`,
+      // Two distinct guards, both required. `has(...)` answers "is the key
+      // there at all" — on update the merged record is `{...previous, ...data}`
+      // and a driver that stores only written columns hands back no key, which
+      // aborts the whole predicate (#630). `!= null` then answers "does it hold
+      // a value" — strict CEL cannot compare dyn<null> < int, the hazard
+      // written up on `account.object.ts`. `list_price` is `required`, but the
+      // rule also runs on partial updates that omit it.
+      condition: P`has(record.list_price) && record.list_price != null && record.list_price < 0`,
     },
     {
       name: 'cost_less_than_price',
       type: 'script',
       severity: 'warning',
       message: 'Cost should be less than List Price',
-      // Both operands need the guard: `cost` is optional and absent on every
+      // Both operands need both guards: `cost` is optional and absent on every
       // seeded product, so this warning has never once evaluated.
-      condition: P`record.cost != null && record.list_price != null && record.cost >= record.list_price`,
+      condition: P`has(record.cost) && record.cost != null && has(record.list_price) && record.list_price != null && record.cost >= record.list_price`,
     },
   ],
 });

--- a/src/objects/quote.object.ts
+++ b/src/objects/quote.object.ts
@@ -228,20 +228,25 @@ export const Quote = ObjectSchema.create({
   },
   
   // Validation Rules
+  //
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'expiration_after_quote',
       type: 'script',
       severity: 'error',
       message: 'Expiration Date must be after Quote Date',
-      condition: P`record.expiration_date != null && record.quote_date != null && record.expiration_date <= record.quote_date`,
+      condition: P`has(record.expiration_date) && record.expiration_date != null && has(record.quote_date) && record.quote_date != null && record.expiration_date <= record.quote_date`,
     },
     {
       name: 'valid_discount',
       type: 'script',
       severity: 'error',
       message: 'Discount cannot exceed 100%',
-      condition: P`record.discount != null && record.discount > 100`,
+      condition: P`has(record.discount) && record.discount != null && record.discount > 100`,
     },
     {
       // #575 B4. `crm_quote` had a full lifecycle vocabulary and no transition

--- a/src/objects/quote_line_item.object.ts
+++ b/src/objects/quote_line_item.object.ts
@@ -115,13 +115,17 @@ export const QuoteLineItem = ObjectSchema.create({
     }),
   },
 
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'unit_price_positive',
       type: 'script',
       severity: 'error',
       message: 'Sales price cannot be negative',
-      condition: P`record.unit_price != null && record.unit_price < 0`,
+      condition: P`has(record.unit_price) && record.unit_price != null && record.unit_price < 0`,
     },
   ],
 });

--- a/src/objects/task.object.ts
+++ b/src/objects/task.object.ts
@@ -274,27 +274,31 @@ export const Task = ObjectSchema.create({
   
   // Removed: list_views and form_views belong in UI configuration, not object definition
   
+  // Predicates below are TOTAL: every `record.x` read is `has()`-guarded, so the
+  // rule returns a verdict even when the merged record has no such key. See
+  // AGENTS.md "Validation predicates must be TOTAL" and
+  // test/object-validation-predicates.test.ts, which fails the build otherwise.
   validations: [
     {
       name: 'completed_date_required',
       type: 'script',
       severity: 'error',
       message: 'Completed date is required when status is Completed',
-      condition: P`record.status == "completed" && isBlank(record.completed_date)`,
+      condition: P`has(record.status) && record.status == "completed" && (!has(record.completed_date) || isBlank(record.completed_date))`,
     },
     {
       name: 'recurrence_fields_required',
       type: 'script',
       severity: 'error',
       message: 'Recurrence type is required for recurring tasks',
-      condition: P`record.is_recurring == true && isBlank(record.recurrence_type)`,
+      condition: P`has(record.is_recurring) && record.is_recurring == true && (!has(record.recurrence_type) || isBlank(record.recurrence_type))`,
     },
     {
       name: 'related_to_required',
       type: 'script',
       severity: 'warning',
       message: 'At least one related record should be selected',
-      condition: P`isBlank(record.related_to_account) && isBlank(record.related_to_contact) && isBlank(record.related_to_opportunity) && isBlank(record.related_to_lead) && isBlank(record.related_to_case)`,
+      condition: P`(!has(record.related_to_account) || isBlank(record.related_to_account)) && (!has(record.related_to_contact) || isBlank(record.related_to_contact)) && (!has(record.related_to_opportunity) || isBlank(record.related_to_opportunity)) && (!has(record.related_to_lead) || isBlank(record.related_to_lead)) && (!has(record.related_to_case) || isBlank(record.related_to_case))`,
     },
   ],
   

--- a/test/object-validation-predicates.test.ts
+++ b/test/object-validation-predicates.test.ts
@@ -1,8 +1,10 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { ObjectQL, evaluateValidationRules } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
 import stack from '../objectstack.config';
 import { REPO_ROOT } from './helpers/repo-root';
 
@@ -26,8 +28,109 @@ import { REPO_ROOT } from './helpers/repo-root';
  *      is rejected on one object and accepted on another — and the message
  *      shown to the user stops matching what the predicate does.
  *
- * Neither is visible in review without reading the CEL character by character,
- * which is exactly why they survived. See #514 (items 3 and 12).
+ *   3. **Non-total predicate.** A field reference with no `has(...)` guard
+ *      aborts the whole predicate on a record whose merged shape has no such
+ *      key, and the engine's answer to a predicate that cannot answer is to
+ *      SKIP the rule. See the house rule below — this is #630.
+ *
+ * None is visible in review without reading the CEL character by character,
+ * which is exactly why they survived. See #514 (items 3 and 12) and #630.
+ */
+
+/**
+ * ═══ HOUSE RULE: validation predicates must be TOTAL ═══════════════════════
+ *
+ * **Every `record.x` read in an authored predicate carries a `has(record.x)`
+ * guard.** A predicate must return a verdict for every record shape it can be
+ * handed — never abort. This file enforces it; you do not have to remember it.
+ *
+ * ### Why the rule exists (all figures measured on 17.0.0-rc.1)
+ *
+ * `evaluateValidationRules` evaluates a rule against `{...previous, ...data}`
+ * and fills absent fields with `null` **only on insert**. On update, `previous`
+ * is whatever the driver returned, and strict CEL aborts with `No such key`
+ * the moment a predicate reads a key that is not there. The engine's response
+ * to an unevaluable predicate is to skip the rule:
+ *
+ *     WARN Validation rule 'x' predicate failed to evaluate (…) — skipped
+ *
+ * A rule that reads as enforced then requires nothing at all — silently. It is
+ * the same "declared ≠ enforced" failure this repo keeps deleting rules over
+ * (`cannot_edit_converted` #575 B1, `revenue_positive` #571).
+ *
+ * `!= null` does **not** substitute for `has(...)`: measured on an absent key,
+ * `record.f != null` aborts exactly like `record.f != "v"` does. Only `has()`
+ * is total, and `coalesce(record.f, "")` aborts too — its argument is
+ * evaluated before the call.
+ *
+ *   | predicate                             | key absent | key null | key set |
+ *   | ------------------------------------- | ---------- | -------- | ------- |
+ *   | `isBlank(record.f)`                   | **abort**  | true     | false   |
+ *   | `record.f != null`                    | **abort**  | false    | true    |
+ *   | `coalesce(record.f, "")`              | **abort**  | ""       | "v"     |
+ *   | `has(record.f)`                       | false      | true     | true    |
+ *   | `!has(record.f) \|\| isBlank(record.f)` | true      | true     | false   |
+ *   | `has(record.f) && !isBlank(record.f)` | false      | false    | true    |
+ *
+ * So the two authoring shapes are:
+ *
+ *   - "f holds no value"  → `(!has(record.f) || isBlank(record.f))`
+ *   - "f holds a value"   → `has(record.f) && record.f <op> …`
+ *
+ * ### Which driver hands back an incomplete record — measured, not assumed
+ *
+ *   | driver                          | absent column comes back as | rule on update |
+ *   | ------------------------------- | --------------------------- | -------------- |
+ *   | `@objectstack/driver-sql`       | key present, `null`         | ENFORCED       |
+ *   | `@objectstack/driver-sqlite-wasm` | key present, `null`       | ENFORCED       |
+ *   | `@objectstack/driver-memory`    | **key absent**              | **SKIPPED**    |
+ *   | `@objectstack/driver-mongodb`   | **key absent** (see below)  | **SKIPPED**    |
+ *
+ * The SQL family is column-complete because `SELECT *` returns a NULL for every
+ * unset column, and the engine reads `previous` with no field projection
+ * (`{ object, where: { id }, limit: 1 }`), so it is a full row. The Mongo
+ * driver returns the stored document minus `_id` and fills nothing in — a
+ * document written without a field comes back without that key. HotCRM is a
+ * marketplace app; it does not choose the datasource its host runs on.
+ *
+ * ### The decision, and what the rejected option would have cost (#630)
+ *
+ * Two routes were on the table. **Chosen: make the predicates total.**
+ *
+ * The rejected route was "make the in-memory test driver column-complete, so
+ * the test double behaves like the production driver". It is the more appealing
+ * one on its face — the bug does exist because a test double disagreed with
+ * production — and it was rejected for three measured reasons:
+ *
+ *   1. **It cannot be done at the source.** `@objectstack/driver-memory` is a
+ *      published platform package; this repo does not modify platform code. All
+ *      HotCRM could build is a test-side wrapper, which only helps tests that
+ *      remember to use it. That is the same "every author must remember"
+ *      objection raised against this route — except its forgetting mode is
+ *      worse: a test that news up `InMemoryDriver` directly silently reverts to
+ *      the trap, and nothing checks for it.
+ *   2. **It would have hidden this class of bug rather than fixed it.** The
+ *      in-memory driver's sparse rows are the only place in the stack that
+ *      exercises the "merged record lacks the key" shape. Making the double
+ *      agree with SQL would make the suite green while every Mongo-backed
+ *      install stayed silently unprotected. The sparse double is an asset —
+ *      do not "fix" it.
+ *   3. **It leaves the predicate depending on an environmental property.** A
+ *      rule whose correctness rests on "the storage layer happens to return
+ *      NULLs" is a rule one datasource swap away from being inert. Totality is
+ *      a property of the rule itself, which is where a contract belongs.
+ *
+ * The cost of the chosen route — "a rule every future author must remember, and
+ * forgetting it is silent" — is paid off by the two tests below: the structural
+ * one greps for the guard, and `predicates are TOTAL on the real engine` runs
+ * every predicate through `evaluateValidationRules` against a record with no
+ * keys at all and fails on any `failed to evaluate` warning. Forgetting the
+ * guard is now loud, at PR time, which is the only way a house rule survives.
+ *
+ * Out of scope here, filed upstream as objectstack-ai/objectstack#4649: whether
+ * the engine should treat an unevaluable predicate on an `error`-severity rule
+ * as a failure rather than a skip. A rule that cannot answer is not a rule that
+ * passed — but that is a platform decision, not a HotCRM one.
  */
 
 type AnyRec = Record<string, any>;
@@ -59,9 +162,13 @@ const scriptRules = objects.flatMap((obj) =>
 /**
  * Operands of a relational comparison (`<`, `<=`, `>`, `>=`).
  *
- * `!=` and `==` are deliberately not matched: equality against `null` is the
- * guard itself, and CEL evaluates it fine on an absent field. Only the
- * ordering operators abort.
+ * `!=` and `==` are deliberately not matched: comparison against `null` is the
+ * guard this section is about, and only the ordering operators abort on it.
+ *
+ * That guard covers the `dyn<null> < int` hazard and nothing else. It does NOT
+ * make the predicate total — measured on an absent key, `record.f != null`
+ * aborts exactly like `record.f < 0` does. Absent-key totality is a separate
+ * property, enforced by the `has(...)` tests further down (#630).
  */
 const OPERAND = String.raw`record\.\w+|previous\.\w+|\w+\([^()]*\)|-?[\d.]+|"[^"]*"`;
 const RELATIONAL = new RegExp(
@@ -198,5 +305,216 @@ describe('annual_revenue has a single enforcement point', () => {
     const hook = readFileSync(join(REPO_ROOT, 'src/objects/account.hook.ts'), 'utf8');
     expect(hook).toMatch(/input\.annual_revenue\s*<\s*0/);
     expect(hook).toMatch(/greater than or equal to 0/);
+  });
+});
+
+// ───────────────────────────────────────── totality (#630) ──
+//
+// See the HOUSE RULE block at the top of this file for why these two tests
+// exist and what the rejected alternative would have cost.
+
+/** Authored CEL predicates that hang off a field, not off `validations[]`. */
+const FIELD_PREDICATE_KEYS = ['requiredWhen', 'readonlyWhen', 'visibleWhen'] as const;
+
+/** Every authored predicate in the stack: rules, field predicates, option visibility. */
+const allPredicates: { id: string; source: string }[] = [
+  ...objects.flatMap((obj) =>
+    ((obj.validations ?? []) as AnyRec[])
+      .filter((v) => v.type === 'script' || v.type === 'cross_field')
+      .map((v) => ({ id: `${obj.name}.${v.name}`, source: celSource(v.condition) })),
+  ),
+  ...objects.flatMap((obj) =>
+    Object.entries((obj.fields ?? {}) as Record<string, AnyRec>).flatMap(([field, def]) =>
+      FIELD_PREDICATE_KEYS.filter((k) => def?.[k]).map((k) => ({
+        id: `${obj.name}.${field}.${k}`,
+        source: celSource(def[k]),
+      })),
+    ),
+  ),
+  ...objects.flatMap((obj) =>
+    Object.entries((obj.fields ?? {}) as Record<string, AnyRec>).flatMap(([field, def]) =>
+      ((def?.options ?? []) as AnyRec[])
+        .filter((o) => o?.visibleWhen)
+        .map((o) => ({
+          id: `${obj.name}.${field}.options[${o.value}].visibleWhen`,
+          source: celSource(o.visibleWhen),
+        })),
+    ),
+  ),
+];
+
+/** Fields the predicate reads without a `has(...)` guard in the same expression. */
+function unhas(source: string): string[] {
+  const referenced = [...new Set([...source.matchAll(/record\.(\w+)/g)].map((m) => m[1]))];
+  return referenced.filter(
+    (field) => !new RegExp(String.raw`has\(record\.${field}\)`).test(source),
+  );
+}
+
+describe('every authored predicate guards every field it reads', () => {
+  it('finds predicates to check at all', () => {
+    // Guard the guard: a typo in the flattening above would make the sweep
+    // below pass over an empty list.
+    expect(allPredicates.length).toBeGreaterThan(20);
+    expect(allPredicates.some((p) => p.id === 'crm_task.completed_date_required')).toBe(true);
+    expect(allPredicates.some((p) => p.id.endsWith('.requiredWhen'))).toBe(true);
+  });
+
+  it('reads no record field without has(...)', () => {
+    const offenders = allPredicates
+      .map((p) => ({ id: p.id, unguarded: unhas(p.source) }))
+      .filter((p) => p.unguarded.length > 0);
+
+    expect(
+      offenders,
+      'These predicates read a field with no has(…) guard. On a record whose merged ' +
+        'shape omits the key — every update on a driver that stores only written ' +
+        'columns — strict CEL aborts and the engine SKIPS the rule entirely. ' +
+        'Use `(!has(record.f) || isBlank(record.f))` for "f is empty" and ' +
+        '`has(record.f) && record.f <op> …` for "f holds a value".',
+    ).toEqual([]);
+  });
+});
+
+/**
+ * The same property, measured instead of grepped.
+ *
+ * The test above is a regex over source text and can be satisfied by a guard
+ * that sits in the wrong place. This one hands each object's real predicates to
+ * the engine's own `evaluateValidationRules` with `mode: 'update'` and a
+ * `previous` that has no keys at all — the exact shape the in-memory and Mongo
+ * drivers produce — and fails on any `failed to evaluate` warning, which is how
+ * the engine reports that it skipped a rule.
+ *
+ * A `ValidationError` here is a PASS: a rule that fires returned a verdict.
+ * Only silence-by-abort is the defect.
+ */
+describe('predicates are TOTAL on the real engine', () => {
+  /** Run one object's rules and return the engine's "I skipped it" warnings. */
+  function skippedWarnings(obj: AnyRec, data: AnyRec, previous: AnyRec | null): string[] {
+    const warns: string[] = [];
+    const logger = { warn: (...a: unknown[]) => void warns.push(a.map(String).join(' ')) };
+    try {
+      evaluateValidationRules(obj as never, data, 'update', { previous, logger } as never);
+    } catch {
+      // ValidationError — a rule reached a verdict, which is the good outcome.
+    }
+    return warns.filter((w) => /failed to evaluate/.test(w));
+  }
+
+  /** Every field any of this object's predicates reads. */
+  function referencedFields(obj: AnyRec): string[] {
+    const sources = allPredicates
+      .filter((p) => p.id.startsWith(`${obj.name}.`))
+      .map((p) => p.source)
+      .join(' ');
+    return [...new Set([...sources.matchAll(/record\.(\w+)/g)].map((m) => m[1]))];
+  }
+
+  it.each(objects.map((o) => [o.name as string, o] as const))(
+    '%s answers on a record with no keys at all',
+    (_name, obj) => {
+      expect(skippedWarnings(obj, {}, {})).toEqual([]);
+    },
+  );
+
+  it.each(objects.map((o) => [o.name as string, o] as const))(
+    '%s answers when every field is present but null',
+    (_name, obj) => {
+      const allNull = Object.fromEntries(Object.keys(obj.fields ?? {}).map((f) => [f, null]));
+      expect(skippedWarnings(obj, {}, allNull)).toEqual([]);
+    },
+  );
+
+  it.each(objects.map((o) => [o.name as string, o] as const))(
+    '%s answers when any single referenced field is the one that is missing',
+    (_name, obj) => {
+      // The shape a partial update actually produces: most columns came back,
+      // one did not. Sweeping one field at a time catches a guard that only
+      // works because a neighbouring clause short-circuits first.
+      const bad: string[] = [];
+      for (const field of referencedFields(obj)) {
+        const previous = Object.fromEntries(
+          Object.keys(obj.fields ?? {})
+            .filter((f) => f !== field)
+            .map((f) => [f, null]),
+        );
+        const warns = skippedWarnings(obj, {}, previous);
+        if (warns.length > 0) bad.push(`${field}: ${warns.join(' | ')}`);
+      }
+      expect(bad, `predicates aborted when a single key was absent:\n  ${bad.join('\n  ')}`).toEqual(
+        [],
+      );
+    },
+  );
+});
+
+/**
+ * End-to-end, on the driver that actually produces the sparse record.
+ *
+ * Everything above tests the predicate in isolation. This drives a real
+ * ObjectQL over `InMemoryDriver` — which stores only the columns a row was
+ * written with — and performs the exact operation from #630: insert a task
+ * without `completed_date`, then update its status to `completed`. Before the
+ * guards landed, the merged record had no `completed_date` key, CEL aborted,
+ * the engine logged `predicate failed to evaluate … — skipped`, and the save
+ * SUCCEEDED with the rule silently doing nothing.
+ */
+describe('the rule fires on a driver whose stored record omits the key', () => {
+  const task = objects.find((o) => o.name === 'crm_task') as AnyRec;
+  let ql: AnyRec;
+
+  beforeAll(async () => {
+    ql = (await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: { crm_task: task } as never,
+    })) as never;
+  });
+  afterAll(async () => {
+    await ql?.close();
+  });
+
+  const newTask = async () => {
+    const api = ql.createContext({ isSystem: true });
+    const row = await api
+      .object('crm_task')
+      .insert({ subject: 'Call back', status: 'not_started', priority: 'normal' });
+    return { api, row };
+  };
+
+  it('stores no key for a column it was never given — the precondition', async () => {
+    const { api, row } = await newTask();
+    const stored = await api.object('crm_task').findOne({ where: { id: row.id } });
+    // Not `toBeNull()`: the key is ABSENT, which is the whole point. If a
+    // platform upgrade makes this driver column-complete, this assertion fails
+    // and the tests below stop proving anything — that is the intended signal.
+    expect('completed_date' in (stored ?? {})).toBe(false);
+  });
+
+  it('rejects status=completed with no completed_date', async () => {
+    const { api, row } = await newTask();
+    await expect(
+      api.object('crm_task').update({ status: 'completed' }, { where: { id: row.id } }),
+    ).rejects.toThrow(/Completed date is required/i);
+  });
+
+  it('accepts status=completed when the date comes with it', async () => {
+    const { api, row } = await newTask();
+    await api
+      .object('crm_task')
+      .update(
+        { status: 'completed', completed_date: new Date().toISOString() },
+        { where: { id: row.id } },
+      );
+    const stored = await api.object('crm_task').findOne({ where: { id: row.id } });
+    expect(stored?.status).toBe('completed');
+  });
+
+  it('leaves an unrelated update alone', async () => {
+    // The rule must not fire just because the update did not mention status.
+    const { api, row } = await newTask();
+    await api.object('crm_task').update({ priority: 'high' }, { where: { id: row.id } });
+    const stored = await api.object('crm_task').findOne({ where: { id: row.id } });
+    expect(stored?.priority).toBe('high');
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/hotcrm#630

## 先说结论:issue 的前提成立,但只成立了一半

PM 要求的第一步是实测「SQL 驱动的 `previous` 确实列完备,所以只有内存驱动暴露」。**实测确认前提成立,P1 的定级是对的** —— 但同时发现了 issue 里没有提到的第四个驱动。

用一个只有 `record.status == "closed" && isBlank(record.reason)` 规则的探针对象,插入一条不写 `reason` 的记录,再 update 成 `closed`:

| 驱动 | 未写入列读回来是什么 | update 时规则 |
| --- | --- | --- |
| `@objectstack/driver-sql` (better-sqlite3) | `reason: null`,键在 | **ENFORCED**(抛 ValidationError) |
| `@objectstack/driver-sqlite-wasm` | `reason: null`,键在 | **ENFORCED** |
| `@objectstack/driver-memory` | 键不存在 | **SKIPPED**(update 静默成功) |
| `@objectstack/driver-mongodb` | 键不存在 | 暴露(见下) |

SQL 家族列完备的原因也核对了:引擎读 `previous` 用的是 `{ object, where: { id }, limit: 1 }`,不带字段投影,所以是整行;`SELECT *` 对未写入列返回 NULL。`needsPriorRecord()` 对任何 `script` 规则都返回 true,所以单条和批量 update 两条路径都会去取 prior row —— 不存在「SQL 上也拿不到 previous」的漏网路径。

**issue 没提到的那条**:`@objectstack/driver-mongodb` 的 `find`/`findOne` 返回的是存储的文档去掉 `_id`,不做任何字段补齐(`projection: { _id: 0 }`,没有补 null 的步骤),行为和内存驱动一致。它是平台的一等公民驱动、同版本线发布。HotCRM 是 marketplace app,不选择宿主用哪个数据源 —— 所以「只有测试替身暴露、生产没事」这个说法对 SQLite/Postgres 成立,对 Mongo 宿主不成立。这一条没有把本件推回 P0(HotCRM 自己的 dev/demo/生产配置走的是 SQL 家族,已实测执行),但它把「家规」的选择从两难变成了单选题,理由见下。

## 家规:选择「谓词必须是全函数」,不选「把内存驱动改成列完备」

PM 给的两条路是 (a) 每处字段引用都带 `has()` 守卫,(b) 让内存测试驱动列完备。**选 (a)**,理由不是它便宜,是 (b) 在这个仓库里做不到它承诺的事:

1. **(b) 没法在源头做。** `@objectstack/driver-memory` 是已发布的平台包,本仓库不改平台代码。HotCRM 能做的只是一个测试侧的包装器 —— 而包装器只对「记得用它」的测试有效。这正是 PM 对 (a) 的那条反对意见(「每个作者都得记住,忘了是静默的」),只是 (b) 的遗忘模式更糟:新测试直接 `new InMemoryDriver()` 就悄悄退回陷阱,而且没有任何东西会检查。`test/lead-duplicate-management.test.ts` 今天就是这么写的。
2. **(b) 会把这一类 bug 藏起来,而不是修掉。** 内存驱动的稀疏行是整个技术栈里**唯一**会产出「merged 记录缺键」形状的地方。把替身改得跟 SQL 一致,测试会全绿,而每一个 Mongo 宿主继续静默失去保护。这个稀疏的替身是资产,不是缺陷 —— 代码注释里明确写了「不要去修它」,并加了一条断言:如果哪天平台升级让内存驱动变成列完备,那条断言会红,提醒后人下面几个测试已经不再证明任何东西。
3. **(b) 让谓词的正确性挂在环境属性上。** 「存储层碰巧返回 NULL」不是契约,是巧合;一次数据源切换就能让规则集体失效。全函数性是规则自身的属性,契约该待的地方。

(a) 的代价 —— 「靠人记」—— 由测试付掉,见下。决定和被否路线的代价写在 `test/object-validation-predicates.test.ts` 顶部的 HOUSE RULE 块里(不是只写在 PR 描述里),AGENTS.md 的约束清单里加了一条摘要 + 一节速查表。

## 改了什么

24 条 script validation 里 23 条暴露(唯一幸存的是 #629 里已经带 `has()` 守卫的 `crm_lead.duplicate_disqualification_requires_survivor`)。两种书写形状:

- 「f 没有值」 → `(!has(record.f) || isBlank(record.f))`
- 「f 有值」 → `has(record.f) && record.f < 比较运算符 > …`

`!= null` **不能**替代 `has()`:实测在缺键上 `record.f != null` 和 `record.f < 0` 一样 abort。它守的是另一个坑(`dyn< null > < int`,#514 item 3),所以数值比较两个守卫都要带。`coalesce(record.f, "")` 也 abort —— 参数在调用前求值,所以 `has()` 是唯一的全函数访问器。

一处语义需要单独说明:`crm_opportunity.close_date_future` 里 `stage` 用的是 `(!has(record.stage) || (…))` 而不是前置 `has(record.stage) &&`。缺键意味着「没有记录 stage」,而没有记录的 stage 不是已关闭的 stage,所以该告警应当照常发出;写成前置 `has()` 会把告警吞掉 —— 那就是换了个方式静默。

## 测试

三层,item 2 是 PM 指定必做的那条:

1. **结构检查** —— 扫全部 `validations[].condition` + `requiredWhen`/`readonlyWhen`/`visibleWhen` + option `visibleWhen`,任何一处 `record.x` 没有配套 `has(record.x)` 就失败,并在断言消息里给出正确写法。
2. **真引擎上的全函数性** —— 把每个对象的谓词交给引擎自己的 `evaluateValidationRules(obj, {}, 'update', { previous, logger })`,断言 logger 里没有任何 `failed to evaluate`。三种记录形状:全部键缺失、全部字段 present-as-null、以及**逐个字段单独缺失**(后者能抓住「只是因为相邻子句短路了才没炸」的假守卫)。这层是量出来的而不是 grep 出来的,正则骗不过去。`ValidationError` 在这里算通过 —— 会开火的规则说明它给出了裁决,只有 abort 导致的沉默才是缺陷。
3. **端到端** —— 真 ObjectQL + `InMemoryDriver`,复现 issue 里的原始操作:插入一条不带 `completed_date` 的 task,再 update `status: 'completed'`。

反向验证过这些测试确实有牙:把 `crm_task.completed_date_required` 单独改回未守卫的写法,4 个测试立刻红,其中包括端到端那条(`promise resolved instead of rejecting` —— 也就是 issue 描述的那次静默放行)。

```
Test Files  40 passed (40)
     Tests  899 passed | 1 skipped (900)

pnpm typecheck  ✓
pnpm validate   ✓ Validation passed (941ms)
pnpm hygiene    ✓ source hygiene clean
pnpm build      ✓ Build complete — dist/objectstack.json
pnpm lint       1 warning(既有的 crm_campaign_member field-group-shadowed,与本改动无关)
```

## 用户可见的行为变化

SQL / SQLite 宿主上**没有变化** —— 那里规则本来就在执行。内存和 Mongo 宿主上,受影响的规则从「什么都不做」变成「按声明执行」,所以以前能存下的记录现在可能被正确拒绝(例如把 task 改成 Completed 却不给完成日期)。changeset 里写明了这一点。

## 范围之外

- **suggested work 第 3 条**(引擎该不该把「求值失败」当失败而非跳过)按 PM 指示未动平台代码,上游 objectstack-ai/objectstack#4649。
- **sharing rule 与 flow start condition 的同类风险**:实测这两个面的谓词同样一处 `has()` 都没有(9 条 sharing rule 全中,9 条 flow 条件全中)。但它们拿到的记录形状和 abort 后的后果都与 validation 路径不同(sharing rule 若 fail-open 就是信息泄露,fail-close 只是更严),没有实测就不该动手,也不属于本 issue 的范围 —— 已另开 objectstack-ai/hotcrm#633(未指派),把已量到的清单和还需要量什么写清楚了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf
