### PR TITLE
test(flows): pin the cold-boot re-bind so a flow can never be what an unreadable warning hides (#653)

### DIFF
--- a/.changeset/cold-boot-flow-rebind-pin.md
+++ b/.changeset/cold-boot-flow-rebind-pin.md
@@ -1,0 +1,50 @@
+---
+'hotcrm': patch
+---
+
+Pin the cold-boot flow re-bind: every authored flow must register through the
+real automation engine, in `pnpm test`, with the whole validation error.
+
+Through 17.0.0-rc.1 every boot of this app emitted **24 warnings — one per
+flow** — from the automation service's `kernel:ready` re-bind, and each one
+printed the single character `[`. The re-bind is additive, and the boot pull
+had already registered the flows, so automations kept firing and the noise read
+as cosmetic. It was not: any host that boots from the stored view alone (a
+metadata reload, a `sys_metadata`-first host) has only that path, and would
+have inherited a flow set of **zero**, silently.
+
+Both halves were platform-side, and only one of them is fixed.
+
+`registerFlow` parses with `FlowSchema`, which #4001 closed — an unrecognized
+key throws instead of being dropped. `err.message` was therefore a Zod issue
+array, and interpolating it into a one-line `logger.warn` left only its opening
+bracket. The full text, once read, named a key **this app never wrote**:
+
+```
+[ { "code": "unrecognized_keys", "keys": [ "_diagnostics" ], "path": [], … } ]
+```
+
+`getMetaItems({ type: 'flow' })` decorates every served item with
+`_diagnostics`, and the bind fed that served document straight back into the
+strict schema — the read path failing its own output. 17.0.0-rc.2 fixed it at
+the read seam (`stripReadDecorations`, cloud#971) rather than by loosening
+`FlowSchema`, so the upgrade in #663 already cleared all 24 warnings here; on
+current `main` the boot reports `Bound 24 flow(s) from the protocol at
+kernel:ready`. **No HotCRM metadata was ever at fault, and none is changed.**
+
+The truncated warning itself is still live in rc.2 — the next flow that fails
+to bind reports the same unreadable `[` — and is filed upstream, because a log
+line in `@objectstack/service-automation` is not this app's to fix.
+
+What *is* this app's to fix is never being the thing that log line hides. Adds
+`test/flow-cold-boot-rebind.test.ts`, which runs every flow in `allFlows`
+through the exact `AutomationEngine.registerFlow` call the re-bind makes —
+JSON-round-tripped first, since the re-bind sees the stored document and not
+the TypeScript object — and reports the **complete** Zod issue array on
+failure. It also reconstructs the #653 class directly: a read-decorated flow
+must still be rejected (proving the schema stays closed, so a genuine authoring
+error cannot hide either) and must become registrable again after
+`stripReadDecorations` (proving the rc.2 remedy is still the remedy, keyed off
+`METADATA_READ_DECORATIONS` so a decoration added later is covered too).
+
+Refs #653.

--- a/test/flow-cold-boot-rebind.test.ts
+++ b/test/flow-cold-boot-rebind.test.ts
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { AutomationEngine } from '@objectstack/service-automation';
+import { METADATA_READ_DECORATIONS, stripReadDecorations } from '@objectstack/spec/kernel';
+import { allFlows } from '../src/flows';
+
+/**
+ * ═══ The cold-boot flow re-bind must register EVERY flow (#653) ════════════
+ *
+ * At `kernel:ready` the automation service re-binds flows from the protocol's
+ * flattened view (`syncFlowsFromProtocol` → `readFlowDefsFromProtocol` →
+ * `engine.registerFlow`). On 17.0.0-rc.1 that path failed for **all 24** flows
+ * on every `objectstack dev --fresh`, and the warning it printed was the
+ * single character `[` — so nobody could act on it.
+ *
+ * ### What the `[` actually said (measured)
+ *
+ * `registerFlow` parses with `FlowSchema`, and #4001 closed the metadata
+ * schemas: an unrecognized key now THROWS instead of being dropped. `err.message`
+ * was therefore a Zod issue array, and interpolating it into a one-line
+ * `logger.warn` left only its opening bracket:
+ *
+ * ```
+ * [ { "code": "unrecognized_keys",
+ *     "keys": [ "_diagnostics" ],
+ *     "path": [],
+ *     "message": "Unrecognized key(s) on this flow: `_diagnostics`. …" } ]
+ * ```
+ *
+ * The rejected key was **not ours**. `getMetaItems({ type: 'flow' })` decorates
+ * every served item with `_diagnostics` (and `_draft` on a preview read), and
+ * the bind fed that served document straight back into the strict schema — the
+ * read path failing its own output. 17.0.0-rc.2 fixed it at the read seam
+ * (`stripReadDecorations`, cloud#971) rather than by loosening `FlowSchema`,
+ * and this app inherited the fix with the rc.2 upgrade (#663). Measured on
+ * current `main`: `INFO [Automation] Bound 24 flow(s) from the protocol at
+ * kernel:ready`, zero warnings.
+ *
+ * ### Why this file exists anyway
+ *
+ * The bind stayed broken for a whole release line because its only symptom was
+ * an unreadable boot warning, and the boot pull covered for it — flows kept
+ * firing, so the re-bind path was never proven. Any host that boots from the
+ * stored view alone (a metadata reload, a `sys_metadata`-first host) has only
+ * this path, and it would have inherited a flow set of zero, silently.
+ *
+ * So the app-side half is pinned here instead of in a log line: every flow we
+ * author survives the exact `registerFlow` call the re-bind makes, in `pnpm
+ * test`, with the **whole** validation error in the failure message. The
+ * platform-side half (the truncated warning, still live in rc.2) is filed
+ * upstream — this test cannot fix a log line in `@objectstack/service-automation`,
+ * but it does mean a HotCRM flow can never be the thing that log line is
+ * hiding.
+ */
+
+const silentLogger: any = {
+  info() {}, warn() {}, error() {}, debug() {}, trace() {}, fatal() {},
+};
+silentLogger.child = () => silentLogger;
+
+/**
+ * Register one flow the way the cold-boot bind does, returning the FULL error
+ * message on rejection. The whole point of #653 is that a one-line render of a
+ * Zod issue array tells you nothing, so nothing here is truncated.
+ */
+function registerFailure(def: unknown, name: string): string | null {
+  const engine = new AutomationEngine(silentLogger);
+  try {
+    engine.registerFlow(name, def as never);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+/**
+ * The re-bind never sees the TypeScript object — it sees what came back out of
+ * the artifact / `sys_metadata`, i.e. a JSON round-trip. Doing the same here
+ * keeps a value that only survives in memory (a `Date`, an `undefined` that
+ * masks a required key, a function) from passing a test it would fail at boot.
+ */
+const storedForm = (flow: unknown) => JSON.parse(JSON.stringify(flow));
+
+describe('cold-boot flow re-bind (#653)', () => {
+  it('registers every authored flow through the real engine', () => {
+    const failures = allFlows
+      .map((flow) => ({ name: flow.name, error: registerFailure(storedForm(flow), flow.name) }))
+      .filter((r) => r.error !== null);
+
+    expect(
+      failures.map((f) => `\n─── ${f.name} ───\n${f.error}`).join('\n'),
+      `${failures.length} of ${allFlows.length} flow(s) failed the cold-boot bind`,
+    ).toBe('');
+  });
+
+  it('covers the whole flow set, not a subset', () => {
+    expect(allFlows.length).toBeGreaterThan(0);
+    expect(new Set(allFlows.map((f) => f.name)).size).toBe(allFlows.length);
+  });
+
+  /**
+   * The failure class #653 reported, reconstructed: a flow is fine, the READ
+   * decorates it, and the strict schema rejects the decoration. Both halves are
+   * asserted because each guards a different regression —
+   *
+   *   - `FlowSchema` still rejecting an unknown key proves the strictness
+   *     #4001 introduced is intact (a lenient schema would hide real authoring
+   *     errors, which is the opposite of what this app wants); and
+   *   - `stripReadDecorations` still removing every key in
+   *     `METADATA_READ_DECORATIONS` proves the rc.2 remedy is still the remedy.
+   *
+   * It does NOT prove the automation service still calls the strip — that seam
+   * lives upstream and needs a kernel. What it does prove is that if a future
+   * upgrade adds a decoration key the strip does not cover, or drops the strip
+   * from the spec, this fails in `pnpm test` rather than as 24 boot warnings
+   * rendered as `[`.
+   */
+  it('rejects a read-decorated flow, and the platform strip is what makes it registrable again', () => {
+    expect(METADATA_READ_DECORATIONS.length).toBeGreaterThan(0);
+    const sample = storedForm(allFlows[0]);
+
+    for (const decoration of METADATA_READ_DECORATIONS) {
+      const decorated = { ...sample, [decoration]: { note: 'served by getMetaItems' } };
+
+      const error = registerFailure(decorated, sample.name);
+      expect(error, `\`${decoration}\` no longer fails FlowSchema — is the schema still closed?`)
+        .not.toBeNull();
+      expect(error).toContain(decoration);
+
+      expect(registerFailure(stripReadDecorations(decorated), sample.name)).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/hotcrm#653

## 先说结论：前提已经过期，两个缺陷都在平台侧，其中一个已经修好了

Issue 在 17.0.0-rc.1 上测得 24 条告警。`main` 已于 08-03 随 #663 升到 **17.0.0-rc.2**。在当前 `origin/main` 上复测，**24 条告警全部消失**：

```
$ npx objectstack dev --fresh -p 41874
$ grep -c "cold-boot flow bind" boot1.log
0
```

而且不是"路径没跑所以没报错"——开 `--log-level info` 复测，重绑定确实跑了，而且全绑上了：

```
INFO [Automation] Pulled 24 flow(s) from ObjectQL registry
INFO [Automation] Bound 24 flow(s) from the protocol at kernel:ready
INFO [Automation] 24 flow(s) registered, 18 bound to triggers, 0 unbound-but-triggered
```

**本仓元数据从头到尾没有问题，这个 PR 一行 `src/flows/**` 都没有改。**

## 那 `[` 到底说的是什么

按分诊要求，先拿完整错误再谈归因。把 rc.2 在 `node_modules` 里的修复临时改回 rc.1 的行为（`readFlowDefsFromProtocol` 中 `return stripReadDecorations(doc)` → `return doc`，仅本地、未提交），24 条告警**逐字复现**：

```
2026-08-04T00:38:50.385Z WARN [Automation] cold-boot flow bind: failed to register campaign_enrollment: [
… 24 条 …
```

再把那行日志里的换行换成可见字符重跑一次，它想说的话才第一次走出第一行：

```
[
  {
    "code": "unrecognized_keys",
    "keys": [ "_diagnostics" ],
    "path": [],
    "message": "Unrecognized key(s) on this flow: `_diagnostics`. Until #4001 these were dropped silently — the flow still parsed, so a trigger binding or config the author wrote was quietly ignored."
  }
]
```

被拒的键**不是我们写的**。`getMetaItems({ type: 'flow' })` 会给每个 item 打上 `_diagnostics` 装饰，冷启动重绑定又把这份"被服务过的文档"原样喂回 `FlowSchema`——#4001 关闭 metadata schema 之后未知键改为抛出，于是读取路径栽在了自己的输出上。上游在 rc.2 的 changelog 里确认了同一件事（`5b843fb` / cloud#971），修法是在**读取缝合处** strip，而不是放宽 `FlowSchema`——理由与本仓的 contract-first 一致：payload 之所以畸形是因为我们自己装饰了它，生产者的注解由生产者摘除。

归因用两组对照坐实过，不是从 changelog 推的：rc.1 引擎 × 当前 flows、rc.1 引擎 × #663 之前的 flows（在 `5a11631^` 上真实 build 出的 artifact），**24/24 全部注册成功**——说明 artifact 形态从来没被拒过，被拒的只有读取路径装饰后的协议视图。

## 第 2 个缺陷仍然活着，已上报上游

截断本身在 rc.2 一行未动：三个绑定点（cold-boot bind、`metadata:reloaded` re-sync、boot pull）都是 `${err.message}` 单行插值，下一个真绑不上的 flow 还是只会给出一个 `[`。

已按分诊要求上报 **objectstack-ai/objectstack#5048**，附完整错误、最小复现、根因分析与建议修法（把 Zod issues 当结构化数据交给 logger 第二参数）。这条日志属于 `@objectstack/service-automation`，不在本仓绕过。

值得记一笔的是因果方向：cloud#971 能横跨整条 rc.1 发布线没人发现，**唯一原因就是第 2 个缺陷让第 1 个隐了身**——绑定是加性的，boot pull 已注册过一遍，record-change 插件是第二条绑定路径，于是它对外的全部表现就是 24 条谁也读不懂的告警。

## 本仓这一半：把它钉住

平台的日志行修不了，但可以保证 HotCRM 的 flow 永远不是那条日志所隐藏的东西。新增 `test/flow-cold-boot-rebind.test.ts`：

- **每个 `allFlows` 里的 flow 过一遍真实的 `AutomationEngine.registerFlow`** —— 重绑定调用的那个方法本身，不是它的近似。先做一次 JSON round-trip，因为重绑定看到的是存储态文档而不是 TypeScript 对象（只在内存里成立的 `Date` / `undefined` 因此不会蒙混过关）。失败时打印**完整**的 issue 数组：

  ```
  AssertionError: 1 of 24 flow(s) failed the cold-boot bind
  + ─── campaign_enrollment ───
  + [ { "code": "unrecognized_keys", "keys": [ "bogus_key" ], "path": [], "message": "…" } ]
  ```

  （上面是注入一个坏键后的实测输出——测试的失败信息本身就是这个 issue 要的那份诊断。）

- **把 #653 的失败类别原样重建**：一个被读取装饰过的 flow 必须**仍然被拒**（证明 schema 依然是关闭的——放宽它会同时藏起真正的作者错误，正是本仓最不想要的方向），并且必须在 `stripReadDecorations` 之后**重新可注册**（证明 rc.2 的解法仍然是解法）。断言以 `METADATA_READ_DECORATIONS` 为准，所以将来新增的装饰键自动被覆盖。

  它证明不了自动化服务是否还在调用那个 strip——那道缝合在上游，需要真实 kernel。但如果某次升级引入了 strip 覆盖不到的装饰键、或从 spec 里撤掉了 strip，这会在 `pnpm test` 里红，而不是变成 24 条渲染为 `[` 的启动告警。

## 验证

```
$ npx tsc --noEmit                       # exit 0
$ npx vitest run --maxWorkers=2
  Test Files  49 passed (49)
       Tests  1168 passed | 1 skipped (1169)
```

`node_modules` 的临时插桩已还原（`grep -c stripReadDecorations` 回到 2），`git status` 干净。未触碰 #650 将要处理的 decision 节点条件。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rvtsew6XgsSjxVa59HRPRK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvtsew6XgsSjxVa59HRPRK)_