### PR TITLE
test(e2e): state the seed-visibility precondition instead of depending on it (#665)

### DIFF
--- a/.changeset/e2e-seed-visibility-precondition.md
+++ b/.changeset/e2e-seed-visibility-precondition.md
@@ -1,0 +1,29 @@
+---
+'hotcrm': patch
+---
+
+Fail the end-to-end suite with the actual reason when the demo seed is loaded but
+invisible to the account it runs as.
+
+`pnpm test:e2e` against a dev server that has been up for more than ten minutes
+failed eleven of sixteen specs on `no seeded accounts returned` and `no seeded
+crm_account — the demo seed did not load`. The seed had loaded. `e2e/global-setup.ts`
+signs **up** `e2e-admin@hotcrm.test`, which lands as a plain org member that owns
+nothing and holds no sharing grant, and every seeded row starts out owned by nobody —
+which under `sharingModel: 'private'` is the only reason it could read them at all.
+Once `demo_bootstrap` (or `pnpm demo:staff`) claims those rows for the first user, the
+suite reads zero, and reported it as a missing seed.
+
+Global setup now states that precondition instead of depending on it silently. Two
+`?limit=1` reads separate the two states that both look like "zero rows":
+`crm_account` is `private` and swept by `demo_bootstrap`, so it goes dark the moment
+the seeds are claimed; `crm_product` is `public_read` and in no sweep, so no ownership
+state can hide it. Products but no accounts means the seed is there and claimed — the
+run aborts with that sentence and `pnpm demo:reset`; neither means nothing seeded, and
+says so. The spec-level assertions, still reachable if the sweep fires mid-run, now
+carry the same cause rather than blaming the seed loader.
+
+What the suite proves is unchanged: no sharing grant, no permission set, no switch to
+the seeded dev admin. The guard also cannot turn a passing run red — it returns on the
+first readable row, and waits out a seed that is still loading rather than calling it
+absent.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -2,6 +2,7 @@
 
 import { test as base, expect, type APIRequestContext } from '@playwright/test';
 import { TOKEN_ENV } from './global-setup';
+import { SEEDS_UNREADABLE_MID_RUN } from './seed-precondition';
 
 /**
  * Authenticated e2e fixtures.
@@ -82,6 +83,6 @@ export async function seededAccountId(api: APIRequestContext): Promise<string> {
   const res = await api.get('/api/v1/data/crm_account?limit=1');
   expect(res.ok(), `could not read seeded accounts: ${res.status()}`).toBeTruthy();
   const [first] = recordsOf(await res.json());
-  expect(first, 'no seeded crm_account — the demo seed did not load').toBeTruthy();
+  expect(first, `no seeded crm_account — ${SEEDS_UNREADABLE_MID_RUN}`).toBeTruthy();
   return first.id as string;
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { request, type FullConfig } from '@playwright/test';
+import { assertSeedPrecondition } from './seed-precondition';
 
 /**
  * One sign-in for the whole run.
@@ -95,6 +96,13 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 
     if (!token) throw new Error('auth succeeded but returned no session token');
     process.env[TOKEN_ENV] = token;
+
+    // Authentication is not the same thing as access. This account is a plain
+    // org `member`, and under `sharingModel: 'private'` it reads a seeded row
+    // only while that row is owned by nobody — see `./seed-precondition.ts`.
+    // Checking it here turns one environmental state into one instruction,
+    // instead of eleven specs failing on "no seeded accounts returned" (#665).
+    await assertSeedPrecondition(ctx, token, EMAIL);
   } finally {
     await ctx.dispose();
   }

--- a/e2e/seed-precondition.ts
+++ b/e2e/seed-precondition.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The precondition the e2e suite has always depended on, now stated out loud.
+ *
+ * Eleven of the sixteen specs read seeded CRM rows, and whether those rows are
+ * *visible* to the user the suite runs as is an environmental property nothing
+ * declared (#665):
+ *
+ *   - `global-setup.ts` signs **up** `e2e-admin@hotcrm.test`. That account is a
+ *     plain org `member`. It owns nothing and holds no sharing grant.
+ *   - `crm_account`, `crm_lead`, `crm_opportunity`, `crm_case`, `crm_task`,
+ *     `crm_quote` and `crm_contract` are `sharingModel: 'private'`. The OWD
+ *     baseline admits a row's owner and a share can only widen from there.
+ *   - Seeded rows land **ownerless** (`{ isSystem: true }` writes skip the
+ *     security plugin's `owner_id` injection — see `src/data/index.ts`), and an
+ *     ownerless private row is admitted to everyone. That is the state a fresh
+ *     database starts in and the one every spec was written against.
+ *   - `demo_bootstrap`, on its ten-minute schedule, claims every ownerless row for
+ *     the first user. `pnpm demo:staff` has the same effect. From that moment
+ *     the e2e user reads **zero** private rows.
+ *
+ * CI never reaches that state, and not by luck — measured on both paths:
+ *
+ *   - CI's `webServer` runs `objectstack start`, which seeds no dev admin. The
+ *     account this suite signs up is therefore the org's FIRST user (`sys_user`
+ *     holds exactly one row), so when the sweep runs it claims the seeds FOR
+ *     the suite: every seeded account comes out carrying this account's id as
+ *     `owner_id`, and the specs read them before and after the sweep alike.
+ *   - `pnpm dev` seeds `admin@objectos.ai`. The first user is then that admin,
+ *     the sweep claims the seeds away from this suite at the next wall-clock
+ *     ten-minute boundary, and every seeded-row assertion fails from then on.
+ *
+ * So the failure is real, local-only, and permanent once it starts — and it
+ * reported itself as a missing seed. The seed is fine; the rows are somebody
+ * else's.
+ *
+ * This module makes that state a single, actionable failure in global setup
+ * instead of eleven misleading ones spread across the run. It does **not**
+ * change what the suite proves: no sharing grant, no permission set, no switch
+ * to the seeded dev admin. Making the specs independent of seed ownership
+ * altogether is deliberately a separate change.
+ */
+
+/**
+ * The two probes, and why one is not enough.
+ *
+ * A single "are there accounts?" read cannot tell *seeds claimed* from *seeds
+ * never loaded* — both answer zero — and those two states have opposite
+ * remedies. A second read against an object whose visibility does not depend on
+ * ownership separates them for one extra request:
+ *
+ *   - `crm_account` is `private` AND is swept by `demo_bootstrap`, so it goes
+ *     to zero the moment the seeds are claimed.
+ *   - `crm_product` is `public_read` AND is in no sweep (`demo_bootstrap`'s
+ *     `CLAIMED_OBJECTS` covers leads, accounts, contacts, opportunities, cases,
+ *     tasks, quotes and contracts — not products), so it stays visible to every
+ *     authenticated member no matter who owns what.
+ *
+ * Both are seeded by `CrmSeedData`, so "products but no accounts" can only mean
+ * the accounts are hidden, and "neither" can only mean nothing seeded at all.
+ */
+export const CLAIMABLE_PROBE_OBJECT = 'crm_account';
+export const OWNERSHIP_BLIND_PROBE_OBJECT = 'crm_product';
+
+/** What the two probes together say about the database under the suite. */
+export type SeedVisibility =
+  /** The suite can read seeded private rows — the state every spec assumes. */
+  | 'visible'
+  /** Seeds loaded, but the private ones are owned by somebody else. */
+  | 'claimed'
+  /** Nothing seeded at all — a different problem with a different remedy. */
+  | 'absent';
+
+/** Rows each probe returned for the e2e user. */
+export interface SeedProbeCounts {
+  claimable: number;
+  ownershipBlind: number;
+}
+
+/** Read the two counts as one of the three states above. */
+export function classifySeedVisibility(counts: SeedProbeCounts): SeedVisibility {
+  if (counts.claimable > 0) return 'visible';
+  return counts.ownershipBlind > 0 ? 'claimed' : 'absent';
+}
+
+/**
+ * The message the developer actually needs, for whichever state we are in.
+ *
+ * Both branches name the cause before the remedy: a message that only says what
+ * to type teaches nothing about why, and this failure recurs every ten minutes
+ * on a long-lived dev server.
+ */
+export function seedPreconditionMessage(state: 'claimed' | 'absent', email: string): string {
+  const shared = [
+    '',
+    'Remedy — run the suite the way CI does: a cold database served by `objectstack start`.',
+    '',
+    '    pnpm demo:reset          # rm -rf .objectstack/data && rebuild',
+    '    pnpm start               # terminal 1 — NOT `pnpm dev`, see below',
+    '    pnpm test:e2e            # terminal 2',
+    '',
+    'Why `start` and not `dev`: `objectstack dev` seeds the platform dev admin',
+    '(`admin@objectos.ai`), so the org\'s FIRST user is that admin and `demo_bootstrap` claims',
+    'the seeds for it, away from this suite. `objectstack start` seeds no admin, so this',
+    'suite\'s own account is the first user and the sweep claims the seeds FOR it — measured:',
+    'on a cold `start` database `sys_user` holds exactly one row (this account) and every',
+    'seeded account carries its id as `owner_id`. That is why CI has always been green.',
+    '',
+    'To stay on `pnpm dev`, reset and run before the next sweep. The schedule is on wall-clock',
+    'ten-minute boundaries, so that window is anywhere from seconds to ten minutes — measured:',
+    'a dev server booted at :49 had every seeded account owned by the dev admin by :50. That',
+    'race is what objectstack-ai/hotcrm#665 records; this guard reports it instead of letting',
+    '11 specs fail on a message about a seed that loaded perfectly well.',
+  ].join('\n');
+
+  if (state === 'claimed') {
+    return [
+      `e2e precondition failed: the demo seed is loaded but INVISIBLE to ${email}.`,
+      '',
+      `\`${CLAIMABLE_PROBE_OBJECT}\` returned 0 rows while \`${OWNERSHIP_BLIND_PROBE_OBJECT}\` returned rows — so the seed`,
+      'is there, and the private records are simply owned by another user. The `demo_bootstrap`',
+      'scheduled flow (or `pnpm demo:staff`) claims every ownerless seeded record for the first',
+      'user; under `sharingModel: \'private\'` this suite\'s account — a plain org member that owns',
+      'nothing and holds no sharing grant — then reads zero of them.',
+      shared,
+    ].join('\n');
+  }
+
+  return [
+    'e2e precondition failed: this server has no demo seed data.',
+    '',
+    `Neither \`${CLAIMABLE_PROBE_OBJECT}\` nor \`${OWNERSHIP_BLIND_PROBE_OBJECT}\` returned a single row for ${email}, and`,
+    `\`${OWNERSHIP_BLIND_PROBE_OBJECT}\` is \`public_read\` and owned by nobody — no ownership or sharing state can`,
+    'hide it. So the seed did not load, rather than having been claimed by another user.',
+    'Check the server boot log for seed errors before rerunning.',
+    shared,
+  ].join('\n');
+}
+
+/**
+ * What a seeded-row assertion should say when it fails *despite* the guard.
+ *
+ * The guard runs once, in global setup. `demo_bootstrap` fires every ten
+ * minutes, so it can claim the seeds part-way through a run that started with
+ * them readable — which leaves `smoke.spec.ts` and `seededAccountId()` reachable
+ * on exactly the state the guard exists to explain. They say so themselves
+ * rather than repeating "the demo seed did not load", which is the one
+ * explanation this failure has never had.
+ */
+export const SEEDS_UNREADABLE_MID_RUN =
+  'global setup verified these rows were readable, so they were not missing when the run ' +
+  'started: `demo_bootstrap` most likely claimed the seeds mid-run and this account, a ' +
+  'plain org member, can no longer see them (#665). Run `pnpm demo:reset` and rerun.';
+
+/**
+ * The slice of Playwright's `APIRequestContext` this module uses.
+ *
+ * Declared structurally rather than imported so the guard can be exercised by
+ * the unit suite against a stub — the branch that must never fire on CI is
+ * worth a test that does not need a browser, a server or a database.
+ */
+export interface SeedProbeContext {
+  get(
+    url: string,
+    options?: { headers?: Record<string, string>; failOnStatusCode?: boolean },
+  ): Promise<{
+    ok(): boolean;
+    status(): number;
+    text(): Promise<string>;
+    json(): Promise<unknown>;
+  }>;
+}
+
+export interface SeedPreconditionOptions {
+  /**
+   * How long to keep re-probing before declaring the seeds unreadable.
+   *
+   * Not a nicety: `waitForQuiet` infers "the seed storm has passed" from health
+   * latency, which is a proxy, not a fact. A cold CI database that is still
+   * inserting when global setup reaches this point would answer zero rows and
+   * be classified `absent` — a green run turned red by the guard meant to
+   * protect it. Waiting converts that race into a pause. The guard can then
+   * only fire in states where the suite was already going to fail: this returns
+   * the instant the rows appear.
+   */
+  timeoutMs?: number;
+  pollMs?: number;
+  /** Injected so the timeout path is testable without real waiting. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** Rows in a list response (`{ object, records }`), or `null` if not one. */
+function countRecords(body: unknown): number | null {
+  const records = (body as { records?: unknown } | null)?.records;
+  return Array.isArray(records) ? records.length : null;
+}
+
+/** One authenticated `?limit=1` read; throws when the API itself is unhappy. */
+async function probe(ctx: SeedProbeContext, objectName: string, token: string): Promise<number> {
+  const res = await ctx.get(`/api/v1/data/${objectName}?limit=1`, {
+    headers: { Authorization: `Bearer ${token}` },
+    failOnStatusCode: false,
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `e2e precondition probe failed: GET /api/v1/data/${objectName} → ${res.status()}: ${await res.text()}\n` +
+        'The suite authenticated, so this is not a credentials problem — the object is ' +
+        'unreadable for this user, or the server is unhealthy. Neither is a seed-data state.',
+    );
+  }
+  const count = countRecords(await res.json());
+  if (count === null) {
+    throw new Error(
+      `e2e precondition probe failed: GET /api/v1/data/${objectName} answered 200 without a ` +
+        '`records` array. The list envelope changed shape; e2e/fixtures.ts reads the same key.',
+    );
+  }
+  return count;
+}
+
+/**
+ * Fail global setup loudly when the seeded rows this suite reads are not
+ * readable by the account it signed in as.
+ *
+ * Returns silently in the only state the specs are written for.
+ */
+export async function assertSeedPrecondition(
+  ctx: SeedProbeContext,
+  token: string,
+  email: string,
+  options: SeedPreconditionOptions = {},
+): Promise<void> {
+  const { timeoutMs = 30_000, pollMs = 2_000, sleep = defaultSleep } = options;
+  const deadline = Date.now() + timeoutMs;
+
+  let counts: SeedProbeCounts;
+  for (;;) {
+    const claimable = await probe(ctx, CLAIMABLE_PROBE_OBJECT, token);
+    if (claimable > 0) return;
+    counts = { claimable, ownershipBlind: await probe(ctx, OWNERSHIP_BLIND_PROBE_OBJECT, token) };
+    if (Date.now() >= deadline) break;
+    await sleep(pollMs);
+  }
+
+  const state = classifySeedVisibility(counts);
+  if (state === 'visible') return;
+  throw new Error(seedPreconditionMessage(state, email));
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { test, expect, recordsOf } from './fixtures';
+import { SEEDS_UNREADABLE_MID_RUN } from './seed-precondition';
 
 /**
  * Server smoke tests — the routes are mounted and the CRM data is reachable.
@@ -52,7 +53,7 @@ test('REST API serves seeded hotcrm records to an authenticated caller', async (
   expect(res.ok(), `authenticated read failed: ${res.status()} ${await res.text()}`).toBeTruthy();
 
   const records = recordsOf(await res.json());
-  expect(records.length, 'no seeded accounts returned').toBeGreaterThan(0);
+  expect(records.length, `no seeded accounts returned — ${SEEDS_UNREADABLE_MID_RUN}`).toBeGreaterThan(0);
   // A real record, not just a 200 with an empty envelope.
   expect(typeof records[0].id).toBe('string');
   expect(typeof records[0].name).toBe('string');

--- a/test/e2e-seed-precondition.test.ts
+++ b/test/e2e-seed-precondition.test.ts
@@ -1,0 +1,202 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import {
+  CLAIMABLE_PROBE_OBJECT,
+  OWNERSHIP_BLIND_PROBE_OBJECT,
+  SEEDS_UNREADABLE_MID_RUN,
+  assertSeedPrecondition,
+  classifySeedVisibility,
+  seedPreconditionMessage,
+  type SeedProbeContext,
+} from '../e2e/seed-precondition';
+import { Account } from '../src/objects/account.object';
+import { Product } from '../src/objects/product.object';
+import { DemoBootstrapFlow } from '../src/flows/demo-bootstrap.flow';
+import { CrmSeedData } from '../src/data/index';
+
+/**
+ * The e2e seed-visibility guard (#665).
+ *
+ * `e2e/global-setup.ts` now refuses to start a run whose seeded rows the e2e
+ * account cannot read, instead of letting eleven specs fail on "no seeded
+ * accounts returned" — a message about a seed that had loaded perfectly well.
+ *
+ * Two things are worth pinning, and Playwright can pin neither: the guard's
+ * METADATA PREMISES (which object goes dark when the seeds are claimed and
+ * which one cannot), and the branch that must never fire on CI. The guard is
+ * therefore written against a structural request-context interface so it runs
+ * here against a stub — no browser, no server, no database.
+ */
+
+type Rec = Record<string, any>;
+
+describe('the premises the guard reads the two probes by', () => {
+  const seeded = new Set((CrmSeedData as unknown as Array<{ object: string }>).map((d) => d.object));
+
+  /**
+   * Every `objectName` `demo_bootstrap` touches, loop bodies included. The
+   * sweep is what makes a seeded row stop being visible to a non-owner, so
+   * membership of this set is exactly the property the claimable probe needs.
+   */
+  const swept = new Set<string>();
+  const collect = (nodes: Rec[]): void => {
+    for (const node of nodes) {
+      const objectName = node?.config?.objectName;
+      if (typeof objectName === 'string') swept.add(objectName);
+      const body = node?.config?.body?.nodes;
+      if (Array.isArray(body)) collect(body as Rec[]);
+    }
+  };
+  collect((DemoBootstrapFlow.nodes ?? []) as unknown as Rec[]);
+
+  it('both probes are actually seeded — an unseeded probe reads zero always', () => {
+    expect(seeded.has(CLAIMABLE_PROBE_OBJECT)).toBe(true);
+    expect(seeded.has(OWNERSHIP_BLIND_PROBE_OBJECT)).toBe(true);
+  });
+
+  it('the claimable probe is private AND swept, so it goes dark when the seeds are claimed', () => {
+    expect((Account as Rec).sharingModel).toBe('private');
+    expect(swept.has(CLAIMABLE_PROBE_OBJECT)).toBe(true);
+  });
+
+  it('the ownership-blind probe is public_read AND swept by nothing, so it never goes dark', () => {
+    // Either half failing would collapse the guard's two states into one: a
+    // probe that can itself be hidden reports "the seed did not load" for an
+    // org whose seed loaded and was claimed, which is the exact misdiagnosis
+    // #665 is about. Adding `crm_product` to `CLAIMED_OBJECTS` must fail here.
+    expect((Product as Rec).sharingModel).toBe('public_read');
+    expect(swept.has(OWNERSHIP_BLIND_PROBE_OBJECT)).toBe(false);
+  });
+});
+
+describe('classifySeedVisibility', () => {
+  it('reads any readable private row as the state the specs are written for', () => {
+    expect(classifySeedVisibility({ claimable: 1, ownershipBlind: 0 })).toBe('visible');
+    expect(classifySeedVisibility({ claimable: 5, ownershipBlind: 12 })).toBe('visible');
+  });
+
+  it('reads "products but no accounts" as seeds claimed by another user', () => {
+    expect(classifySeedVisibility({ claimable: 0, ownershipBlind: 12 })).toBe('claimed');
+  });
+
+  it('reads "neither" as no seed at all — a different problem', () => {
+    expect(classifySeedVisibility({ claimable: 0, ownershipBlind: 0 })).toBe('absent');
+  });
+});
+
+describe('the messages', () => {
+  it('name the cause and the remedy for a claimed seed', () => {
+    const msg = seedPreconditionMessage('claimed', 'e2e-admin@hotcrm.test');
+    expect(msg).toContain('INVISIBLE');
+    expect(msg).toContain('demo_bootstrap');
+    expect(msg).toContain('pnpm demo:reset');
+    expect(msg).toContain('e2e-admin@hotcrm.test');
+    // The one thing it must not say, because it is what the old failure said.
+    expect(msg).not.toContain('the demo seed did not load');
+  });
+
+  it('say something different, and true, when nothing is seeded', () => {
+    const msg = seedPreconditionMessage('absent', 'e2e-admin@hotcrm.test');
+    expect(msg).toContain('no demo seed data');
+    expect(msg).toContain('pnpm demo:reset');
+    expect(msg).not.toContain('INVISIBLE');
+  });
+
+  it('gives the mid-run assertions a cause instead of "the seed did not load"', () => {
+    // The guard runs once; `demo_bootstrap` fires every ten minutes, so the
+    // spec-level assertions stay reachable and carry this instead.
+    expect(SEEDS_UNREADABLE_MID_RUN).toContain('demo_bootstrap');
+    expect(SEEDS_UNREADABLE_MID_RUN).toContain('pnpm demo:reset');
+  });
+});
+
+/** A request context answering a scripted number of rows per probe pass. */
+function stubContext(passes: Array<Record<string, number | { status: number; body?: string }>>) {
+  const requested: string[] = [];
+  // The claimable probe opens every pass, so counting it advances the script.
+  let pass = -1;
+  const ctx: SeedProbeContext = {
+    async get(url) {
+      requested.push(url);
+      const objectName = url.replace('/api/v1/data/', '').split('?')[0];
+      if (objectName === CLAIMABLE_PROBE_OBJECT) pass++;
+      const scripted = passes[Math.min(pass, passes.length - 1)][objectName];
+      if (typeof scripted === 'object') {
+        return {
+          ok: () => false,
+          status: () => scripted.status,
+          text: async () => scripted.body ?? '',
+          json: async () => ({}),
+        };
+      }
+      return {
+        ok: () => true,
+        status: () => 200,
+        text: async () => '',
+        json: async () => ({ object: objectName, records: Array.from({ length: scripted }, () => ({ id: 'x' })) }),
+      };
+    },
+  };
+  return { ctx, requested };
+}
+
+const noWait = { timeoutMs: 0, pollMs: 0, sleep: async () => {} };
+
+describe('assertSeedPrecondition', () => {
+  it('passes — and costs one request — when the private rows are readable', async () => {
+    // This is CI's state and a freshly reset local server's state. The second
+    // probe is never even issued, so nothing about the ownership-blind object
+    // can influence a run that was going to be green.
+    const { ctx, requested } = stubContext([{ [CLAIMABLE_PROBE_OBJECT]: 5 }]);
+    await expect(assertSeedPrecondition(ctx, 'tok', 'e2e-admin@hotcrm.test', noWait)).resolves.toBeUndefined();
+    expect(requested).toEqual([`/api/v1/data/${CLAIMABLE_PROBE_OBJECT}?limit=1`]);
+  });
+
+  it('fails with the claimed-seed instruction when only the blind probe returns rows', async () => {
+    const { ctx } = stubContext([{ [CLAIMABLE_PROBE_OBJECT]: 0, [OWNERSHIP_BLIND_PROBE_OBJECT]: 12 }]);
+    await expect(
+      assertSeedPrecondition(ctx, 'tok', 'e2e-admin@hotcrm.test', noWait),
+    ).rejects.toThrow(/INVISIBLE[\s\S]*pnpm demo:reset/);
+  });
+
+  it('fails with the missing-seed message when neither returns rows', async () => {
+    const { ctx } = stubContext([{ [CLAIMABLE_PROBE_OBJECT]: 0, [OWNERSHIP_BLIND_PROBE_OBJECT]: 0 }]);
+    await expect(
+      assertSeedPrecondition(ctx, 'tok', 'e2e-admin@hotcrm.test', noWait),
+    ).rejects.toThrow(/no demo seed data/);
+  });
+
+  it('waits out a seed still loading rather than calling it absent', async () => {
+    // `waitForQuiet` infers "the seed storm has passed" from health latency,
+    // which is a proxy. A cold database still inserting when global setup
+    // reaches the guard would answer zero rows on the first pass — and a guard
+    // that failed there would turn a green CI run red, which is the one thing
+    // it must not do. It returns the instant the rows appear.
+    const { ctx } = stubContext([
+      { [CLAIMABLE_PROBE_OBJECT]: 0, [OWNERSHIP_BLIND_PROBE_OBJECT]: 0 },
+      { [CLAIMABLE_PROBE_OBJECT]: 9 },
+    ]);
+    await expect(
+      assertSeedPrecondition(ctx, 'tok', 'e2e-admin@hotcrm.test', { timeoutMs: 5_000, pollMs: 0, sleep: async () => {} }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('reports an unhappy API as an API problem, not as a seed-data state', async () => {
+    const { ctx } = stubContext([{ [CLAIMABLE_PROBE_OBJECT]: { status: 500, body: 'boom' } }]);
+    await expect(assertSeedPrecondition(ctx, 'tok', 'e2e-admin@hotcrm.test', noWait)).rejects.toThrow(
+      /probe failed:.*→ 500/,
+    );
+  });
+
+  it('rejects a 200 that is not a list envelope instead of reading it as zero rows', async () => {
+    const ctx: SeedProbeContext = {
+      async get() {
+        return { ok: () => true, status: () => 200, text: async () => '', json: async () => ({ data: [] }) };
+      },
+    };
+    await expect(assertSeedPrecondition(ctx, 'tok', 'e2e-admin@hotcrm.test', noWait)).rejects.toThrow(
+      /without a `records` array/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/hotcrm#665

按 PM 裁定实现**方案 3**:把 e2e 套件一直隐式依赖、却从未声明的前置条件——「种子记录此刻对套件登录的账号可见」——在 `e2e/global-setup.ts` 里显式断言。不满足时整轮 run 以**一条**说明真实成因和可执行补救的错误中止,而不是让 11 个 spec 带着 `no seeded accounts returned` / `the demo seed did not load` 级联失败(那句话描述的是一个加载得好好的种子)。

套件证明的东西**没有任何变化**:不加共享授权、不加权限集、不改用 seeded dev admin。方案 1 / 2 明确不在本 PR 范围,方案 2 已单独立案(见文末)。

## 两个探针,而不是一个

只读一次 `crm_account` 无法区分「种子被别人认领了」和「种子根本没播种」——两者都返回 0 行,而补救方式相反。所以多花一个请求,读一个**可见性与 ownership 无关**的对象:

| 探针 | OWD | 被 `demo_bootstrap` 扫描 | 种子被认领后 |
| --- | --- | --- | --- |
| `crm_account` | `private` | 是 | 归零 |
| `crm_product` | `public_read` | 否 | 始终可见 |

两者都在 `CrmSeedData` 里。于是「有 product、没有 account」只能是种子在、但属于别人;「两者都没有」只能是根本没播种。这两条前提不是注释,`test/e2e-seed-precondition.test.ts` 直接对元数据断言:把 `crm_product` 加进 `demo_bootstrap` 的 `CLAIMED_OBJECTS`,或改掉任一 `sharingModel`,测试就红——否则守卫会悄悄退化成把「被认领」误报成「没播种」,正是 #665 要消灭的那种误诊。

## 为什么这条守卫不可能把 CI 变红

三层保证,前两层是结构性的:

1. **只在套件本来就要失败的状态里才可能触发。** 第一个探针读到任何一行就立刻返回,连第二个请求都不发。CI 现在能过 `smoke.spec.ts` 的 `records.length > 0`,就意味着这个探针在 CI 上恒 > 0。
2. **仍在播种中的冷库会被等待,而不是被判成 absent。** `waitForQuiet` 用 health 延迟推断「播种风暴过去了」,那是代理指标不是事实。守卫最多轮询 30s,行一出现立即返回。
3. **实测 CI 那条路径的机制。** CI 的 `webServer` 跑 `objectstack start`,它**不播种 dev admin**:套件注册的账号就是组织里的第一个用户(`sys_user` 恰好 1 行),`demo_bootstrap` 于是把种子认领**给它自己**——冷库上实测每条 `crm_account` 的 `owner_id` 都等于该账号 id。CI 一直绿是因为这个,不是因为运气。而 `pnpm dev` 播种 `admin@objectos.ai`,第一个用户变成那个 admin,下一个整十分钟边界一到,种子就被从套件手里认领走。

## 验证(全部在本机对真实 booted server 跑出来,不是推理)

**A. `objectstack dev` + 已被认领的种子 → 守卫按预期响亮失败**(即 #665 的复现态)。用真实的 `e2e/global-setup.ts`(sign-up/sign-in + 守卫)打一台 `pnpm demo:reset` 后启动的 dev server:

```
=== GLOBAL SETUP FAILED ===

e2e precondition failed: the demo seed is loaded but INVISIBLE to e2e-admin@hotcrm.test.

`crm_account` returned 0 rows while `crm_product` returned rows — so the seed
is there, and the private records are simply owned by another user. ...

Remedy — run the suite the way CI does: a cold database served by `objectstack start`.

    pnpm demo:reset          # rm -rf .objectstack/data && rebuild
    pnpm start               # terminal 1 — NOT `pnpm dev`, see below
    pnpm test:e2e            # terminal 2
```

以 dev admin 身份核对成因:9 条 `crm_account` 的 `owner_id` 全是 dev admin 的 id(server 于 :49 启动,:50 的 sweep 已认领完毕)。

**B. `objectstack start` 冷库(CI 路径)→ 守卫不触发**:

```
=== GLOBAL SETUP PASSED — the guard did not fire ===
```

同一台 server 上以套件账号读:`sys_user` 只有 1 行(`e2e-admin@hotcrm.test`),sweep 跑过之后 `crm_account.owner_id` 全部等于该账号 id——即 CI 上 sweep 前后都可读。

**C. 真正的 `playwright test` 走一遍**(复用同一台 server,含真实 global setup + 守卫):

```
✓ 1 [chromium] › e2e/smoke.spec.ts:42:5 › the CRM data API is auth-gated (42ms)
✓ 2 [chromium] › e2e/smoke.spec.ts:51:5 › REST API serves seeded hotcrm records to an authenticated caller (118ms)
✓ 3 [chromium] › e2e/smoke.spec.ts:62:5 › every core CRM object is queryable (802ms)

  3 passed (4.3s)
```

容器里没有 chromium,`page` 驱动的那几个 spec 只能交给 CI 跑;它们不读种子行,与本改动无关。

**D. 单元与静态检查**:

```
pnpm typecheck                     → 通过(tsc --noEmit,e2e/ 与 test/ 都在 include 内)
pnpm test                          → 49 files / 1180 passed | 1 skipped
pnpm exec vitest run test/e2e-seed-precondition.test.ts → 15 passed
pnpm hygiene                       → clean
```

新测试用结构化的请求上下文接口对着 stub 跑,所以「绝不能在 CI 触发的那条分支」有测试覆盖,却不需要浏览器、server 或数据库。

## 仍会被跑到的两处措辞

守卫只在 global setup 跑一次,而 `demo_bootstrap` 每十分钟一次,所以 sweep 可能在一轮 run **中途**认领种子——`e2e/smoke.spec.ts` 和 `seededAccountId()` 因此仍可达。这两处现在带上同一句成因(`SEEDS_UNREADABLE_MID_RUN`),而不再指控种子加载器。

## 后续

方案 2(给 e2e 账号显式授权,或让 spec 自持数据,从而彻底摆脱对种子 ownership 的依赖)已作为**未指派**的独立 issue 立案,引用 #665 与本 PR。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvtsew6XgsSjxVa59HRPRK)_