### PR TITLE
fix(campaign-member): 报名过市场活动的线索/联系人恢复可删除 —— 参与行随人级联删除 (#696)

### DIFF
--- a/.changeset/campaign-member-cascade-on-party-delete.md
+++ b/.changeset/campaign-member-cascade-on-party-delete.md
@@ -1,0 +1,38 @@
+---
+'hotcrm': patch
+---
+
+Let a lead or contact who was enrolled in a campaign be deleted again. Anyone who
+had ever been added to a campaign was **permanently undeletable** — through the
+API and through the UI — and the refusal named an object the caller had not
+touched:
+
+```
+DELETE /api/v1/data/crm_lead/<id>
+→ 400 {"error":"A campaign member must reference either a Lead or a Contact",
+       "code":"VALIDATION_FAILED","object":"crm_lead"}
+```
+
+The cause was a default nobody wrote down. `crm_campaign_member.crm_lead` and
+`.crm_contact` declared no `deleteBehavior`, so both took `Field.lookup`'s spec
+default of `set_null`. Deleting the person made the engine's referential pass
+clear that column, the cleared row instantly violated
+`lead_or_contact_required` — the rule the same object declares — and the whole
+delete rolled back. Since `enroll_leads` and the `campaign_enrollment` flow are
+ordinary parts of the marketing flow, ordinary use reached it, and a GDPR-style
+"delete this person" request could not be served at all.
+
+Both party lookups now declare `deleteBehavior: 'cascade'`. A campaign member is
+a junction row whose whole meaning is "this person is enrolled in this
+campaign"; once the person is gone the row denotes nothing, so deleting a lead
+or a contact now removes that person's campaign memberships with them.
+`restrict` would have produced an accurate message but left the person
+undeletable until someone un-enrolled them by hand, and the problem being fixed
+is undeletable people, not confusing text.
+
+**What changes for you:** deleting a lead or contact silently removes their
+`crm_campaign_member` rows, so a campaign's member count and response-rate
+metrics drop accordingly — deliberately, since the person is gone. Memberships
+naming anybody else, and the campaign side of the junction, are untouched: the
+required `crm_campaign` lookup still refuses to delete a campaign that has
+members, because a campaign's member list is its historical record. Refs #696.

--- a/src/objects/campaign_member.object.ts
+++ b/src/objects/campaign_member.object.ts
@@ -80,15 +80,33 @@ export const CampaignMember = ObjectSchema.create({
       group: 'basic',
     }),
 
+    // `deleteBehavior: 'cascade'` on BOTH party lookups (#696). A lookup
+    // defaults to `set_null`, and that default made every enrolled person
+    // permanently undeletable: deleting the lead cleared this column, the
+    // cleared row instantly violated `lead_or_contact_required` below, and the
+    // whole delete rolled back with a 400 naming an object the caller never
+    // touched ("A campaign member must reference either a Lead or a Contact",
+    // `"object":"crm_lead"`). A GDPR "delete this person" request could not be
+    // served through the API or the UI.
+    //
+    // Cascade rather than `restrict`: this is a JUNCTION row whose entire
+    // meaning is "this person is enrolled in this campaign". Once the person is
+    // gone the row denotes nothing, so keeping it (restrict) would only trade
+    // one undeletable person for a manual un-enrol chore, and the impact this
+    // fixes is undeletable people, not a confusing message. Cascade also makes
+    // the object's own rule unfalsifiable by construction: there is no longer a
+    // reachable state in which a stored member row breaks it.
     crm_lead: Field.lookup('crm_lead', {
       label: 'Lead',
       group: 'basic',
+      deleteBehavior: 'cascade',
       description: 'Set when the member was a Lead at enrollment time',
     }),
 
     crm_contact: Field.lookup('crm_contact', {
       label: 'Contact',
       group: 'basic',
+      deleteBehavior: 'cascade',
       description: 'Set when the member is an existing Contact',
     }),
 

--- a/test/campaign-member-cascade.test.ts
+++ b/test/campaign-member-cascade.test.ts
@@ -1,0 +1,273 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import stack from '../objectstack.config';
+
+/**
+ * Deleting an enrolled person must work (#696).
+ *
+ * ### The bug this file exists to keep dead
+ *
+ * `crm_campaign_member` carries a record-level rule, `lead_or_contact_required`,
+ * that rejects a member row naming neither a Lead nor a Contact. Both party
+ * lookups used to take `Field.lookup`'s SPEC DEFAULT for `deleteBehavior`,
+ * which is `set_null` — measured on 17.0.0-rc.2, the resolved field literally
+ * reads `"deleteBehavior":"set_null"` even though the source declared nothing.
+ *
+ * So the engine's own referential pass turned the delete into a self-defeating
+ * sequence: `cascadeDeleteRelations` cleared `crm_campaign_member.crm_lead`,
+ * the row it had just edited instantly broke the rule the same object declares,
+ * and the whole delete rolled back. Measured before the fix, on this exact
+ * harness:
+ *
+ *     DELETE lead error: A campaign member must reference either a Lead or a Contact
+ *     members after:     [ …the member row, untouched… ]
+ *     lead after:        [ …the lead, still there… ]
+ *
+ * Over REST that surfaces as a 400 naming a DIFFERENT object than the one the
+ * caller addressed (`"object":"crm_lead"`, message about campaign members), and
+ * it makes anyone who was ever enrolled in a campaign permanently undeletable
+ * through the API and the UI — a GDPR "delete this person" request could not be
+ * served at all. Since `enroll_leads` / `campaign_enrollment` are ordinary parts
+ * of the marketing flow, ordinary use reaches it.
+ *
+ * ### The fix, and why cascade rather than restrict
+ *
+ * `deleteBehavior: 'cascade'` on both party lookups. A campaign member is a
+ * JUNCTION row whose whole meaning is "this person is enrolled in this
+ * campaign"; once the person is gone the row denotes nothing. `restrict` would
+ * have produced an accurate message — the platform's own
+ * "N dependent crm_campaign_member record(s) reference it via crm_lead" — but
+ * the person would still be undeletable until someone un-enrolled them by hand,
+ * and the impact being fixed here is undeletable PEOPLE, not confusing text.
+ *
+ * Cascade also removes the state that made this possible: with it, no stored
+ * member row can be manoeuvred into breaking its object's own rule. Declared is
+ * enforced, with nothing for a consumer to be lenient about.
+ *
+ * ### Scope
+ *
+ * This is the campaign-member half only. `crm_event_attendee` has the same
+ * construction (`attendee_resolves`, severity `error`, over `set_null` party
+ * lookups) and the same defect — measured, and filed separately; do not fix it
+ * by editing this file's object.
+ */
+
+type AnyRec = Record<string, any>;
+
+const objects: AnyRec[] = (stack as any).objects ?? [];
+const byName = (n: string) => objects.find((o) => o.name === n) as AnyRec;
+
+const CAMPAIGN_MEMBER = byName('crm_campaign_member');
+
+// ───────────────────────────────────────────────── the declaration ──
+
+describe('crm_campaign_member declares cascade on both party lookups', () => {
+  /**
+   * A structural pin, deliberately kept next to the end-to-end run below: the
+   * hazard is a MISSING key, and a missing key is invisible in review because
+   * the spec quietly fills in `set_null`. Asserting the resolved value catches
+   * both a deletion of the declaration and a future spec default flip.
+   */
+  it.each(['crm_lead', 'crm_contact'])('%s cascades', (field) => {
+    expect(CAMPAIGN_MEMBER.fields[field].type).toBe('lookup');
+    expect(CAMPAIGN_MEMBER.fields[field].deleteBehavior).toBe('cascade');
+  });
+
+  it('still declares the rule that the cascade keeps satisfiable', () => {
+    const rule = (CAMPAIGN_MEMBER.validations ?? []).find(
+      (v: AnyRec) => v.name === 'lead_or_contact_required',
+    );
+    expect(rule).toBeDefined();
+    expect(rule.severity).toBe('error');
+  });
+
+  /**
+   * The CAMPAIGN side is deliberately NOT cascade, and is not changed by #696.
+   * `crm_campaign` is a REQUIRED lookup, and the engine escalates a `set_null`
+   * default on a required lookup to `restrict` — a campaign with members
+   * refuses to delete, with a message that names the real obstacle. That is the
+   * correct answer there (a campaign's member list is its historical record,
+   * not a per-person artefact), and it is pinned so a copy-paste of the two
+   * lines above cannot silently start shredding campaign history.
+   */
+  it('leaves the required campaign lookup on the default', () => {
+    expect(CAMPAIGN_MEMBER.fields.crm_campaign.required).toBe(true);
+    expect(CAMPAIGN_MEMBER.fields.crm_campaign.deleteBehavior).toBe('set_null');
+  });
+});
+
+// ─────────────────────────────────────────── on the real engine ──
+
+/**
+ * End-to-end over a real ObjectQL — the only place the interaction is visible.
+ * `cascadeDeleteRelations` is engine behaviour driven by metadata; no
+ * metadata-only assertion can show that a delete now succeeds, and no hook
+ * harness runs the referential pass at all.
+ *
+ * `InMemoryDriver` is used for the same reason `object-validation-predicates`
+ * uses it: it stores only the columns a row was written with, so the merged
+ * record handed to the validator has ABSENT keys — the shape that made the rule
+ * fire in the first place. A column-complete driver would still reproduce this
+ * bug (the cleared column is `null`, not absent, and `isBlank(null)` is true),
+ * but the sparse one exercises the harder shape.
+ */
+describe('deleting an enrolled person', () => {
+  let ql: AnyRec;
+  let api: AnyRec;
+
+  beforeEach(async () => {
+    ql = (await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: {
+        crm_campaign_member: CAMPAIGN_MEMBER,
+        crm_campaign: byName('crm_campaign'),
+        crm_lead: byName('crm_lead'),
+        crm_contact: byName('crm_contact'),
+        crm_account: byName('crm_account'),
+      } as never,
+    })) as never;
+    api = ql.createContext({ isSystem: true });
+  });
+  afterEach(async () => {
+    await ql?.close();
+  });
+
+  const newCampaign = (name = 'Spring Webinar') =>
+    api.object('crm_campaign').insert({
+      name,
+      type: 'webinar',
+      status: 'in_progress',
+      start_date: '2026-01-01',
+      end_date: '2026-03-01',
+    });
+
+  const newLead = (email = 'wei.zhang@acme.test') =>
+    api.object('crm_lead').insert({
+      first_name: 'Wei',
+      last_name: 'Zhang',
+      company: 'ACME',
+      status: 'new',
+      lead_source: 'web',
+      email,
+    });
+
+  const newContact = async (email = 'li.wang@acme.test') => {
+    const account = await api.object('crm_account').insert({
+      name: `ACME ${email}`,
+      type: 'customer',
+      industry: 'technology',
+    });
+    return api.object('crm_contact').insert({
+      first_name: 'Li',
+      last_name: 'Wang',
+      crm_account: account.id,
+      email,
+    });
+  };
+
+  const members = () => api.object('crm_campaign_member').find({ where: {} });
+
+  it('deletes a lead enrolled in several campaigns, and takes its memberships with it', async () => {
+    const [spring, autumn] = await Promise.all([newCampaign('Spring'), newCampaign('Autumn')]);
+    const lead = await newLead();
+    for (const campaign of [spring, autumn]) {
+      await api.object('crm_campaign_member').insert({
+        crm_campaign: campaign.id,
+        crm_lead: lead.id,
+        status: 'sent',
+      });
+    }
+    expect(await members()).toHaveLength(2);
+
+    // The assertion that WAS the bug: this used to reject with
+    // "A campaign member must reference either a Lead or a Contact".
+    await expect(
+      api.object('crm_lead').delete({ where: { id: lead.id } }),
+    ).resolves.not.toThrow();
+
+    expect(await api.object('crm_lead').find({ where: { id: lead.id } })).toHaveLength(0);
+    expect(await members()).toHaveLength(0);
+  });
+
+  it('deletes an enrolled contact the same way', async () => {
+    const campaign = await newCampaign();
+    const contact = await newContact();
+    await api.object('crm_campaign_member').insert({
+      crm_campaign: campaign.id,
+      crm_contact: contact.id,
+      status: 'opened',
+    });
+
+    await expect(
+      api.object('crm_contact').delete({ where: { id: contact.id } }),
+    ).resolves.not.toThrow();
+
+    expect(await api.object('crm_contact').find({ where: { id: contact.id } })).toHaveLength(0);
+    expect(await members()).toHaveLength(0);
+  });
+
+  it('leaves every membership that named somebody else alone', async () => {
+    const campaign = await newCampaign();
+    const lead = await newLead();
+    const bystanderLead = await newLead('bystander@acme.test');
+    const contact = await newContact();
+
+    await api.object('crm_campaign_member').insert({
+      crm_campaign: campaign.id, crm_lead: lead.id, status: 'sent',
+    });
+    // The two rows that must SURVIVE: one naming the other party TYPE, one
+    // naming a different record of the same type. A cascade that keyed off the
+    // object rather than the id would take both.
+    const keepContact = await api.object('crm_campaign_member').insert({
+      crm_campaign: campaign.id, crm_contact: contact.id, status: 'clicked',
+    });
+    const keepLead = await api.object('crm_campaign_member').insert({
+      crm_campaign: campaign.id, crm_lead: bystanderLead.id, status: 'sent',
+    });
+
+    await api.object('crm_lead').delete({ where: { id: lead.id } });
+
+    const remaining = (await members()).map((r: AnyRec) => r.id).sort();
+    expect(remaining).toEqual([keepContact.id, keepLead.id].sort());
+  });
+
+  it('still refuses a member row that names nobody — the rule is intact, not neutered', async () => {
+    const campaign = await newCampaign();
+    await expect(
+      api.object('crm_campaign_member').insert({ crm_campaign: campaign.id, status: 'sent' }),
+    ).rejects.toThrow(/must reference either a Lead or a Contact/i);
+  });
+
+  /**
+   * The one semantic cost of cascading on BOTH lookups, measured and written
+   * down rather than left for the next reader to trip over: a row naming a lead
+   * AND a contact is removed when EITHER party is deleted, even though the
+   * other party still exists.
+   *
+   * It is accepted because no such row is reachable today — the enrollment flow
+   * and `enroll_leads` write `crm_lead` only, `lead_conversion` never touches
+   * this object, and `content/docs/marketing/campaign-members.mdx` states the
+   * intended semantics as "either a lead or a contact — but not both". If a
+   * future change (e.g. #597) starts writing both, this test is the place that
+   * says what has to be decided again.
+   */
+  it('removes a both-parties row on either delete (documented consequence)', async () => {
+    const campaign = await newCampaign();
+    const lead = await newLead();
+    const contact = await newContact();
+    await api.object('crm_campaign_member').insert({
+      crm_campaign: campaign.id,
+      crm_lead: lead.id,
+      crm_contact: contact.id,
+      status: 'sent',
+    });
+
+    await api.object('crm_lead').delete({ where: { id: lead.id } });
+
+    expect(await members()).toHaveLength(0);
+    expect(await api.object('crm_contact').find({ where: { id: contact.id } })).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #696

## 前提复核（先证伪，再动手）

issue 只是线索，先在 `origin/main` 上把它说的机制原样跑了一遍。**前提成立，且比 issue 描述得更精确一点**：问题不在于谁写错了 `deleteBehavior`，而在于**根本没人写过它**。

`Field.lookup` 的 spec 默认值就是 `set_null`（`@objectstack/spec@17.0.0-rc.2`：`deleteBehavior: z.enum(["set_null","cascade","restrict"]).optional().default("set_null")`）。所以源码里一个字都没写，解析出来的字段却实打实地带着 `"deleteBehavior":"set_null"` —— 这正是它在 review 里隐身的原因：**缺失的 key 是看不见的**。

在真实 ObjectQL + InMemoryDriver 上实测（修复前）：

```
crm_lead field:    {... "reference":"crm_lead",    "deleteBehavior":"set_null" ...}
crm_contact field: {... "reference":"crm_contact", "deleteBehavior":"set_null" ...}

DELETE lead error: A campaign member must reference either a Lead or a Contact
members after:     [ …那行 member，原封不动… ]
lead after:        [ …那条 lead，还在… ]
```

即引擎的 `cascadeDeleteRelations` 把 `crm_campaign_member.crm_lead` 置空 → 它刚改过的这一行立刻违反本对象自己声明的 `lead_or_contact_required` → 整个删除回滚。issue 描述的"置空后自我违规"机制**逐字属实**。

顺带确认了两件容易误判的事：

- 提示里点名的 commit 0f72853（#634，把校验谓词做成 total）**不是诱因**。它只是给谓词加了 `has()` 守卫；置空后 `isBlank(null)` 依然为真，规则照样命中。这个删除在加守卫之前和之后都是失败的。
- `__referentialFieldClear` 这个上下文标记只被 `plugin-security` 用来放行字段权限检查，**不会跳过校验规则** —— 所以指望平台自己网开一面是没有的。

## 修法：`deleteBehavior: 'cascade'`，元数据一行到位

先查了 hotcrm 的元数据表达能力：`deleteBehavior` 是 lookup/masterDetail 上的一等 key，本仓已有先例（`crm_contact.crm_account` 就写着 `deleteBehavior: 'cascade'`）。既然元数据表达得了，就不必下沉到 hook —— **`lead.hook.ts` / `contact.hook.ts` 一个字都没动**，#693 的守卫文案改写完整地留给后续那一轮。

选 `cascade` 而不是 `restrict`，三条轴上都成立：

- **真实业务需求**：campaign_member 是一张 junction 行，全部语义就是"这个人报名了这场活动"。人没了，这行什么也不指。`restrict` 能给出一句准确的报错，但人依然删不掉 —— 只是把"删不掉"换成"先手工退订"。而本 issue 的 impact 是**人删不掉**（GDPR"删除此人"必须能走通），不是文案难看。纯改文案不构成对本 issue 的关闭。
- **长期架构**：级联之后，**不存在任何可达状态能让一行已存储的 member 违反本对象自己的规则**。规则从"声明了但可被引擎自己推翻"变成结构上恒真。
- **让 AI 写的元数据不容易出错**：这是声明式的一行，不是消费端的容忍（没有 `??` 兜底、没有宽松解析）。声明即执行。

campaign 那一侧**故意不动**：`crm_campaign` 是 required lookup，引擎会把 required 上的 `set_null` 默认自动升级成 `restrict`，所以有成员的活动依旧拒绝删除 —— 那里这才是对的（活动的成员名单是它自己的历史记录，不是某个人的附属品）。这条也写成了断言，防止有人照着上面两行一路 copy-paste 把活动历史削掉。

## 测试：`test/campaign-member-cascade.test.ts`（9 项）

跑真实 ObjectQL over `InMemoryDriver` —— 挑这个 driver 的理由和 `object-validation-predicates.test.ts` 一致：它只存写过的列，交给校验器的合并记录带的是**缺失的 key**，正是当初触发规则的那种形状。

- 结构钉：两个 party lookup 的 `deleteBehavior` 解析值为 `cascade`（缺 key 在 review 里隐身，所以断言的是**解析后的值**，顺带能接住未来 spec 默认值翻转）
- 报名了多场活动的 lead 干净删除，其 member 行随之消失
- contact 同样
- 指向别人的 member 行（另一种 party 类型 / 同类型的另一条记录）全部幸存
- 规则本身没被架空：直接插入一行谁也不指的 member，依旧被拒
- 一行同时指向 lead 和 contact 的记录，任一方被删都会消失 —— 这是级联在两个 lookup 上的**唯一语义代价**，实测下来写进测试而不是留给下一个读代码的人踩。今天不可达（enrollment flow / `enroll_leads` 只写 `crm_lead`，`lead_conversion` 不碰本对象，产品文档也写明"二者取一，不可兼有"），一旦 #597 之类的改动开始同时写两边，这条测试就是重新拍板的地方。

### 反向验证（方向是先预测再跑的）

预测：删掉那两行声明 → 结构钉 + 四条删除路径**转红**；不依赖本次改动的三条（规则仍被声明、campaign lookup 仍是默认值、空 member 仍被拒）**保持绿**。实跑一致：

```
× crm_lead cascades          AssertionError: expected 'set_null' to be 'cascade'
× crm_contact cascades       AssertionError: expected 'set_null' to be 'cascade'
× deletes a lead enrolled in several campaigns …
    promise rejected "ValidationError: A campaign member must r…" instead of resolving
× deletes an enrolled contact the same way          （同上）
× leaves every membership that named somebody else alone
    ValidationError: A campaign member must reference either a Lead or a Contact
× removes a both-parties row on either delete
    AssertionError: expected [ { …(9) } ] to have a length of +0 but got 1
Tests  6 failed | 3 passed (9)
```

转红时打出来的正是 issue 里那句原文，说明测试钉住的确实是这个缺陷本身。

## 验证

```
pnpm test        56 files / 1328 passed | 1 skipped
pnpm typecheck   clean
pnpm validate    ✓ Validation passed (1014ms)   —— 余下告警为既有项
pnpm lint        13 warning(s) / 14 suggestion(s)（全部既有）
pnpm hygiene     ✓ source hygiene clean
pnpm build       ✓ Build complete
```

平台依赖未动，仍钉在 `@objectstack/*` 17.0.0-rc.2；无任何平台侧改动或绕行。

## 顺带发现（已另开 issue，本 PR 不修）

`crm_event_attendee` 是**同一构造的同一缺陷**：三个 party lookup（`crm_contact` / `crm_lead` / `sys_user`）同样吃 `set_null` 默认值，同一对象上同样挂着 severity `error` 的 `attendee_resolves`。实测：

```
EVENT_ATTENDEE delete-lead: An attendee must point at a Contact, a Lead, a User, or name an external guest
EVENT_ATTENDEE lead survives? true
```

且并非僵尸代码 —— `src/actions/global.actions.ts:339` 会真实写入这些行，且从不填 `external_name`。已按越界即停的约定另开 #711，未在本 PR 触碰。

另外顺带核过、确认**不是**缺陷的两处：`crm_task.related_to_required` 与 `crm_event.related_to_required` 也命中同样的 `set_null` 扫描，但它们 severity 是 `warning`，不阻断写入。

一处未动的小账：`content/docs/marketing/campaign-members.mdx` 尚未提到"删除一个人会一并移除其活动报名记录"这一新行为，本次按派单的文件边界没有改文档 —— 变更说明已写进 changeset，是否补一句文档留给维护者定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_