### PR TITLE
fix(i18n): complete all four locales and retire the exemption ledger (#645, #494)

### DIFF
--- a/.changeset/all-locales-complete.md
+++ b/.changeset/all-locales-complete.md
@@ -1,0 +1,36 @@
+---
+'hotcrm': patch
+---
+
+All four locales are now complete on every translatable surface, and the exemption ledger that tracked the gap is retired rather than emptied.
+
+`objectstack lint` went from **723 warnings to 13**. Every one of the 710 removed was an i18n gap; the 13 that remain are unrelated (naming prefixes, a shadowed field group). `pnpm lint` runs with `--skip-i18n` and now reports the same 13 as a full run — the flag has nothing left to skip.
+
+**ja-JP and es-ES were each missing 355 keys.** The `pages` group was absent from both bundles outright, so every page in the app rendered its nav label, breadcrumb and header in English regardless of locale. On top of that: 34 navigation nodes, 10 object descriptions, the 12 Sales-dashboard win/loss widget strings, 13 view labels and empty states, and 169 picklist option labels each.
+
+**`en` was missing 133 keys and nothing could see them.** When a key is absent the resolver falls back to the English string in the metadata, so in the source locale a missing entry and a correct one are indistinguishable — invisible at runtime, invisible to the linter, invisible to a reviewer clicking through. It still mattered: every other bundle is authored by mirroring this one's shape, so a key with no slot here is a key the next translator has no place to put. That is precisely how three locales ended up with no `pages` group.
+
+## Consistency is now structural rather than a copy discipline
+
+Shared picklists in ja-JP are declared once and spread into each use site, mirroring the `activityActions` pattern already in the file and `_picklists.ts` on the metadata side. es-ES asserts the same relationships programmatically against the loaded bundle. The discipline they replace had already failed: `crm_lead.industry` read 業界 against `crm_account.industry` 業種 for the same 15-value shared set.
+
+Drift the sweep exposed and fixed:
+
+- `crm_account.owner` in ja-JP was 取引先責任者 — the **object label for `crm_contact`**. The "Account Owner" field rendered as the word "Contact".
+- The `crm_account` lookup read アカウント on case/contract/quote/campaign-member screens while the object itself is 取引先; same field, different word depending on which page you opened. `crm_task.related_to_type` forces the fix anyway — its option values *are* object names.
+- `crm_opportunity.stage` was フェーズ beside ステージ更新, ステージ開始日, 現ステージ滞在日数, and a dashboard showing ステージ × リードソース next to フェーズ別パイプライン.
+- `crm_account.type.former` is `'Former Customer'` in `account.object.ts`, but the `en` bundle had truncated it to `'Former'` — and es-ES, mirroring that bundle, rendered a bare `'Anterior'`: an adjective with no noun, beside three option labels that are all nouns.
+
+## The guard
+
+`PENDING_SELECT_LABELS` is **deleted**, not emptied. It held 34 fields over 12 objects — 111 (locale, field) pairs, ~380 option labels — of debt that #631 could not fix without burying the field its PR was about. An empty ledger is an invitation to add a row; the two assertions that existed only to keep it honest (stale rows, ghost rows) go with it. What remains says unconditionally what the ledger was always converging on: every select field, every option value, every locale.
+
+The surface guard is widened from zh-CN-only to all four locales, deriving the list from `localePacks` rather than hard-coding it, so a fifth locale is held to the bar the day it appears. Widening it is what surfaced the 105 invisible `en` gaps in the first place.
+
+This suite is the only real gate: `objectstack lint` has rules that find these gaps and CI never runs them, because `pnpm lint` passes `--skip-i18n` and `objectstack lint` exits 0 on warnings regardless.
+
+## Not addressed
+
+View **tab** labels (#661) remain untranslatable in every locale: `tabs[].label` has no key in `ObjectTranslationDataSchema` and no resolver in `i18n-resolver.ts`, so the gap is upstream.
+
+Several help strings in the object definitions read as developer shorthand and are now mirrored consistently into all four bundles — `crm_forecast.attainment_pct` ("Negative quota guarded"), `best_case_amount` / `commit_amount` (leaking raw `best_case` / `commit` option values where every neighbour uses display labels), `crm_opportunity_line_item.list_price` ("Auto-populated from product.list_price"). Fixing the English belongs in a change to the object definitions, not to a translation bundle.

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -66,7 +66,7 @@ export const en: TranslationData = {
         name: { label: 'Account Name', help: 'Legal name of the company or organization' },
         type: {
           label: 'Type',
-          options: { prospect: 'Prospect', customer: 'Customer', partner: 'Partner', former: 'Former' },
+          options: { prospect: 'Prospect', customer: 'Customer', partner: 'Partner', former: 'Former Customer' },
         },
         industry: {
           label: 'Industry',
@@ -89,7 +89,7 @@ export const en: TranslationData = {
         },
         office_location: { label: 'Office Location' },
         owner: { label: 'Account Owner' },
-        parent_account: { label: 'Parent Account' },
+        parent_account: { label: 'Parent Account', help: 'Parent company in hierarchy' },
         description: { label: 'Description' },
         is_active: { label: 'Active' },
         last_activity_date: { label: 'Last Activity Date' },
@@ -110,6 +110,11 @@ export const en: TranslationData = {
         },
         renewal_owner: { label: 'Renewal Owner (CSM)' },
         next_renewal_date: { label: 'Next Renewal Date' },
+        name_normalized: {
+          label: 'Account Name (Normalized)',
+          help: 'Match key for lead conversion: Account Name lower-cased, trimmed, with internal whitespace collapsed. Maintained by the account_protection hook — never edit directly.',
+        },
+        display_title: { label: 'Display Title' },
       },
       _views: {
         all_accounts: { label: 'All Accounts', description: 'Primary account list with revenue & industry summaries' },
@@ -147,9 +152,9 @@ export const en: TranslationData = {
         },
         owner: { label: 'Contact Owner' },
         description: { label: 'Description' },
-        is_primary: { label: 'Primary Contact' },
+        is_primary: { label: 'Primary Contact', help: 'Is this the main contact for the account?' },
         avatar: { label: 'Profile Picture' },
-        reports_to: { label: 'Reports To' },
+        reports_to: { label: 'Reports To', help: 'Direct manager/supervisor' },
         mailing_street: { label: 'Mailing Street' },
         mailing_city: { label: 'Mailing City' },
         mailing_state: { label: 'Mailing State/Province' },
@@ -183,6 +188,10 @@ export const en: TranslationData = {
         },
         send_email: {
           label: 'Send Email',
+          params: {
+            subject: { label: 'Subject' },
+            body: { label: 'Body' },
+          },
         },
       },
     },
@@ -194,8 +203,8 @@ export const en: TranslationData = {
       fields: {
         article_number: { label: 'Article #' },
         title: { label: 'Title' },
-        summary: { label: 'Summary' },
-        body: { label: 'Body' },
+        summary: { label: 'Summary', help: 'One-paragraph TL;DR shown in search results and AI citations.' },
+        body: { label: 'Body', help: 'Full article content (Markdown).' },
         category: {
           label: 'Category',
           options: {
@@ -218,6 +227,7 @@ export const en: TranslationData = {
         },
         audience: {
           label: 'Audience',
+          help: 'Public articles are visible in the customer portal; internal articles are agent-only.',
           options: { public: 'Public', internal: 'Internal' },
         },
         language: {
@@ -225,12 +235,13 @@ export const en: TranslationData = {
           options: { en: 'English', zh_cn: 'Simplified Chinese', es_es: 'Spanish', ja_jp: 'Japanese' },
         },
         owner: { label: 'Owner' },
-        related_to_case: { label: 'Source Case' },
+        related_to_case: { label: 'Source Case', help: 'Case this article was authored from (optional).' },
         published_at: { label: 'Published At' },
         last_reviewed_at: { label: 'Last Reviewed' },
         view_count: { label: 'Views' },
         helpful_count: { label: 'Helpful' },
         not_helpful_count: { label: 'Not Helpful' },
+        display_title: { label: 'Display Title' },
       },
       _views: {
         all_articles: { label: 'All Articles' },
@@ -249,21 +260,41 @@ export const en: TranslationData = {
         period: { label: 'Period', options: { month: 'Month', quarter: 'Quarter' } },
         period_start: { label: 'Period Start' },
         period_end: { label: 'Period End' },
-        period_label: { label: 'Period' },
-        snapshot_date: { label: 'Snapshot Date' },
+        period_label: { label: 'Period', help: 'Human-friendly label, e.g. "Q3 2026" or "Aug 2026".' },
+        snapshot_date: { label: 'Snapshot Date', help: 'The day this snapshot was captured.' },
         source: {
           label: 'Source',
           options: { scheduled: 'Scheduled snapshot', ai: 'AI skill', manual: 'Manual entry' },
         },
         quota: { label: 'Quota' },
-        pipeline_amount: { label: 'Pipeline' },
-        best_case_amount: { label: 'Best Case' },
-        commit_amount: { label: 'Commit' },
-        closed_amount: { label: 'Closed' },
-        expected_amount: { label: 'Expected' },
-        attainment_pct: { label: 'Attainment %' },
-        coverage_ratio: { label: 'Coverage' },
+        pipeline_amount: {
+          label: 'Pipeline',
+          help: 'Sum of all open opportunities closing in this period (any stage).',
+        },
+        best_case_amount: {
+          label: 'Best Case',
+          help: 'Open opportunities in the best_case or commit forecast category.',
+        },
+        commit_amount: {
+          label: 'Commit',
+          help: 'Open opportunities in the commit forecast category (owner-committed).',
+        },
+        closed_amount: { label: 'Closed', help: 'Already-closed-won amount in this period.' },
+        expected_amount: {
+          label: 'Expected',
+          help: 'Closed + Commit — what the owner reasonably expects to ship.',
+        },
+        attainment_pct: { label: 'Attainment %', help: '(Closed / Quota) * 100. Negative quota guarded.' },
+        coverage_ratio: {
+          label: 'Coverage',
+          help: 'Pipeline ÷ (Quota − Closed). Health-check for whether enough pipeline exists.',
+        },
         notes: { label: 'Notes' },
+        display_title: { label: 'Display Title' },
+        seed_key: {
+          label: 'Seed Key',
+          help: 'Demo-fixture identity. Written only by the seed loader; empty on every real snapshot.',
+        },
       },
       _views: {
         all_forecasts: { label: 'All Forecasts' },
@@ -318,7 +349,7 @@ export const en: TranslationData = {
         },
         mobile: { label: 'Mobile' },
         website: { label: 'Website' },
-        rating: { label: 'Lead Score' },
+        rating: { label: 'Lead Score', help: 'Lead quality score (1-5 stars)' },
         converted_account: { label: 'Converted Account' },
         converted_contact: { label: 'Converted Contact' },
         converted_opportunity: { label: 'Converted Opportunity' },
@@ -326,7 +357,7 @@ export const en: TranslationData = {
         address: { label: 'Address' },
         annual_revenue: { label: 'Annual Revenue' },
         number_of_employees: { label: 'Number of Employees' },
-        notes: { label: 'Notes' },
+        notes: { label: 'Notes', help: 'Rich text notes with formatting' },
         do_not_call: { label: 'Do Not Call' },
         email_opt_out: { label: 'Email Opt Out' },
         disqualification_reason: {
@@ -340,23 +371,41 @@ export const en: TranslationData = {
         },
         duplicate_of_type: {
           label: 'Duplicate Of',
+          help: 'Which object holds the surviving record this lead repeats.',
           options: { crm_lead: 'Lead', crm_contact: 'Contact' },
         },
         duplicate_of_lead: { label: 'Duplicate Of Lead' },
         duplicate_of_contact: { label: 'Duplicate Of Contact' },
         duplicate_status: {
           label: 'Duplicate Status',
+          help: 'Suspected = flagged automatically at intake. Confirmed = a human verified the match.',
           options: { suspected: 'Suspected', confirmed: 'Confirmed' },
         },
+        display_title: { label: 'Display Title' },
+        company_normalized: {
+          label: 'Company (Normalized)',
+          help: 'Match key for lead conversion: Company lower-cased, trimmed, with internal whitespace collapsed. Maintained by the lead_duplicate_check hook — never edit directly.',
+        },
+        next_followup_date: { label: 'Next Follow-up Date' },
+        last_contacted_date: { label: 'Last Contacted' },
       },
       _views: {
-        all_leads: { label: 'All Leads' },
+        all_leads: {
+          label: 'All Leads',
+          emptyState: { title: 'No Leads Yet', message: 'Get started by creating your first lead' },
+        },
         kanban_by_status: { label: 'Lead Pipeline' },
         calendar_by_created: { label: 'Lead Calendar' },
         gallery_view: { label: 'Lead Cards' },
         my_leads: { label: 'My Leads' },
         high_priority: { label: 'High Priority' },
-        suspected_duplicates: { label: 'Suspected Duplicates' },
+        suspected_duplicates: {
+          label: 'Suspected Duplicates',
+          emptyState: {
+            title: 'No Suspected Duplicates',
+            message: 'Nothing to review — every re-captured email has been checked.',
+          },
+        },
       },
       _actions: {
         ...activityActions,
@@ -368,6 +417,9 @@ export const en: TranslationData = {
         create_campaign: {
           label: 'Add to Campaign',
           successMessage: 'Leads added to campaign!',
+          params: {
+            crm_campaign: { label: 'Campaign' },
+          },
         },
         schedule_followup: {
           label: 'Schedule Follow-up',
@@ -430,9 +482,12 @@ export const en: TranslationData = {
             competitor_c: 'Competitor C',
           },
         },
-        crm_campaign: { label: 'Campaign' },
+        crm_campaign: { label: 'Campaign', help: 'Marketing campaign that generated this opportunity' },
         days_in_stage: { label: 'Days in Current Stage' },
-        stage_entry_date: { label: 'Stage Entry Date' },
+        stage_entry_date: {
+          label: 'Stage Entry Date',
+          help: 'Date this opportunity entered its current stage.',
+        },
         is_private: { label: 'Private' },
         approval_status: {
           label: 'Approval Status',
@@ -441,6 +496,7 @@ export const en: TranslationData = {
         approved_date: { label: 'Approved Date' },
         win_reason: {
           label: 'Win Reason',
+          help: 'Why this deal was won. Required to close an opportunity as Won.',
           options: {
             better_product: 'Better Product', better_price: 'Better Price', relationship: 'Existing Relationship',
             better_support: 'Better Support', best_fit: 'Best Fit / Features',
@@ -449,12 +505,16 @@ export const en: TranslationData = {
         },
         loss_reason: {
           label: 'Loss Reason',
+          help: 'Why this deal was lost. Required to close an opportunity as Lost.',
           options: {
             price: 'Price Too High', competitor: 'Lost to Competitor', no_budget: 'No Budget',
             no_decision: 'No Decision', timing: 'Bad Timing', features: 'Missing Features', other: 'Other',
           },
         },
-        loss_details: { label: 'Loss/Win Details' },
+        loss_details: {
+          label: 'Loss/Win Details',
+          help: 'Free-text context behind the win or loss reason.',
+        },
       },
       _views: {
         open_opportunities: { label: 'Open Deals' },
@@ -474,6 +534,9 @@ export const en: TranslationData = {
         mass_update_stage: {
           label: 'Update Stage',
           successMessage: 'Opportunities updated successfully!',
+          params: {
+            stage: { label: 'New Stage' },
+          },
         },
         generate_quote: {
           label: 'Generate Quote',
@@ -523,13 +586,22 @@ export const en: TranslationData = {
         is_sla_violated: { label: 'SLA Violated' },
         is_escalated: { label: 'Escalated' },
         escalation_reason: { label: 'Escalation Reason' },
-        parent_case: { label: 'Parent Case' },
+        parent_case: { label: 'Parent Case', help: 'Related parent case' },
         resolution: { label: 'Resolution' },
-        customer_rating: { label: 'Customer Satisfaction' },
+        customer_rating: {
+          label: 'Customer Satisfaction',
+          help: 'Customer satisfaction rating (1-5 stars)',
+        },
         customer_feedback: { label: 'Customer Feedback' },
-        customer_signature: { label: 'Customer Signature' },
-        internal_notes: { label: 'Internal Notes' },
+        customer_signature: {
+          label: 'Customer Signature',
+          help: 'Digital signature acknowledging case resolution',
+        },
+        internal_notes: { label: 'Internal Notes', help: 'Internal notes not visible to customer' },
         is_closed: { label: 'Is Closed' },
+        display_title: { label: 'Display Title' },
+        priority_rank: { label: 'Priority Rank' },
+        escalated_date: { label: 'Escalated Date' },
       },
       _views: {
         all_cases: { label: 'All Cases' },
@@ -656,6 +728,8 @@ export const en: TranslationData = {
         product_manager: { label: 'Product Manager' },
         image: { label: 'Product Image' },
         datasheet: { label: 'Datasheet' },
+        display_title: { label: 'Display Title' },
+        tax_rate: { label: 'Default Tax Rate %' },
       },
       _views: {
         all_products: { label: 'All Products' },
@@ -701,6 +775,7 @@ export const en: TranslationData = {
         shipping_address: { label: 'Shipping Address' },
         description: { label: 'Description' },
         internal_notes: { label: 'Internal Notes' },
+        display_title: { label: 'Display Title' },
       },
       _views: {
         all_quotes: { label: 'All Quotes' },
@@ -761,6 +836,8 @@ export const en: TranslationData = {
         progress_percent: { label: 'Progress (%)' },
         estimated_hours: { label: 'Estimated Hours' },
         actual_hours: { label: 'Actual Hours' },
+        priority_rank: { label: 'Priority Rank' },
+        reminder_sent: { label: 'Reminder Sent' },
       },
       _views: {
         all_tasks: { label: 'All Tasks' },
@@ -807,7 +884,7 @@ export const en: TranslationData = {
         actual_cost: { label: 'Actual Cost' },
         expected_revenue: { label: 'Expected Revenue' },
         actual_revenue: { label: 'Actual Revenue' },
-        target_size: { label: 'Target Size' },
+        target_size: { label: 'Target Size', help: 'Target number of leads/contacts' },
         num_sent: { label: 'Number Sent' },
         num_responses: { label: 'Number of Responses' },
         num_leads: { label: 'Number of Leads' },
@@ -816,10 +893,11 @@ export const en: TranslationData = {
         num_won_opportunities: { label: 'Won Opportunities' },
         response_rate: { label: 'Response Rate %' },
         roi: { label: 'ROI %' },
-        parent_campaign: { label: 'Parent Campaign' },
+        parent_campaign: { label: 'Parent Campaign', help: 'Parent campaign in hierarchy' },
         owner: { label: 'Campaign Owner' },
         landing_page_url: { label: 'Landing Page' },
         is_active: { label: 'Active' },
+        display_title: { label: 'Display Title' },
       },
       _views: {
         all_campaigns: { label: 'All Campaigns' },
@@ -896,10 +974,13 @@ export const en: TranslationData = {
           label: 'Attendee Type',
           options: { contact: 'Contact', lead: 'Lead', user: 'User' },
         },
-        crm_contact: { label: 'Contact' },
-        crm_lead: { label: 'Lead' },
-        sys_user: { label: 'User' },
-        external_name: { label: 'External Attendee' },
+        crm_contact: { label: 'Contact', help: 'Set when the attendee is an existing customer contact' },
+        crm_lead: { label: 'Lead', help: 'Set when the attendee is still an unconverted lead' },
+        sys_user: { label: 'User', help: 'Set when the attendee is a colleague' },
+        external_name: {
+          label: 'External Attendee',
+          help: 'Name of an attendee who is not a CRM record',
+        },
         response: {
           label: 'Response',
           options: {
@@ -922,8 +1003,8 @@ export const en: TranslationData = {
       fields: {
         member_number: { label: 'Member Number' },
         crm_campaign: { label: 'Campaign' },
-        crm_lead: { label: 'Lead' },
-        crm_contact: { label: 'Contact' },
+        crm_lead: { label: 'Lead', help: 'Set when the member was a Lead at enrollment time' },
+        crm_contact: { label: 'Contact', help: 'Set when the member is an existing Contact' },
         status: {
           label: 'Status',
           options: {
@@ -953,8 +1034,11 @@ export const en: TranslationData = {
         crm_product: { label: 'Product' },
         description: { label: 'Description' },
         quantity: { label: 'Quantity' },
-        list_price: { label: 'List Price' },
-        unit_price: { label: 'Sales Price' },
+        list_price: { label: 'List Price', help: 'Auto-populated from product.list_price' },
+        unit_price: {
+          label: 'Sales Price',
+          help: 'Negotiated unit price (may differ from list price)',
+        },
         discount: { label: 'Discount %' },
         total_price: { label: 'Total' },
         line_number: { label: 'Line #' },
@@ -1084,6 +1168,12 @@ export const en: TranslationData = {
         open_pipeline_by_owner: { title: 'Open Pipeline by Owner', description: 'In-flight pipeline value, deal count and avg win probability per rep' },
         quota_attainment_by_rep: { title: 'Quota Attainment by Rep', description: 'Current-quarter quota, closed revenue and attainment per rep, from forecast snapshots' },
         pipeline_stage_by_source: { title: 'Pipeline by Stage × Lead Source', description: 'Cross-tab of open opportunity amount by stage and source' },
+        win_rate_12m: { title: 'Win Rate (12M)', description: 'Deals won as a share of all deals settled in the last 12 months' },
+        won_deals_12m: { title: 'Deals Won (12M)', description: 'The numerator of the win rate' },
+        lost_deals_12m: { title: 'Deals Lost (12M)', description: 'The other half of the win-rate denominator' },
+        win_rate_by_owner: { title: 'Win / Loss by Rep', description: 'Deals won, deals lost and win rate per rep — last 12 months' },
+        win_rate_by_lead_source: { title: 'Win / Loss by Lead Source', description: 'Which sources produce deals that actually close — last 12 months' },
+        loss_reason_breakdown: { title: 'Why We Lose', description: 'Lost deals by reason — last 12 months' },
       },
     },
     service_dashboard: {
@@ -1101,6 +1191,51 @@ export const en: TranslationData = {
         sla_compliance_gauge: { title: 'SLA Compliance', description: 'Percent of cases resolved within SLA this period' },
         open_cases_by_priority: { title: 'Open Cases by Priority', description: 'Open cases and their SLA-violation rate, broken down by priority' },
       },
+    },
+  },
+
+  pages: {
+    account_detail_page: {
+      label: 'Account Detail',
+      description: 'Slotted account record page — custom header + persistent discussion feed.',
+    },
+    account_workbench: {
+      label: 'Account Workbench',
+      description: 'Curated account list for the sales team: quick filters only, no view management.',
+    },
+    app_launcher_page: {
+      label: 'App Launcher',
+      description: 'Central hub for accessing all applications',
+      subtitle: 'Select an app to get started',
+    },
+    case_detail_page: {
+      label: 'Case Detail',
+      description: 'Service-agent case record: highlights, SLA path, details and activity timeline.',
+      title: '{case_number} · {subject}',
+      subtitle: '{crm_account}',
+    },
+    lead_detail_page: {
+      label: 'Lead Detail',
+      description: 'Comprehensive lead detail page with highlights, details, and related information',
+      title: '{first_name} {last_name}',
+      subtitle: '{company}',
+    },
+    opportunity_detail_page: {
+      label: 'Opportunity Detail',
+      description:
+        'Comprehensive opportunity detail page with path, highlights, details, and related lists',
+      title: '{name}',
+      subtitle: '{crm_account}',
+    },
+    sales_home_page: {
+      label: 'Sales Home',
+      description: 'Sales team home page with key metrics and quick actions',
+      title: 'Sales Dashboard',
+      subtitle: 'Welcome back, {current_user.first_name}',
+    },
+    utility_bar_page: {
+      label: 'Utility Bar',
+      description: 'Quick access utility bar with floating tools',
     },
   },
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -125,7 +125,10 @@ export const en: TranslationData = {
       label: 'Contact',
       pluralLabel: 'Contacts',
       fields: {
-        salutation: { label: 'Salutation' },
+        salutation: {
+          label: 'Salutation',
+          options: { mr: 'Mr.', ms: 'Ms.', mrs: 'Mrs.', dr: 'Dr.', prof: 'Prof.' },
+        },
         first_name: { label: 'First Name' },
         last_name: { label: 'Last Name' },
         full_name: { label: 'Full Name' },
@@ -153,7 +156,15 @@ export const en: TranslationData = {
         mailing_postal_code: { label: 'Mailing Postal Code' },
         mailing_country: { label: 'Mailing Country' },
         birthdate: { label: 'Birthdate' },
-        lead_source: { label: 'Lead Source' },
+        lead_source: {
+          label: 'Lead Source',
+          options: {
+            web: 'Web', referral: 'Referral', event: 'Event / Trade Show',
+            webinar: 'Webinar', partner: 'Partner', advertisement: 'Advertisement',
+            paid_search: 'Paid Search', social: 'Social Media', content: 'Content / Blog',
+            cold_call: 'Cold Call', email_campaign: 'Email Campaign', other: 'Other',
+          },
+        },
         do_not_call: { label: 'Do Not Call' },
         email_opt_out: { label: 'Email Opt Out' },
         last_contacted_date: { label: 'Last Contacted' },
@@ -190,11 +201,16 @@ export const en: TranslationData = {
           options: {
             getting_started: 'Getting Started', how_to: 'How-To',
             troubleshooting: 'Troubleshooting', billing: 'Billing & Pricing', api: 'API & Integrations',
+            release_notes: 'Release Notes', policy: 'Policy',
           },
         },
         tags: {
           label: 'Tags',
-          options: { auth: 'Auth', sso: 'SSO', mobile: 'Mobile', email: 'Email' },
+          options: {
+            auth: 'Auth', sso: 'SSO', mobile: 'Mobile', email: 'Email',
+            reports: 'Reports', performance: 'Performance', data_import: 'Data Import',
+            webhooks: 'Webhooks',
+          },
         },
         status: {
           label: 'Status',
@@ -285,9 +301,21 @@ export const en: TranslationData = {
         owner: { label: 'Lead Owner' },
         is_converted: { label: 'Converted' },
         description: { label: 'Description' },
-        salutation: { label: 'Salutation' },
+        salutation: {
+          label: 'Salutation',
+          options: { mr: 'Mr.', ms: 'Ms.', mrs: 'Mrs.', dr: 'Dr.', prof: 'Prof.' },
+        },
         full_name: { label: 'Full Name' },
-        industry: { label: 'Industry' },
+        industry: {
+          label: 'Industry',
+          options: {
+            technology: 'Technology', software: 'Software / SaaS', finance: 'Finance',
+            healthcare: 'Healthcare', retail: 'Retail', manufacturing: 'Manufacturing',
+            education: 'Education', real_estate: 'Real Estate', media: 'Media & Entertainment',
+            logistics: 'Logistics', hospitality: 'Hospitality', energy: 'Energy & Utilities',
+            government: 'Government', nonprofit: 'Non-profit', other: 'Other',
+          },
+        },
         mobile: { label: 'Mobile' },
         website: { label: 'Website' },
         rating: { label: 'Lead Score' },
@@ -395,7 +423,13 @@ export const en: TranslationData = {
             cold_call: 'Cold Call', email_campaign: 'Email Campaign', other: 'Other',
           },
         },
-        competitors: { label: 'Competitors' },
+        competitors: {
+          label: 'Competitors',
+          options: {
+            competitor_a: 'Competitor A', competitor_b: 'Competitor B',
+            competitor_c: 'Competitor C',
+          },
+        },
         crm_campaign: { label: 'Campaign' },
         days_in_stage: { label: 'Days in Current Stage' },
         stage_entry_date: { label: 'Stage Entry Date' },
@@ -457,9 +491,25 @@ export const en: TranslationData = {
         description: { label: 'Description' },
         crm_account: { label: 'Account' },
         crm_contact: { label: 'Contact' },
-        status: { label: 'Status' },
-        priority: { label: 'Priority' },
-        type: { label: 'Case Type' },
+        status: {
+          label: 'Status',
+          options: {
+            new: 'New', in_progress: 'In Progress', waiting_customer: 'Waiting on Customer',
+            waiting_support: 'Waiting on Support', escalated: 'Escalated',
+            resolved: 'Resolved', closed: 'Closed',
+          },
+        },
+        priority: {
+          label: 'Priority',
+          options: { low: 'Low', medium: 'Medium', high: 'High', critical: 'Critical' },
+        },
+        type: {
+          label: 'Case Type',
+          options: {
+            question: 'Question', problem: 'Problem',
+            feature_request: 'Feature Request', bug: 'Bug',
+          },
+        },
         origin: {
           label: 'Case Origin',
           options: { email: 'Email', phone: 'Phone', web: 'Web', chat: 'Chat', social_media: 'Social Media' },
@@ -512,16 +562,40 @@ export const en: TranslationData = {
         crm_contact: { label: 'Primary Contact' },
         crm_opportunity: { label: 'Related Opportunity' },
         owner: { label: 'Contract Owner' },
-        status: { label: 'Status' },
+        status: {
+          label: 'Status',
+          options: {
+            draft: 'Draft', in_approval: 'In Approval', activated: 'Activated',
+            expired: 'Expired', terminated: 'Terminated',
+          },
+        },
         contract_term_months: { label: 'Contract Term (Months)' },
         start_date: { label: 'Start Date' },
         end_date: { label: 'End Date' },
         contract_value: { label: 'Contract Value' },
-        billing_frequency: { label: 'Billing Frequency' },
-        payment_terms: { label: 'Payment Terms' },
+        billing_frequency: {
+          label: 'Billing Frequency',
+          options: {
+            monthly: 'Monthly', quarterly: 'Quarterly',
+            annually: 'Annually', one_time: 'One-time',
+          },
+        },
+        payment_terms: {
+          label: 'Payment Terms',
+          options: {
+            net_15: 'Net 15', net_30: 'Net 30', net_60: 'Net 60',
+            net_90: 'Net 90', due_on_receipt: 'Due on Receipt',
+          },
+        },
         auto_renewal: { label: 'Auto Renewal' },
         renewal_notice_days: { label: 'Renewal Notice (Days)' },
-        contract_type: { label: 'Contract Type' },
+        contract_type: {
+          label: 'Contract Type',
+          options: {
+            subscription: 'Subscription', service: 'Service Agreement', license: 'License',
+            partnership: 'Partnership', nda: 'NDA', msa: 'MSA',
+          },
+        },
         signed_date: { label: 'Signed Date' },
         signed_by: { label: 'Signed By' },
         document_url: { label: 'Contract Document' },
@@ -544,10 +618,36 @@ export const en: TranslationData = {
         product_code: { label: 'Product Code' },
         name: { label: 'Product Name' },
         description: { label: 'Description' },
-        category: { label: 'Category' },
-        family: { label: 'Product Family' },
+        category: {
+          label: 'Category',
+          options: {
+            software: 'Software', hardware: 'Hardware', service: 'Service',
+            subscription: 'Subscription', support: 'Support',
+          },
+        },
+        family: {
+          label: 'Product Family',
+          options: {
+            enterprise: 'Enterprise Solutions', smb: 'SMB Solutions',
+            services: 'Professional Services', cloud: 'Cloud Services',
+          },
+        },
         list_price: { label: 'List Price' },
         cost: { label: 'Cost' },
+        billing_type: {
+          label: 'Billing Type',
+          options: {
+            one_time: 'One-Time', monthly: 'Monthly', quarterly: 'Quarterly',
+            annual: 'Annual', usage: 'Usage',
+          },
+        },
+        unit_of_measure: {
+          label: 'Unit of Measure',
+          options: {
+            each: 'Each', license: 'License', seat: 'Seat',
+            hour: 'Hour', day: 'Day', month: 'Month',
+          },
+        },
         sku: { label: 'SKU' },
         quantity_on_hand: { label: 'Quantity on Hand' },
         reorder_point: { label: 'Reorder Point' },
@@ -574,7 +674,13 @@ export const en: TranslationData = {
         crm_contact: { label: 'Contact' },
         crm_opportunity: { label: 'Opportunity' },
         owner: { label: 'Quote Owner' },
-        status: { label: 'Status' },
+        status: {
+          label: 'Status',
+          options: {
+            draft: 'Draft', in_review: 'In Review', presented: 'Presented',
+            accepted: 'Accepted', rejected: 'Rejected', expired: 'Expired',
+          },
+        },
         quote_date: { label: 'Quote Date' },
         expiration_date: { label: 'Expiration Date' },
         subtotal: { label: 'Subtotal' },
@@ -583,7 +689,13 @@ export const en: TranslationData = {
         tax: { label: 'Tax' },
         shipping_handling: { label: 'Shipping & Handling' },
         total_price: { label: 'Total Price' },
-        payment_terms: { label: 'Payment Terms' },
+        payment_terms: {
+          label: 'Payment Terms',
+          options: {
+            net_15: 'Net 15', net_30: 'Net 30', net_60: 'Net 60',
+            net_90: 'Net 90', due_on_receipt: 'Due on Receipt',
+          },
+        },
         shipping_terms: { label: 'Shipping Terms' },
         billing_address: { label: 'Billing Address' },
         shipping_address: { label: 'Shipping Address' },
@@ -603,21 +715,45 @@ export const en: TranslationData = {
       fields: {
         subject: { label: 'Subject' },
         description: { label: 'Description' },
-        status: { label: 'Status' },
-        priority: { label: 'Priority' },
-        type: { label: 'Task Type' },
+        status: {
+          label: 'Status',
+          options: {
+            not_started: 'Not Started', in_progress: 'In Progress', waiting: 'Waiting',
+            completed: 'Completed', deferred: 'Deferred',
+          },
+        },
+        priority: {
+          label: 'Priority',
+          options: { low: 'Low', normal: 'Normal', high: 'High', urgent: 'Urgent' },
+        },
+        type: {
+          label: 'Task Type',
+          options: {
+            call: 'Call', email: 'Email', meeting: 'Meeting',
+            follow_up: 'Follow-up', demo: 'Demo', other: 'Other',
+          },
+        },
         due_date: { label: 'Due Date' },
         reminder_date: { label: 'Reminder Date/Time' },
         completed_date: { label: 'Completed Date' },
         owner: { label: 'Assigned To' },
-        related_to_type: { label: 'Related To Type' },
+        related_to_type: {
+          label: 'Related To Type',
+          options: {
+            crm_account: 'Account', crm_contact: 'Contact', crm_opportunity: 'Opportunity',
+            crm_lead: 'Lead', crm_case: 'Case',
+          },
+        },
         related_to_account: { label: 'Related Account' },
         related_to_contact: { label: 'Related Contact' },
         related_to_opportunity: { label: 'Related Opportunity' },
         related_to_lead: { label: 'Related Lead' },
         related_to_case: { label: 'Related Case' },
         is_recurring: { label: 'Recurring Task' },
-        recurrence_type: { label: 'Recurrence Type' },
+        recurrence_type: {
+          label: 'Recurrence Type',
+          options: { daily: 'Daily', weekly: 'Weekly', monthly: 'Monthly', yearly: 'Yearly' },
+        },
         recurrence_interval: { label: 'Recurrence Interval' },
         recurrence_end_date: { label: 'Recurrence End Date' },
         is_completed: { label: 'Is Completed' },
@@ -643,9 +779,28 @@ export const en: TranslationData = {
         campaign_code: { label: 'Campaign Code' },
         name: { label: 'Campaign Name' },
         description: { label: 'Description' },
-        type: { label: 'Campaign Type' },
-        channel: { label: 'Primary Channel' },
-        status: { label: 'Status' },
+        type: {
+          label: 'Campaign Type',
+          options: {
+            email: 'Email', webinar: 'Webinar', trade_show: 'Trade Show',
+            conference: 'Conference', direct_mail: 'Direct Mail', social_media: 'Social Media',
+            content: 'Content Marketing', partner: 'Partner Marketing',
+          },
+        },
+        channel: {
+          label: 'Primary Channel',
+          options: {
+            digital: 'Digital', social: 'Social', email: 'Email',
+            events: 'Events', partner: 'Partner',
+          },
+        },
+        status: {
+          label: 'Status',
+          options: {
+            planning: 'Planning', in_progress: 'In Progress',
+            completed: 'Completed', aborted: 'Aborted',
+          },
+        },
         start_date: { label: 'Start Date' },
         end_date: { label: 'End Date' },
         budgeted_cost: { label: 'Budgeted Cost' },

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -69,7 +69,11 @@ export const esES: TranslationData = {
         display_title: { label: 'Título Mostrado' },
         type: {
           label: 'Tipo',
-          options: { prospect: 'Prospecto', customer: 'Cliente', partner: 'Socio', former: 'Anterior' },
+          // `former` is 'Former Customer' in account.object.ts; the `en` bundle
+          // had truncated it to 'Former', and translating that truncation gave
+          // a bare 'Anterior' — an adjective with no noun, next to three option
+          // labels that are all nouns.
+          options: { prospect: 'Prospecto', customer: 'Cliente', partner: 'Socio', former: 'Cliente Anterior' },
         },
         industry: {
           label: 'Industria',

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -58,9 +58,15 @@ export const esES: TranslationData = {
     crm_account: {
       label: 'Cuenta',
       pluralLabel: 'Cuentas',
+      description: 'Empresas y organizaciones con las que mantenemos relación comercial',
       fields: {
         account_number: { label: 'Número de Cuenta' },
         name: { label: 'Nombre de Cuenta', help: 'Nombre legal de la empresa u organización' },
+        name_normalized: {
+          label: 'Nombre de Cuenta (Normalizado)',
+          help: 'Clave de coincidencia para la conversión de prospectos: el Nombre de Cuenta en minúsculas, sin espacios sobrantes y con los espacios internos reducidos a uno. Lo mantiene el hook account_protection — nunca lo edite directamente.',
+        },
+        display_title: { label: 'Título Mostrado' },
         type: {
           label: 'Tipo',
           options: { prospect: 'Prospecto', customer: 'Cliente', partner: 'Socio', former: 'Anterior' },
@@ -86,12 +92,36 @@ export const esES: TranslationData = {
         },
         office_location: { label: 'Ubicación de Oficina' },
         owner: { label: 'Propietario de Cuenta' },
-        parent_account: { label: 'Cuenta Matriz' },
+        parent_account: { label: 'Cuenta Matriz', help: 'Empresa matriz en la jerarquía' },
         description: { label: 'Descripción' },
         is_active: { label: 'Activo' },
         last_activity_date: { label: 'Fecha de Última Actividad' },
         brand_color: { label: 'Color de Marca' },
         logo: { label: 'Logo de la Empresa' },
+        tier: {
+          label: 'Nivel de Cliente',
+          options: {
+            strategic: 'Estratégico', enterprise: 'Gran Empresa',
+            mid_market: 'Mediana Empresa', smb: 'PYME',
+          },
+        },
+        segment: {
+          label: 'Segmento',
+          options: {
+            net_new: 'Cliente Nuevo', growth: 'Crecimiento',
+            at_risk: 'En Riesgo', stable: 'Estable',
+          },
+        },
+        health_score: {
+          label: 'Índice de Salud',
+          help: 'Indicador de salud mantenido por el CSM',
+          options: {
+            healthy: 'Saludable', watching: 'En Observación',
+            at_risk: 'En Riesgo', churning: 'En Fuga',
+          },
+        },
+        renewal_owner: { label: 'Responsable de Renovación (CSM)' },
+        next_renewal_date: { label: 'Próxima Fecha de Renovación' },
       },
       _views: {
         all_accounts: { label: 'Todas las Cuentas', description: 'Lista maestra de cuentas con ingresos e industria' },
@@ -99,6 +129,8 @@ export const esES: TranslationData = {
         account_map: { label: 'Mapa de Cuentas', description: 'Distribución geográfica de cuentas' },
         enterprise_accounts: { label: 'Cuentas Empresariales', description: 'Cuentas con mayores ingresos anuales' },
         my_accounts: { label: 'Mis Cuentas', description: 'Cuentas asignadas al usuario actual' },
+        renewals_due: { label: '🔄 Próximas Renovaciones' },
+        at_risk_accounts: { label: '⚠️ Cuentas en Riesgo' },
       },
       _actions: { ...activityActions },
     },
@@ -106,8 +138,13 @@ export const esES: TranslationData = {
     crm_contact: {
       label: 'Contacto',
       pluralLabel: 'Contactos',
+      description: 'Personas asociadas a las cuentas',
       fields: {
-        salutation: { label: 'Título' },
+        // Mismo juego de valores que `crm_lead.salutation` — tradúzcanse igual.
+        salutation: {
+          label: 'Título',
+          options: { mr: 'Sr.', ms: 'Srta.', mrs: 'Sra.', dr: 'Dr.', prof: 'Prof.' },
+        },
         first_name: { label: 'Nombre' },
         last_name: { label: 'Apellido' },
         full_name: { label: 'Nombre Completo' },
@@ -126,16 +163,26 @@ export const esES: TranslationData = {
         },
         owner: { label: 'Propietario de Contacto' },
         description: { label: 'Descripción' },
-        is_primary: { label: 'Contacto Principal' },
+        is_primary: { label: 'Contacto Principal', help: '¿Es este el contacto principal de la cuenta?' },
         avatar: { label: 'Foto de Perfil' },
-        reports_to: { label: 'Reporta A' },
+        reports_to: { label: 'Reporta A', help: 'Jefe o supervisor directo' },
         mailing_street: { label: 'Calle de Correo' },
         mailing_city: { label: 'Ciudad de Correo' },
         mailing_state: { label: 'Estado/Provincia de Correo' },
         mailing_postal_code: { label: 'Código Postal' },
         mailing_country: { label: 'País de Correo' },
         birthdate: { label: 'Fecha de Nacimiento' },
-        lead_source: { label: 'Origen del Prospecto' },
+        // Juego compartido con `crm_lead.lead_source` y
+        // `crm_opportunity.lead_source` — los tres deben coincidir literalmente.
+        lead_source: {
+          label: 'Origen del Prospecto',
+          options: {
+            web: 'Web', referral: 'Referencia', event: 'Evento / Feria',
+            webinar: 'Seminario Web', partner: 'Socio', advertisement: 'Publicidad',
+            paid_search: 'Búsqueda de Pago', social: 'Redes Sociales', content: 'Contenido / Blog',
+            cold_call: 'Llamada en Frío', email_campaign: 'Campaña de Email', other: 'Otro',
+          },
+        },
         do_not_call: { label: 'No Llamar' },
         email_opt_out: { label: 'Excluir de Correos' },
         last_contacted_date: { label: 'Último contacto' },
@@ -154,6 +201,10 @@ export const esES: TranslationData = {
         },
         send_email: {
           label: 'Enviar Correo',
+          params: {
+            subject: { label: 'Asunto' },
+            body: { label: 'Cuerpo' },
+          },
         },
       },
     },
@@ -164,28 +215,41 @@ export const esES: TranslationData = {
       description: 'Respuestas y guías reutilizables para clientes y agentes',
       fields: {
         article_number: { label: 'N.º Artículo' },
+        display_title: { label: 'Título Mostrado' },
         title: { label: 'Título' },
-        summary: { label: 'Resumen' },
-        body: { label: 'Contenido' },
+        summary: { label: 'Resumen', help: 'Resumen de un párrafo que se muestra en los resultados de búsqueda y en las citas de la IA.' },
+        body: { label: 'Contenido', help: 'Contenido completo del artículo (Markdown).' },
         category: {
           label: 'Categoría',
           options: {
             getting_started: 'Primeros pasos', how_to: 'Cómo hacerlo',
             troubleshooting: 'Resolución de problemas', billing: 'Facturación', api: 'API e Integraciones',
+            release_notes: 'Notas de versión', policy: 'Políticas',
           },
         },
-        tags: { label: 'Etiquetas', options: { auth: 'Autenticación', sso: 'SSO', mobile: 'Móvil', email: 'Correo' } },
+        tags: {
+          label: 'Etiquetas',
+          options: {
+            auth: 'Autenticación', sso: 'SSO', mobile: 'Móvil', email: 'Correo',
+            reports: 'Informes', performance: 'Rendimiento',
+            data_import: 'Importación de datos', webhooks: 'Webhooks',
+          },
+        },
         status: {
           label: 'Estado',
           options: { draft: 'Borrador', in_review: 'En revisión', published: 'Publicado', archived: 'Archivado' },
         },
-        audience: { label: 'Audiencia', options: { public: 'Público', internal: 'Interno' } },
+        audience: {
+          label: 'Audiencia',
+          help: 'Los artículos públicos son visibles en el portal de clientes; los internos solo los ven los agentes.',
+          options: { public: 'Público', internal: 'Interno' },
+        },
         language: {
           label: 'Idioma',
           options: { en: 'Inglés', zh_cn: 'Chino simplificado', es_es: 'Español', ja_jp: 'Japonés' },
         },
         owner: { label: 'Propietario' },
-        related_to_case: { label: 'Caso de origen' },
+        related_to_case: { label: 'Caso de origen', help: 'Caso a partir del cual se redactó este artículo (opcional).' },
         published_at: { label: 'Publicado el' },
         last_reviewed_at: { label: 'Última revisión' },
         view_count: { label: 'Vistas' },
@@ -209,21 +273,26 @@ export const esES: TranslationData = {
         period: { label: 'Periodo', options: { month: 'Mes', quarter: 'Trimestre' } },
         period_start: { label: 'Inicio del periodo' },
         period_end: { label: 'Fin del periodo' },
-        period_label: { label: 'Periodo' },
-        snapshot_date: { label: 'Fecha de instantánea' },
+        period_label: { label: 'Periodo', help: 'Etiqueta legible, p. ej. «T3 2026» o «Ago 2026».' },
+        display_title: { label: 'Título Mostrado' },
+        snapshot_date: { label: 'Fecha de instantánea', help: 'El día en que se capturó esta instantánea.' },
         source: {
           label: 'Origen',
           options: { scheduled: 'Instantánea programada', ai: 'Skill de IA', manual: 'Entrada manual' },
         },
         quota: { label: 'Cuota' },
-        pipeline_amount: { label: 'Pipeline' },
-        best_case_amount: { label: 'Mejor caso' },
-        commit_amount: { label: 'Compromiso' },
-        closed_amount: { label: 'Cerrado' },
-        expected_amount: { label: 'Esperado' },
-        attainment_pct: { label: 'Cumplimiento %' },
-        coverage_ratio: { label: 'Cobertura' },
+        pipeline_amount: { label: 'Pipeline', help: 'Suma de todas las oportunidades abiertas que cierran en este periodo (en cualquier etapa).' },
+        best_case_amount: { label: 'Mejor caso', help: 'Oportunidades abiertas en la categoría de pronóstico Mejor caso o Compromiso.' },
+        commit_amount: { label: 'Compromiso', help: 'Oportunidades abiertas en la categoría de pronóstico Compromiso (comprometidas por el propietario).' },
+        closed_amount: { label: 'Cerrado', help: 'Importe ya cerrado ganado en este periodo.' },
+        expected_amount: { label: 'Esperado', help: 'Cerrado + Compromiso: lo que el propietario espera razonablemente cerrar.' },
+        attainment_pct: { label: 'Cumplimiento %', help: '(Cerrado / Cuota) * 100. Se protege frente a cuotas negativas.' },
+        coverage_ratio: { label: 'Cobertura', help: 'Pipeline ÷ (Cuota − Cerrado). Comprobación de si existe pipeline suficiente.' },
         notes: { label: 'Notas' },
+        seed_key: {
+          label: 'Clave de semilla',
+          help: 'Identidad del juego de datos de demostración. Solo la escribe el cargador de semillas; está vacía en cualquier instantánea real.',
+        },
       },
       _views: {
         all_forecasts: { label: 'Todas las previsiones' },
@@ -235,10 +304,16 @@ export const esES: TranslationData = {
     crm_lead: {
       label: 'Prospecto',
       pluralLabel: 'Prospectos',
+      description: 'Clientes potenciales todavía sin calificar',
       fields: {
         first_name: { label: 'Nombre' },
         last_name: { label: 'Apellido' },
         company: { label: 'Empresa' },
+        company_normalized: {
+          label: 'Empresa (Normalizado)',
+          help: 'Clave de coincidencia para la conversión de prospectos: la Empresa en minúsculas, sin espacios sobrantes y con los espacios internos reducidos a uno. Lo mantiene el hook lead_duplicate_check — nunca lo edite directamente.',
+        },
+        display_title: { label: 'Título Mostrado' },
         title: { label: 'Cargo' },
         email: { label: 'Correo Electrónico' },
         phone: { label: 'Teléfono' },
@@ -261,12 +336,29 @@ export const esES: TranslationData = {
         owner: { label: 'Propietario' },
         is_converted: { label: 'Convertido' },
         description: { label: 'Descripción' },
-        salutation: { label: 'Tratamiento' },
+        // Mismo juego de valores que `crm_contact.salutation` — tradúzcanse igual.
+        salutation: {
+          label: 'Tratamiento',
+          options: { mr: 'Sr.', ms: 'Srta.', mrs: 'Sra.', dr: 'Dr.', prof: 'Prof.' },
+        },
         full_name: { label: 'Nombre Completo' },
-        industry: { label: 'Industria' },
+        // Los 15 valores son los mismos que en `crm_account.industry` — deben
+        // coincidir literalmente entre ambas pantallas.
+        industry: {
+          label: 'Industria',
+          options: {
+            technology: 'Tecnología', software: 'Software / SaaS', finance: 'Finanzas',
+            healthcare: 'Salud', retail: 'Comercio', manufacturing: 'Manufactura',
+            education: 'Educación', real_estate: 'Inmobiliaria', media: 'Medios y Entretenimiento',
+            logistics: 'Logística', hospitality: 'Hostelería', energy: 'Energía y Servicios Públicos',
+            government: 'Gobierno', nonprofit: 'Sin Ánimo de Lucro', other: 'Otro',
+          },
+        },
         mobile: { label: 'Móvil' },
         website: { label: 'Sitio Web' },
-        rating: { label: 'Puntuación de Prospecto' },
+        rating: { label: 'Puntuación de Prospecto', help: 'Puntuación de calidad del prospecto (1-5 estrellas)' },
+        next_followup_date: { label: 'Próxima Fecha de Seguimiento' },
+        last_contacted_date: { label: 'Último Contacto' },
         converted_account: { label: 'Cuenta Convertida' },
         converted_contact: { label: 'Contacto Convertido' },
         converted_opportunity: { label: 'Oportunidad Convertida' },
@@ -274,7 +366,7 @@ export const esES: TranslationData = {
         address: { label: 'Dirección' },
         annual_revenue: { label: 'Ingresos Anuales' },
         number_of_employees: { label: 'Número de Empleados' },
-        notes: { label: 'Notas' },
+        notes: { label: 'Notas', help: 'Notas enriquecidas con formato' },
         do_not_call: { label: 'No Llamar' },
         email_opt_out: { label: 'Excluir de Correos' },
         disqualification_reason: {
@@ -288,23 +380,35 @@ export const esES: TranslationData = {
         },
         duplicate_of_type: {
           label: 'Duplicado De',
+          help: 'Qué objeto contiene el registro superviviente que este prospecto repite.',
           options: { crm_lead: 'Prospecto', crm_contact: 'Contacto' },
         },
         duplicate_of_lead: { label: 'Prospecto Duplicado' },
         duplicate_of_contact: { label: 'Contacto Duplicado' },
         duplicate_status: {
           label: 'Estado del Duplicado',
+          help: 'Sospechoso = marcado automáticamente en la captura. Confirmado = una persona verificó la coincidencia.',
           options: { suspected: 'Sospechoso', confirmed: 'Confirmado' },
         },
       },
       _views: {
-        all_leads: { label: 'Todos los Prospectos' },
+        all_leads: {
+          label: 'Todos los Prospectos',
+          emptyState: { title: 'Todavía no hay prospectos', message: 'Empiece creando su primer prospecto' },
+        },
         kanban_by_status: { label: 'Pipeline de Prospectos' },
         calendar_by_created: { label: 'Calendario de Prospectos' },
         gallery_view: { label: 'Galería de Prospectos' },
         my_leads: { label: 'Mis Prospectos' },
         high_priority: { label: 'Alta Prioridad' },
-        suspected_duplicates: { label: 'Duplicados Sospechosos' },
+        hot_leads: { label: '🔥 Prospectos Calientes' },
+        suspected_duplicates: {
+          label: 'Duplicados Sospechosos',
+          emptyState: {
+            title: 'Sin duplicados sospechosos',
+            message: 'Nada que revisar: se han comprobado todos los correos recapturados.',
+          },
+        },
       },
       _actions: {
         ...activityActions,
@@ -316,6 +420,9 @@ export const esES: TranslationData = {
         create_campaign: {
           label: 'Agregar a Campaña',
           successMessage: '¡Prospecto agregado a la campaña!',
+          params: {
+            crm_campaign: { label: 'Campaña' },
+          },
         },
         schedule_followup: {
           label: 'Programar Seguimiento',
@@ -327,6 +434,7 @@ export const esES: TranslationData = {
     crm_opportunity: {
       label: 'Oportunidad',
       pluralLabel: 'Oportunidades',
+      description: 'Oportunidades de venta y negocios en el pipeline',
       fields: {
         name: { label: 'Nombre de Oportunidad' },
         crm_account: { label: 'Cuenta' },
@@ -371,16 +479,28 @@ export const esES: TranslationData = {
             cold_call: 'Llamada en Frío', email_campaign: 'Campaña de Email', other: 'Otro',
           },
         },
-        competitors: { label: 'Competidores' },
-        crm_campaign: { label: 'Campaña' },
+        competitors: {
+          label: 'Competidores',
+          options: { competitor_a: 'Competidor A', competitor_b: 'Competidor B', competitor_c: 'Competidor C' },
+        },
+        crm_campaign: { label: 'Campaña', help: 'Campaña de marketing que generó esta oportunidad' },
         days_in_stage: { label: 'Días en Etapa Actual' },
-        stage_entry_date: { label: 'Fecha de Entrada a la Etapa' },
+        stage_entry_date: { label: 'Fecha de Entrada a la Etapa', help: 'Fecha en la que esta oportunidad entró en su etapa actual.' },
         is_private: { label: 'Privado' },
+        approval_status: {
+          label: 'Estado de Aprobación',
+          options: {
+            not_required: 'No Requerida', pending: 'Pendiente',
+            approved: 'Aprobada', rejected: 'Rechazada',
+          },
+        },
+        approved_date: { label: 'Fecha de Aprobación' },
         // #593 — obligatorias al cerrar la oportunidad, y el desglose de
         // motivos de pérdida las muestra en el panel de ventas, así que el
         // valor almacenado nunca debe llegar crudo al selector.
         win_reason: {
           label: 'Motivo de Ganancia',
+          help: 'Por qué se ganó este negocio. Obligatorio para cerrar una oportunidad como Ganada.',
           options: {
             better_product: 'Mejor Producto', better_price: 'Mejor Precio',
             relationship: 'Relación Existente', better_support: 'Mejor Soporte',
@@ -390,13 +510,17 @@ export const esES: TranslationData = {
         },
         loss_reason: {
           label: 'Motivo de Pérdida',
+          help: 'Por qué se perdió este negocio. Obligatorio para cerrar una oportunidad como Perdida.',
           options: {
             price: 'Precio Demasiado Alto', competitor: 'Perdida ante Competidor',
             no_budget: 'Sin Presupuesto', no_decision: 'Sin Decisión',
             timing: 'Momento Inadecuado', features: 'Funcionalidades Faltantes', other: 'Otro',
           },
         },
-        loss_details: { label: 'Detalles de Ganancia/Pérdida' },
+        loss_details: {
+          label: 'Detalles de Ganancia/Pérdida',
+          help: 'Contexto en texto libre detrás del motivo de ganancia o pérdida.',
+        },
       },
       _views: {
         open_opportunities: { label: 'Oportunidades Abiertas' },
@@ -406,6 +530,8 @@ export const esES: TranslationData = {
         deal_timeline: { label: 'Línea de Tiempo' },
         deal_gallery: { label: 'Galería de Negocios' },
         my_open_deals: { label: 'Mis Negocios Abiertos' },
+        closing_this_quarter: { label: 'Cierres de Este Trimestre' },
+        stale_opportunities: { label: '⚠️ Oportunidades Estancadas · Más Tiempo en Etapa Primero' },
       },
       _actions: {
         ...activityActions,
@@ -416,6 +542,17 @@ export const esES: TranslationData = {
         mass_update_stage: {
           label: 'Actualizar Etapa',
           successMessage: '¡Etapa de oportunidad actualizada!',
+          params: {
+            // Mismos valores que `fields.stage` — deben coincidir literalmente.
+            stage: {
+              label: 'Nueva Etapa',
+              options: {
+                prospecting: 'Prospección', qualification: 'Calificación',
+                needs_analysis: 'Análisis de Necesidades', proposal: 'Propuesta',
+                negotiation: 'Negociación', closed_won: 'Cerrada Ganada', closed_lost: 'Cerrada Perdida',
+              },
+            },
+          },
         },
         generate_quote: {
           label: 'Generar Presupuesto',
@@ -427,15 +564,36 @@ export const esES: TranslationData = {
     crm_case: {
       label: 'Caso',
       pluralLabel: 'Casos',
+      description: 'Casos de soporte y solicitudes de servicio de clientes',
       fields: {
         case_number: { label: 'Número de Caso' },
+        display_title: { label: 'Título Mostrado' },
         subject: { label: 'Asunto' },
         description: { label: 'Descripción' },
         crm_account: { label: 'Cuenta' },
         crm_contact: { label: 'Contacto' },
-        status: { label: 'Estado' },
-        priority: { label: 'Prioridad' },
-        type: { label: 'Tipo de Caso' },
+        status: {
+          label: 'Estado',
+          options: {
+            new: 'Nuevo', in_progress: 'En Curso',
+            waiting_customer: 'Esperando al Cliente', waiting_support: 'Esperando a Soporte',
+            escalated: 'Escalado', resolved: 'Resuelto', closed: 'Cerrado',
+          },
+        },
+        priority: {
+          label: 'Prioridad',
+          options: { low: 'Baja', medium: 'Media', high: 'Alta', critical: 'Crítica' },
+        },
+        priority_rank: { label: 'Rango de Prioridad' },
+        type: {
+          label: 'Tipo de Caso',
+          options: {
+            question: 'Consulta', problem: 'Problema',
+            feature_request: 'Solicitud de Funcionalidad', bug: 'Error',
+          },
+        },
+        // `email` y `chat` se dejan como préstamos: son el término habitual en
+        // español de negocios y concuerdan con `crm_campaign.channel`.
         origin: {
           label: 'Origen del Caso',
           options: { email: 'Email', phone: 'Teléfono', web: 'Web', chat: 'Chat', social_media: 'Redes Sociales' },
@@ -448,13 +606,14 @@ export const esES: TranslationData = {
         sla_due_date: { label: 'Fecha Límite SLA' },
         is_sla_violated: { label: 'SLA Incumplido' },
         is_escalated: { label: 'Escalado' },
+        escalated_date: { label: 'Fecha de Escalación' },
         escalation_reason: { label: 'Motivo de Escalación' },
-        parent_case: { label: 'Caso Principal' },
+        parent_case: { label: 'Caso Principal', help: 'Caso principal relacionado' },
         resolution: { label: 'Resolución' },
-        customer_rating: { label: 'Satisfacción del Cliente' },
+        customer_rating: { label: 'Satisfacción del Cliente', help: 'Valoración de satisfacción del cliente (1-5 estrellas)' },
         customer_feedback: { label: 'Comentarios del Cliente' },
-        customer_signature: { label: 'Firma del Cliente' },
-        internal_notes: { label: 'Notas Internas' },
+        customer_signature: { label: 'Firma del Cliente', help: 'Firma digital que confirma la resolución del caso' },
+        internal_notes: { label: 'Notas Internas', help: 'Notas internas no visibles para el cliente' },
         is_closed: { label: 'Está Cerrado' },
       },
       _views: {
@@ -463,6 +622,8 @@ export const esES: TranslationData = {
         sla_calendar: { label: 'Calendario SLA' },
         case_timeline: { label: 'Línea de Tiempo de Casos' },
         escalated_cases: { label: 'Casos Escalados' },
+        my_open_cases: { label: 'Mis Casos Abiertos' },
+        sla_at_risk: { label: '⏰ SLA en Riesgo' },
       },
       _actions: {
         ...activityActions,
@@ -482,22 +643,46 @@ export const esES: TranslationData = {
     crm_contract: {
       label: 'Contrato',
       pluralLabel: 'Contratos',
+      description: 'Contratos y acuerdos legales',
       fields: {
         contract_number: { label: 'Número de Contrato' },
         crm_account: { label: 'Cuenta' },
         crm_contact: { label: 'Contacto Principal' },
         crm_opportunity: { label: 'Oportunidad Relacionada' },
         owner: { label: 'Propietario del Contrato' },
-        status: { label: 'Estado' },
+        status: {
+          label: 'Estado',
+          options: {
+            draft: 'Borrador', in_approval: 'En Aprobación', activated: 'Activado',
+            expired: 'Expirado', terminated: 'Rescindido',
+          },
+        },
         contract_term_months: { label: 'Plazo del Contrato (Meses)' },
         start_date: { label: 'Fecha de Inicio' },
         end_date: { label: 'Fecha de Fin' },
         contract_value: { label: 'Valor del Contrato' },
-        billing_frequency: { label: 'Frecuencia de Facturación' },
-        payment_terms: { label: 'Términos de Pago' },
+        billing_frequency: {
+          label: 'Frecuencia de Facturación',
+          options: { monthly: 'Mensual', quarterly: 'Trimestral', annually: 'Anual', one_time: 'Pago Único' },
+        },
+        // Mismo juego de valores que `crm_quote.payment_terms` — tradúzcanse igual.
+        payment_terms: {
+          label: 'Términos de Pago',
+          options: {
+            net_15: 'Neto 15', net_30: 'Neto 30', net_60: 'Neto 60', net_90: 'Neto 90',
+            due_on_receipt: 'Pago a la Recepción',
+          },
+        },
         auto_renewal: { label: 'Renovación Automática' },
         renewal_notice_days: { label: 'Aviso de Renovación (Días)' },
-        contract_type: { label: 'Tipo de Contrato' },
+        contract_type: {
+          label: 'Tipo de Contrato',
+          options: {
+            subscription: 'Suscripción', service: 'Acuerdo de Servicio', license: 'Licencia',
+            partnership: 'Asociación', nda: 'Acuerdo de Confidencialidad (NDA)',
+            msa: 'Acuerdo Marco de Servicios (MSA)',
+          },
+        },
         signed_date: { label: 'Fecha de Firma' },
         signed_by: { label: 'Firmado Por' },
         document_url: { label: 'Documento de Contrato' },
@@ -516,12 +701,26 @@ export const esES: TranslationData = {
     crm_product: {
       label: 'Producto',
       pluralLabel: 'Productos',
+      description: 'Productos y servicios que ofrece la empresa',
       fields: {
         product_code: { label: 'Código de Producto' },
+        display_title: { label: 'Título Mostrado' },
         name: { label: 'Nombre de Producto' },
         description: { label: 'Descripción' },
-        category: { label: 'Categoría' },
-        family: { label: 'Familia de Producto' },
+        category: {
+          label: 'Categoría',
+          options: {
+            software: 'Software', hardware: 'Hardware', service: 'Servicio',
+            subscription: 'Suscripción', support: 'Soporte',
+          },
+        },
+        family: {
+          label: 'Familia de Producto',
+          options: {
+            enterprise: 'Soluciones para Gran Empresa', smb: 'Soluciones para PYMEs',
+            services: 'Servicios Profesionales', cloud: 'Servicios en la Nube',
+          },
+        },
         list_price: { label: 'Precio de Lista' },
         cost: { label: 'Costo' },
         sku: { label: 'SKU' },
@@ -529,6 +728,21 @@ export const esES: TranslationData = {
         reorder_point: { label: 'Punto de Reorden' },
         is_active: { label: 'Activo' },
         is_taxable: { label: 'Imponible' },
+        tax_rate: { label: 'Tasa de Impuesto por Defecto %' },
+        billing_type: {
+          label: 'Tipo de Facturación',
+          options: {
+            one_time: 'Pago Único', monthly: 'Mensual', quarterly: 'Trimestral',
+            annual: 'Anual', usage: 'Por Uso',
+          },
+        },
+        unit_of_measure: {
+          label: 'Unidad de Medida',
+          options: {
+            each: 'Unidad', license: 'Licencia', seat: 'Puesto',
+            hour: 'Hora', day: 'Día', month: 'Mes',
+          },
+        },
         product_manager: { label: 'Gerente de Producto' },
         image: { label: 'Imagen de Producto' },
         datasheet: { label: 'Ficha Técnica' },
@@ -543,14 +757,22 @@ export const esES: TranslationData = {
     crm_quote: {
       label: 'Cotización',
       pluralLabel: 'Cotizaciones',
+      description: 'Cotizaciones de precios para clientes',
       fields: {
         quote_number: { label: 'Número de Cotización' },
+        display_title: { label: 'Título Mostrado' },
         name: { label: 'Nombre de Cotización' },
         crm_account: { label: 'Cuenta' },
         crm_contact: { label: 'Contacto' },
         crm_opportunity: { label: 'Oportunidad' },
         owner: { label: 'Propietario de Cotización' },
-        status: { label: 'Estado' },
+        status: {
+          label: 'Estado',
+          options: {
+            draft: 'Borrador', in_review: 'En Revisión', presented: 'Presentada',
+            accepted: 'Aceptada', rejected: 'Rechazada', expired: 'Expirada',
+          },
+        },
         quote_date: { label: 'Fecha de Cotización' },
         expiration_date: { label: 'Fecha de Expiración' },
         subtotal: { label: 'Subtotal' },
@@ -559,7 +781,14 @@ export const esES: TranslationData = {
         tax: { label: 'Impuesto' },
         shipping_handling: { label: 'Envío y Manipulación' },
         total_price: { label: 'Precio Total' },
-        payment_terms: { label: 'Términos de Pago' },
+        // Mismo juego de valores que `crm_contract.payment_terms` — tradúzcanse igual.
+        payment_terms: {
+          label: 'Términos de Pago',
+          options: {
+            net_15: 'Neto 15', net_30: 'Neto 30', net_60: 'Neto 60', net_90: 'Neto 90',
+            due_on_receipt: 'Pago a la Recepción',
+          },
+        },
         shipping_terms: { label: 'Términos de Envío' },
         billing_address: { label: 'Dirección de Facturación' },
         shipping_address: { label: 'Dirección de Envío' },
@@ -576,24 +805,54 @@ export const esES: TranslationData = {
     crm_task: {
       label: 'Tarea',
       pluralLabel: 'Tareas',
+      description: 'Actividades y tareas pendientes',
       fields: {
         subject: { label: 'Asunto' },
         description: { label: 'Descripción' },
-        status: { label: 'Estado' },
-        priority: { label: 'Prioridad' },
-        type: { label: 'Tipo de Tarea' },
+        status: {
+          label: 'Estado',
+          options: {
+            not_started: 'No Iniciada', in_progress: 'En Curso', waiting: 'En Espera',
+            completed: 'Completada', deferred: 'Aplazada',
+          },
+        },
+        priority: {
+          label: 'Prioridad',
+          options: { low: 'Baja', normal: 'Normal', high: 'Alta', urgent: 'Urgente' },
+        },
+        priority_rank: { label: 'Rango de Prioridad' },
+        type: {
+          label: 'Tipo de Tarea',
+          options: {
+            call: 'Llamada', email: 'Email', meeting: 'Reunión',
+            follow_up: 'Seguimiento', demo: 'Demostración', other: 'Otro',
+          },
+        },
         due_date: { label: 'Fecha Límite' },
         reminder_date: { label: 'Fecha/Hora de Recordatorio' },
+        reminder_sent: { label: 'Recordatorio Enviado' },
         completed_date: { label: 'Fecha de Finalización' },
         owner: { label: 'Asignado A' },
-        related_to_type: { label: 'Tipo de Objeto Relacionado' },
+        // Los valores son nombres de objeto: se reutilizan las etiquetas ya
+        // traducidas de cada objeto en este mismo paquete (igual que
+        // `crm_event.related_to_type`).
+        related_to_type: {
+          label: 'Tipo de Objeto Relacionado',
+          options: {
+            crm_account: 'Cuenta', crm_contact: 'Contacto', crm_opportunity: 'Oportunidad',
+            crm_lead: 'Prospecto', crm_case: 'Caso',
+          },
+        },
         related_to_account: { label: 'Cuenta Relacionada' },
         related_to_contact: { label: 'Contacto Relacionado' },
         related_to_opportunity: { label: 'Oportunidad Relacionada' },
         related_to_lead: { label: 'Prospecto Relacionado' },
         related_to_case: { label: 'Caso Relacionado' },
         is_recurring: { label: 'Tarea Recurrente' },
-        recurrence_type: { label: 'Tipo de Recurrencia' },
+        recurrence_type: {
+          label: 'Tipo de Recurrencia',
+          options: { daily: 'Diaria', weekly: 'Semanal', monthly: 'Mensual', yearly: 'Anual' },
+        },
         recurrence_interval: { label: 'Intervalo de Recurrencia' },
         recurrence_end_date: { label: 'Fecha Fin de Recurrencia' },
         is_completed: { label: 'Está Completado' },
@@ -609,26 +868,49 @@ export const esES: TranslationData = {
         task_gantt: { label: 'Plan de Ejecución' },
         task_timeline: { label: 'Línea de Tiempo' },
         my_open_tasks: { label: 'Mis Tareas Abiertas' },
+        todays_tasks: { label: '📅 Mis Tareas Prioritarias' },
+        overdue_tasks: { label: '⏰ Tareas Abiertas · Más Vencidas Primero' },
       },
     },
 
     crm_campaign: {
       label: 'Campaña',
       pluralLabel: 'Campañas',
+      description: 'Campañas e iniciativas de marketing',
       fields: {
         campaign_code: { label: 'Código de Campaña' },
+        display_title: { label: 'Título Mostrado' },
         name: { label: 'Nombre de Campaña' },
         description: { label: 'Descripción' },
-        type: { label: 'Tipo de Campaña' },
-        channel: { label: 'Canal Principal' },
-        status: { label: 'Estado' },
+        type: {
+          label: 'Tipo de Campaña',
+          options: {
+            email: 'Email', webinar: 'Seminario Web', trade_show: 'Feria Comercial',
+            conference: 'Conferencia', direct_mail: 'Correo Postal', social_media: 'Redes Sociales',
+            content: 'Marketing de Contenidos', partner: 'Marketing con Socios',
+          },
+        },
+        channel: {
+          label: 'Canal Principal',
+          options: {
+            digital: 'Digital', social: 'Redes Sociales', email: 'Email',
+            events: 'Eventos', partner: 'Socios',
+          },
+        },
+        status: {
+          label: 'Estado',
+          options: {
+            planning: 'Planificación', in_progress: 'En Curso',
+            completed: 'Completada', aborted: 'Cancelada',
+          },
+        },
         start_date: { label: 'Fecha de Inicio' },
         end_date: { label: 'Fecha de Fin' },
         budgeted_cost: { label: 'Costo Presupuestado' },
         actual_cost: { label: 'Costo Real' },
         expected_revenue: { label: 'Ingresos Previstos' },
         actual_revenue: { label: 'Ingresos Reales' },
-        target_size: { label: 'Tamaño Objetivo' },
+        target_size: { label: 'Tamaño Objetivo', help: 'Número objetivo de prospectos/contactos' },
         num_sent: { label: 'Cantidad Enviada' },
         num_responses: { label: 'Número de Respuestas' },
         num_leads: { label: 'Número de Prospectos' },
@@ -637,7 +919,7 @@ export const esES: TranslationData = {
         num_won_opportunities: { label: 'Oportunidades Ganadas' },
         response_rate: { label: 'Tasa de Respuesta %' },
         roi: { label: 'ROI %' },
-        parent_campaign: { label: 'Campaña Principal' },
+        parent_campaign: { label: 'Campaña Principal', help: 'Campaña principal en la jerarquía' },
         owner: { label: 'Propietario de Campaña' },
         landing_page_url: { label: 'Página de Aterrizaje' },
         is_active: { label: 'Activo' },
@@ -717,10 +999,10 @@ export const esES: TranslationData = {
           label: 'Tipo de asistente',
           options: { contact: 'Contacto', lead: 'Prospecto', user: 'Usuario' },
         },
-        crm_contact: { label: 'Contacto' },
-        crm_lead: { label: 'Prospecto' },
-        sys_user: { label: 'Usuario' },
-        external_name: { label: 'Asistente externo' },
+        crm_contact: { label: 'Contacto', help: 'Se rellena cuando el asistente es un contacto de cliente ya existente' },
+        crm_lead: { label: 'Prospecto', help: 'Se rellena cuando el asistente sigue siendo un prospecto sin convertir' },
+        sys_user: { label: 'Usuario', help: 'Se rellena cuando el asistente es un compañero de la empresa' },
+        external_name: { label: 'Asistente externo', help: 'Nombre de un asistente que no es un registro del CRM' },
         response: {
           label: 'Respuesta',
           options: {
@@ -743,8 +1025,8 @@ export const esES: TranslationData = {
       fields: {
         member_number: { label: 'Número de Miembro' },
         crm_campaign: { label: 'Campaña' },
-        crm_lead: { label: 'Prospecto' },
-        crm_contact: { label: 'Contacto' },
+        crm_lead: { label: 'Prospecto', help: 'Se rellena cuando el miembro era un Prospecto en el momento de la inscripción' },
+        crm_contact: { label: 'Contacto', help: 'Se rellena cuando el miembro es un Contacto existente' },
         status: {
           label: 'Estado',
           options: {
@@ -774,8 +1056,8 @@ export const esES: TranslationData = {
         crm_product: { label: 'Producto' },
         description: { label: 'Descripción' },
         quantity: { label: 'Cantidad' },
-        list_price: { label: 'Precio de Lista' },
-        unit_price: { label: 'Precio de Venta' },
+        list_price: { label: 'Precio de Lista', help: 'Se rellena automáticamente desde product.list_price' },
+        unit_price: { label: 'Precio de Venta', help: 'Precio unitario negociado (puede diferir del precio de lista)' },
         discount: { label: 'Descuento (%)' },
         total_price: { label: 'Total' },
         line_number: { label: 'Nº de Línea' },
@@ -806,11 +1088,53 @@ export const esES: TranslationData = {
     crm_enterprise: {
       label: 'HotCRM',
       description: 'Gestión de relaciones con clientes para ventas, servicio y marketing',
+      // Indexado por el `id` del nodo de navegación (espacio de nombres plano,
+      // sea cual sea la profundidad del nodo).
       navigation: {
         group_activity: { label: 'Actividad' },
+        nav_event: { label: 'Eventos' },
+        nav_event_calendar: { label: 'Calendario' },
+        nav_event_history: { label: 'Historial de Interacciones' },
+        nav_activity_dashboard: { label: 'Actividad de Ventas' },
+        nav_my_calendar: { label: 'Mi Calendario' },
+        nav_home: { label: 'Inicio' },
+
         group_sales: { label: 'Ventas' },
+        nav_lead: { label: 'Prospectos' },
+        nav_account: { label: 'Cuentas' },
+        nav_account_workbench: { label: 'Mesa de Trabajo de Cuentas' },
+        nav_contact: { label: 'Contactos' },
+        nav_opportunity: { label: 'Oportunidades' },
+        nav_pipeline: { label: 'Pipeline' },
+        nav_quote: { label: 'Cotizaciones' },
+        nav_contract: { label: 'Contratos' },
+        nav_sales_dashboard: { label: 'Rendimiento de Ventas' },
+
+        group_work: { label: 'Mi Trabajo' },
+        nav_my_tasks: { label: 'Mis Tareas' },
+        nav_my_deals: { label: 'Mis Negocios' },
+        nav_my_leads: { label: 'Mis Prospectos' },
+        nav_my_cases: { label: 'Mis Casos' },
+        nav_all_tasks: { label: 'Todas las Tareas' },
+
         group_service: { label: 'Servicio' },
+        nav_case: { label: 'Casos' },
+        nav_knowledge: { label: 'Conocimiento' },
+        nav_service_dashboard: { label: 'Resumen de Servicio' },
+
         group_marketing: { label: 'Marketing' },
+        nav_campaign: { label: 'Campañas' },
+        nav_product: { label: 'Productos' },
+
+        group_insights: { label: 'Análisis' },
+        nav_crm_dashboard: { label: 'Resumen CRM' },
+        nav_forecast: { label: 'Previsiones' },
+        nav_report_pipeline_coverage: { label: 'Cobertura del Pipeline' },
+        nav_report_lead_inflow: { label: 'Entrada de Prospectos' },
+        nav_report_sla: { label: 'Cumplimiento de SLA' },
+
+        group_approvals: { label: 'Aprobaciones' },
+        nav_approval_requests: { label: 'Bandeja de Entrada' },
       },
     },
   },
@@ -905,6 +1229,12 @@ export const esES: TranslationData = {
         open_pipeline_by_owner: { title: 'Pipeline abierto por responsable', description: 'Valor del pipeline en curso, número de negocios y probabilidad media de cierre por comercial' },
         quota_attainment_by_rep: { title: 'Cumplimiento de cuota por representante', description: 'Cuota del trimestre actual, ingresos cerrados y cumplimiento por representante, según instantáneas de pronóstico' },
         pipeline_stage_by_source: { title: 'Pipeline por Etapa × Origen', description: 'Tabla cruzada del importe de oportunidades abiertas por etapa y origen' },
+        win_rate_12m: { title: 'Tasa de éxito (12M)', description: 'Negocios ganados como porcentaje de todos los negocios resueltos en los últimos 12 meses' },
+        won_deals_12m: { title: 'Negocios ganados (12M)', description: 'El numerador de la tasa de éxito' },
+        lost_deals_12m: { title: 'Negocios perdidos (12M)', description: 'La otra mitad del denominador de la tasa de éxito' },
+        win_rate_by_owner: { title: 'Ganados / perdidos por representante', description: 'Negocios ganados, negocios perdidos y tasa de éxito por representante — últimos 12 meses' },
+        win_rate_by_lead_source: { title: 'Ganados / perdidos por origen del prospecto', description: 'Qué orígenes producen negocios que realmente se cierran — últimos 12 meses' },
+        loss_reason_breakdown: { title: 'Por qué perdemos', description: 'Negocios perdidos por motivo — últimos 12 meses' },
       },
     },
     service_dashboard: {
@@ -922,6 +1252,53 @@ export const esES: TranslationData = {
         sla_compliance_gauge: { title: 'Cumplimiento de SLA', description: 'Porcentaje de casos resueltos dentro del SLA en este período' },
         open_cases_by_priority: { title: 'Casos abiertos por prioridad', description: 'Casos abiertos y su tasa de incumplimiento de SLA, desglosados por prioridad' },
       },
+    },
+  },
+
+  // `title` / `subtitle` son las propiedades del componente `page:header`.
+  // Los marcadores `{…}` se sustituyen sobre la cadena TRADUCIDA, así que el
+  // token debe conservarse tal cual: traducido, no resuelve y se ve vacío.
+  pages: {
+    account_detail_page: {
+      label: 'Detalle de Cuenta',
+      description: 'Página de registro de cuenta por slots: cabecera personalizada + feed de discusión permanente.',
+    },
+    account_workbench: {
+      label: 'Mesa de Trabajo de Cuentas',
+      description: 'Lista de cuentas curada para el equipo comercial: solo filtros rápidos, sin gestión de vistas.',
+    },
+    app_launcher_page: {
+      label: 'Lanzador de Aplicaciones',
+      description: 'Punto de acceso central a todas las aplicaciones',
+      subtitle: 'Seleccione una aplicación para empezar',
+    },
+    case_detail_page: {
+      label: 'Detalle de Caso',
+      description: 'Página de caso para el agente de servicio: datos destacados, progreso del SLA, detalles y cronología de actividad.',
+      title: '{case_number} · {subject}',
+      subtitle: '{crm_account}',
+    },
+    lead_detail_page: {
+      label: 'Detalle de Prospecto',
+      description: 'Página completa de detalle del prospecto, con datos destacados, detalles e información relacionada',
+      title: '{first_name} {last_name}',
+      subtitle: '{company}',
+    },
+    opportunity_detail_page: {
+      label: 'Detalle de Oportunidad',
+      description: 'Página completa de detalle de la oportunidad, con recorrido de etapas, datos destacados, detalles y listas relacionadas',
+      title: '{name}',
+      subtitle: '{crm_account}',
+    },
+    sales_home_page: {
+      label: 'Inicio de Ventas',
+      description: 'Página de inicio del equipo comercial con métricas clave y acciones rápidas',
+      title: 'Panel de Ventas',
+      subtitle: 'Bienvenido de nuevo, {current_user.first_name}',
+    },
+    utility_bar_page: {
+      label: 'Barra de Utilidades',
+      description: 'Barra de acceso rápido con herramientas flotantes',
     },
   },
 };

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -53,27 +53,67 @@ const activityActions = {
   },
 };
 
+/**
+ * 共有ピックリスト（`_picklists.ts`）は複数オブジェクトで同一の値集合を持つ。
+ * 訳語がオブジェクトごとにぶれると、同じピックリストが画面によって別の言葉で
+ * 表示される不具合になる（#494）。ここで一度だけ定義して各所に展開する。
+ * キーは表示ラベルではなく **保存値** であることに注意（#494 の主因）。
+ */
+const salutationOptions = { mr: 'Mr.', ms: 'Ms.', mrs: 'Mrs.', dr: '博士', prof: '教授' };
+
+const industryOptions = {
+  technology: 'テクノロジー', software: 'ソフトウェア / SaaS', finance: '金融',
+  healthcare: 'ヘルスケア', retail: '小売', manufacturing: '製造',
+  education: '教育', real_estate: '不動産', media: 'メディア・エンタメ',
+  logistics: '物流', hospitality: 'ホスピタリティ', energy: 'エネルギー・公益',
+  government: '政府・行政', nonprofit: '非営利', other: 'その他',
+};
+
+const leadSourceOptions = {
+  web: 'ウェブ', referral: '紹介', event: 'イベント・展示会',
+  webinar: 'ウェビナー', partner: 'パートナー', advertisement: '広告',
+  paid_search: '有料検索', social: 'ソーシャルメディア', content: 'コンテンツ・ブログ',
+  cold_call: 'コールドコール', email_campaign: 'メールキャンペーン', other: 'その他',
+};
+
+const paymentTermsOptions = {
+  net_15: '15 日以内払い', net_30: '30 日以内払い', net_60: '60 日以内払い',
+  net_90: '90 日以内払い', due_on_receipt: '請求書受領時払い',
+};
+
+const opportunityStageOptions = {
+  prospecting: '見込み調査', qualification: '選定',
+  needs_analysis: 'ニーズ分析', proposal: '提案',
+  negotiation: '交渉', closed_won: '成立', closed_lost: '不成立',
+};
+
+/** `related_to_type` の値は **オブジェクト名**。各オブジェクトの label と必ず一致させる。 */
+const relatedToTypeOptions = {
+  crm_account: '取引先', crm_contact: '取引先責任者', crm_opportunity: '商談',
+  crm_lead: 'リード', crm_case: 'ケース',
+};
+
 export const jaJP: TranslationData = {
   objects: {
     crm_account: {
       label: '取引先',
       pluralLabel: '取引先',
+      description: '当社と取引のある企業・組織',
       fields: {
         account_number: { label: '取引先番号' },
         name: { label: '取引先名', help: '会社または組織の正式名称' },
+        name_normalized: {
+          label: '取引先名（正規化）',
+          help: 'リード変換の照合キー。取引先名を小文字化し、前後の空白を除去して、内部の連続する空白を 1 つにまとめたもの。account_protection フックが自動で維持します — 直接編集しないでください。',
+        },
+        display_title: { label: '表示名' },
         type: {
           label: 'タイプ',
           options: { prospect: '見込み客', customer: '顧客', partner: 'パートナー', former: '過去の取引先' },
         },
         industry: {
           label: '業種',
-          options: {
-            technology: 'テクノロジー', software: 'ソフトウェア / SaaS', finance: '金融',
-            healthcare: 'ヘルスケア', retail: '小売', manufacturing: '製造',
-            education: '教育', real_estate: '不動産', media: 'メディア・エンタメ',
-            logistics: '物流', hospitality: 'ホスピタリティ', energy: 'エネルギー・公益',
-            government: '政府・行政', nonprofit: '非営利', other: 'その他',
-          },
+          options: { ...industryOptions },
         },
         annual_revenue: { label: '年間売上' },
         number_of_employees: { label: '従業員数' },
@@ -85,13 +125,31 @@ export const jaJP: TranslationData = {
           help: '請求先住所から導出 — テリトリー共有ルールが照合する国コード。',
         },
         office_location: { label: 'オフィス所在地' },
-        owner: { label: '取引先責任者' },
-        parent_account: { label: '親取引先' },
+        owner: { label: '取引先所有者' },
+        parent_account: { label: '親取引先', help: '階層構造における親会社' },
         description: { label: '説明' },
         is_active: { label: '有効' },
         last_activity_date: { label: '最終活動日' },
         brand_color: { label: 'ブランドカラー' },
         logo: { label: '会社ロゴ' },
+        tier: {
+          label: '顧客ランク',
+          options: {
+            strategic: '戦略顧客', enterprise: 'エンタープライズ',
+            mid_market: 'ミッドマーケット', smb: '中小企業',
+          },
+        },
+        segment: {
+          label: '顧客セグメント',
+          options: { net_new: '新規獲得', growth: '成長', at_risk: 'リスクあり', stable: '安定' },
+        },
+        health_score: {
+          label: 'ヘルススコア',
+          help: 'カスタマーサクセス担当（CSM）が管理する健全性の指標',
+          options: { healthy: '良好', watching: '要観察', at_risk: 'リスクあり', churning: '解約進行中' },
+        },
+        renewal_owner: { label: '更新担当者 (CSM)' },
+        next_renewal_date: { label: '次回更新日' },
       },
       _views: {
         all_accounts: { label: '全取引先', description: '売上と業種を含む取引先の一覧' },
@@ -99,6 +157,8 @@ export const jaJP: TranslationData = {
         account_map: { label: '取引先マップ', description: '取引先の地理的分布' },
         enterprise_accounts: { label: 'エンタープライズ取引先', description: '年商最上位の主要顧客' },
         my_accounts: { label: '私の取引先', description: '自分が所有する取引先' },
+        renewals_due: { label: '🔄 更新予定' },
+        at_risk_accounts: { label: '⚠️ リスクのある取引先' },
       },
       _actions: { ...activityActions },
     },
@@ -106,8 +166,9 @@ export const jaJP: TranslationData = {
     crm_contact: {
       label: '取引先責任者',
       pluralLabel: '取引先責任者',
+      description: '取引先に所属する担当者',
       fields: {
-        salutation: { label: '敬称' },
+        salutation: { label: '敬称', options: { ...salutationOptions } },
         first_name: { label: '名' },
         last_name: { label: '姓' },
         full_name: { label: '氏名' },
@@ -124,18 +185,18 @@ export const jaJP: TranslationData = {
             hr: '人事部', operations: 'オペレーション部',
           },
         },
-        owner: { label: '所有者' },
+        owner: { label: '取引先責任者の所有者' },
         description: { label: '説明' },
-        is_primary: { label: '主担当者' },
+        is_primary: { label: '主担当者', help: 'この取引先の主担当者かどうか' },
         avatar: { label: 'プロフィール画像' },
-        reports_to: { label: '上司' },
+        reports_to: { label: '上司', help: '直属の上司・管理者' },
         mailing_street: { label: '郵送先 番地' },
         mailing_city: { label: '郵送先 市区町村' },
         mailing_state: { label: '郵送先 都道府県' },
         mailing_postal_code: { label: '郵便番号' },
         mailing_country: { label: '郵送先 国' },
         birthdate: { label: '生年月日' },
-        lead_source: { label: 'リードソース' },
+        lead_source: { label: 'リードソース', options: { ...leadSourceOptions } },
         do_not_call: { label: '電話拒否' },
         email_opt_out: { label: 'メール配信停止' },
         last_contacted_date: { label: '最終接触日時' },
@@ -154,6 +215,10 @@ export const jaJP: TranslationData = {
         },
         send_email: {
           label: 'メール送信',
+          params: {
+            subject: { label: '件名' },
+            body: { label: '本文' },
+          },
         },
       },
     },
@@ -165,27 +230,40 @@ export const jaJP: TranslationData = {
       fields: {
         article_number: { label: '記事番号' },
         title: { label: 'タイトル' },
-        summary: { label: '要約' },
-        body: { label: '本文' },
+        display_title: { label: '表示名' },
+        summary: { label: '要約', help: '検索結果や AI の引用に表示される 1 段落の要約。' },
+        body: { label: '本文', help: '記事の本文（Markdown）。' },
         category: {
           label: 'カテゴリ',
           options: {
             getting_started: 'はじめに', how_to: 'ハウツー',
             troubleshooting: 'トラブルシューティング', billing: '請求と料金', api: 'API と連携',
+            release_notes: 'リリースノート', policy: 'ポリシー',
           },
         },
-        tags: { label: 'タグ', options: { auth: '認証', sso: 'SSO', mobile: 'モバイル', email: 'メール' } },
+        tags: {
+          label: 'タグ',
+          options: {
+            auth: '認証', sso: 'SSO', mobile: 'モバイル', email: 'メール',
+            reports: 'レポート', performance: 'パフォーマンス',
+            data_import: 'データインポート', webhooks: 'Webhook',
+          },
+        },
         status: {
           label: 'ステータス',
           options: { draft: '下書き', in_review: 'レビュー中', published: '公開済み', archived: 'アーカイブ' },
         },
-        audience: { label: '対象', options: { public: '公開', internal: '社内' } },
+        audience: {
+          label: '対象',
+          help: '公開記事はカスタマーポータルに表示され、社内記事はエージェントのみが閲覧できます。',
+          options: { public: '公開', internal: '社内' },
+        },
         language: {
           label: '言語',
           options: { en: '英語', zh_cn: '簡体字中国語', es_es: 'スペイン語', ja_jp: '日本語' },
         },
         owner: { label: '所有者' },
-        related_to_case: { label: '元のケース' },
+        related_to_case: { label: '元のケース', help: 'この記事の元になったケース（任意）。' },
         published_at: { label: '公開日時' },
         last_reviewed_at: { label: '最終レビュー' },
         view_count: { label: '閲覧数' },
@@ -209,21 +287,47 @@ export const jaJP: TranslationData = {
         period: { label: '期間', options: { month: '月次', quarter: '四半期' } },
         period_start: { label: '期間開始' },
         period_end: { label: '期間終了' },
-        period_label: { label: '期間' },
-        snapshot_date: { label: 'スナップショット日' },
+        period_label: {
+          label: '期間',
+          help: '「2026 年第 3 四半期」「2026 年 8 月」のような読みやすい期間ラベル。',
+        },
+        display_title: { label: '表示名' },
+        snapshot_date: { label: 'スナップショット日', help: 'このスナップショットを取得した日。' },
         source: {
           label: 'ソース',
           options: { scheduled: '定期スナップショット', ai: 'AI スキル', manual: '手動入力' },
         },
         quota: { label: 'クォータ' },
-        pipeline_amount: { label: 'パイプライン' },
-        best_case_amount: { label: 'ベストケース' },
-        commit_amount: { label: 'コミット' },
-        closed_amount: { label: 'クローズ' },
-        expected_amount: { label: '予想' },
-        attainment_pct: { label: '達成率 %' },
-        coverage_ratio: { label: 'カバレッジ' },
+        pipeline_amount: {
+          label: 'パイプライン',
+          help: 'この期間にクローズ予定のオープン商談の合計金額（ステージを問わない）。',
+        },
+        best_case_amount: {
+          label: 'ベストケース',
+          help: '売上予測カテゴリが「ベストケース」または「コミット」のオープン商談。',
+        },
+        commit_amount: {
+          label: 'コミット',
+          help: '売上予測カテゴリが「コミット」のオープン商談（担当者がコミット済み）。',
+        },
+        closed_amount: { label: 'クローズ', help: 'この期間にすでに成立した金額。' },
+        expected_amount: {
+          label: '予想',
+          help: 'クローズ + コミット — 担当者が無理なく着地を見込める金額。',
+        },
+        attainment_pct: {
+          label: '達成率 %',
+          help: '（クローズ ÷ クォータ）× 100。クォータが負の場合はガードされます。',
+        },
+        coverage_ratio: {
+          label: 'カバレッジ',
+          help: 'パイプライン ÷（クォータ − クローズ）。パイプラインが十分かを確認する指標。',
+        },
         notes: { label: 'メモ' },
+        seed_key: {
+          label: 'シードキー',
+          help: 'デモデータの識別子。シードローダーだけが書き込み、実際のスナップショットでは常に空です。',
+        },
       },
       _views: {
         all_forecasts: { label: 'すべてのフォーキャスト' },
@@ -235,13 +339,25 @@ export const jaJP: TranslationData = {
     crm_lead: {
       label: 'リード',
       pluralLabel: 'リード',
+      description: 'まだ適格判定を受けていない見込み客',
       fields: {
+        salutation: { label: '敬称', options: { ...salutationOptions } },
         first_name: { label: '名' },
         last_name: { label: '姓' },
+        full_name: { label: '氏名' },
+        display_title: { label: '表示名' },
         company: { label: '会社名' },
+        company_normalized: {
+          label: '会社名（正規化）',
+          help: 'リード変換の照合キー。会社名を小文字化し、前後の空白を除去して、内部の連続する空白を 1 つにまとめたもの。lead_duplicate_check フックが自動で維持します — 直接編集しないでください。',
+        },
         title: { label: '役職' },
         email: { label: 'メール' },
         phone: { label: '電話' },
+        industry: {
+          label: '業種',
+          options: { ...industryOptions },
+        },
         status: {
           label: 'ステータス',
           options: {
@@ -249,34 +365,25 @@ export const jaJP: TranslationData = {
             unqualified: '不適格', converted: '取引開始済み',
           },
         },
-        lead_source: {
-          label: 'リードソース',
-          options: {
-            web: 'ウェブ', referral: '紹介', event: 'イベント・展示会',
-            webinar: 'ウェビナー', partner: 'パートナー', advertisement: '広告',
-            paid_search: '有料検索', social: 'ソーシャルメディア', content: 'コンテンツ・ブログ',
-            cold_call: 'コールドコール', email_campaign: 'メールキャンペーン', other: 'その他',
-          },
-        },
+        lead_source: { label: 'リードソース', options: { ...leadSourceOptions } },
         owner: { label: 'リード所有者' },
         is_converted: { label: '取引開始済み' },
         description: { label: '説明' },
-        salutation: { label: '敬称' },
-        full_name: { label: '氏名' },
-        industry: { label: '業界' },
         mobile: { label: '携帯電話' },
-        website: { label: 'ウェブサイト' },
-        rating: { label: 'リードスコア' },
-        converted_account: { label: '変換後アカウント' },
-        converted_contact: { label: '変換後連絡先' },
-        converted_opportunity: { label: '変換後商談' },
+        website: { label: 'Webサイト' },
+        rating: { label: 'リードスコア', help: 'リードの品質スコア（1〜5 段階）' },
+        converted_account: { label: '変換後の取引先' },
+        converted_contact: { label: '変換後の取引先責任者' },
+        converted_opportunity: { label: '変換後の商談' },
         converted_date: { label: '変換日' },
         address: { label: '住所' },
         annual_revenue: { label: '年間売上' },
         number_of_employees: { label: '従業員数' },
-        notes: { label: 'メモ' },
+        notes: { label: 'メモ', help: '書式設定に対応したリッチテキストのメモ' },
         do_not_call: { label: '電話拒否' },
         email_opt_out: { label: 'メール配信停止' },
+        next_followup_date: { label: '次回フォローアップ日' },
+        last_contacted_date: { label: '最終接触日時' },
         disqualification_reason: {
           label: '不適格理由',
           help: 'ステータスが「不適格」の場合は必須',
@@ -288,23 +395,35 @@ export const jaJP: TranslationData = {
         },
         duplicate_of_type: {
           label: '重複対象',
-          options: { crm_lead: 'リード', crm_contact: '連絡先' },
+          help: '重複元として残るレコードが属するオブジェクトの種別。',
+          options: { crm_lead: 'リード', crm_contact: '取引先責任者' },
         },
-        duplicate_of_lead: { label: '重複リード' },
-        duplicate_of_contact: { label: '重複連絡先' },
+        duplicate_of_lead: { label: '重複するリード' },
+        duplicate_of_contact: { label: '重複する取引先責任者' },
         duplicate_status: {
           label: '重複ステータス',
+          help: '「重複の疑い」= 登録時に自動で付与。「重複確定」= 担当者が一致を確認済み。',
           options: { suspected: '重複の疑い', confirmed: '重複確定' },
         },
       },
       _views: {
-        all_leads: { label: '全リード' },
+        all_leads: {
+          label: '全リード',
+          emptyState: { title: 'リードがまだありません', message: '最初のリードを作成して始めましょう' },
+        },
         kanban_by_status: { label: 'リードパイプライン' },
         calendar_by_created: { label: 'リードカレンダー' },
         gallery_view: { label: 'リードカード' },
         my_leads: { label: '私のリード' },
         high_priority: { label: '優先度高' },
-        suspected_duplicates: { label: '重複の疑いがあるリード' },
+        hot_leads: { label: '🔥 ホットリード' },
+        suspected_duplicates: {
+          label: '重複の疑いがあるリード',
+          emptyState: {
+            title: '重複の疑いはありません',
+            message: '確認は不要です — 再登録されたメールアドレスはすべてチェック済みです。',
+          },
+        },
       },
       _actions: {
         ...activityActions,
@@ -316,6 +435,9 @@ export const jaJP: TranslationData = {
         create_campaign: {
           label: 'キャンペーンに追加',
           successMessage: 'キャンペーンに追加しました！',
+          params: {
+            crm_campaign: { label: 'キャンペーン' },
+          },
         },
         schedule_followup: {
           label: 'フォローアップを設定',
@@ -327,6 +449,7 @@ export const jaJP: TranslationData = {
     crm_opportunity: {
       label: '商談',
       pluralLabel: '商談',
+      description: 'パイプライン上の商談・案件',
       fields: {
         name: { label: '商談名' },
         crm_account: { label: '取引先' },
@@ -335,12 +458,8 @@ export const jaJP: TranslationData = {
         amount: { label: '金額' },
         expected_revenue: { label: '期待収益' },
         stage: {
-          label: 'フェーズ',
-          options: {
-            prospecting: '見込み調査', qualification: '選定',
-            needs_analysis: 'ニーズ分析', proposal: '提案',
-            negotiation: '交渉', closed_won: '成立', closed_lost: '不成立',
-          },
+          label: 'ステージ',
+          options: { ...opportunityStageOptions },
         },
         probability: { label: '確度 (%)' },
         close_date: { label: '完了予定日' },
@@ -356,30 +475,31 @@ export const jaJP: TranslationData = {
         forecast_category: {
           label: '売上予測カテゴリ',
           options: {
-            pipeline: 'パイプライン', best_case: '最良ケース',
+            pipeline: 'パイプライン', best_case: 'ベストケース',
             commit: 'コミット', omitted: '除外', closed: '完了',
           },
         },
         description: { label: '説明' },
         next_step: { label: '次のステップ' },
-        lead_source: {
-          label: 'リードソース',
-          options: {
-            web: 'ウェブ', referral: '紹介', event: 'イベント・展示会',
-            webinar: 'ウェビナー', partner: 'パートナー', advertisement: '広告',
-            paid_search: '有料検索', social: 'ソーシャルメディア', content: 'コンテンツ・ブログ',
-            cold_call: 'コールドコール', email_campaign: 'メールキャンペーン', other: 'その他',
-          },
+        lead_source: { label: 'リードソース', options: { ...leadSourceOptions } },
+        competitors: {
+          label: '競合他社',
+          options: { competitor_a: '競合 A', competitor_b: '競合 B', competitor_c: '競合 C' },
         },
-        competitors: { label: '競合他社' },
-        crm_campaign: { label: 'キャンペーン' },
+        crm_campaign: { label: 'キャンペーン', help: 'この商談を生み出したマーケティングキャンペーン' },
         days_in_stage: { label: '現ステージ滞在日数' },
-        stage_entry_date: { label: 'ステージ開始日' },
+        stage_entry_date: { label: 'ステージ開始日', help: 'この商談が現在のステージに入った日。' },
         is_private: { label: '非公開' },
+        approval_status: {
+          label: '承認ステータス',
+          options: { not_required: '承認不要', pending: '承認待ち', approved: '承認済み', rejected: '却下' },
+        },
+        approved_date: { label: '承認日' },
         // #593 — 商談クローズ時に必須。失注理由は営業ダッシュボードの
         // 内訳ウィジェットにも出るため、保存値がそのまま画面に出てはいけない。
         win_reason: {
           label: '受注理由',
+          help: '受注に至った理由。商談を「成立」でクローズする際に必須です。',
           options: {
             better_product: '製品が優れている', better_price: '価格が優れている',
             relationship: '既存の関係', better_support: 'サポートが優れている',
@@ -389,13 +509,14 @@ export const jaJP: TranslationData = {
         },
         loss_reason: {
           label: '失注理由',
+          help: '失注した理由。商談を「不成立」でクローズする際に必須です。',
           options: {
             price: '価格が高すぎる', competitor: '競合他社に敗北',
             no_budget: '予算なし', no_decision: '意思決定なし',
             timing: 'タイミング不適', features: '機能不足', other: 'その他',
           },
         },
-        loss_details: { label: '受注・失注の詳細' },
+        loss_details: { label: '受注・失注の詳細', help: '受注・失注理由の補足説明（自由記述）。' },
       },
       _views: {
         open_opportunities: { label: '進行中の商談' },
@@ -405,6 +526,8 @@ export const jaJP: TranslationData = {
         deal_timeline: { label: '商談タイムライン' },
         deal_gallery: { label: '商談カード' },
         my_open_deals: { label: '私のオープン商談' },
+        stale_opportunities: { label: '⚠️ 停滞商談 · ステージ滞在が長い順' },
+        closing_this_quarter: { label: '今四半期にクローズ予定' },
       },
       _actions: {
         ...activityActions,
@@ -415,6 +538,12 @@ export const jaJP: TranslationData = {
         mass_update_stage: {
           label: 'ステージ更新',
           successMessage: '商談ステージを更新しました！',
+          params: {
+            stage: {
+              label: '新しいステージ',
+              options: { ...opportunityStageOptions },
+            },
+          },
         },
         generate_quote: {
           label: '見積を作成',
@@ -426,15 +555,34 @@ export const jaJP: TranslationData = {
     crm_case: {
       label: 'ケース',
       pluralLabel: 'ケース',
+      description: 'カスタマーサポートのケースとサービス依頼',
       fields: {
         case_number: { label: 'ケース番号' },
         subject: { label: '件名' },
+        display_title: { label: '表示名' },
         description: { label: '説明' },
-        crm_account: { label: 'アカウント' },
-        crm_contact: { label: '連絡先' },
-        status: { label: 'ステータス' },
-        priority: { label: '優先度' },
-        type: { label: 'ケース種別' },
+        crm_account: { label: '取引先' },
+        crm_contact: { label: '取引先責任者' },
+        status: {
+          label: 'ステータス',
+          options: {
+            new: '新規', in_progress: '対応中',
+            waiting_customer: '顧客の回答待ち', waiting_support: 'サポートの回答待ち',
+            escalated: 'エスカレーション済', resolved: '解決済', closed: 'クローズ済',
+          },
+        },
+        priority: {
+          label: '優先度',
+          options: { low: '低', medium: '中', high: '高', critical: '重大' },
+        },
+        priority_rank: { label: '優先度ランク' },
+        type: {
+          label: 'ケース種別',
+          options: {
+            question: '問い合わせ', problem: '不具合',
+            feature_request: '機能要望', bug: 'バグ',
+          },
+        },
         origin: {
           label: 'ケース発生元',
           options: { email: 'メール', phone: '電話', web: 'ウェブ', chat: 'チャット', social_media: 'ソーシャルメディア' },
@@ -447,13 +595,14 @@ export const jaJP: TranslationData = {
         sla_due_date: { label: 'SLA期限' },
         is_sla_violated: { label: 'SLA違反' },
         is_escalated: { label: 'エスカレーション済' },
+        escalated_date: { label: 'エスカレーション日' },
         escalation_reason: { label: 'エスカレーション理由' },
-        parent_case: { label: '親ケース' },
+        parent_case: { label: '親ケース', help: '関連する親ケース' },
         resolution: { label: '解決内容' },
-        customer_rating: { label: '顧客満足度' },
+        customer_rating: { label: '顧客満足度', help: '顧客満足度の評価（1〜5 段階）' },
         customer_feedback: { label: '顧客フィードバック' },
-        customer_signature: { label: '顧客署名' },
-        internal_notes: { label: '内部メモ' },
+        customer_signature: { label: '顧客署名', help: 'ケースの解決を確認する電子署名' },
+        internal_notes: { label: '内部メモ', help: '顧客には表示されない社内向けメモ' },
         is_closed: { label: 'クローズ済' },
       },
       _views: {
@@ -462,6 +611,8 @@ export const jaJP: TranslationData = {
         sla_calendar: { label: 'SLA カレンダー' },
         case_timeline: { label: 'ケースタイムライン' },
         escalated_cases: { label: 'エスカレートしたケース' },
+        my_open_cases: { label: '私のオープンケース' },
+        sla_at_risk: { label: '⏰ SLA リスクあり' },
       },
       _actions: {
         ...activityActions,
@@ -481,22 +632,39 @@ export const jaJP: TranslationData = {
     crm_contract: {
       label: '契約',
       pluralLabel: '契約',
+      description: '顧客と締結した法的な契約・合意',
       fields: {
         contract_number: { label: '契約番号' },
-        crm_account: { label: 'アカウント' },
-        crm_contact: { label: '主担当連絡先' },
+        crm_account: { label: '取引先' },
+        crm_contact: { label: '主担当者' },
         crm_opportunity: { label: '関連商談' },
         owner: { label: '契約担当者' },
-        status: { label: 'ステータス' },
+        status: {
+          label: 'ステータス',
+          options: {
+            draft: '下書き', in_approval: '承認中', activated: '有効',
+            expired: '期限切れ', terminated: '解約',
+          },
+        },
         contract_term_months: { label: '契約期間（月）' },
         start_date: { label: '開始日' },
         end_date: { label: '終了日' },
         contract_value: { label: '契約金額' },
-        billing_frequency: { label: '請求頻度' },
-        payment_terms: { label: '支払条件' },
+        billing_frequency: {
+          label: '請求頻度',
+          options: { monthly: '月次', quarterly: '四半期', annually: '年次', one_time: '一括' },
+        },
+        payment_terms: { label: '支払条件', options: { ...paymentTermsOptions } },
         auto_renewal: { label: '自動更新' },
         renewal_notice_days: { label: '更新通知（日）' },
-        contract_type: { label: '契約種別' },
+        contract_type: {
+          label: '契約種別',
+          options: {
+            subscription: 'サブスクリプション契約', service: 'サービス契約',
+            license: 'ライセンス契約', partnership: 'パートナーシップ契約',
+            nda: '秘密保持契約 (NDA)', msa: '基本契約 (MSA)',
+          },
+        },
         signed_date: { label: '署名日' },
         signed_by: { label: '署名者' },
         document_url: { label: '契約書類' },
@@ -515,12 +683,26 @@ export const jaJP: TranslationData = {
     crm_product: {
       label: '製品',
       pluralLabel: '製品',
+      description: '自社が提供する製品・サービス',
       fields: {
         product_code: { label: '製品コード' },
         name: { label: '製品名' },
+        display_title: { label: '表示名' },
         description: { label: '説明' },
-        category: { label: 'カテゴリ' },
-        family: { label: '製品ファミリ' },
+        category: {
+          label: 'カテゴリ',
+          options: {
+            software: 'ソフトウェア', hardware: 'ハードウェア', service: 'サービス',
+            subscription: 'サブスクリプション', support: 'サポート',
+          },
+        },
+        family: {
+          label: '製品ファミリ',
+          options: {
+            enterprise: 'エンタープライズ向けソリューション', smb: '中小企業向けソリューション',
+            services: 'プロフェッショナルサービス', cloud: 'クラウドサービス',
+          },
+        },
         list_price: { label: '定価' },
         cost: { label: 'コスト' },
         sku: { label: 'SKU' },
@@ -528,6 +710,21 @@ export const jaJP: TranslationData = {
         reorder_point: { label: '発注点' },
         is_active: { label: '有効' },
         is_taxable: { label: '課税対象' },
+        tax_rate: { label: '既定の税率 %' },
+        billing_type: {
+          label: '課金タイプ',
+          options: {
+            one_time: '一括', monthly: '月次', quarterly: '四半期',
+            annual: '年次', usage: '従量課金',
+          },
+        },
+        unit_of_measure: {
+          label: '単位',
+          options: {
+            each: '個', license: 'ライセンス', seat: 'シート',
+            hour: '時間', day: '日', month: '月',
+          },
+        },
         product_manager: { label: 'プロダクトマネージャー' },
         image: { label: '製品画像' },
         datasheet: { label: 'データシート' },
@@ -542,14 +739,22 @@ export const jaJP: TranslationData = {
     crm_quote: {
       label: '見積',
       pluralLabel: '見積',
+      description: '顧客に提示する価格見積',
       fields: {
         quote_number: { label: '見積番号' },
         name: { label: '見積名' },
-        crm_account: { label: 'アカウント' },
-        crm_contact: { label: '連絡先' },
+        display_title: { label: '表示名' },
+        crm_account: { label: '取引先' },
+        crm_contact: { label: '取引先責任者' },
         crm_opportunity: { label: '商談' },
         owner: { label: '見積担当者' },
-        status: { label: 'ステータス' },
+        status: {
+          label: 'ステータス',
+          options: {
+            draft: '下書き', in_review: 'レビュー中', presented: '提示済み',
+            accepted: '承認済み', rejected: '却下', expired: '期限切れ',
+          },
+        },
         quote_date: { label: '見積日' },
         expiration_date: { label: '有効期限' },
         subtotal: { label: '小計' },
@@ -558,7 +763,7 @@ export const jaJP: TranslationData = {
         tax: { label: '税額' },
         shipping_handling: { label: '配送・手数料' },
         total_price: { label: '合計金額' },
-        payment_terms: { label: '支払条件' },
+        payment_terms: { label: '支払条件', options: { ...paymentTermsOptions } },
         shipping_terms: { label: '配送条件' },
         billing_address: { label: '請求先住所' },
         shipping_address: { label: '配送先住所' },
@@ -575,24 +780,48 @@ export const jaJP: TranslationData = {
     crm_task: {
       label: 'タスク',
       pluralLabel: 'タスク',
+      description: '活動と ToDo',
       fields: {
         subject: { label: '件名' },
         description: { label: '説明' },
-        status: { label: 'ステータス' },
-        priority: { label: '優先度' },
-        type: { label: 'タスク種別' },
+        status: {
+          label: 'ステータス',
+          options: {
+            not_started: '未着手', in_progress: '進行中', waiting: '待機中',
+            completed: '完了', deferred: '保留',
+          },
+        },
+        priority: {
+          label: '優先度',
+          options: { low: '低', normal: '通常', high: '高', urgent: '緊急' },
+        },
+        priority_rank: { label: '優先度ランク' },
+        type: {
+          label: 'タスク種別',
+          options: {
+            call: '電話', email: 'メール', meeting: '会議',
+            follow_up: 'フォローアップ', demo: 'デモ', other: 'その他',
+          },
+        },
         due_date: { label: '期限' },
         reminder_date: { label: 'リマインダー日時' },
+        reminder_sent: { label: 'リマインダー送信済み' },
         completed_date: { label: '完了日' },
         owner: { label: '担当者' },
-        related_to_type: { label: '関連オブジェクト種別' },
-        related_to_account: { label: '関連アカウント' },
-        related_to_contact: { label: '関連連絡先' },
+        related_to_type: {
+          label: '関連オブジェクト種別',
+          options: { ...relatedToTypeOptions },
+        },
+        related_to_account: { label: '関連取引先' },
+        related_to_contact: { label: '関連取引先責任者' },
         related_to_opportunity: { label: '関連商談' },
         related_to_lead: { label: '関連リード' },
         related_to_case: { label: '関連ケース' },
         is_recurring: { label: '繰り返しタスク' },
-        recurrence_type: { label: '繰り返し種別' },
+        recurrence_type: {
+          label: '繰り返し種別',
+          options: { daily: '毎日', weekly: '毎週', monthly: '毎月', yearly: '毎年' },
+        },
         recurrence_interval: { label: '繰り返し間隔' },
         recurrence_end_date: { label: '繰り返し終了日' },
         is_completed: { label: '完了済' },
@@ -608,26 +837,50 @@ export const jaJP: TranslationData = {
         task_gantt: { label: '実行計画' },
         task_timeline: { label: '工数タイムライン' },
         my_open_tasks: { label: '私のオープンタスク' },
+        todays_tasks: { label: '📅 私の優先タスク' },
+        overdue_tasks: { label: '⏰ オープンタスク · 期限超過が長い順' },
       },
     },
 
     crm_campaign: {
       label: 'キャンペーン',
       pluralLabel: 'キャンペーン',
+      description: 'マーケティングキャンペーンと施策',
       fields: {
         campaign_code: { label: 'キャンペーンコード' },
         name: { label: 'キャンペーン名' },
+        display_title: { label: '表示名' },
         description: { label: '説明' },
-        type: { label: 'キャンペーン種別' },
-        channel: { label: '主要チャネル' },
-        status: { label: 'ステータス' },
+        type: {
+          label: 'キャンペーン種別',
+          options: {
+            email: 'メール', webinar: 'ウェビナー', trade_show: '展示会',
+            conference: 'カンファレンス', direct_mail: 'ダイレクトメール',
+            social_media: 'ソーシャルメディア', content: 'コンテンツマーケティング',
+            partner: 'パートナーマーケティング',
+          },
+        },
+        channel: {
+          label: '主要チャネル',
+          options: {
+            digital: 'デジタル', social: 'ソーシャル', email: 'メール',
+            events: 'イベント', partner: 'パートナー',
+          },
+        },
+        status: {
+          label: 'ステータス',
+          options: {
+            planning: '計画中', in_progress: '実施中',
+            completed: '完了', aborted: '中止',
+          },
+        },
         start_date: { label: '開始日' },
         end_date: { label: '終了日' },
         budgeted_cost: { label: '予算コスト' },
         actual_cost: { label: '実コスト' },
         expected_revenue: { label: '予測売上' },
         actual_revenue: { label: '実収益' },
-        target_size: { label: 'ターゲット規模' },
+        target_size: { label: 'ターゲット規模', help: '対象とするリード・取引先責任者の目標件数' },
         num_sent: { label: '送信数' },
         num_responses: { label: '応答数' },
         num_leads: { label: 'リード数' },
@@ -636,7 +889,7 @@ export const jaJP: TranslationData = {
         num_won_opportunities: { label: '受注商談' },
         response_rate: { label: '応答率（%）' },
         roi: { label: 'ROI（%）' },
-        parent_campaign: { label: '親キャンペーン' },
+        parent_campaign: { label: '親キャンペーン', help: '階層構造における上位のキャンペーン' },
         owner: { label: 'キャンペーン担当者' },
         landing_page_url: { label: 'ランディングページ' },
         is_active: { label: '有効' },
@@ -683,10 +936,7 @@ export const jaJP: TranslationData = {
         location: { label: '場所', help: '会議室・住所・会議リンク' },
         related_to_type: {
           label: '関連レコード種別',
-          options: {
-            crm_account: '取引先', crm_contact: '取引先責任者', crm_opportunity: '商談',
-            crm_lead: 'リード', crm_case: 'ケース',
-          },
+          options: { ...relatedToTypeOptions },
         },
         related_to_account: { label: '関連取引先' },
         related_to_contact: { label: '関連取引先責任者' },
@@ -716,10 +966,10 @@ export const jaJP: TranslationData = {
           label: '参加者種別',
           options: { contact: '取引先責任者', lead: 'リード', user: '社内ユーザー' },
         },
-        crm_contact: { label: '取引先責任者' },
-        crm_lead: { label: 'リード' },
-        sys_user: { label: '社内ユーザー' },
-        external_name: { label: '社外参加者' },
+        crm_contact: { label: '取引先責任者', help: '参加者が既存の取引先責任者である場合に設定します' },
+        crm_lead: { label: 'リード', help: '参加者がまだ変換されていないリードである場合に設定します' },
+        sys_user: { label: '社内ユーザー', help: '参加者が社内の同僚である場合に設定します' },
+        external_name: { label: '社外参加者', help: 'CRM に登録されていない参加者の氏名' },
         response: {
           label: '回答',
           options: {
@@ -738,12 +988,12 @@ export const jaJP: TranslationData = {
     crm_campaign_member: {
       label: 'キャンペーンメンバー',
       pluralLabel: 'キャンペーンメンバー',
-      description: 'キャンペーンの対象となったリード・連絡先とその反応状況',
+      description: 'キャンペーンの対象となったリード・取引先責任者とその反応状況',
       fields: {
         member_number: { label: 'メンバー番号' },
         crm_campaign: { label: 'キャンペーン' },
-        crm_lead: { label: 'リード' },
-        crm_contact: { label: '連絡先' },
+        crm_lead: { label: 'リード', help: '登録時点でリードだったメンバーに設定されます' },
+        crm_contact: { label: '取引先責任者', help: '既存の取引先責任者であるメンバーに設定されます' },
         status: {
           label: 'ステータス',
           options: {
@@ -773,8 +1023,8 @@ export const jaJP: TranslationData = {
         crm_product: { label: '製品' },
         description: { label: '説明' },
         quantity: { label: '数量' },
-        list_price: { label: '定価' },
-        unit_price: { label: '販売価格' },
+        list_price: { label: '定価', help: '製品のカタログ価格から自動入力されます' },
+        unit_price: { label: '販売価格', help: '交渉後の単価（定価と異なる場合があります）' },
         discount: { label: '割引率（%）' },
         total_price: { label: '合計' },
         line_number: { label: '行番号' },
@@ -805,11 +1055,53 @@ export const jaJP: TranslationData = {
     crm_enterprise: {
       label: 'HotCRM',
       description: '営業・サービス・マーケティング向け顧客関係管理システム',
+      // Keyed by navigation-node `id` (a flat keyspace regardless of depth).
       navigation: {
-        group_activity: { label: '活動' },
+        nav_home: { label: 'ホーム' },
+
         group_sales: { label: '営業' },
-        group_service: { label: 'サービス' },
+        nav_lead: { label: 'リード' },
+        nav_account: { label: '取引先' },
+        nav_account_workbench: { label: '取引先ワークベンチ' },
+        nav_contact: { label: '取引先責任者' },
+        nav_opportunity: { label: '商談' },
+        nav_pipeline: { label: 'パイプライン' },
+        nav_quote: { label: '見積' },
+        nav_contract: { label: '契約' },
+        nav_sales_dashboard: { label: '営業実績' },
+
+        group_work: { label: 'マイワーク' },
+        nav_my_tasks: { label: '私のタスク' },
+        nav_my_deals: { label: '私の商談' },
+        nav_my_leads: { label: '私のリード' },
+        nav_my_cases: { label: '私のケース' },
+        nav_my_calendar: { label: 'マイカレンダー' },
+        nav_all_tasks: { label: '全タスク' },
+
+        group_activity: { label: '活動' },
+        nav_event: { label: 'イベント' },
+        nav_event_calendar: { label: 'カレンダー' },
+        nav_event_history: { label: '対話履歴' },
+        nav_activity_dashboard: { label: '営業活動' },
+
         group_marketing: { label: 'マーケティング' },
+        nav_campaign: { label: 'キャンペーン' },
+        nav_product: { label: '製品' },
+
+        group_service: { label: 'サービス' },
+        nav_case: { label: 'ケース' },
+        nav_knowledge: { label: 'ナレッジベース' },
+        nav_service_dashboard: { label: 'サービス概要' },
+
+        group_insights: { label: 'インサイト' },
+        nav_crm_dashboard: { label: 'CRM 概要' },
+        nav_forecast: { label: 'フォーキャスト' },
+        nav_report_pipeline_coverage: { label: 'パイプラインカバレッジ' },
+        nav_report_lead_inflow: { label: 'リード流入' },
+        nav_report_sla: { label: 'SLA 実績' },
+
+        group_approvals: { label: '承認' },
+        nav_approval_requests: { label: '受信トレイ' },
       },
     },
   },
@@ -865,11 +1157,11 @@ export const jaJP: TranslationData = {
       widgets: {
         total_revenue: { title: '総売上', description: '当期の成立済み売上' },
         active_deals: { title: '進行中の商談', description: 'パイプライン上のオープン商談' },
-        won_deals: { title: '勝利商談数', description: '当期に成立した商談の総数' },
+        won_deals: { title: '成立商談数', description: '当期に成立した商談の総数' },
         avg_deal_size: { title: '平均商談規模', description: '成立済み商談の平均金額' },
         revenue_trends: { title: '売上トレンド', description: '過去12か月の成立済み売上' },
         lead_source: { title: 'リードソース', description: '獲得チャネル別のパイプライン金額' },
-        pipeline_by_stage: { title: 'フェーズ別パイプライン', description: '各営業フェーズのオープン商談金額' },
+        pipeline_by_stage: { title: 'ステージ別パイプライン', description: '各営業ステージのオープン商談金額' },
         top_products: { title: '売れ筋製品', description: '製品カテゴリ別の定価ベース売上' },
         pipeline_by_owner: { title: '担当者別パイプライン', description: '営業担当者ごとのオープンパイプライン金額と商談数' },
       },
@@ -884,7 +1176,7 @@ export const jaJP: TranslationData = {
         open_leads: { title: 'オープンリード', description: '未取引開始のリード' },
         revenue_trend: { title: '売上トレンド', description: '過去12か月の成立済み売上' },
         revenue_by_industry: { title: '業種別売上', description: '本年度の成立済み売上を業種別に分類' },
-        pipeline_by_stage: { title: 'フェーズ別パイプライン', description: '営業フェーズ別のオープン商談金額' },
+        pipeline_by_stage: { title: 'ステージ別パイプライン', description: '営業ステージ別のオープン商談金額' },
         new_accounts_by_month: { title: '新規取引先', description: '過去6か月の取引先作成ペース' },
         accounts_by_industry: { title: '業種別取引先', description: '業種ごとの年間売上合計と取引先数' },
       },
@@ -897,13 +1189,19 @@ export const jaJP: TranslationData = {
         closed_won_qtd: { title: '今四半期成立額', description: '今四半期に成立した売上' },
         open_opportunities: { title: 'オープン商談', description: '進行中のアクティブ商談' },
         avg_deal_size: { title: '平均商談規模', description: '今四半期の成立済み商談の平均金額' },
-        pipeline_by_stage: { title: 'フェーズ別パイプライン', description: '各営業フェーズのオープン商談金額' },
+        pipeline_by_stage: { title: 'ステージ別パイプライン', description: '各営業ステージのオープン商談金額' },
         monthly_revenue_trend: { title: '月次売上トレンド', description: '過去12か月の成立済み売上' },
         pipeline_by_forecast_category: { title: '予測カテゴリ別パイプライン', description: '売上予測カテゴリ別のオープンパイプライン金額' },
         lead_source_breakdown: { title: 'リードソース', description: 'パイプラインの流入元' },
         open_pipeline_by_owner: { title: '担当者別オープンパイプライン', description: '営業担当者ごとの進行中パイプライン金額・商談数・平均勝率' },
         quota_attainment_by_rep: { title: '担当者別ノルマ達成状況', description: '予測スナップショットに基づく担当者別の今四半期ノルマ・成約収益・達成率' },
         pipeline_stage_by_source: { title: 'ステージ × リードソース', description: 'ステージとソース別の進行中商談金額のクロス集計' },
+        win_rate_12m: { title: '勝率（直近12か月）', description: '直近12か月に決着した商談のうち成立した割合' },
+        won_deals_12m: { title: '成立商談数（直近12か月）', description: '勝率の分子' },
+        lost_deals_12m: { title: '失注商談数（直近12か月）', description: '勝率の分母のもう半分' },
+        win_rate_by_owner: { title: '担当者別 受注／失注', description: '直近12か月の担当者ごとの成立数・失注数・勝率' },
+        win_rate_by_lead_source: { title: 'リードソース別 受注／失注', description: '実際に成立につながるのはどのソースか — 直近12か月' },
+        loss_reason_breakdown: { title: '失注の理由', description: '直近12か月の失注商談を理由別に集計' },
       },
     },
     service_dashboard: {
@@ -921,6 +1219,55 @@ export const jaJP: TranslationData = {
         sla_compliance_gauge: { title: 'SLA 達成率', description: '当期 SLA 内に解決したケースの割合' },
         open_cases_by_priority: { title: '優先度別オープンケース', description: 'オープンケースとそのSLA違反率を優先度別に集計' },
       },
+    },
+  },
+
+  // `title` / `subtitle` translate the page's `page:header`; `title` falls back
+  // to `label` when omitted, so it is authored only where the two differ.
+  // Header strings carrying `{field}` tokens keep the token spelling verbatim —
+  // the console substitutes on the raw key, so a translated token resolves to
+  // nothing and the header renders blank.
+  pages: {
+    account_detail_page: {
+      label: '取引先詳細',
+      description: 'スロット構成の取引先レコードページ — カスタムヘッダーと常設のディスカッションフィード。',
+    },
+    account_workbench: {
+      label: '取引先ワークベンチ',
+      description: '営業チーム向けに厳選した取引先リスト。クイックフィルターのみで、ビュー管理は行いません。',
+    },
+    app_launcher_page: {
+      label: 'アプリランチャー',
+      description: 'すべてのアプリケーションにアクセスするための統合ハブ',
+      subtitle: '開始するアプリを選択してください',
+    },
+    case_detail_page: {
+      label: 'ケース詳細',
+      description: 'サービス担当者向けのケースレコードページ：ハイライト、SLA パス、詳細、活動タイムライン。',
+      title: '{case_number} · {subject}',
+      subtitle: '{crm_account}',
+    },
+    lead_detail_page: {
+      label: 'リード詳細',
+      description: 'ハイライト・詳細・関連情報を備えたリードの総合詳細ページ。',
+      title: '{first_name} {last_name}',
+      subtitle: '{company}',
+    },
+    opportunity_detail_page: {
+      label: '商談詳細',
+      description: 'ステージパス・ハイライト・詳細・関連リストを備えた商談の総合詳細ページ。',
+      title: '{name}',
+      subtitle: '{crm_account}',
+    },
+    sales_home_page: {
+      label: '営業ホーム',
+      description: '主要指標とクイックアクションをまとめた営業チームのホームページ',
+      title: '営業ダッシュボード',
+      subtitle: 'おかえりなさい、{current_user.first_name} さん',
+    },
+    utility_bar_page: {
+      label: 'ユーティリティバー',
+      description: 'フローティングツールへのクイックアクセスバー',
     },
   },
 };

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -1315,72 +1315,21 @@ describe('action labels are translated in every locale', () => {
  */
 describe('select fields are translated in every locale', () => {
   /**
-   * Select fields knowingly still missing translations, keyed
-   * `object.field` → the locales that lack them.
+   * There is no exemption list any more, and re-introducing one is a regression.
    *
-   * This map may only ever SHRINK. It is a ledger of pre-existing debt, not a
-   * place to park new work: a field added or extended from here on has no entry
-   * to hide behind, so it fails on the PR that introduces it. Two assertions
-   * below keep the ledger from rotting — an entry whose gap has since been
-   * filled fails as stale, and an entry naming a field or locale that does not
-   * exist fails as a ghost.
+   * This guard shipped with a `PENDING_SELECT_LABELS` ledger: 34 fields over 12
+   * objects, 111 (locale, field) pairs, ~380 option labels of pre-existing debt
+   * that #631 could not fix without burying the one field its PR was about. The
+   * ledger was allowed to shrink and never grow, and #645 emptied it. It is gone
+   * rather than left behind as an empty object, along with the two assertions
+   * that existed only to keep it honest (stale rows, ghost rows) — an empty
+   * ledger is an invitation to add a row, and the assertions below say what the
+   * ledger was always converging on: every select field, every option value,
+   * every locale, no exceptions.
    *
-   * Surveyed when #631 landed: 34 fields over 12 objects — 111 (locale, field)
-   * pairs, ~380 option labels. They are enumerated in #645 rather than fixed
-   * here, because translating that much in a one-field bug-fix PR would bury the
-   * field the PR is actually about.
+   * A field added or extended from here on therefore fails on the PR that
+   * introduces it, which is the whole point.
    */
-  /**
-   * Every row is written out literally rather than derived from `localePacks`,
-   * so that adding a fifth locale surfaces as new gaps to fill instead of
-   * silently extending every exemption to cover it.
-   *
-   * No row lists `zh-CN` any more: the 15 fields that were untranslated in all
-   * four locales were completed in Chinese first, ahead of a zh-CN customer
-   * trial. Simplified Chinese is therefore the one locale with full select
-   * coverage — a row regaining `zh-CN` is a regression, not a re-scope.
-   */
-  const PENDING_SELECT_LABELS: Record<string, string[]> = {
-    'crm_account.tier': ['ja-JP', 'es-ES'],
-    'crm_account.segment': ['ja-JP', 'es-ES'],
-    'crm_account.health_score': ['ja-JP', 'es-ES'],
-    'crm_campaign.type': ['en', 'ja-JP', 'es-ES'],
-    'crm_campaign.channel': ['en', 'ja-JP', 'es-ES'],
-    'crm_campaign.status': ['en', 'ja-JP', 'es-ES'],
-    'crm_case.status': ['en', 'ja-JP', 'es-ES'],
-    'crm_case.priority': ['en', 'ja-JP', 'es-ES'],
-    'crm_case.type': ['en', 'ja-JP', 'es-ES'],
-    'crm_contact.salutation': ['en', 'ja-JP', 'es-ES'],
-    'crm_contact.lead_source': ['en', 'ja-JP', 'es-ES'],
-    'crm_contract.status': ['en', 'ja-JP', 'es-ES'],
-    'crm_contract.billing_frequency': ['en', 'ja-JP', 'es-ES'],
-    'crm_contract.payment_terms': ['en', 'ja-JP', 'es-ES'],
-    'crm_contract.contract_type': ['en', 'ja-JP', 'es-ES'],
-    // Partial: 5 of 7 categories and 4 of 8 tags are translated everywhere.
-    'crm_knowledge_article.category': ['en', 'ja-JP', 'es-ES'],
-    'crm_knowledge_article.tags': ['en', 'ja-JP', 'es-ES'],
-    'crm_lead.salutation': ['en', 'ja-JP', 'es-ES'],
-    'crm_lead.industry': ['en', 'ja-JP', 'es-ES'],
-    'crm_opportunity.competitors': ['en', 'ja-JP', 'es-ES'],
-    // `crm_opportunity.win_reason` / `loss_reason` left the ledger in #593:
-    // both became REQUIRED at close and both now drive a Sales-dashboard
-    // widget, so an untranslated option is no longer a cosmetic gap — it is a
-    // raw stored value (`no_budget`, `quote_accepted`) in a picklist a rep is
-    // forced to choose from, and in a chart legend. `approval_status` stays:
-    // it is untouched by that change and belongs to #645's sweep.
-    'crm_opportunity.approval_status': ['ja-JP', 'es-ES'],
-    'crm_product.category': ['en', 'ja-JP', 'es-ES'],
-    'crm_product.family': ['en', 'ja-JP', 'es-ES'],
-    'crm_product.billing_type': ['en', 'ja-JP', 'es-ES'],
-    'crm_product.unit_of_measure': ['en', 'ja-JP', 'es-ES'],
-    'crm_quote.status': ['en', 'ja-JP', 'es-ES'],
-    'crm_quote.payment_terms': ['en', 'ja-JP', 'es-ES'],
-    'crm_task.status': ['en', 'ja-JP', 'es-ES'],
-    'crm_task.priority': ['en', 'ja-JP', 'es-ES'],
-    'crm_task.type': ['en', 'ja-JP', 'es-ES'],
-    'crm_task.related_to_type': ['en', 'ja-JP', 'es-ES'],
-    'crm_task.recurrence_type': ['en', 'ja-JP', 'es-ES'],
-  };
 
   /** Every authored select field, with its option VALUES (what the DB stores). */
   const selectFields = objects.flatMap((obj) =>
@@ -1393,9 +1342,6 @@ describe('select fields are translated in every locale', () => {
         values: (f.options as AnyRec[]).map((o) => String(o.value)),
       })),
   );
-
-  const isPending = (key: string, locale: string) =>
-    (PENDING_SELECT_LABELS[key] ?? []).includes(locale);
 
   /** The translation entry for one select field in one locale pack. */
   const entryFor = (pack: AnyRec, objectName: string, fieldName: string): AnyRec | undefined =>
@@ -1414,7 +1360,6 @@ describe('select fields are translated in every locale', () => {
     const bad: string[] = [];
     for (const { key, objectName, fieldName } of selectFields) {
       for (const [locale, pack] of localePacks) {
-        if (isPending(key, locale)) continue;
         if (!entryFor(pack, objectName, fieldName)?.label) {
           bad.push(`${locale}: ${objectName}.fields.${fieldName}.label`);
         }
@@ -1435,7 +1380,6 @@ describe('select fields are translated in every locale', () => {
     const bad: string[] = [];
     for (const { key, objectName, fieldName, values } of selectFields) {
       for (const [locale, pack] of localePacks) {
-        if (isPending(key, locale)) continue;
         const options = entryFor(pack, objectName, fieldName)?.options ?? {};
         const missing = values.filter((v) => !options[v]);
         if (missing.length) {
@@ -1450,47 +1394,6 @@ describe('select fields are translated in every locale', () => {
     ).toEqual([]);
   });
 
-  it('the pending map contains no stale entries', () => {
-    // A field that has since been translated must leave the ledger, or the
-    // ledger stops meaning anything and the field silently loses its guard.
-    const byKey = new Map(selectFields.map((f) => [f.key, f]));
-    const stale: string[] = [];
-    for (const [key, locales] of Object.entries(PENDING_SELECT_LABELS)) {
-      const field = byKey.get(key);
-      if (!field) continue; // ghost — reported by the test below
-      for (const locale of locales) {
-        const pack = packFor(locale);
-        if (!pack) continue; // ghost locale — reported by the test below
-        const entry = entryFor(pack, field.objectName, field.fieldName);
-        const complete =
-          !!entry?.label && field.values.every((v) => (entry.options ?? {})[v]);
-        if (complete) stale.push(`${locale}: ${key}`);
-      }
-    }
-    expect(
-      stale,
-      `these are now fully translated — remove them from PENDING_SELECT_LABELS:\n  ${stale.join('\n  ')}`,
-    ).toEqual([]);
-  });
-
-  it('the pending map only names real fields and real locales', () => {
-    const keys = new Set(selectFields.map((f) => f.key));
-    const locales = new Set(localePacks.map(([l]) => l));
-    const ghosts: string[] = [];
-    for (const [key, pending] of Object.entries(PENDING_SELECT_LABELS)) {
-      if (!keys.has(key)) {
-        ghosts.push(`${key} is not a select field on any object`);
-        continue;
-      }
-      for (const locale of pending) {
-        if (!locales.has(locale)) ghosts.push(`${key} names unknown locale "${locale}"`);
-      }
-    }
-    expect(
-      ghosts,
-      `PENDING_SELECT_LABELS has entries that check nothing:\n  ${ghosts.join('\n  ')}`,
-    ).toEqual([]);
-  });
 });
 
 /**
@@ -1605,15 +1508,15 @@ describe('app AI bindings resolve to a platform agent', () => {
 });
 
 /**
- * Simplified Chinese is complete on every translatable surface, not just on
- * select options.
+ * EVERY locale is complete on every translatable surface, not just on select
+ * options.
  *
- * `PENDING_SELECT_LABELS` above guards ONE surface (picklist option labels) and
- * guards it well. It says nothing about the other four an authored bundle owns
- * — field labels/help, page header copy, dashboard widget titles, and list-view
- * empty states — and those were exactly where the remaining 98 zh-CN gaps sat:
- * every page in the app rendered its header, nav label and breadcrumb in
- * English, and the six win/loss widgets on the Sales dashboard did the same.
+ * The guard above covers ONE surface — picklist option labels. It says nothing
+ * about the other four an authored bundle owns (field labels/help, page header
+ * copy, dashboard widget titles, list-view empty states), and those are exactly
+ * where the gaps sat: every page in the app rendered its header, nav label and
+ * breadcrumb in English in three of four locales, and the Sales-dashboard
+ * win/loss widgets did the same.
  *
  * Nothing in CI could have caught that. `pnpm lint` runs with `--skip-i18n`,
  * and `objectstack lint` exits 0 on warnings regardless — so the i18n rules
@@ -1621,108 +1524,124 @@ describe('app AI bindings resolve to a platform agent', () => {
  * PR. This suite is the only gate, which is why the assertions live here rather
  * than in a lint config.
  *
- * Scoped to zh-CN on purpose. `en` / `ja-JP` / `es-ES` still carry the debt
- * enumerated in #645 and #494; widening this guard is that work's finish line,
- * not its entry fee.
+ * This started as a zh-CN-only guard, because zh-CN was completed first ahead
+ * of a customer trial while `en` / `ja-JP` / `es-ES` still carried the debt in
+ * #645 and #494. That debt is now paid, so the guard covers all four — which
+ * was always the stated finish line, and is the only version of it that stops
+ * the next locale from drifting.
+ *
+ * Derived from `localePacks` rather than a hard-coded list: a fifth locale
+ * added to the bundle is held to the same bar the day it appears, instead of
+ * silently enjoying an exemption nobody wrote down.
  */
-describe('zh-CN is complete on every authored surface', () => {
-  const zh = (): AnyRec => {
-    const pack = packFor('zh-CN');
-    expect(pack, 'no zh-CN locale pack found in stack.translations').toBeTruthy();
-    return pack as AnyRec;
+describe('every locale is complete on every authored surface', () => {
+  const packs = (): [string, AnyRec][] => {
+    // Guards the guard: an empty list would make every assertion below pass by
+    // checking nothing — how the navigation guard in this file spent its life.
+    expect(localePacks.length, 'no locale packs found in stack.translations').toBeGreaterThan(0);
+    return localePacks;
   };
 
-  it('every authored field label and help string has a zh-CN translation', () => {
-    const pack = zh();
+  it('every authored field label and help string is translated', () => {
     const bad: string[] = [];
-    for (const obj of objects) {
-      const fields = pack.objects?.[obj.name]?.fields ?? {};
-      for (const [name, f] of Object.entries<AnyRec>(obj.fields ?? {})) {
-        // `help` mirrors the authored `description` — the field-level spelling
-        // differs between the two surfaces (spec: FieldTranslationSchema).
-        if (f?.label && !fields[name]?.label) bad.push(`${obj.name}.${name}.label`);
-        if (f?.description && !fields[name]?.help) bad.push(`${obj.name}.${name}.help`);
-      }
-    }
-    expect(bad, `fields with no zh-CN translation:\n  ${bad.join('\n  ')}`).toEqual([]);
-  });
-
-  it('every page has zh-CN nav copy and header copy', () => {
-    const pack = zh();
-    const bad: string[] = [];
-    for (const page of pages) {
-      const t = pack.pages?.[page.name];
-      if (page.label && !t?.label) bad.push(`${page.name}.label`);
-      if (page.description && !t?.description) bad.push(`${page.name}.description`);
-
-      // A page's header copy is addressed by the PAGE name: `page:header`
-      // instances carry no stable id, so `pages.<name>.title` / `.subtitle` are
-      // the only keys that reach them. `title` legitimately falls back to
-      // `label`, so it is only required when the two differ.
-      const header = (page.regions ?? [])
-        .flatMap((r: AnyRec) => r.components ?? [])
-        .find((c: AnyRec) => c?.type === 'page:header');
-      const title = header?.properties?.title;
-      const subtitle = header?.properties?.subtitle;
-      if (title && title !== page.label && !t?.title) bad.push(`${page.name}.title`);
-      if (subtitle && !t?.subtitle) bad.push(`${page.name}.subtitle`);
-    }
-    expect(bad, `pages with untranslated zh-CN copy:\n  ${bad.join('\n  ')}`).toEqual([]);
-  });
-
-  it('every dashboard widget has a zh-CN title and description', () => {
-    const pack = zh();
-    const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
-    const bad: string[] = [];
-    for (const d of dashboards) {
-      const widgets = pack.dashboards?.[d.name]?.widgets ?? {};
-      for (const w of d.widgets ?? []) {
-        if (!w?.id) continue;
-        if (w.title && !widgets[w.id]?.title) bad.push(`${d.name}.${w.id}.title`);
-        if (w.description && !widgets[w.id]?.description) bad.push(`${d.name}.${w.id}.description`);
-      }
-    }
-    expect(bad, `widgets with no zh-CN copy:\n  ${bad.join('\n  ')}`).toEqual([]);
-  });
-
-  it('every view empty state has zh-CN copy', () => {
-    // The empty state is the ONE string a view shows when it has no rows — the
-    // exact moment a trial user is most likely to be reading it.
-    const pack = zh();
-    const bad: string[] = [];
-    for (const record of views) {
-      const containers: [string, AnyRec][] = [
-        ...(record.list ? [['list', record.list] as [string, AnyRec]] : []),
-        ...Object.entries<AnyRec>(record.listViews ?? {}),
-      ];
-      for (const [key, view] of containers) {
-        const empty = view?.emptyState;
-        if (!empty?.title && !empty?.message) continue;
-        const objectName = view?.data?.object ?? record.list?.data?.object ?? record.object;
-        const name = view?.name ?? key;
-        const t = pack.objects?.[objectName]?._views?.[name]?.emptyState;
-        if (empty.title && !t?.title) bad.push(`${objectName}.${name}.emptyState.title`);
-        if (empty.message && !t?.message) bad.push(`${objectName}.${name}.emptyState.message`);
-      }
-    }
-    expect(bad, `empty states with no zh-CN copy:\n  ${bad.join('\n  ')}`).toEqual([]);
-  });
-
-  it('every action parameter label has a zh-CN translation', () => {
-    // A param label is the field caption inside an action's modal — untranslated,
-    // it is a bare English word on an otherwise Chinese form.
-    const pack = zh();
-    const bad: string[] = [];
-    for (const action of stackActions) {
-      if (!action.objectName) continue;
-      const params = pack.objects?.[action.objectName]?._actions?.[action.name]?.params ?? {};
-      for (const p of action.params ?? []) {
-        const key = p?.name ?? p?.field;
-        if (key && p?.label && !params[key]?.label) {
-          bad.push(`${action.objectName}.${action.name}.params.${key}.label`);
+    for (const [locale, pack] of packs()) {
+      for (const obj of objects) {
+        const fields = pack.objects?.[obj.name]?.fields ?? {};
+        for (const [name, f] of Object.entries<AnyRec>(obj.fields ?? {})) {
+          // `help` mirrors the authored `description` — the field-level spelling
+          // differs between the two surfaces (spec: FieldTranslationSchema).
+          if (f?.label && !fields[name]?.label) bad.push(`${locale}: ${obj.name}.${name}.label`);
+          if (f?.description && !fields[name]?.help) bad.push(`${locale}: ${obj.name}.${name}.help`);
         }
       }
     }
-    expect(bad, `action params with no zh-CN label:\n  ${bad.join('\n  ')}`).toEqual([]);
+    expect(bad, `fields with no translation:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every page has translated nav copy and header copy', () => {
+    const bad: string[] = [];
+    for (const [locale, pack] of packs()) {
+      for (const page of pages) {
+        const t = pack.pages?.[page.name];
+        if (page.label && !t?.label) bad.push(`${locale}: ${page.name}.label`);
+        if (page.description && !t?.description) bad.push(`${locale}: ${page.name}.description`);
+
+        // A page's header copy is addressed by the PAGE name: `page:header`
+        // instances carry no stable id, so `pages.<name>.title` / `.subtitle` are
+        // the only keys that reach them. `title` legitimately falls back to
+        // `label`, so it is only required when the two differ.
+        const header = (page.regions ?? [])
+          .flatMap((r: AnyRec) => r.components ?? [])
+          .find((c: AnyRec) => c?.type === 'page:header');
+        const title = header?.properties?.title;
+        const subtitle = header?.properties?.subtitle;
+        if (title && title !== page.label && !t?.title) bad.push(`${locale}: ${page.name}.title`);
+        if (subtitle && !t?.subtitle) bad.push(`${locale}: ${page.name}.subtitle`);
+      }
+    }
+    expect(bad, `pages with untranslated copy:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every dashboard widget has a translated title and description', () => {
+    const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
+    const bad: string[] = [];
+    for (const [locale, pack] of packs()) {
+      for (const d of dashboards) {
+        const widgets = pack.dashboards?.[d.name]?.widgets ?? {};
+        for (const w of d.widgets ?? []) {
+          if (!w?.id) continue;
+          if (w.title && !widgets[w.id]?.title) bad.push(`${locale}: ${d.name}.${w.id}.title`);
+          if (w.description && !widgets[w.id]?.description) {
+            bad.push(`${locale}: ${d.name}.${w.id}.description`);
+          }
+        }
+      }
+    }
+    expect(bad, `widgets with no translated copy:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every view empty state is translated', () => {
+    // The empty state is the ONE string a view shows when it has no rows — the
+    // exact moment a trial user is most likely to be reading it.
+    const bad: string[] = [];
+    for (const [locale, pack] of packs()) {
+      for (const record of views) {
+        const containers: [string, AnyRec][] = [
+          ...(record.list ? [['list', record.list] as [string, AnyRec]] : []),
+          ...Object.entries<AnyRec>(record.listViews ?? {}),
+        ];
+        for (const [key, view] of containers) {
+          const empty = view?.emptyState;
+          if (!empty?.title && !empty?.message) continue;
+          const objectName = view?.data?.object ?? record.list?.data?.object ?? record.object;
+          const name = view?.name ?? key;
+          const t = pack.objects?.[objectName]?._views?.[name]?.emptyState;
+          if (empty.title && !t?.title) bad.push(`${locale}: ${objectName}.${name}.emptyState.title`);
+          if (empty.message && !t?.message) {
+            bad.push(`${locale}: ${objectName}.${name}.emptyState.message`);
+          }
+        }
+      }
+    }
+    expect(bad, `empty states with no translated copy:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every action parameter label is translated', () => {
+    // A param label is the field caption inside an action's modal — untranslated,
+    // it is a bare English word on an otherwise localized form.
+    const bad: string[] = [];
+    for (const [locale, pack] of packs()) {
+      for (const action of stackActions) {
+        if (!action.objectName) continue;
+        const params = pack.objects?.[action.objectName]?._actions?.[action.name]?.params ?? {};
+        for (const p of action.params ?? []) {
+          const key = p?.name ?? p?.field;
+          if (key && p?.label && !params[key]?.label) {
+            bad.push(`${locale}: ${action.objectName}.${action.name}.params.${key}.label`);
+          }
+        }
+      }
+    }
+    expect(bad, `action params with no translated label:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 });


### PR DESCRIPTION
## Description

`objectstack lint` goes from **723 warnings to 13**. All 710 removed were i18n gaps; the 13 remaining are unrelated (naming prefixes, one shadowed field group). `pnpm lint` runs with `--skip-i18n` and now reports the same 13 as a full run — the flag has nothing left to skip.

**ja-JP and es-ES were each missing 355 keys.** The `pages` group was absent from both bundles outright, so every page in the app rendered its nav label, breadcrumb and header in English no matter the locale. On top of that, each was missing 34 navigation nodes, 10 object descriptions, the 12 Sales-dashboard win/loss widget strings, 13 view labels and empty states, and 169 picklist option labels.

**`en` was missing 133 keys and nothing could see them.** When a key is absent the resolver falls back to the English string in the metadata, so in the source locale a missing entry and a correct one render identically — invisible at runtime, to the linter, and to a reviewer clicking through. It still matters: every other bundle is authored by mirroring this one's shape, so a key with no slot here is a key the next translator has nowhere to put. That is exactly how ja-JP and es-ES both ended up with no `pages` group.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #645
Related to #494
Does not address #661 (see Additional Notes)

## Changes Made

Five commits, one coherent unit each:

| Commit | What |
|---|---|
| `48b00bb` | `en` select option labels — 153 labels over 28 fields |
| `ccb4563` | ja-JP complete — 355 → 0 |
| `0c22930` | es-ES complete — 355 → 0 |
| `bd73b87` | retire `PENDING_SELECT_LABELS`; widen the surface guard to all locales |
| `b856b11` | `en` non-option surfaces — the 105 gaps widening exposed |

### Consistency is now structural, not a copy discipline

Shared picklists in ja-JP are declared once and spread into each use site, mirroring the `activityActions` pattern already in that file and `_picklists.ts` on the metadata side. es-ES asserts the same relationships programmatically against the loaded bundle. The discipline they replace had already failed: `crm_lead.industry` read 業界 against `crm_account.industry` 業種 for the same 15-value shared set.

Drift the sweep exposed and fixed — worth a reviewer's eye, since these change existing strings rather than adding missing ones:

- **`crm_account.owner` in ja-JP was 取引先責任者 — the object label for `crm_contact`.** The "Account Owner" field rendered as the word "Contact".
- The `crm_account` lookup read アカウント on case / contract / quote / campaign-member screens while the object itself is 取引先 — the same field, a different word depending on which page you opened it from. `crm_task.related_to_type` forces the fix regardless: its option values *are* object names and must reuse each object's own label.
- `crm_opportunity.stage` was フェーズ beside ステージ更新, ステージ開始日, 現ステージ滞在日数, and a dashboard showing ステージ × リードソース next to フェーズ別パイプライン.
- `crm_account.type.former` is `'Former Customer'` in `account.object.ts`, but the `en` bundle had truncated it to `'Former'` — and es-ES, mirroring that bundle, rendered a bare `'Anterior'`: an adjective with no noun, beside three option labels that are all nouns.

### The guard

`PENDING_SELECT_LABELS` is **deleted, not emptied**. It held 34 fields over 12 objects — 111 (locale, field) pairs, ~380 option labels — of debt #631 could not fix without burying the field its PR was about. An empty ledger is an invitation to add a row, so the two assertions that existed only to keep it honest (stale rows, ghost rows) go with it. What remains states unconditionally what the ledger was always converging on: every select field, every option value, every locale.

The surface guard is widened from zh-CN-only to all four locales, deriving the list from `localePacks` rather than hard-coding it, so a fifth locale is held to the bar the day it appears. Widening it is what surfaced the 105 invisible `en` gaps in the first place.

**This suite is the only real gate.** `objectstack lint` has rules that find every one of these gaps and CI never runs them — `pnpm lint` passes `--skip-i18n`, and `objectstack lint` exits 0 on warnings regardless.

## Testing

- [x] Unit tests pass — **1278 passed, 1 skipped, 52 files**
- [x] Linting passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [x] New tests added — the widened guard
- [x] `pnpm validate` and `pnpm typecheck` clean

Per-locale i18n warnings after: `en` 0, `zh-CN` 0, `ja-JP` 0, `es-ES` 0.

Each locale was verified independently of the agent that produced it: lint count, a brace-depth duplicate-key scan over all four bundles (a duplicate key in a JS object literal silently drops the earlier value, which has bitten this file family before), and spot-checks of the claimed drift fixes against the object definitions.

## Checklist

- [x] **I have added a changeset** (`.changeset/all-locales-complete.md`)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**View tab labels (#661) are still untranslatable, in every locale.** `tabs[].label` is declared as an `I18nLabelSchema` — documented as "i18n keys are auto-generated by the framework" — but `ObjectTranslationDataSchema` is a `strictObject` carrying only `_views` / `_actions` / `_sections`, so there is no key to translate it into and an author cannot add one. `i18n-resolver.ts` has no tab-label resolver. The gap is upstream; the 59 tab labels across 15 objects stay English until it closes there.

**Six help strings in the object definitions read as developer shorthand**, and are now mirrored consistently into all four bundles rather than quietly improved in translation:

- `crm_forecast.attainment_pct` — "Negative quota guarded" is an implementation note, and hard to translate meaningfully.
- `crm_forecast.best_case_amount` / `commit_amount` — leak raw `best_case` / `commit` option values into user-facing help where every neighbouring string uses the display labels.
- `crm_forecast.coverage_ratio` — uses U+2212 MINUS while sibling strings use ASCII operators for the same arithmetic.
- `crm_opportunity_line_item.list_price` — "Auto-populated from product.list_price" names an internal field path rather than the labels the user sees.
- `crm_case.internal_notes` — "not visible to customer" is missing an article; the sibling `customer_signature` help is well-formed, so it reads as a typo.
- `crm_lead.notes` — "Rich text notes with formatting" describes the widget and says the same thing twice.

Also noted, deliberately left alone: `crm_contact.department.hr` is `'Human Resources'` in every bundle against the object's `'HR'`. All four locales independently chose the expanded form and it reads better, so the object definition is the odd one out. Both that and the six strings above belong in a change to the object definitions, not to a translation bundle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8UZqd6mJMPHAXKb6XcHmi)_