### PR TITLE
fix(i18n): translate section headings in every locale, and stop deriving the guard from lint (#683)

### DIFF
--- a/.changeset/section-headings-every-locale.md
+++ b/.changeset/section-headings-every-locale.md
@@ -1,0 +1,26 @@
+---
+'hotcrm': patch
+---
+
+Section headings are translated in all four locales, and the guard no longer takes its list of surfaces from a linter.
+
+`_sections` holds the headings above every form and detail-page group — "Basic Information", "Ownership & Status", "SLA & Priority". The metadata declares **85 of them across 15 objects**. Before this change `ja-JP` and `es-ES` carried **2 each**, so a Japanese or Spanish user read English headings on essentially every record page and form, under an otherwise fully translated UI. `en` carried 2 as well; `zh-CN` had 66 and was missing 19, including every section on `crm_event` and `crm_event_attendee` — objects added in #592 whose headings no locale had ever translated.
+
+## Why a completed sweep missed an entire surface
+
+#679 reported all four locales complete, and `objectstack lint` agreed: zero i18n warnings. Both were wrong in the same way.
+
+The guard added in #679 chose its surfaces by reading off lint's warning categories — missing-option, -field, -navigation, -page, -action, -view, -widget, -object. **There is no `_sections` category.** Sections were never considered, so the guard inherited the linter's blind spot exactly and then certified the result. A locale could ship 83 English headings and report a clean bill of health from every tool pointed at it (#683).
+
+The correction is in how the new assertion derives its work, not just that it exists: it walks the metadata and asks what that declares, from two sources that must both be collected —
+
+1. every distinct `group` across an object's fields (the fields are the authority for which sections *exist*; `fieldGroups` only supplies each one's English heading), and
+2. every `sections[].name` in the page and view tree **at any depth** — detail pages nest them inside `page:tabs` → components → `properties.sections`, and a shallow walk misses precisely those. A first pass at this derivation under-counted by nine for that reason.
+
+A companion assertion fails if the derivation ever returns a trivially small set, so a broken derivation cannot masquerade as a passing check — the failure mode this suite already has one historical example of.
+
+## Consistency the sweep forced
+
+Where two section keys on one object share the same English text — `crm_case.basic` and `crm_case.info` are both "Case Information", one on the form and one on the detail page — every locale now renders them identically. Where the same key carries genuinely different English across objects, the locales diverge deliberately: `assignment` is "Assignment" on `crm_lead` but "Ownership" on `crm_campaign`.
+
+Two metadata inconsistencies surfaced and are left for the object definitions rather than papered over in translation: `crm_opportunity`'s `crm_forecast` section is labelled "Forecast & Metrics" by the object and "Stage & Forecast" by the detail page, so one translation has to serve both screens; and `crm_event_attendee.response` means "Invitation" while `crm_campaign_member.response` means "Response Tracking".

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -123,6 +123,14 @@ export const en: TranslationData = {
         enterprise_accounts: { label: 'Enterprise Accounts', description: 'Accounts with the highest annual revenue' },
         my_accounts: { label: 'My Accounts', description: 'Accounts owned by the current user' },
       },
+      _sections: {
+        basic: { label: 'Basic Information' },
+        financials: { label: 'Financials' },
+        contact_info: { label: 'Contact Information' },
+        ownership: { label: 'Ownership & Status' },
+        branding: { label: 'Branding' },
+        system: { label: 'System' },
+      },
       _actions: { ...activityActions },
     },
 
@@ -178,6 +186,14 @@ export const en: TranslationData = {
         all_contacts: { label: 'All Contacts' },
         contact_directory: { label: 'People Directory' },
         primary_contacts: { label: 'Primary Contacts' },
+      },
+      _sections: {
+        identity: { label: 'Identity' },
+        account_info: { label: 'Account & Role' },
+        contact_info: { label: 'Contact Information' },
+        mailing_address: { label: 'Mailing Address' },
+        additional: { label: 'Additional Info' },
+        preferences: { label: 'Communication Preferences' },
       },
       _actions: {
         ...activityActions,
@@ -249,6 +265,12 @@ export const en: TranslationData = {
         my_drafts: { label: 'My Drafts' },
         stale_articles: { label: 'Stale (>180d)' },
       },
+      _sections: {
+        basic: { label: 'Article Information' },
+        content: { label: 'Content' },
+        taxonomy: { label: 'Categorization' },
+        metrics: { label: 'Engagement' },
+      },
     },
 
     crm_forecast: {
@@ -300,6 +322,11 @@ export const en: TranslationData = {
         all_forecasts: { label: 'All Forecasts' },
         this_quarter_forecasts: { label: 'This Quarter' },
         my_forecast: { label: 'My Forecast' },
+      },
+      _sections: {
+        basic: { label: 'Snapshot' },
+        amounts: { label: 'Amounts' },
+        meta: { label: 'Source' },
       },
     },
 
@@ -406,6 +433,23 @@ export const en: TranslationData = {
             message: 'Nothing to review — every re-captured email has been checked.',
           },
         },
+      },
+      _sections: {
+        identity: { label: 'Identity' },
+        company_info: { label: 'Company Information' },
+        contact_info: { label: 'Contact Information' },
+        qualification: { label: 'Qualification' },
+        assignment: { label: 'Assignment' },
+        address: { label: 'Address' },
+        additional: { label: 'Additional Info' },
+        preferences: { label: 'Communication Preferences' },
+        conversion: { label: 'Conversion' },
+        duplicates: { label: 'Duplicate Management' },
+        // Detail-page sections (src/pages/lead_detail.page.ts)
+        info: { label: 'Lead Information' },
+        crm_contact: { label: 'Contact' },
+        detail: { label: 'Lead Detail' },
+        description: { label: 'Description' },
       },
       _actions: {
         ...activityActions,
@@ -525,6 +569,18 @@ export const en: TranslationData = {
         deal_gallery: { label: 'Deal Cards' },
         my_open_deals: { label: 'My Open Deals' },
       },
+      _sections: {
+        basic: { label: 'Basic Information' },
+        financials: { label: 'Financials' },
+        sales_process: { label: 'Sales Process' },
+        classification: { label: 'Classification' },
+        competition: { label: 'Competition & Campaigns' },
+        notes: { label: 'Notes & Next Steps' },
+        crm_forecast: { label: 'Forecast & Metrics' },
+        // Detail-page sections (src/pages/opportunity_detail.page.ts)
+        info: { label: 'Opportunity Information' },
+        description: { label: 'Description' },
+      },
       _actions: {
         ...activityActions,
         clone_opportunity: {
@@ -610,6 +666,18 @@ export const en: TranslationData = {
         case_timeline: { label: 'Case Timeline' },
         escalated_cases: { label: 'Escalated Cases' },
       },
+      _sections: {
+        basic: { label: 'Case Information' },
+        origin: { label: 'Origin & Routing' },
+        sla: { label: 'SLA & Priority' },
+        resolution: { label: 'Resolution' },
+        escalation: { label: 'Escalation' },
+        system: { label: 'System' },
+        // Detail-page sections (src/pages/case_detail.page.ts)
+        info: { label: 'Case Information' },
+        status: { label: 'Status & SLA' },
+        description: { label: 'Description' },
+      },
       _actions: {
         ...activityActions,
         escalate_case: {
@@ -681,6 +749,14 @@ export const en: TranslationData = {
         contract_gantt: { label: 'Contract Terms' },
         contract_timeline: { label: 'Contract Timeline' },
       },
+      _sections: {
+        basic: { label: 'Contract Information' },
+        parties: { label: 'Parties' },
+        terms: { label: 'Terms & Dates' },
+        value: { label: 'Contract Value' },
+        status: { label: 'Status & Approval' },
+        renewal: { label: 'Renewal' },
+      },
     },
 
     crm_product: {
@@ -736,6 +812,11 @@ export const en: TranslationData = {
         product_catalog: { label: 'Product Catalog' },
         low_stock: { label: 'Low Stock' },
       },
+      _sections: {
+        basic: { label: 'Product Information' },
+        pricing: { label: 'Pricing & Billing' },
+        metadata: { label: 'Resources' },
+      },
     },
 
     crm_quote: {
@@ -781,6 +862,13 @@ export const en: TranslationData = {
         all_quotes: { label: 'All Quotes' },
         quote_pipeline: { label: 'Quote Pipeline' },
         quote_calendar: { label: 'Quote Calendar' },
+      },
+      _sections: {
+        basic: { label: 'Quote Information' },
+        pricing: { label: 'Pricing' },
+        terms: { label: 'Terms & Validity' },
+        address: { label: 'Addresses' },
+        system: { label: 'System' },
       },
     },
 
@@ -847,6 +935,14 @@ export const en: TranslationData = {
         task_timeline: { label: 'Worklog Timeline' },
         my_open_tasks: { label: 'My Open Tasks' },
       },
+      _sections: {
+        basic: { label: 'Task Information' },
+        scheduling: { label: 'Scheduling' },
+        related: { label: 'Related Records' },
+        recurrence: { label: 'Recurrence' },
+        effort: { label: 'Progress & Effort' },
+        system: { label: 'System' },
+      },
     },
 
     crm_campaign: {
@@ -905,6 +1001,14 @@ export const en: TranslationData = {
         campaign_calendar: { label: 'Launch Calendar' },
         campaign_timeline: { label: 'Marketing Timeline' },
       },
+      _sections: {
+        basic: { label: 'Campaign Information' },
+        schedule: { label: 'Schedule' },
+        budget: { label: 'Budget & ROI' },
+        metrics: { label: 'Performance' },
+        assignment: { label: 'Ownership' },
+        assets: { label: 'Campaign Assets' },
+      },
       _actions: {
         enroll_leads: {
           label: 'Enroll Leads',
@@ -961,6 +1065,12 @@ export const en: TranslationData = {
         upcoming_events: { label: '📅 Upcoming · Soonest First' },
         held_events: { label: '✅ Interaction History' },
       },
+      _sections: {
+        basic: { label: 'Event Information' },
+        schedule: { label: 'Schedule' },
+        related: { label: 'Related Records' },
+        outcome: { label: 'Outcome' },
+      },
     },
 
     crm_event_attendee: {
@@ -993,6 +1103,10 @@ export const en: TranslationData = {
       },
       _views: {
         all_event_attendees: { label: 'Event Attendees' },
+      },
+      _sections: {
+        basic: { label: 'Attendee' },
+        response: { label: 'Invitation' },
       },
     },
 

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -136,6 +136,14 @@ export const esES: TranslationData = {
         renewals_due: { label: '🔄 Próximas Renovaciones' },
         at_risk_accounts: { label: '⚠️ Cuentas en Riesgo' },
       },
+      _sections: {
+        basic: { label: 'Información Básica' },
+        financials: { label: 'Datos Financieros' },
+        contact_info: { label: 'Información de Contacto' },
+        ownership: { label: 'Propiedad y Estado' },
+        branding: { label: 'Identidad de Marca' },
+        system: { label: 'Sistema' },
+      },
       _actions: { ...activityActions },
     },
 
@@ -195,6 +203,16 @@ export const esES: TranslationData = {
         all_contacts: { label: 'Todos los Contactos' },
         contact_directory: { label: 'Directorio de Contactos' },
         primary_contacts: { label: 'Contactos Principales' },
+      },
+      _sections: {
+        identity: { label: 'Identidad' },
+        account_info: { label: 'Cuenta y Cargo' },
+        contact_info: { label: 'Información de Contacto' },
+        // Los campos de esta sección se traducen «… de Correo»
+        // (`mailing_street`, `mailing_city`…): el encabezado los acompaña.
+        mailing_address: { label: 'Dirección de Correo' },
+        additional: { label: 'Información Adicional' },
+        preferences: { label: 'Preferencias de Comunicación' },
       },
       _actions: {
         ...activityActions,
@@ -266,6 +284,12 @@ export const esES: TranslationData = {
         my_drafts: { label: 'Mis borradores' },
         stale_articles: { label: 'Obsoletos (>180d)' },
       },
+      _sections: {
+        basic: { label: 'Información del Artículo' },
+        content: { label: 'Contenido' },
+        taxonomy: { label: 'Categorización' },
+        metrics: { label: 'Interacción' },
+      },
     },
 
     crm_forecast: {
@@ -302,6 +326,11 @@ export const esES: TranslationData = {
         all_forecasts: { label: 'Todas las previsiones' },
         this_quarter_forecasts: { label: 'Este trimestre' },
         my_forecast: { label: 'Mi previsión' },
+      },
+      _sections: {
+        basic: { label: 'Instantánea' },
+        amounts: { label: 'Importes' },
+        meta: { label: 'Origen' },
       },
     },
 
@@ -413,6 +442,26 @@ export const esES: TranslationData = {
             message: 'Nada que revisar: se han comprobado todos los correos recapturados.',
           },
         },
+      },
+      _sections: {
+        // Nombres de sección de `record:details` en la página de detalle
+        // (lead_detail.page.ts).
+        info: { label: 'Información del Prospecto' },
+        crm_contact: { label: 'Contacto' },
+        detail: { label: 'Detalle del Prospecto' },
+        address: { label: 'Dirección' },
+        description: { label: 'Descripción' },
+        // Claves de sección del objeto (lead.object.ts) que usan los
+        // formularios de registro.
+        identity: { label: 'Identidad' },
+        company_info: { label: 'Información de la Empresa' },
+        contact_info: { label: 'Información de Contacto' },
+        qualification: { label: 'Calificación' },
+        assignment: { label: 'Asignación' },
+        conversion: { label: 'Conversión' },
+        additional: { label: 'Información Adicional' },
+        preferences: { label: 'Preferencias de Comunicación' },
+        duplicates: { label: 'Gestión de Duplicados' },
       },
       _actions: {
         ...activityActions,
@@ -537,6 +586,25 @@ export const esES: TranslationData = {
         closing_this_quarter: { label: 'Cierres de Este Trimestre' },
         stale_opportunities: { label: '⚠️ Oportunidades Estancadas · Más Tiempo en Etapa Primero' },
       },
+      _sections: {
+        // Nombres de sección de `record:details` en la página de detalle
+        // (opportunity_detail.page.ts).
+        info: { label: 'Información de la Oportunidad' },
+        // La clave `crm_forecast` la comparten la sección de la página de
+        // detalle («Stage & Forecast») y el grupo de campos del objeto
+        // («Forecast & Metrics»). Ambas cubren etapa, probabilidad y
+        // categoría de pronóstico, así que se traduce una sola vez.
+        crm_forecast: { label: 'Etapa y Previsión' },
+        description: { label: 'Descripción' },
+        // Claves de sección del objeto (opportunity.object.ts) que usan los
+        // formularios de registro.
+        basic: { label: 'Información Básica' },
+        financials: { label: 'Datos Financieros' },
+        sales_process: { label: 'Proceso de Venta' },
+        classification: { label: 'Clasificación' },
+        competition: { label: 'Competencia y Campañas' },
+        notes: { label: 'Notas y Próximos Pasos' },
+      },
       _actions: {
         ...activityActions,
         clone_opportunity: {
@@ -629,6 +697,22 @@ export const esES: TranslationData = {
         my_open_cases: { label: 'Mis Casos Abiertos' },
         sla_at_risk: { label: '⏰ SLA en Riesgo' },
       },
+      _sections: {
+        // Nombres de sección de `record:details` en la página de detalle
+        // (case_detail.page.ts).
+        info: { label: 'Información del Caso' },
+        status: { label: 'Estado y SLA' },
+        description: { label: 'Descripción' },
+        // Claves de sección del objeto (case.object.ts) que usan los
+        // formularios de registro. `basic` repite el inglés de `info`
+        // («Case Information»), así que comparte traducción.
+        basic: { label: 'Información del Caso' },
+        origin: { label: 'Origen y Asignación' },
+        sla: { label: 'SLA y Prioridad' },
+        resolution: { label: 'Resolución' },
+        escalation: { label: 'Escalación' },
+        system: { label: 'Sistema' },
+      },
       _actions: {
         ...activityActions,
         escalate_case: {
@@ -700,6 +784,14 @@ export const esES: TranslationData = {
         contract_gantt: { label: 'Plazos del Contrato' },
         contract_timeline: { label: 'Línea de Tiempo' },
       },
+      _sections: {
+        basic: { label: 'Información del Contrato' },
+        parties: { label: 'Partes' },
+        terms: { label: 'Términos y Fechas' },
+        value: { label: 'Valor del Contrato' },
+        status: { label: 'Estado y Aprobación' },
+        renewal: { label: 'Renovación' },
+      },
     },
 
     crm_product: {
@@ -756,6 +848,11 @@ export const esES: TranslationData = {
         product_catalog: { label: 'Catálogo de Productos' },
         low_stock: { label: 'Stock Bajo' },
       },
+      _sections: {
+        basic: { label: 'Información del Producto' },
+        pricing: { label: 'Precios y Facturación' },
+        metadata: { label: 'Recursos' },
+      },
     },
 
     crm_quote: {
@@ -803,6 +900,13 @@ export const esES: TranslationData = {
         all_quotes: { label: 'Todas las Cotizaciones' },
         quote_pipeline: { label: 'Pipeline de Cotizaciones' },
         quote_calendar: { label: 'Calendario de Cotizaciones' },
+      },
+      _sections: {
+        basic: { label: 'Información de la Cotización' },
+        pricing: { label: 'Precios' },
+        terms: { label: 'Términos y Vigencia' },
+        address: { label: 'Direcciones' },
+        system: { label: 'Sistema' },
       },
     },
 
@@ -875,6 +979,14 @@ export const esES: TranslationData = {
         todays_tasks: { label: '📅 Mis Tareas Prioritarias' },
         overdue_tasks: { label: '⏰ Tareas Abiertas · Más Vencidas Primero' },
       },
+      _sections: {
+        basic: { label: 'Información de la Tarea' },
+        scheduling: { label: 'Programación' },
+        related: { label: 'Registros Relacionados' },
+        recurrence: { label: 'Recurrencia' },
+        effort: { label: 'Progreso y Esfuerzo' },
+        system: { label: 'Sistema' },
+      },
     },
 
     crm_campaign: {
@@ -934,6 +1046,16 @@ export const esES: TranslationData = {
         campaign_calendar: { label: 'Calendario de Campañas' },
         campaign_timeline: { label: 'Línea de Tiempo de Marketing' },
       },
+      _sections: {
+        basic: { label: 'Información de Campaña' },
+        schedule: { label: 'Programación' },
+        budget: { label: 'Presupuesto y ROI' },
+        metrics: { label: 'Rendimiento' },
+        // El inglés de este grupo es «Ownership», no «Assignment»: agrupa al
+        // propietario de la campaña, igual que `crm_account.ownership`.
+        assignment: { label: 'Propiedad' },
+        assets: { label: 'Recursos de Campaña' },
+      },
       _actions: {
         enroll_leads: {
           label: 'Inscribir Prospectos',
@@ -990,6 +1112,12 @@ export const esES: TranslationData = {
         upcoming_events: { label: '📅 Próximos · Más cercanos primero' },
         held_events: { label: '✅ Historial de interacciones' },
       },
+      _sections: {
+        basic: { label: 'Información del Evento' },
+        schedule: { label: 'Programación' },
+        related: { label: 'Registros Relacionados' },
+        outcome: { label: 'Resultado' },
+      },
     },
 
     crm_event_attendee: {
@@ -1019,6 +1147,12 @@ export const esES: TranslationData = {
       },
       _views: {
         all_event_attendees: { label: 'Asistentes al evento' },
+      },
+      _sections: {
+        // El inglés es «Attendee» / «Invitation», no el par
+        // «Basic Information» / «Response Tracking» de crm_campaign_member.
+        basic: { label: 'Asistente' },
+        response: { label: 'Invitación' },
       },
     },
 

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -160,6 +160,14 @@ export const jaJP: TranslationData = {
         renewals_due: { label: '🔄 更新予定' },
         at_risk_accounts: { label: '⚠️ リスクのある取引先' },
       },
+      _sections: {
+        basic: { label: '基本情報' },
+        financials: { label: '財務情報' },
+        contact_info: { label: '連絡先情報' },
+        ownership: { label: '所有者・ステータス' },
+        branding: { label: 'ブランディング' },
+        system: { label: 'システム' },
+      },
       _actions: { ...activityActions },
     },
 
@@ -205,6 +213,14 @@ export const jaJP: TranslationData = {
         all_contacts: { label: '全取引先責任者' },
         contact_directory: { label: '責任者ディレクトリ' },
         primary_contacts: { label: '主担当者' },
+      },
+      _sections: {
+        identity: { label: '基本情報' },
+        account_info: { label: '取引先・役職' },
+        contact_info: { label: '連絡先情報' },
+        mailing_address: { label: '郵送先住所' },
+        additional: { label: 'その他の情報' },
+        preferences: { label: 'コミュニケーション設定' },
       },
       _actions: {
         ...activityActions,
@@ -276,6 +292,12 @@ export const jaJP: TranslationData = {
         my_drafts: { label: '自分の下書き' },
         stale_articles: { label: '古い (>180日)' },
       },
+      _sections: {
+        basic: { label: '記事情報' },
+        content: { label: 'コンテンツ' },
+        taxonomy: { label: '分類' },
+        metrics: { label: '利用状況' },
+      },
     },
 
     crm_forecast: {
@@ -333,6 +355,11 @@ export const jaJP: TranslationData = {
         all_forecasts: { label: 'すべてのフォーキャスト' },
         this_quarter_forecasts: { label: '今四半期' },
         my_forecast: { label: '自分のフォーキャスト' },
+      },
+      _sections: {
+        basic: { label: 'スナップショット' },
+        amounts: { label: '金額' },
+        meta: { label: 'ソース' },
       },
     },
 
@@ -424,6 +451,24 @@ export const jaJP: TranslationData = {
             message: '確認は不要です — 再登録されたメールアドレスはすべてチェック済みです。',
           },
         },
+      },
+      _sections: {
+        // 詳細ページの `record:details` セクション名（lead_detail.page.ts）
+        info: { label: 'リード情報' },
+        crm_contact: { label: '連絡先' },
+        detail: { label: 'リード詳細' },
+        address: { label: '住所' },
+        description: { label: '説明' },
+        // オブジェクト定義のセクションキー（lead.object.ts）— 入力フォームで使用
+        identity: { label: '基本情報' },
+        company_info: { label: '会社情報' },
+        contact_info: { label: '連絡先情報' },
+        qualification: { label: '適格判定' },
+        assignment: { label: '担当者' },
+        additional: { label: 'その他の情報' },
+        preferences: { label: 'コミュニケーション設定' },
+        conversion: { label: '変換' },
+        duplicates: { label: '重複管理' },
       },
       _actions: {
         ...activityActions,
@@ -529,6 +574,19 @@ export const jaJP: TranslationData = {
         stale_opportunities: { label: '⚠️ 停滞商談 · ステージ滞在が長い順' },
         closing_this_quarter: { label: '今四半期にクローズ予定' },
       },
+      _sections: {
+        // 詳細ページの `record:details` セクション名（opportunity_detail.page.ts）
+        info: { label: '商談情報' },
+        crm_forecast: { label: 'ステージ・売上予測' },
+        description: { label: '説明' },
+        // オブジェクト定義のセクションキー（opportunity.object.ts）— 入力フォームで使用
+        basic: { label: '基本情報' },
+        financials: { label: '財務情報' },
+        sales_process: { label: '営業プロセス' },
+        classification: { label: '分類' },
+        competition: { label: '競合・キャンペーン' },
+        notes: { label: 'メモ・次のステップ' },
+      },
       _actions: {
         ...activityActions,
         clone_opportunity: {
@@ -614,6 +672,19 @@ export const jaJP: TranslationData = {
         my_open_cases: { label: '私のオープンケース' },
         sla_at_risk: { label: '⏰ SLA リスクあり' },
       },
+      _sections: {
+        // 詳細ページの `record:details` セクション名（case_detail.page.ts）
+        info: { label: 'ケース情報' },
+        status: { label: 'ステータス・SLA' },
+        description: { label: '説明' },
+        // オブジェクト定義のセクションキー（case.object.ts）— 入力フォームで使用
+        basic: { label: 'ケース情報' },
+        origin: { label: '発生元・振り分け' },
+        sla: { label: 'SLA・優先度' },
+        resolution: { label: '解決' },
+        escalation: { label: 'エスカレーション' },
+        system: { label: 'システム' },
+      },
       _actions: {
         ...activityActions,
         escalate_case: {
@@ -678,6 +749,14 @@ export const jaJP: TranslationData = {
         contract_gantt: { label: '契約期間' },
         contract_timeline: { label: '契約タイムライン' },
       },
+      _sections: {
+        basic: { label: '契約情報' },
+        parties: { label: '契約当事者' },
+        terms: { label: '契約条件・期間' },
+        value: { label: '契約金額' },
+        status: { label: 'ステータス・承認' },
+        renewal: { label: '更新' },
+      },
     },
 
     crm_product: {
@@ -734,6 +813,11 @@ export const jaJP: TranslationData = {
         product_catalog: { label: '製品カタログ' },
         low_stock: { label: '低在庫' },
       },
+      _sections: {
+        basic: { label: '製品情報' },
+        pricing: { label: '価格・請求' },
+        metadata: { label: '関連資料' },
+      },
     },
 
     crm_quote: {
@@ -774,6 +858,13 @@ export const jaJP: TranslationData = {
         all_quotes: { label: '全見積' },
         quote_pipeline: { label: '見積パイプライン' },
         quote_calendar: { label: '見積カレンダー' },
+      },
+      _sections: {
+        basic: { label: '見積情報' },
+        pricing: { label: '価格' },
+        terms: { label: '条件・有効期限' },
+        address: { label: '住所' },
+        system: { label: 'システム' },
       },
     },
 
@@ -840,6 +931,14 @@ export const jaJP: TranslationData = {
         todays_tasks: { label: '📅 私の優先タスク' },
         overdue_tasks: { label: '⏰ オープンタスク · 期限超過が長い順' },
       },
+      _sections: {
+        basic: { label: 'タスク情報' },
+        scheduling: { label: 'スケジュール' },
+        related: { label: '関連レコード' },
+        recurrence: { label: '繰り返し' },
+        effort: { label: '進捗・工数' },
+        system: { label: 'システム' },
+      },
     },
 
     crm_campaign: {
@@ -900,6 +999,14 @@ export const jaJP: TranslationData = {
         campaign_calendar: { label: 'キャンペーンカレンダー' },
         campaign_timeline: { label: 'マーケティングタイムライン' },
       },
+      _sections: {
+        basic: { label: 'キャンペーン情報' },
+        schedule: { label: 'スケジュール' },
+        budget: { label: '予算・ROI' },
+        metrics: { label: '実績' },
+        assignment: { label: '担当者' },
+        assets: { label: 'キャンペーンアセット' },
+      },
       _actions: {
         enroll_leads: {
           label: 'リードを一括登録',
@@ -953,6 +1060,12 @@ export const jaJP: TranslationData = {
         upcoming_events: { label: '📅 開催予定 · 直近順' },
         held_events: { label: '✅ 対話履歴' },
       },
+      _sections: {
+        basic: { label: 'イベント情報' },
+        schedule: { label: 'スケジュール' },
+        related: { label: '関連レコード' },
+        outcome: { label: '実施結果' },
+      },
     },
 
     crm_event_attendee: {
@@ -982,6 +1095,10 @@ export const jaJP: TranslationData = {
       },
       _views: {
         all_event_attendees: { label: 'イベント参加者' },
+      },
+      _sections: {
+        basic: { label: '参加者' },
+        response: { label: '招待' },
       },
     },
 

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -427,6 +427,7 @@ export const zhCN: TranslationData = {
         additional: { label: '附加信息' },
         preferences: { label: '沟通偏好' },
         conversion: { label: '转化' },
+        duplicates: { label: '重复线索管理' },
       },
       _actions: {
         ...activityActions,
@@ -712,6 +713,14 @@ export const zhCN: TranslationData = {
         priority_rank: { label: '优先级排序' },
         reminder_sent: { label: '提醒已发送' },
       },
+      _sections: {
+        basic: { label: '任务信息' },
+        scheduling: { label: '日程安排' },
+        related: { label: '关联记录' },
+        recurrence: { label: '重复规则' },
+        system: { label: '系统' },
+        effort: { label: '进度与工时' },
+      },
       _views: {
         all_tasks: { label: '全部任务' },
         task_board: { label: '任务看板' },
@@ -771,6 +780,14 @@ export const zhCN: TranslationData = {
         landing_page_url: { label: '着陆页' },
         is_active: { label: '是否启用' },
         display_title: { label: '显示名称' },
+      },
+      _sections: {
+        basic: { label: '活动信息' },
+        schedule: { label: '日程安排' },
+        budget: { label: '预算与投资回报' },
+        metrics: { label: '效果数据' },
+        assignment: { label: '归属' },
+        assets: { label: '活动素材' },
       },
       _views: {
         all_campaigns: { label: '全部营销活动' },
@@ -1018,6 +1035,12 @@ export const zhCN: TranslationData = {
         related_to_case: { label: '关联工单' },
         outcome_notes: { label: '会后纪要', help: '达成了什么共识，下一步做什么' },
       },
+      _sections: {
+        basic: { label: '活动信息' },
+        schedule: { label: '日程安排' },
+        related: { label: '关联记录' },
+        outcome: { label: '结果' },
+      },
       _views: {
         all_events: { label: '全部活动' },
         event_calendar: { label: '活动日历' },
@@ -1052,6 +1075,10 @@ export const zhCN: TranslationData = {
         },
         is_organizer: { label: '组织者' },
         invited_date: { label: '邀请时间' },
+      },
+      _sections: {
+        basic: { label: '参与者' },
+        response: { label: '邀请' },
       },
       _views: {
         all_event_attendees: { label: '活动参与者' },

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -1533,6 +1533,25 @@ describe('app AI bindings resolve to a platform agent', () => {
  * Derived from `localePacks` rather than a hard-coded list: a fifth locale
  * added to the bundle is held to the same bar the day it appears, instead of
  * silently enjoying an exemption nobody wrote down.
+ *
+ * ### The surface list is derived from the METADATA, never from lint's categories
+ *
+ * The `_sections` assertion below was missing from the first version of this
+ * guard, and its absence is the lesson the rest of the file should be read
+ * against. The surfaces were chosen by reading off `objectstack lint`'s warning
+ * categories — missing-option / -field / -navigation / -page / -action / -view
+ * / -widget / -object. There is no `_sections` category, so sections were never
+ * considered, and the guard inherited the linter's blind spot while reporting
+ * that every locale was complete.
+ *
+ * What that cost: 83 of 85 section headings were untranslated in `ja-JP` and
+ * `es-ES`, so a Japanese user read "Basic Information" and "Ownership & Status"
+ * on every record page under an otherwise fully Japanese UI — while lint
+ * reported zero i18n warnings for that locale (#683).
+ *
+ * A tool's warning list is a record of what someone thought to check, not of
+ * what exists. Every assertion here therefore walks the metadata itself and
+ * asks what it declares; none of them asks a linter what it noticed.
  */
 describe('every locale is complete on every authored surface', () => {
   const packs = (): [string, AnyRec][] => {
@@ -1643,5 +1662,75 @@ describe('every locale is complete on every authored surface', () => {
       }
     }
     expect(bad, `action params with no translated label:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  /**
+   * Section headings — the surface `objectstack lint` cannot see (#683).
+   *
+   * A section is named in two independent places, and both must be collected or
+   * the requirement is understated:
+   *
+   *  1. Every distinct `group` on an object's fields. `fieldGroups` declares the
+   *     English heading for each, but a group used by a field and absent from
+   *     `fieldGroups` still renders a heading, so the FIELDS are the authority
+   *     for which sections exist.
+   *  2. Every `sections[].name` in the page and view tree — at ANY depth. Detail
+   *     pages nest them inside `page:tabs` → components → `properties.sections`,
+   *     and a shallow walk silently misses exactly those, which is how a first
+   *     pass at this derivation under-counted by nine.
+   */
+  const sectionsByObject = (): Map<string, Set<string>> => {
+    const need = new Map<string, Set<string>>();
+    const add = (objectName?: string, name?: string) => {
+      if (!objectName || !name) return;
+      if (!need.has(objectName)) need.set(objectName, new Set());
+      need.get(objectName)!.add(name);
+    };
+
+    for (const obj of objects) {
+      for (const f of Object.values<AnyRec>(obj.fields ?? {})) add(obj.name, f?.group);
+    }
+
+    const walk = (node: AnyRec | AnyRec[] | undefined, bound?: string): void => {
+      if (!node || typeof node !== 'object') return;
+      if (Array.isArray(node)) { for (const x of node) walk(x, bound); return; }
+      const here = node.object ?? node.properties?.object ?? node.data?.object ?? bound;
+      for (const arr of [node.sections, node.properties?.sections]) {
+        if (Array.isArray(arr)) for (const s of arr) add(here, s?.name);
+      }
+      // `fields` is skipped: it is a map of field definitions, not layout, and
+      // descending into it would attribute a field named `sections` as layout.
+      for (const [key, value] of Object.entries(node)) {
+        if (key !== 'fields' && value && typeof value === 'object') walk(value as AnyRec, here);
+      }
+    };
+    for (const page of pages) walk(page, page.object);
+    for (const view of views) walk(view, view.object ?? view.list?.data?.object);
+
+    return need;
+  };
+
+  it('sees a non-trivial set of sections to check', () => {
+    // Without this, a derivation that silently returned nothing would make the
+    // assertion below pass while checking nothing — the failure mode this whole
+    // describe block exists to rule out.
+    const need = sectionsByObject();
+    const total = [...need.values()].reduce((n, s) => n + s.size, 0);
+    expect(need.size, 'no objects declare sections — derivation is broken').toBeGreaterThan(10);
+    expect(total, 'suspiciously few sections found — derivation is broken').toBeGreaterThan(60);
+  });
+
+  it('every form and detail-page section heading is translated', () => {
+    const need = sectionsByObject();
+    const bad: string[] = [];
+    for (const [locale, pack] of packs()) {
+      for (const [objectName, names] of need) {
+        const translated = pack.objects?.[objectName]?._sections ?? {};
+        for (const name of names) {
+          if (!translated[name]?.label) bad.push(`${locale}: ${objectName}.${name}`);
+        }
+      }
+    }
+    expect(bad, `section headings with no translation:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 });


### PR DESCRIPTION
## Description

`_sections` holds the heading above every form and detail-page group — "Basic Information", "Ownership & Status", "SLA & Priority". The metadata declares **85 across 15 objects**. Before this change:

| Locale | Had | Missing |
|---|---|---|
| `en` | 2 | 83 |
| `zh-CN` | 66 | **19** |
| `ja-JP` | 2 | 83 |
| `es-ES` | 2 | 83 |

A Japanese or Spanish user read English headings on essentially every record page and form, under an otherwise fully translated UI. `zh-CN`'s 19 include **every section on `crm_event` and `crm_event_attendee`** — objects added in #592 whose headings no locale had ever translated, so the gap was still growing.

## The part worth reviewing: why a completed sweep missed an entire surface

#679 reported all four locales complete, and `objectstack lint` agreed — zero i18n warnings. Both were wrong in the same way, and it is my error.

The guard added in #679 chose its surfaces by reading off lint's warning categories: `missing-option`, `-field`, `-navigation`, `-page`, `-action`, `-view`, `-widget`, `-object`. **There is no `_sections` category.** So sections were never considered, the guard inherited the linter's blind spot exactly, and then certified the result. A locale could ship 83 English headings and get a clean bill of health from every tool pointed at it (#683 caught it by looking at a screenshot).

The fix is in *how the new assertion decides what to check*, not merely that one exists. It walks the metadata and asks what that declares, from two sources that must **both** be collected:

1. **Every distinct `group` across an object's fields.** The fields are the authority for which sections exist — `fieldGroups` only supplies each one's English heading, and a group used by a field but absent from `fieldGroups` still renders.
2. **Every `sections[].name` in the page and view tree, at any depth.** Detail pages nest them inside `page:tabs` → components → `properties.sections`. A shallow walk misses precisely those — a first pass at this derivation under-counted by nine for exactly that reason.

A companion assertion fails if the derivation ever returns a trivially small set, so a broken derivation cannot masquerade as a passing check. This suite already contains one historical green-but-vacuous test (`every navigation node has a zh-CN label`, which spent its life looking up the wrong bundle shape), so that is not a hypothetical failure mode here.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #683 (part 1 — the missing translation surface). Part 2 of that issue, the absent `objectstack lint` rule, is upstream and unaddressed here.
Follow-up to #679, whose completeness claim this corrects.

## Changes Made

- **`en.ts` +83**, **`ja-JP.ts` +83**, **`es-ES.ts` +83**, **`zh-CN.ts` +19** section keys. All four bundles now carry 15 `_sections` blocks and 85 keys.
- **`test/metadata-references.test.ts`** — the derivation above, the completeness assertion, and the anti-vacuity check.

### Consistency the sweep forced

- Where two keys on one object share the same English text — `crm_case.basic` and `crm_case.info` are both "Case Information", one on the form and one on the detail page — every locale renders them identically. Verified programmatically across all four bundles, not by eye.
- Where the same key carries genuinely different English across objects, the locales diverge deliberately: `assignment` is "Assignment" on `crm_lead` but "Ownership" on `crm_campaign`.

## Testing

- [x] Unit tests pass — **1280 passed, 1 skipped, 52 files**
- [x] Linting passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [x] New tests added — the completeness assertion and its anti-vacuity companion
- [x] `pnpm validate` and `pnpm typecheck` clean

Verified independently of the agents that produced each locale: 0 of 85 missing in all four; a brace-depth duplicate-key scan clean across all four bundles (a duplicate silently drops the earlier value, which has bitten this file family before); and the identical-English → identical-translation check above.

Note that `objectstack lint` reported **0 i18n warnings for every locale both before and after this change** — it is blind to this surface, which is the whole point.

## Checklist

- [x] **I have added a changeset** (`.changeset/section-headings-every-locale.md`)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Two metadata inconsistencies surfaced and are deliberately left to the object definitions** rather than papered over in translation, per the split #687 established:

- `crm_opportunity`'s `crm_forecast` section is labelled **"Forecast & Metrics"** by `opportunity.object.ts` and **"Stage & Forecast"** by `opportunity_detail.page.ts` — one key, two English labels, so a single translation has to serve both screens. All three translated locales independently chose the stage-and-forecast reading.
- `crm_event_attendee.response` means **"Invitation"** while `crm_campaign_member.response` means **"Response Tracking"** — the same key with two meanings.

Also flagged by the locale sweeps, same category: `crm_campaign.assignment` labelled "Ownership" while `crm_account` keys that concept as `ownership`; `crm_product.metadata` labelled "Resources"; `crm_forecast.basic` labelled "Snapshot" where every other object's `basic` is "&lt;Thing&gt; Information".

**Reviewers who read Japanese, Spanish or Chinese:** the judgment calls are terminology consistency with the fields sitting under each heading — es-ES matched the bundle's existing *Prospecto* / *Caso* rather than the more common *cliente potencial* / *incidencia*, and ja-JP anchored on 取引先 / 取引先責任者 / 商談 / リード / ケース.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8UZqd6mJMPHAXKb6XcHmi)_