### PR TITLE
docs: controlled_by_parent 可达范围按实测改写(#694 本仓侧纠偏)

### DIFF
--- a/.changeset/controlled-by-parent-reach-docs-truth-sweep.md
+++ b/.changeset/controlled-by-parent-reach-docs-truth-sweep.md
@@ -1,0 +1,53 @@
+---
+'hotcrm': patch
+---
+
+Completes the `controlled_by_parent` doc-truth correction over the sites the first
+batch's file surface did not reach. Prose and comments only — every OWD, sharing
+model, sharing rule, RLS policy and profile grant is byte-identical.
+
+Same measurement as the first batch, pinned by `test/parent-derived-reach.test.ts`
+on 17.0.0-rc.2: the ADR-0055 derivation resolves the master id set through the
+master's row-level security policies only, under a system context — ownership
+scope and `sys_record_share` grants are never folded in — so a parent-derived
+child is readable by every holder of object-level read on it, and the
+parent-write gate is exactly as wide.
+
+Corrected:
+
+- `src/objects/event_attendee.object.ts` claimed reads are filtered to attendees
+  whose `crm_event` the caller can read and that "an attendee row is therefore
+  never more visible than the meeting it belongs to". `crm_event` is private and
+  reps hold it own-only, so this was the widest gap between documented and
+  shipped reach in the app.
+- `src/objects/opportunity_line_item.object.ts` claimed reads are filtered to
+  lines whose `crm_opportunity` the caller can read — the twin of the
+  `crm_quote_line_item` wording already corrected. It now also names the one RLS
+  policy this app authors on a master (the private-deal filter on
+  `crm_opportunity`, carried by the `sales_manager` and `marketing_user` sets),
+  which is the only thing that narrows a derived master set here.
+- `src/objects/campaign_member.object.ts` claimed reads are filtered to members
+  whose `crm_campaign` the caller can read. Because `crm_campaign` is
+  `public_read` the practical read delta is small — a caller holding campaign
+  read already reads every campaign — so the note says that rather than
+  overstating it, and records that the write side genuinely does narrow through
+  the platform's `member_default` owner-only-writes policy.
+- `src/profiles/sales-manager.profile.ts` and
+  `src/profiles/marketing-user.profile.ts` described attendee, member and line
+  item rows as following the event / campaign / deal.
+- `content/docs/administration/profiles.mdx` told admins a rep's contacts follow
+  the accounts they can see, and that line item control is scoped to the rep's
+  own deals and quotes.
+- `content/docs/administration/sharing-and-security.mdx`: the Campaign Member OWD
+  row said "membership follows the campaign", and the corrected section said
+  HotCRM authors no master RLS policy at all — it authors exactly one.
+- `content/docs/revenue/contracts.mdx` offered a Controlled-by-Parent OWD as the
+  way to make contracts follow the account; in this release that derives
+  org-wide, which is not what the sentence promised.
+
+The narrow "filtered to readable parents" semantics is the intended one. The
+platform gap is tracked upstream as objectstack-ai/objectstack#5386; the guard
+test goes red the moment the derivation narrows, which is the signal to rewrite
+these sites and re-take the OWD decision (#549).
+
+Refs #694.

--- a/.changeset/controlled-by-parent-reach-docs-truth.md
+++ b/.changeset/controlled-by-parent-reach-docs-truth.md
@@ -1,0 +1,39 @@
+---
+'hotcrm': patch
+---
+
+The docs and code comments describing `controlled_by_parent` now say what the platform actually does: a parent-derived child is readable org-wide, not filtered to the parents the caller can read.
+
+No behavior changes — every OWD, sharing model, sharing rule and profile grant is
+byte-identical. What changed is that three prose sites stopped claiming the
+opposite of measured reality.
+
+`test/parent-derived-reach.test.ts` boots the shipped stack (ObjectQL +
+`plugin-security` + `plugin-sharing`) over this app's own metadata and measures
+what a `sales_rep` gets back. On 17.0.0-rc.2 a rep who can read exactly ONE
+account reads BOTH accounts' contacts, and a rep who can read NO quote at all
+still reads every quote's line items. The ADR-0055 derivation resolves the master
+id set through the master's row-level security policies only, under a system
+context — ownership scope and `sys_record_share` grants are never folded in — and
+HotCRM authors no RLS policy on any master, so the master set is every record.
+The write gate resolves the master through that same filter, so it is exactly as
+wide.
+
+Corrected:
+
+- `src/objects/quote_line_item.object.ts` claimed "reads are filtered to lines
+  whose `crm_quote` the caller can read".
+- `src/profiles/sales-rep.profile.ts` claimed a rep's territory account carries
+  its contacts, and that the parent derivation is what scopes line items to the
+  rep's own book. Every `controlled_by_parent` grant in that set is org-wide read
+  today.
+- `content/docs/administration/sharing-and-security.mdx` told admins contacts
+  "follow the account", that a manual share carries its parent-derived children,
+  and that a Controlled by Parent record is granted when its parent is visible.
+
+The narrow "filtered to readable parents" semantics is the intended one. The
+platform gap is tracked as objectstack-ai/objectstack#5386; the guard test above
+pins the measured reach and goes red the moment the derivation narrows, which is
+the signal to rewrite these sites and re-take the OWD decision (#549).
+
+Refs #694.

--- a/content/docs/administration/profiles.mdx
+++ b/content/docs/administration/profiles.mdx
@@ -43,8 +43,8 @@ Permission sets are **explicit-allow only**: if an object is not listed in a set
 ### 💼 Sales Representative
 
 - Create, read and edit their **own** leads, accounts, opportunities, quotes and tasks
-- **Contacts** follow the account: a rep sees the contacts of every account they can see, including accounts reaching them through a territory or account-team share
-- **Opportunity and quote line items** — full control on their own deals and quotes, which is what the "Products" related list and quote building need
+- **Contacts**: every contact in the org — not only those on accounts the rep can see. Contact is Controlled by Parent, and in this release that derivation resolves org-wide rather than per account (see [Sharing & security](/docs/administration/sharing-and-security), *Controlled by Parent, in practice*)
+- **Opportunity and quote line items** — full control, which is what the "Products" related list and quote building need. Controlled by Parent again, so this reaches every deal's and every quote's lines, not only the rep's own
 - Read the **product** catalog, **campaigns**, **campaign members**, **knowledge articles** and **competitor** battlecards, and file a new competitor they ran into
 - Read their **own forecast snapshots** (they are written by the nightly forecast job, never by hand)
 - Read their own **contracts** and **cases**; deleting is a manager privilege (their own tasks excepted)

--- a/content/docs/administration/sharing-and-security.mdx
+++ b/content/docs/administration/sharing-and-security.mdx
@@ -24,7 +24,7 @@ OWD is the *most restrictive* setting for each object. Everything else widens it
 | --- | --- | --- |
 | Lead | Private | Reps work their own leads |
 | Account | Private | Account ownership matters |
-| Contact | Controlled by Parent (Account) | Visibility follows the account |
+| Contact | Controlled by Parent (Account) | A contact belongs to its account — but read *Controlled by Parent, in practice* below for what that derives to today |
 | Opportunity | Private | Sensitive deal data |
 | Opportunity Line Item | Controlled by Parent (Opportunity) | A product line is part of the deal |
 | Quote | Private | Pricing is owner's business |
@@ -45,8 +45,10 @@ OWD is the *most restrictive* setting for each object. Everything else widens it
 
 For the four parent-derived objects above, there is nothing to configure per user: access is *computed*.
 
-- **Read** — you see the rows whose parent you can see. A rep opening an account they reached through a territory rule also gets its contacts; the "Products" list on an opportunity shows the same lines the deal shows.
-- **Write** — adding, changing or removing a row requires **edit** access to the parent. You cannot add a line to someone else's quote, and marketing enrolling a campaign member needs edit on that campaign.
+- **Read — in this release the computed answer is org-wide, not parent-scoped.** The intent of Controlled by Parent is "you see the rows whose parent you can see". That is not what ships today: the derivation resolves the set of accessible parents from the *parent object's row-level security policies* only, and HotCRM authors none — so the parent set is every record, for every caller. Measured against the shipped stack (platform 17.0.0-rc.2): a rep who can read exactly one account reads **both** accounts' contacts, and a rep who can read **no** quote at all still reads every quote's line items. In practice, a Controlled by Parent object here is readable by every user whose profile grants read on that object.
+- **Write** — adding, changing or removing a row requires **edit** access to the parent, and that parent is resolved through the same filter as reads. So the write gate is exactly as wide: a profile holding edit on a Controlled by Parent object can write any row of it, including rows under a parent it cannot read.
+
+The narrowing to readable parents is tracked as a platform issue, objectstack-ai/objectstack#5386. The repo test `test/parent-derived-reach.test.ts` pins the reach measured above and fails the moment the platform narrows it — that failure is the signal this section needs rewriting, and HotCRM's OWD choices need re-taking (#549, #694).
 
 Because access is derived, ownership of the child row is irrelevant — a quote line the quote-generation flow created is as visible to the quote's owner as one they typed themselves.
 
@@ -112,7 +114,7 @@ Sharing rules are authored **per object**. Widening `Account` widens accounts �
 
 | Related list on a shared account | What the recipient sees |
 | --- | --- |
-| Contacts | All of them — Contact is Controlled by Parent, so it follows the account |
+| Contacts | All of them — and not only this account's: Contact is Controlled by Parent, which in this release derives org-wide (see above) |
 | Opportunities | Their own deals only, plus open deals ≥ $100,000 if they hold `sales_director` or `executive` |
 | Quotes | Their own only |
 | Contracts | Their own only |
@@ -120,13 +122,13 @@ Sharing rules are authored **per object**. Widening `Account` widens accounts �
 | Tasks | Their own only |
 | Events | Their own only |
 
-So a territory rule hands over the account record and its contacts; the deal, quote, contract, case, task and meeting history underneath stays with its owners, and those related lists can look empty or partial on an account the user can otherwise read in full.
+So a territory rule hands over the account record; the deal, quote, contract, case, task and meeting history underneath stays with its owners, and those related lists can look empty or partial on an account the user can otherwise read in full. The Contacts list is the exception in both directions — it is never empty, because Contact's parent derivation reaches every contact in the org, not just this account's.
 
-Making a child object follow the account is a deliberate widening, not a config detail: author a sharing rule on the child object with criteria matching the account rules, or set the child's OWD to Controlled by Parent. Either one opens that object for **every** holder of it, not only for the territory recipients — which is why HotCRM ships neither by default.
+Making a child object follow the account is a deliberate widening, not a config detail: author a sharing rule on the child object with criteria matching the account rules, or set the child's OWD to Controlled by Parent. Either one opens that object for **every** holder of it, not only for the territory recipients — which is why HotCRM ships neither by default. For Controlled by Parent that is literally what happens today, whatever the parent link suggests: see *Controlled by Parent, in practice* above, and objectstack-ai/objectstack#5386.
 
 ## Layer 4 — Manual shares
 
-A **manual share** grants one user or group **Read** or **Read/Write** on a single record, on top of everything above. Shares live per record, and the parent-derived children of a shared record follow it.
+A **manual share** grants one user or group **Read** or **Read/Write** on a single record, on top of everything above. Shares live per record. A manual share adds nothing to the parent-derived children of that record: the derivation never folds share grants in — and today it does not need to, because those children are already readable to everyone holding read on the child object (see *Controlled by Parent, in practice*).
 
 HotCRM ships **no account-team object** — there is no team roster on the account and no Team tab. The rule named *Account Team Sharing* in the table above is an ordinary criteria rule: it gives every `sales_manager` edit on active customer accounts, not a per-record pod. An org that sells in pods models the pod as a position with its own sharing rule, or as manual shares on the account.
 
@@ -137,7 +139,7 @@ A user sees a record when **all** of the following hold: their profile grants **
 1. They **own** the record.
 2. Their profile grants **View All** on the object.
 3. The **OWD** is Public Read-Only or wider.
-4. The record's **parent** is visible to them (Controlled by Parent).
+4. The object is **Controlled by Parent** — which today grants the record whether or not the parent is visible to them (see *Controlled by Parent, in practice*).
 5. A **sharing rule** matches the record and one of their positions.
 6. The record was **shared manually** with them.
 
@@ -213,6 +215,6 @@ There is no "AI bypass".
 If you think you should be able to see a record and can't:
 
 1. Check **who owns it**.
-2. If you reached it from an account, check **which object it is**: only contacts follow the account. Quotes, contracts, tasks, cases and deals stay with their owner even when the account itself is shared with you.
+2. If you reached it from an account, check **which object it is**: quotes, contracts, tasks, cases and deals stay with their owner even when the account itself is shared with you. Contacts are the one related list that is never withheld — Contact is Controlled by Parent, and in this release that derives org-wide rather than per account (see *Controlled by Parent, in practice*).
 3. Check whether the deal is flagged **Private**.
 4. Ask your admin whether a **sharing rule** should cover your position.

--- a/content/docs/administration/sharing-and-security.mdx
+++ b/content/docs/administration/sharing-and-security.mdx
@@ -35,7 +35,7 @@ OWD is the *most restrictive* setting for each object. Everything else widens it
 | Forecast | Private | A snapshot belongs to its owner; managers hold *View All* |
 | Product | Public Read-Only | Everyone sees the catalog |
 | Campaign | Public Read-Only | Marketing creates, sales sees |
-| Campaign Member | Controlled by Parent (Campaign) | Membership follows the campaign |
+| Campaign Member | Controlled by Parent (Campaign) | Membership is an attribute of the campaign — read *Controlled by Parent, in practice* below |
 | Competitor | Public Read-Only | Shared battlecard library |
 | Knowledge Article | Public Read-Only | The knowledge base is for everyone internally; agents author it |
 
@@ -45,7 +45,7 @@ OWD is the *most restrictive* setting for each object. Everything else widens it
 
 For the four parent-derived objects above, there is nothing to configure per user: access is *computed*.
 
-- **Read — in this release the computed answer is org-wide, not parent-scoped.** The intent of Controlled by Parent is "you see the rows whose parent you can see". That is not what ships today: the derivation resolves the set of accessible parents from the *parent object's row-level security policies* only, and HotCRM authors none — so the parent set is every record, for every caller. Measured against the shipped stack (platform 17.0.0-rc.2): a rep who can read exactly one account reads **both** accounts' contacts, and a rep who can read **no** quote at all still reads every quote's line items. In practice, a Controlled by Parent object here is readable by every user whose profile grants read on that object.
+- **Read — in this release the computed answer is org-wide, not parent-scoped.** The intent of Controlled by Parent is "you see the rows whose parent you can see". That is not what ships today: the derivation resolves the set of accessible parents from the *parent object's row-level security policies* only. The one such policy HotCRM authors on any of these parents is the private-deal filter on Opportunity, carried by the Sales Manager and Marketing User profiles — so for every other parent, and for every caller without that policy, the parent set is every record. Measured against the shipped stack (platform 17.0.0-rc.2): a rep who can read exactly one account reads **both** accounts' contacts, and a rep who can read **no** quote at all still reads every quote's line items. In practice, a Controlled by Parent object here is readable by every user whose profile grants read on that object.
 - **Write** — adding, changing or removing a row requires **edit** access to the parent, and that parent is resolved through the same filter as reads. So the write gate is exactly as wide: a profile holding edit on a Controlled by Parent object can write any row of it, including rows under a parent it cannot read.
 
 The narrowing to readable parents is tracked as a platform issue, objectstack-ai/objectstack#5386. The repo test `test/parent-derived-reach.test.ts` pins the reach measured above and fails the moment the platform narrows it — that failure is the signal this section needs rewriting, and HotCRM's OWD choices need re-taking (#549, #694).

--- a/content/docs/revenue/contracts.mdx
+++ b/content/docs/revenue/contracts.mdx
@@ -108,7 +108,7 @@ Contracts are **private**, and no sharing rule widens them. Contract visibility 
 - **Sales Manager** and **System Administrator** read every contract (*View All* on the object); edits stay with the owner except for admins.
 - **Everyone else** — including a rep who reached the account through a territory or team sharing rule — sees only the contracts they own, so an account's *Contracts* related list can look empty even when the account itself is fully readable.
 
-If your org wants contracts to follow the account, an admin has to author that: a sharing rule on Contract, or a Controlled-by-Parent OWD. Both widen contract visibility for every user of the object — see [Sharing & Security](/docs/administration/sharing-and-security).
+If your org wants contracts to follow the account, an admin has to author that, and neither available route actually delivers "follows the account" today: a sharing rule on Contract widens the records it matches for every holder of the object, and a Controlled-by-Parent OWD derives org-wide in this release — the parent link is not consulted per caller. Both are a broad widening, not an account-scoped one — see [Sharing & Security](/docs/administration/sharing-and-security), *Controlled by Parent, in practice*.
 
 ## Standard list views
 

--- a/src/objects/campaign_member.object.ts
+++ b/src/objects/campaign_member.object.ts
@@ -18,11 +18,32 @@ export const CampaignMember = ObjectSchema.create({
   description: 'Membership and response tracking for marketing campaigns',
 
   // ADR-0090 D1/D7: OWD is an authored decision. Membership is an attribute of
-  // the campaign, so record access DERIVES from it (ADR-0055): reads are
-  // filtered to members whose `crm_campaign` the caller can read, and enrolling
-  // or updating a member requires edit access to that campaign. The relation
+  // the campaign, so record access DERIVES from it (ADR-0055). The relation
   // resolver accepts the REQUIRED `crm_campaign` LOOKUP as the parent, so no
   // master-detail conversion is needed.
+  //
+  // What that derivation delivers TODAY is not "members whose `crm_campaign`
+  // the caller can read". MEASURED on 17.0.0-rc.2 and pinned by
+  // `test/parent-derived-reach.test.ts`: the derivation resolves the master id
+  // set through the master's row-level security policies ONLY, under a SYSTEM
+  // context — ownership and `sys_record_share` grants are never folded in — and
+  // no RLS policy on `crm_campaign` narrows a SELECT here, so the master set is
+  // every campaign. A member row is readable by every holder of object-level
+  // read on this object, campaign grant or not.
+  //
+  // The practical delta is smaller here than on the app's other parent-derived
+  // objects: `crm_campaign` is `public_read`, so a caller who holds campaign
+  // read already reads every campaign, and the intended derivation would return
+  // the same rows for them. What it changes is that the member rows do not
+  // depend on the campaign grant AT ALL. The write side is where a policy does
+  // bite: the platform's `member_default` set carries an owner-only-writes RLS
+  // policy on updates, and because the derivation DOES fold master RLS in, that
+  // policy reaches through to member writes — see the
+  // `marketing_campaign_updates` note in `src/profiles/marketing-user.profile.ts`.
+  //
+  // The narrow "filtered to readable parents" semantics is the intended one; the
+  // platform gap is tracked upstream as objectstack-ai/objectstack#5386 (#694),
+  // and the guard test above goes red when it lands.
   //
   // It was `private` before (#488) — with no owner field on the junction row
   // that meant "whoever inserted it", which is nobody's idea of campaign

--- a/src/objects/event_attendee.object.ts
+++ b/src/objects/event_attendee.object.ts
@@ -31,14 +31,32 @@ import { ATTENDEE_RESPONSE_OPTIONS } from './_picklists';
  * This mirrors `crm_campaign_member`, the app's existing junction, down to the
  * autonumber `nameField` and the `controlled_by_parent` OWD.
  *
- * # Access derives from the event
+ * # Access derives from the event — and today that derivation is org-wide
  *
- * `sharingModel: 'controlled_by_parent'` (ADR-0055): reads are filtered to
- * attendees whose `crm_event` the caller can read, and adding or updating an
- * attendee requires edit access to that event. The relation resolver accepts
- * the REQUIRED `crm_event` lookup as the parent, so no master-detail
- * conversion is needed — same construction as `crm_campaign_member`. An
- * attendee row is therefore never more visible than the meeting it belongs to.
+ * `sharingModel: 'controlled_by_parent'` (ADR-0055). The relation resolver
+ * accepts the REQUIRED `crm_event` lookup as the parent, so no master-detail
+ * conversion is needed — same construction as `crm_campaign_member`.
+ *
+ * The INTENT of that model is "reads are filtered to attendees whose
+ * `crm_event` the caller can read, and adding or updating an attendee requires
+ * edit access to that event". That is not what the platform does today.
+ * MEASURED on 17.0.0-rc.2 and pinned by `test/parent-derived-reach.test.ts`:
+ * the derivation resolves the master id set through the master's row-level
+ * security policies ONLY, under a SYSTEM context — ownership scope and
+ * `sys_record_share` grants are never folded in. HotCRM authors no RLS policy
+ * on `crm_event`, so the master set is EVERY event, for every caller. An
+ * attendee row is therefore readable by every profile that grants read on this
+ * object, and the parent-write gate resolves the master through that same
+ * filter, so it does not narrow writes either.
+ *
+ * The gap is at its widest here: `crm_event` is `private` and reps hold it
+ * `own`-only, so the intended derivation would be a tight filter, while what
+ * ships hands every attendee row of every meeting to every holder of
+ * object-level read on this object. The narrow semantics is the intended one;
+ * the platform gap is tracked upstream as objectstack-ai/objectstack#5386
+ * (#694). The guard test named above goes red the moment the platform narrows
+ * the derivation — that failure is good news, not a regression, and the signal
+ * to rewrite this note.
  */
 export const EventAttendee = ObjectSchema.create({
   name: 'crm_event_attendee',

--- a/src/objects/opportunity_line_item.object.ts
+++ b/src/objects/opportunity_line_item.object.ts
@@ -20,10 +20,30 @@ export const OpportunityLineItem = ObjectSchema.create({
 
   // ADR-0090 D1/D7: OWD is an authored decision. A line item has no meaning
   // apart from its deal, so its record access DERIVES from the opportunity
-  // (ADR-0055): reads are filtered to line items whose `crm_opportunity` the
-  // caller can read, and any write requires edit access to that opportunity.
-  // ADR-0055's relation resolver accepts a REQUIRED LOOKUP as the parent, so
-  // this works without converting the relationship to master-detail.
+  // (ADR-0055) — but note what that derivation resolves to TODAY, which is not
+  // what "derives from the opportunity" suggests.
+  //
+  // MEASURED on 17.0.0-rc.2 and pinned by `test/parent-derived-reach.test.ts`
+  // on the twin `crm_quote_line_item` -> `crm_quote` chain: reads are NOT
+  // filtered to line items whose `crm_opportunity` the caller can read. The
+  // derivation resolves the master id set through the master's row-level
+  // security policies ONLY, under a SYSTEM context — ownership and
+  // `sys_record_share` grants are never folded in. The one RLS policy this app
+  // authors on `crm_opportunity` is the private-deal filter carried by the
+  // `sales_manager` and `marketing_user` sets, so for any caller without it —
+  // `sales_rep` included — the master set is EVERY opportunity, whatever they
+  // own or were shared. A line item here is effectively readable by every holder
+  // of object-level read on this object; where that private-deal policy does
+  // apply it is the POLICY narrowing the master set, never ownership or a share.
+  // The parent-write gate resolves the master through the same filter, so it
+  // does not narrow writes either (#549's measurement).
+  //
+  // The narrow "filtered to readable parents" semantics is the intended one; the
+  // platform gap is tracked upstream as objectstack-ai/objectstack#5386 (#694).
+  // The guard test named above pins the measured reach and goes red the moment
+  // the platform narrows the derivation — that failure is good news, not a
+  // regression. ADR-0055's relation resolver accepts a REQUIRED LOOKUP as the
+  // parent, so this works without converting the relationship to master-detail.
   //
   // It was `private` before (#488), which was the wrong baseline twice over:
   // this object has no owner of its own to speak of, so "private" fell back to the

--- a/src/objects/quote_line_item.object.ts
+++ b/src/objects/quote_line_item.object.ts
@@ -18,10 +18,26 @@ export const QuoteLineItem = ObjectSchema.create({
   description: 'A single product line on a Quote',
 
   // ADR-0090 D1/D7: OWD is an authored decision. Record access DERIVES from the
-  // quote (ADR-0055): reads are filtered to lines whose `crm_quote` the caller
-  // can read, and a write requires edit access to that quote. The relation
-  // resolver accepts a REQUIRED LOOKUP as the parent, so no master-detail
-  // conversion is needed.
+  // quote (ADR-0055) — but note what that derivation resolves to TODAY, which is
+  // not what "derives from the quote" suggests.
+  //
+  // MEASURED on 17.0.0-rc.2 and pinned by `test/parent-derived-reach.test.ts`:
+  // reads are NOT filtered to lines whose `crm_quote` the caller can read. The
+  // derivation resolves the master id set through the master's row-level
+  // security policies only, under a SYSTEM context — ownership and
+  // `sys_record_share` grants are never folded in — and HotCRM authors no RLS
+  // policy on `crm_quote`, so the master set is EVERY quote. A rep who can read
+  // NEITHER quote in the fixture still reads BOTH quotes' lines; in this app a
+  // line item is effectively readable by every holder of object-level read on
+  // this object. The parent-write gate resolves the master through that same
+  // filter, so it does not narrow writes either (#549's measurement).
+  //
+  // The narrow "filtered to readable parents" semantics is the intended one; the
+  // platform gap is tracked upstream as objectstack-ai/objectstack#5386 (#694).
+  // The guard test named above pins the measured reach and goes red the moment
+  // the platform narrows the derivation — that failure is good news, not a
+  // regression. The relation resolver accepts a REQUIRED LOOKUP as the parent,
+  // so no master-detail conversion is needed.
   //
   // It was `private` before (#488). With no owner field on this object that
   // resolved to the platform's auto-stamped `owner_id` — the row's inserter —

--- a/src/profiles/marketing-user.profile.ts
+++ b/src/profiles/marketing-user.profile.ts
@@ -21,9 +21,18 @@ export const MarketingUserProfile = {
     // "Add to Campaign" action (`src/actions/lead.actions.ts`) inserts
     // `crm_campaign_member` rows, and before #488 no permission set granted the
     // object — the action failed for the only persona meant to run it. Rows
-    // derive from the campaign (controlled_by_parent), so record scope follows
-    // the campaigns this profile can already read; deleting membership history
-    // stays a manager/admin privilege, matching every other object here.
+    // derive from the campaign (controlled_by_parent), so there is no record
+    // scope to author — but that derivation does not consult the campaign grant
+    // at all: MEASURED on 17.0.0-rc.2 and pinned by
+    // `test/parent-derived-reach.test.ts`, the master set comes from the
+    // master's row-level security policies only, under a system context, and
+    // nothing narrows a select on `crm_campaign`. For THIS profile the delta is
+    // small — `crm_campaign` is `public_read` and this set holds org-wide
+    // campaign read, so the intended derivation would hand back the same rows —
+    // but read this grant as org-wide on member rows in fact, not as scope that
+    // follows the campaigns above (objectstack-ai/objectstack#5386, #694).
+    // Deleting membership history stays a manager/admin privilege, matching
+    // every other object here.
     crm_campaign_member: { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: false, viewAllRecords: false, modifyAllRecords: false },
     // Read-only reference: knowledge articles for campaign copy
     // (public_read catalog).
@@ -55,8 +64,13 @@ export const MarketingUserProfile = {
     // campaigns only reaches campaigns the user personally created. That also
     // silently broke "Add to Campaign": enrolling a member is a write DERIVED
     // from the campaign (controlled_by_parent), so it requires campaign edit at
-    // the row level. This policy widens campaign updates to every holder of the
-    // set — exactly what the object grant above already declares. `id != null`
+    // the row level. This is the one direction in which the ADR-0055 derivation
+    // really does narrow: a master RLS policy is exactly what it folds in, while
+    // ownership and `sys_record_share` grants are not (which is why the READ
+    // side of these member rows is org-wide — see the `crm_campaign_member`
+    // grant above and objectstack-ai/objectstack#5386, #694). This policy widens
+    // campaign updates to every holder of the set — exactly what the object
+    // grant above already declares. `id != null`
     // is the pushdown-safe "all rows" predicate (verified: compiles to
     // `{id: {$null: false}}`).
     {

--- a/src/profiles/sales-manager.profile.ts
+++ b/src/profiles/sales-manager.profile.ts
@@ -28,7 +28,17 @@ export const SalesManagerProfile = {
     crm_task:        { allowCreate: true,  allowRead: true, allowEdit: true,  allowDelete: true,  viewAllRecords: true,  modifyAllRecords: true, allowTransfer: true },
     // A manager coaches on activity, so this is org-wide read AND write on a
     // private object — the same shape their `crm_task` grant already has.
-    // `crm_event_attendee` derives from the event (ADR-0055): no scope to author.
+    // `crm_event_attendee` is `controlled_by_parent` (ADR-0055): no scope to
+    // author — one would be inert metadata. It does NOT narrow to the events
+    // this set can read either. MEASURED on 17.0.0-rc.2 and pinned by
+    // `test/parent-derived-reach.test.ts`, the derivation resolves the master id
+    // set through the master's row-level security policies only, under a system
+    // context, so ownership and `sys_record_share` grants never enter it; HotCRM
+    // authors no RLS policy on `crm_event`, so this grant is org-wide read and
+    // write on every attendee row. Here that matches the intent — the grants
+    // above are already org-wide on the activity stack — but read it as org-wide
+    // in fact, not as derived scope. Same note in `sales-rep.profile.ts`;
+    // upstream gap objectstack-ai/objectstack#5386 (#694).
     crm_event:       { allowCreate: true,  allowRead: true, allowEdit: true,  allowDelete: true,  viewAllRecords: true,  modifyAllRecords: true, allowTransfer: true },
     crm_event_attendee: { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: false, modifyAllRecords: false },
     // The forecast IS the manager's job: they read every rep's snapshot and
@@ -38,11 +48,27 @@ export const SalesManagerProfile = {
     // Knowledge is service-authored; sales reads it (public_read OWD).
     crm_knowledge_article: { allowCreate: false, allowRead: true, allowEdit: false, allowDelete: false, viewAllRecords: true, modifyAllRecords: false },
     // Enrollment is marketing's job; a manager only reads the membership rows
-    // behind campaign ROI. `crm_campaign_member` is controlled_by_parent, so
-    // rows follow the campaign — no readScope/viewAllRecords applies (ADR-0055).
+    // behind campaign ROI. `crm_campaign_member` is `controlled_by_parent`, so
+    // no readScope/viewAllRecords applies (ADR-0055) — but the rows do not
+    // "follow the campaign": the derivation resolves the master set through the
+    // master's RLS policies only (none narrow a select on `crm_campaign`), so
+    // this is org-wide read on every member row. The practical delta is small
+    // here — `crm_campaign` is `public_read` and this set reads every campaign
+    // anyway — so the intended derivation would return the same rows. See
+    // `campaign_member.object.ts` and objectstack-ai/objectstack#5386 (#694).
     crm_campaign_member:   { allowCreate: false, allowRead: true, allowEdit: false, allowDelete: false, viewAllRecords: false, modifyAllRecords: false },
     // Line items: full CRUD so a manager can fix pricing on any rep's deal or
-    // quote. Rows derive from the opportunity / quote (controlled_by_parent).
+    // quote. Both objects are `controlled_by_parent`, so there is no scope to
+    // author — but that derivation does not narrow these rows to the deals and
+    // quotes the manager can read. MEASURED (see the note in
+    // `sales-rep.profile.ts` and `test/parent-derived-reach.test.ts`): the master
+    // set comes from the master's RLS policies only, never from ownership or a
+    // share. This set authors one such policy — the private-deal filter on
+    // `crm_opportunity` below — and none on `crm_quote`, so quote lines are
+    // org-wide, and opportunity lines are bounded by that policy and nothing
+    // else (the guard test pins the quote chain; the opportunity side follows
+    // from the same measured mechanism). Upstream gap:
+    // objectstack-ai/objectstack#5386 (#694).
     crm_opportunity_line_item: { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: false, modifyAllRecords: false },
     crm_quote_line_item:       { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: false, modifyAllRecords: false },
   },

--- a/src/profiles/sales-rep.profile.ts
+++ b/src/profiles/sales-rep.profile.ts
@@ -13,12 +13,25 @@ export const SalesRepProfile = {
   // What widens that scope today is narrower than it sounds: the territory /
   // account-team rules are authored on `crm_account` ONLY, and a sharing rule
   // widens the object it names — not the records hanging off it. So a rep who
-  // receives an account through a territory rule reads the account and its
-  // contacts (`controlled_by_parent`), while the quotes, contracts and tasks on
-  // it stay own-only, and opportunities widen only through the >= $100k
-  // leadership rules. Whether those children should follow the account is an
-  // open business decision (#549), not a bug in these grants — do not widen
-  // them here to paper over it.
+  // receives an account through a territory rule reads that account, while the
+  // quotes, contracts and tasks on it stay own-only, and opportunities widen
+  // only through the >= $100k leadership rules. Whether those children should
+  // follow the account is an open business decision (#549), not a bug in these
+  // grants — do not widen them here to paper over it.
+  //
+  // The `controlled_by_parent` grants below are the opposite case: they are
+  // WIDER than they read. MEASURED on 17.0.0-rc.2 and pinned by
+  // `test/parent-derived-reach.test.ts`, a parent-derived child is not filtered
+  // to parents the caller can read — the ADR-0055 derivation resolves the master
+  // id set through the master's row-level security policies only, under a system
+  // context, so ownership and `sys_record_share` grants are never folded in.
+  // HotCRM authors no RLS policy on any master, so the master set is every
+  // record: a rep holding ONE account reads BOTH accounts' contacts, and a rep
+  // who can read no quote at all reads every quote's line items. Read every
+  // `controlled_by_parent` grant below as org-wide read on that object. The
+  // narrow semantics is the intended one and the platform gap is tracked
+  // upstream as objectstack-ai/objectstack#5386 (#694); the guard test goes red
+  // when it lands.
   objects: {
     // `allowExport` where an export surface exists — canonical note in
     // `src/profiles/index.ts`. Safe alongside `readScope: 'own'`: export is
@@ -26,11 +39,13 @@ export const SalesRepProfile = {
     crm_lead:        { allowCreate: true,  allowRead: true,  allowEdit: true,  allowDelete: false, viewAllRecords: false, modifyAllRecords: false, readScope: 'own' as const, allowExport: true },
     crm_account:     { allowCreate: true,  allowRead: true,  allowEdit: true,  allowDelete: false, viewAllRecords: false, modifyAllRecords: false, readScope: 'own' as const, allowExport: true },
     // NO readScope: `crm_contact` is `controlled_by_parent` (master-detail to
-    // crm_account), so its rows derive from the account the rep can read —
-    // territory- and team-shared accounts included. A `readScope` here was
-    // inert (the sharing service only applies owner scope to `private` objects)
-    // and read as a promise the engine never kept: it said "own contacts only"
-    // while access actually followed the account (#488).
+    // crm_account), so a `readScope` here is inert — the sharing service only
+    // applies owner scope to `private` objects — and it read as a promise the
+    // engine never kept: it said "own contacts only" while access derived from
+    // the parent (#488). What that derivation delivers today is wider than "the
+    // accounts the rep can read": measured, a rep holding one territory account
+    // reads EVERY account's contacts (see the note at the top of this file,
+    // #694).
     crm_contact:     { allowCreate: true,  allowRead: true,  allowEdit: true,  allowDelete: false, viewAllRecords: false, modifyAllRecords: false, allowExport: true },
     crm_opportunity: { allowCreate: true,  allowRead: true,  allowEdit: true,  allowDelete: false, viewAllRecords: false, modifyAllRecords: false, readScope: 'own' as const, allowExport: true },
     crm_quote:       { allowCreate: true,  allowRead: true,  allowEdit: true,  allowDelete: false, viewAllRecords: false, modifyAllRecords: false, readScope: 'own' as const },
@@ -44,9 +59,10 @@ export const SalesRepProfile = {
     // `crm_event` is `private` like `crm_task` — a personal activity record —
     // so an explicit record scope is required alongside allowRead (an omitted
     // scope silently means "own only" and reads as an unmade decision).
-    // `crm_event_attendee` is `controlled_by_parent`: rows follow the event and
-    // writes require edit on it (ADR-0055), so authoring a readScope here would
-    // be inert metadata the engine never applies.
+    // `crm_event_attendee` is `controlled_by_parent`, so authoring a readScope
+    // here would be inert metadata the engine never applies. Its rows do not
+    // narrow to the events the rep can read either — the derivation is org-wide
+    // today (see the note at the top of this file, #694).
     crm_event:       { allowCreate: true,  allowRead: true,  allowEdit: true,  allowDelete: true,  viewAllRecords: false, modifyAllRecords: false, readScope: 'own' as const },
     crm_event_attendee: { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: false, modifyAllRecords: false },
     // Reference catalog (public_read OWD): reps read knowledge articles, which
@@ -56,12 +72,13 @@ export const SalesRepProfile = {
     // `revenue_forecasting` skill, never by hand — read-only, and only the rep's
     // own snapshots (private OWD + explicit own scope, as above).
     crm_forecast:          { allowCreate: false, allowRead: true, allowEdit: false, allowDelete: false, viewAllRecords: false, modifyAllRecords: false, readScope: 'own' as const },
-    // Product lines on the rep's own deals and quotes. Both objects are
-    // `controlled_by_parent`, so rows follow the opportunity / quote and writes
-    // require edit on that parent (ADR-0055) — that is what scopes a rep to
-    // their own book here, which is why there is no readScope to author.
-    // Without these grants the opportunity "Products" related list and the
-    // whole CPQ path were denied for every non-admin user (#488).
+    // Product lines on deals and quotes. Both objects are
+    // `controlled_by_parent`, so there is no readScope to author — one would be
+    // inert metadata. That derivation does NOT scope a rep to their own book:
+    // measured, a rep reads every quote line and every opportunity line in the
+    // org, whatever they can read of the parent (see the note at the top of this
+    // file, #694). Without these grants the opportunity "Products" related list
+    // and the whole CPQ path were denied for every non-admin user (#488).
     crm_opportunity_line_item: { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: false, modifyAllRecords: false },
     crm_quote_line_item:       { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true, viewAllRecords: false, modifyAllRecords: false },
     // Which campaign sourced a lead — read-only context, derived from the

--- a/test/sharing-coverage.test.ts
+++ b/test/sharing-coverage.test.ts
@@ -11,12 +11,14 @@ import stack from '../objectstack.config';
  *
  * A sharing rule widens **the object it names** — never the records hanging off
  * it. HotCRM authors its widening rules on `crm_account` (territory + team),
- * but the account's children each keep their own baseline: `crm_contact` is
- * `controlled_by_parent` and follows, while `crm_quote`, `crm_contract` and
- * `crm_task` are `private` with no rule of their own, and `crm_opportunity`
- * only widens through the >= $100k leadership rules. A rep who receives an
- * account through a territory rule therefore opens it to partially empty
- * related lists.
+ * but the account's children each keep their own baseline: `crm_quote`,
+ * `crm_contract` and `crm_task` are `private` with no rule of their own, and
+ * `crm_opportunity` only widens through the >= $100k leadership rules. A rep
+ * who receives an account through a territory rule therefore opens it to
+ * partially empty related lists. `crm_contact` is `controlled_by_parent`, which
+ * does NOT mean "follows the account": as MEASURED by
+ * `test/parent-derived-reach.test.ts`, a parent-derived child is readable
+ * org-wide — see the 'derived' note on ACCOUNT_CHILD_COVERAGE below.
  *
  * Whether those children *should* follow the account is an open business
  * decision (#549) — widening any of them changes what every holder of that
@@ -61,7 +63,9 @@ const SHARING_DOC = 'content/docs/administration/sharing-and-security.mdx';
  *                practical reach of a 'derived' child is therefore every record
  *                of that object, for every holder of object-level read — which
  *                is why #549's Option 2 (convert quote/contract) does NOT
- *                deliver "follows the account" and is unresolved here.
+ *                deliver "follows the account" and is unresolved here. The
+ *                narrow semantics is the intended one; the platform gap is
+ *                tracked upstream as objectstack-ai/objectstack#5386 (#694).
  *   'own_only' — private, no sharing rule: the child stays with its owner.
  *   'partial'  — private, but a rule of its own widens SOME records (never by
  *                account criteria — the rules match on the child's own fields).


### PR DESCRIPTION
## Description

#694 的本仓侧文档/注释纠偏(#549 裁定方案 C 后解锁),两批合入:把按「`controlled_by_parent` 名字听起来的语义」写的叙述,改写为**实测语义** —— 当前派生只走主记录的 RLS(本仓仅 `crm_opportunity` 有一条 private-deal 策略,其余主对象无 ⇒ 实际全组织可读),窄语义由上游 objectstack#5386 跟踪、由 `test/parent-derived-reach.test.ts` 钉住(平台收窄之日守卫变红)。**零行为变更**:`git diff -- src/` 的新增行全部为注释,无 OWD / sharingModel / 授权值 / 测试断言改动。

**批次一**(`f6e556be`):`quote_line_item.object.ts`、`sales-rep.profile.ts`(4 处)、`sharing-and-security.mdx`(7 句)、`sharing-coverage.test.ts` 文件头散文。

**批次二**(`1bc70ea9`,全仓 16 处 grep 命中逐一裁决):`event_attendee.object.ts`(删除全仓最强的错误断言「never more visible than the meeting」)、`opportunity_line_item.object.ts`(镜像批次一措辞)、`profiles.mdx:46/:47`、`sales-manager.profile.ts`(3 处,与 sales-rep 口径一致)、`marketing-user.profile.ts`、`campaign_member.object.ts`(如实写明 public_read 使实际差异小、且写方向确有一条被折入的 master RLS 收窄 —— 唯一「派生真咬人」的方向,未被反转)、`contracts.mdx:111`、`sharing-and-security.mdx:38/:48`。其中 :48 是**对批次一自身过度陈述的纠正**(「authors none」→ 精确为「仅 crm_opportunity 一条」)。

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] CI/CD update

## Related Issues

Related to #694(**保持 open** —— 跟踪上游 objectstack#5386 的行为修复,本 PR 只修正叙述)、#549(`pm:on-hold`)

## Changes Made

- 9 个文件、+180/-28,全部为注释/散文 + 1 个 changeset
- 断言口径:意图写成意图、实测写成事实、未单独测量的推论如实标注为推论;不软化、不承诺

## Testing

- [x] Unit tests pass (`npm test`) — 55 文件 / 1317 通过,1 skipped(两批各自跑过)
- [x] Linting passes (`npm run lint`) — 0 errors
- [x] Build succeeds (`npm run build`) — validate ✓
- [x] Manual testing completed — 纯散文改动;事实基准 `test/parent-derived-reach.test.ts` 前后均绿,证明散文所述与发货行为一致
- [ ] New tests added (if applicable) — 守卫已随 #677 存在

## Screenshots

N/A

## Checklist

- [x] **I have added a changeset** (`pnpm changeset`) — required on every PR, or the `skip-changeset` label is applied
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

衍生观察(finding,另单):sharing-and-security.mdx 的 OWD 表漏列 Event Attendee,下文「the four parent-derived objects」实为五个 —— 属文档完整性缺口而非错误断言,不在本 PR 的 truth-only 面内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194QUW67v7vyLToEd9NSeRM