### PR TITLE
fix(data): key forecast demo seeds on a seeder-only identity, not period_label

### DIFF
--- a/.changeset/forecast-seed-identity.md
+++ b/.changeset/forecast-seed-identity.md
@@ -1,0 +1,22 @@
+---
+"hotcrm": patch
+---
+
+Forecast demo seeds no longer upsert on `period_label`, which stopped identifying a single row
+
+`crm_forecast` is a per-owner snapshot, and since the nightly `forecast_snapshot`
+sweep began writing one row per active opportunity owner per quarter, every one
+of those rows carries the same `period_label` ("Q3 2026"). The demo seed still
+used that label as its upsert key, so re-seeding an existing database matched
+whichever row the loader returned first and could overwrite a real
+freshly-computed snapshot with the demo numbers.
+
+`crm_forecast` gains a `seed_key` column that only the seed loader ever writes,
+and the demo seed now upserts on it. The field is `readonly` — seed writes run
+in system context and bypass readonly stripping, user and API writes do not — so
+a genuine forecast row can never carry a value there and can never be matched by
+a re-seed. It is also `hidden`, keeping a fixtures-only column out of forms and
+pickers.
+
+Existing demo databases are unaffected in place; the seeded forecast rows are
+re-keyed on the next reseed (`pnpm demo:reset`). No user-authored data changes.

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -2008,6 +2008,7 @@ const monthEndAgo = (n: number) => new Date(Date.UTC(forecastYear, forecastMonth
 
 /** A settled (past) period snapshot: pipeline is gone, only the closed number remains. */
 const closedPeriod = (
+  seed_key: string,
   period: 'month' | 'quarter',
   start: Date,
   end: Date,
@@ -2015,6 +2016,7 @@ const closedPeriod = (
   closed: number,
   notes: string,
 ) => ({
+  seed_key,
   period,
   period_label: period === 'quarter' ? forecastQuarterLabel(start) : forecastMonthLabel(start),
   period_start: forecastIsoDate(start),
@@ -2029,11 +2031,26 @@ const closedPeriod = (
   notes,
 });
 
+// Upsert identity is the synthetic `seed_key`, NOT `period_label` (#613).
+// `period_label` names a SET of rows once the forecast_snapshot sweep (#590)
+// writes one per active owner per quarter — all reading 'Q3 2026' — and the
+// loader matches against the whole table, so a re-seed could overwrite a real
+// rep's snapshot with the demo numbers. Why a synthetic key and not the true
+// (owner, period, period_start) identity or an insert-once mode: see the
+// `seed_key` declaration in `src/objects/forecast.object.ts`.
+//
+// The keys are POSITIONAL ('current quarter', 'two quarters back'), not
+// calendar values, because the records are positional — recomputed against
+// `new Date()` on every import. A positional key keeps the demo at exactly
+// these eight rows as the calendar rolls forward, re-pointing each at its new
+// period; a calendar-derived key would strand last quarter's demo row and add
+// one row per re-seed.
 const forecasts = defineSeed(Forecast, {
   mode: 'upsert',
-  externalId: 'period_label',
+  externalId: 'seed_key',
   records: [
     {
+      seed_key: 'demo_quarter_current',
       period: 'quarter',
       period_label: forecastQuarterLabel(thisQuarterStart),
       period_start: forecastIsoDate(thisQuarterStart),
@@ -2048,6 +2065,7 @@ const forecasts = defineSeed(Forecast, {
       notes: 'On track — commit + closed covers 64% of quota with the quarter still open.',
     },
     {
+      seed_key: 'demo_month_current',
       period: 'month',
       period_label: forecastMonthLabel(thisMonthStart),
       period_start: forecastIsoDate(thisMonthStart),
@@ -2062,6 +2080,7 @@ const forecasts = defineSeed(Forecast, {
       notes: 'Healthy coverage; two commit deals expected to close this week.',
     },
     {
+      seed_key: 'demo_quarter_minus_1',
       period: 'quarter',
       period_label: forecastQuarterLabel(lastQuarterStart),
       period_start: forecastIsoDate(lastQuarterStart),
@@ -2075,15 +2094,15 @@ const forecasts = defineSeed(Forecast, {
       source: 'scheduled',
       notes: 'Closed at 106% of quota.',
     },
-    closedPeriod('quarter', quarterStartAgo(2), quarterEndAgo(2), 1300000, 1196000,
+    closedPeriod('demo_quarter_minus_2', 'quarter', quarterStartAgo(2), quarterEndAgo(2), 1300000, 1196000,
       'Closed at 92% of quota — two enterprise deals slipped into the next quarter.'),
-    closedPeriod('quarter', quarterStartAgo(3), quarterEndAgo(3), 1200000, 1308000,
+    closedPeriod('demo_quarter_minus_3', 'quarter', quarterStartAgo(3), quarterEndAgo(3), 1200000, 1308000,
       'Closed at 109% of quota, carried by the enterprise renewal cohort.'),
-    closedPeriod('quarter', quarterStartAgo(4), quarterEndAgo(4), 1100000, 1045000,
+    closedPeriod('demo_quarter_minus_4', 'quarter', quarterStartAgo(4), quarterEndAgo(4), 1100000, 1045000,
       'Closed at 95% of quota in the first quarter on the new territory model.'),
-    closedPeriod('month', monthStartAgo(1), monthEndAgo(1), 480000, 505000,
+    closedPeriod('demo_month_minus_1', 'month', monthStartAgo(1), monthEndAgo(1), 480000, 505000,
       'Closed at 105% of quota; the expansion motion covered a soft new-business month.'),
-    closedPeriod('month', monthStartAgo(2), monthEndAgo(2), 460000, 414000,
+    closedPeriod('demo_month_minus_2', 'month', monthStartAgo(2), monthEndAgo(2), 460000, 414000,
       'Closed at 90% of quota — summer slowdown across the mid-market segment.'),
   ]
 });

--- a/src/objects/forecast.object.ts
+++ b/src/objects/forecast.object.ts
@@ -198,6 +198,55 @@ export const Forecast = ObjectSchema.create({
       maxLength: 1000,
       group: 'meta',
     }),
+
+    // Fixture identity — the seed loader's `externalId`, and nothing else.
+    //
+    // `crm_forecast` is a PER-OWNER snapshot: its real identity is
+    // (owner, period, period_start), and every other column is a rendering of
+    // part of that. `period_label` in particular names a SET of rows once the
+    // `forecast_snapshot` sweep (#590) writes one row per active owner per
+    // quarter — they all read 'Q3 2026'. The demo seed used to upsert on that
+    // label, so a re-seed could match, and overwrite, a real rep's snapshot
+    // (#613).
+    //
+    // The three routes considered, and why this one:
+    //
+    //   • Composite `externalId: ['owner', 'period', 'period_start']` — the
+    //     true identity, and the platform does support composite keys (the
+    //     seed file already uses one for opportunity line items). It fails
+    //     HERE for a different reason: a seed cannot name a user (see the note
+    //     at the foot of `src/data/index.ts`), so `owner` is null on every
+    //     seeded row, and the loader's `externalIdKey` returns "" as soon as
+    //     any part is empty. An empty key never matches, so upsert degrades to
+    //     insert-on-every-replay and duplicates the table — strictly worse.
+    //     Dropping `owner` does not rescue it: a runtime row for the current
+    //     quarter carries exactly the same (period, period_start).
+    //
+    //   • `mode: 'insert'` — does NOT mean "insert once". The loader inserts
+    //     unconditionally on every replay boot (framework#3434). `'ignore'` is
+    //     the real insert-once mode, but it decides "already there?" from the
+    //     same `externalId`, so on the broken key it would SKIP the demo row
+    //     because a real rep's row already claimed 'Q3 2026' — a different
+    //     bug, same root cause. Fixing the identity is a prerequisite either
+    //     way, and once fixed `upsert` is both safe and strictly more useful.
+    //
+    //   • A synthetic, seeder-only key — this one.
+    //
+    // `readonly` is the load-bearing part, not decoration: seed writes run
+    // `{ isSystem: true }` and bypass readonly stripping, while readonly
+    // stripping does guard user/API writes — so a genuine forecast row can
+    // never acquire a `seed_key` and can never be matched by a re-seed. That
+    // is what makes the fix structural rather than a naming convention.
+    // `hidden` keeps a fixtures-only column out of forms and pickers, so no
+    // one is ever prompted to fill it in.
+    seed_key: Field.text({
+      label: 'Seed Key',
+      description: 'Demo-fixture identity. Written only by the seed loader; empty on every real snapshot.',
+      maxLength: 64,
+      readonly: true,
+      hidden: true,
+      group: 'meta',
+    }),
   },
 
   indexes: [

--- a/test/forecast-seeds.test.ts
+++ b/test/forecast-seeds.test.ts
@@ -2,6 +2,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { CrmSeedData } from '../src/data/index';
+import { Forecast } from '../src/objects/forecast.object';
+import { ForecastSnapshotFlow } from '../src/flows/forecast-snapshot.flow';
 
 /**
  * Forecast seed calendar-alignment guards (#530).
@@ -25,7 +27,7 @@ import { CrmSeedData } from '../src/data/index';
 type SeedRec = Record<string, unknown>;
 
 const forecastSeed = CrmSeedData.find((s: any) => s.object === 'crm_forecast') as
-  | { records: SeedRec[] }
+  | { records: SeedRec[]; mode?: string; externalId?: string | string[] }
   | undefined;
 
 const records: SeedRec[] = forecastSeed?.records ?? [];
@@ -120,9 +122,94 @@ describe('forecast seed periods are calendar-true (#530)', () => {
     ).toBeDefined();
   });
 
-  it('period_label values are unique (they are the upsert identity)', () => {
+  it('period_label values are unique AMONG THE SEEDS — not a table invariant (#613)', () => {
+    // Restated deliberately. This once read "period_label values are unique
+    // (they are the upsert identity)", and both halves have since become
+    // false: `period_label` is no longer the upsert identity (that is
+    // `seed_key` now), and uniqueness is no longer true of the TABLE. The
+    // `forecast_snapshot` sweep (#590) writes one row per active opportunity
+    // owner per quarter and every one of them reads 'Q3 2026'.
+    //
+    // What survives is a much narrower property: these eight authored records
+    // must not collide with EACH OTHER, so the demo shows eight distinct
+    // periods rather than two rows fighting over one label. Asserting anything
+    // wider would advertise an invariant the database does not hold.
     const labels = records.map((r) => String(r.period_label));
     const dupes = labels.filter((l, i) => labels.indexOf(l) !== i);
-    expect(dupes, `duplicate period_label seeds would clobber each other: ${dupes.join(', ')}`).toEqual([]);
+    expect(dupes, `two seeded forecasts render the same period: ${dupes.join(', ')}`).toEqual([]);
+  });
+});
+
+/**
+ * Seed identity guards (#613).
+ *
+ * The seed upserts against the whole `crm_forecast` table — the loader builds
+ * its existing-record map from every row in the org, not just previously
+ * seeded ones. So the seed's `externalId` has to be a value that a genuine,
+ * owner-scoped runtime snapshot can never carry. `period_label` was not: it
+ * names a set of rows, and a re-seed overwrote whichever member came back
+ * first, demo numbers landing on a real rep's snapshot.
+ *
+ * These pin the replacement, because every part of it fails SILENTLY:
+ * a missing `seed_key` keys to "" and downgrades upsert to
+ * insert-on-every-replay; a writable `seed_key` lets a real row drift into the
+ * seed's line of fire; a reverted `externalId` restores the original bug.
+ */
+describe('the forecast seed keys on a seeder-only identity (#613)', () => {
+  const seedKeyField = (Forecast as any).fields?.seed_key;
+
+  it('the seed upserts on seed_key, not on a shared rendering like period_label', () => {
+    expect(forecastSeed?.externalId, 'forecast seed externalId').toBe('seed_key');
+    expect(forecastSeed?.mode, 'forecast seed mode').toBe('upsert');
+  });
+
+  it('every seeded forecast carries a seed_key', () => {
+    // An empty part collapses the loader's key to "", which never matches an
+    // existing row — so the record is INSERTED again on every replay boot and
+    // the demo table grows without bound. Silent: no error, just duplicates.
+    const missing = records
+      .filter((r) => typeof r.seed_key !== 'string' || (r.seed_key as string).trim() === '')
+      .map((r) => String(r.period_label));
+    expect(missing, `forecast seeds with no seed_key:\n  ${missing.join('\n  ')}`).toEqual([]);
+  });
+
+  it('seed_key values are unique among the seeds', () => {
+    const keys = records.map((r) => String(r.seed_key));
+    const dupes = keys.filter((k, i) => keys.indexOf(k) !== i);
+    expect(dupes, `two forecast seeds share one seed_key and would clobber each other: ${dupes.join(', ')}`).toEqual([]);
+  });
+
+  it('crm_forecast declares seed_key as a readonly, hidden text column', () => {
+    // `readonly` is what makes this structural rather than conventional: seed
+    // writes run `{ isSystem: true }` and bypass readonly stripping, while
+    // user and API writes do not. Drop it and a real forecast row becomes able
+    // to acquire a seed_key — which is the #613 bug again, one field over.
+    expect(seedKeyField, 'crm_forecast has no seed_key field').toBeDefined();
+    expect(seedKeyField?.type).toBe('text');
+    expect(seedKeyField?.readonly, 'seed_key must be readonly so only the seeder can write it').toBe(true);
+    expect(seedKeyField?.hidden, 'seed_key is a fixture column and must stay out of forms').toBe(true);
+  });
+
+  it('no runtime forecast writer populates seed_key', () => {
+    // The other half of the guarantee: even a system-context writer must leave
+    // the column empty, or its rows re-enter the seed's existing-record map.
+    const bad: string[] = [];
+    let writers = 0;
+    const walk = (node: any) => {
+      const fields = node?.config?.fields;
+      if (fields) {
+        writers++;
+        if (Object.prototype.hasOwnProperty.call(fields, 'seed_key')) {
+          bad.push(`${ForecastSnapshotFlow.name}.${node.id} writes seed_key`);
+        }
+      }
+      for (const child of node?.config?.body?.nodes ?? []) walk(child);
+    };
+    for (const node of (ForecastSnapshotFlow as any).nodes ?? []) walk(node);
+    // Guard the guard: the sweep creates a row and updates it, so a walker
+    // that found no field-writing node has stopped matching the flow's shape
+    // and would pass by asserting nothing.
+    expect(writers, 'walker found no record-writing node in the snapshot flow').toBeGreaterThanOrEqual(2);
+    expect(bad, bad.join('\n')).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/hotcrm#613

## 问题

`crm_forecast` 是**按负责人**的快照。自 #590 的 `forecast_snapshot` 夜间扫描开始为每位活跃商机负责人每季度写一行之后,这些行的 `period_label` 全部相同(都是 `'Q3 2026'`)。而演示种子仍然用 `externalId: 'period_label'` 作为 upsert 身份。

关键在于 seed loader 的 `loadExistingRecords` 是对**整张表**做 `find()` 后按 externalId 建映射的,并不区分"以前种子写的行"和"运行时写的行"。所以 `period_label` 标识的是一个**行集合**而不是一行:重新播种时匹配到哪一行取决于驱动的返回顺序,被匹配到的那一行会被演示数字覆盖 —— 可能正是某位真实销售刚算出来的快照。

## 三条路线的实测结论(与 issue 的描述有两处出入)

**issue 的方案 2(复合 externalId)不是平台改动,平台早就支持。** `SeedSchema.externalId` 的类型是 `string | string[]`,loader 的 `externalIdKey` 用 `\0` 拼接各字段,`@objectstack/lint` 的提示语里也把它写成了推荐用法,而且**本仓库已经在用**了 —— `src/data/index.ts` 里的 `opportunityLineItems` 就是 `externalId: ['crm_opportunity', 'crm_product']`。所以这条不需要停下来问平台。

但它**在这里**仍然不可用,原因不同:真正的身份是 `(owner, period, period_start)`,而**种子无法指定用户**(见 `src/data/index.ts` 末尾那段注释),所以每行种子的 `owner` 都是 null。`externalIdKey` 的实现是——只要有任何一段为空就直接返回 `""`:

```js
if (value === void 0 || value === null || value === "") return "";
```

空 key 永远匹配不上(`loadExistingRecords` 里 `if (key)` 会把空 key 的行直接丢掉),于是 upsert 退化成**每次重启都插一遍**,把表撑爆 —— 比现在更糟。去掉 `owner` 也救不回来:运行时当季度那行的 `(period, period_start)` 和种子当季度那行完全一样。

**issue 的方案 3(改成只插一次)按字面写法做不到。** `mode: 'insert'` 不是"插一次",loader 是无条件插入,每次 replay boot 都插(framework#3434,`src/data/index.ts` 里 opportunity line item 那段注释已经记过这个坑)。真正的"只插一次"是 `mode: 'ignore'`,但它判断"是不是已经有了"用的还是同一个 `externalId` —— 在坏 key 上它会因为某位真实销售的行已经占了 `'Q3 2026'` 而**跳过**演示行的写入,演示数据直接缺一行。换了个 bug,根因一样。

**所以修 identity 是前提,不是三选一。** 而 identity 修好之后,`upsert` 比 `ignore` 严格更有用(种子数字改了能刷新),也不再危险,因此保留 `upsert`。

## 谁在依赖 upsert 的刷新语义(PM 要求找证据)

**没有人。** 仓库里刷新演示数据的唯一路径是**清库重播**,不是原地 upsert:

- `package.json`:`"demo:reset": "rm -rf .objectstack/data && pnpm build && ..."`
- `docs/MAINTENANCE.md` §4(自称是 HotCRM 头号坑):`pnpm demo:reset && pnpm dev` — reseed from a clean DB
- `content/docs/getting-started/for-developers.mdx`:"The app boots with seed data on first start."

这条证据本身是支持方案 3 的目标的(确实不需要刷新)。但如上所述方案 3 的机制走不通,而且既然 identity 无论如何都要修,修完之后保留 `upsert` 不多花任何代价。

## 改动

`crm_forecast` 新增 `seed_key`:一个 `readonly` + `hidden` 的文本列,只有 seed loader 会写它;种子改为 `externalId: 'seed_key'`。

`readonly` 是这个方案**结构性**而非约定性的原因:种子写入走 `{ isSystem: true }`,绕过 readonly 剥离;而用户写入和 API 写入不绕过。所以真实的 forecast 行**在机制上无法**获得 `seed_key`,没有 `seed_key` 的行 key 塌成 `""` 后会被 loader 从匹配表里整个丢掉 —— 运行时的行是**按构造**落在种子射程之外,而不是"碰巧不太可能撞上"。`hidden` 让这个纯 fixture 列不出现在表单和选择器里,不会有人被提示去填它。

key 用**位置式**命名(`demo_quarter_current` / `demo_quarter_minus_2` / …)而不是日历值,因为这些记录本身就是位置式的 —— 每次 import 都对 `new Date()` 重算。位置式 key 能让演示表随日历前滚时始终保持这 8 行、各自重新指向新周期;日历式 key 会把上季度那行留在原地,每重播一次就多一行。

`seed_key` 未加入 4 个语言包:它是 `hidden` 的、永不渲染(`display_title` 同理,也没有翻译条目)。`test/metadata-references.test.ts` 的校验是单向的(翻译必须指向真实字段),不要求每个字段都有翻译。

## 测试

按 issue 的硬性要求,`test/forecast-seeds.test.ts` 里"`period_label` 唯一"的断言已改写为**在种子范围内**唯一。原措辞的两半都已经不成立了:`period_label` 不再是 upsert 身份,唯一性也不再是这张表的不变式。

另加 5 条守卫,针对的都是会**静默失败**的环节:`externalId` 被改回去、某条种子漏了 `seed_key`(会退化成每次重播都插)、`seed_key` 之间撞车、字段的 `readonly`/`hidden` 被摘掉(等于把 #613 原样搬到另一个字段上)、以及任何运行时 writer 往这一列写值(遍历 `ForecastSnapshotFlow`,并带"守卫的守卫"防止遍历器失配后空跑)。

变异测试确认守卫会红(把 `externalId` 改回 `period_label`、摘掉 `readonly` 后):

```
× the seed upserts on seed_key, not on a shared rendering like period_label
  AssertionError: forecast seed externalId: expected 'period_label' to be 'seed_key'
× crm_forecast declares seed_key as a readonly, hidden text column
  AssertionError: seed_key must be readonly so only the seeder can write it: expected false to be true
Tests  2 failed | 11 passed (13)
```

全套验证:

```
pnpm validate   ✓ Validation passed (850ms)
pnpm typecheck  ✓ (tsc --noEmit, 无输出)
pnpm lint       ✓ 1 warning, 13 suggestions —— 均为既有项,与本次改动无关
pnpm hygiene    ✓ source hygiene clean
pnpm build      ✓ Build complete — 15 Objects  313 Fields
pnpm test       ✓ Test Files 40 passed (40) · Tests 904 passed | 1 skipped (905)
```

## 顺带发现(已另开 issue,未在本 PR 修)

**#635** — `src/data/index.ts` 在 `main` 上是 99,656 字节,而 `pnpm hygiene` 的上限是 102,400。本次改动一度把它顶到 102,782 直接挂掉 gate;我把大部分说理注释挪到了 `src/objects/forecast.object.ts` 的字段声明处(那本来也是更合适的位置)才压回去,现在是 100,858 字节 —— **只剩约 1.5KB 余量,大约一条种子记录的空间**。下一个往这个 fixture 文件里加演示数据的人会撞上一个"请拆分文件"的报错,而那个重构远大于触发它的改动。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf


---
_Generated by [Claude Code](https://claude.ai/code/session_019SS7C5SXpniKeCApxgARyf)_