### PR TITLE
fix(flows): 记录变更流以平台身份运行，补齐调度流早已declare的 runAs (#684)

### DIFF
--- a/.changeset/record-change-flows-run-as-system.md
+++ b/.changeset/record-change-flows-run-as-system.md
@@ -1,0 +1,66 @@
+---
+'hotcrm': patch
+---
+
+Give the record-change flows the execution identity the scheduled ones already
+had, so system-driven writes stop silently losing their automation — including
+an approval gate that a machine-created deal could walk straight through.
+
+A flow's `runAs` decides who its data operations execute as. Under the schema
+default `'user'`, a run that resolved **no trigger user** has no identity to
+scope to, so the engine refuses its data operations rather than run them
+unscoped. The part that was missed here is that "no trigger user" is not a
+schedule-only condition: a record-change flow is fired by a **write**, and a
+write made without a session — seed loading, an integration or webhook, or
+another `runAs: 'system'` flow's own write — carries no user into the run it
+triggers. Ten scheduled flows had already been given `runAs: 'system'`, each
+with an authored comment saying exactly that; all seven record-change flows
+were left on the default. The platform's build-time lint cannot close the gap,
+because whether a record-change trigger carries a user is only knowable at run
+time.
+
+Measured on `@objectstack/*` 17.0.0-rc.2, driving the real automation engine
+with no trigger user:
+
+- **`case_escalation`** (and its insert-time twin) died at its first data node
+  with `[runAs] refusing a data operation`. A case raised by the seed loader or
+  an integration kept its critical priority forever — a freshly seeded org had
+  never once run this automation over its own data.
+- **`opportunity_approval`** (and its twin) died the same way, at
+  `get_opportunity`, before the approval request was ever opened. A $150K
+  renewal created by the `runAs: 'system'` contract_renewal sweep therefore sat
+  at `approval_status: 'not_required'`, unlocked, with no approval on record.
+  An approval control that engages only for logged-in writers is not a control.
+- **`lead_assignment`** died at its SLA stamp, so a lead arriving from
+  web-to-lead, a CSV import or a partner integration got no follow-up date and
+  no alert at all.
+
+All seven record-change flows now declare `runAs: 'system'` with a per-flow
+rationale in source. The declaration elevates the **user-driven** runs too, so
+that is argued per flow rather than assumed: every data node in these flows is
+keyed to `{record.id}` — the row that just fired the trigger — so user scope
+adds no restriction that matters while adding a failure mode (a rep who may
+create a lead, or an agent who may raise a case, is not thereby granted edit
+rights on it), and for `opportunity_approval` the submitter's own scope is
+positively the wrong identity for a gate that exists to constrain the
+submitter. No flow in this set relies on the triggering user's restricted scope.
+
+The issue's premise held for three of the seven; the remaining four
+(`contact_welcome`, `task_urgent_alert`, `opportunity_won_alert`,
+`case_csat_followup`) were measured **not** refused, and that measurement is
+recorded rather than papered over. They are notify-only, the refusal covers
+`get`/`create`/`update`/`delete` record nodes, and `notify` dispatches through
+the messaging service without a run data context — so a user-less run of those
+completes and delivers today. They carry the declaration anyway because the
+decision worth recording is "record-change automation runs as the platform",
+not "this flow currently happens to have no data node": the day one gains a
+data node it inherits an elevation that was reasoned about, instead of
+discovering a refusal in production.
+
+Pinned two ways so the gap cannot return. `test/actions-flows-integrity.test.ts`
+enumerates record-change flows **from the compiled stack** — not a hand-kept
+import list — and requires each to declare `runAs: 'system'` with an authored
+rationale beside it. `test/flow-record-change.test.ts` runs the real engine
+with no trigger user and asserts the writes land, with the pre-fix shape
+reproduced on demand (`runAs` stripped) so the assertions cannot pass by
+producing nothing. Refs #684, ADR-0049.

--- a/src/flows/case-csat-followup.flow.ts
+++ b/src/flows/case-csat-followup.flow.ts
@@ -23,6 +23,22 @@ export const CaseCsatFollowupFlow: Flow = {
   description: 'When a case closes, wait a day then prompt the owner to collect a satisfaction rating.',
   type: 'record_change',
   status: 'active',
+  // A record-change flow fired by a SYSTEM write carries no trigger user
+  // either (ADR-0049, #1888, #3760), and here that is the NORMAL path, not an
+  // edge case: the close transition this flow waits on is written by the
+  // `close_case` screen flow, which is itself `runAs: 'system'`, so runs
+  // spawned from the Close Case button are user-less by construction.
+  //
+  // Measured honestly on 17.0.0-rc.2: this flow has NO data node (start →
+  // wait → notify → end), and a user-less run was driven end to end through
+  // the real engine — it suspends at the P1D timer and, on resume, the notify
+  // node delivers. The refusal covers get/create/update/delete only, so
+  // declaring `system` changes nothing observable today. Declared for the same
+  // reason as `contact_welcome` — see the fuller note there — and with extra
+  // force here: this flow resumes long after its trigger, so any data node
+  // added to the post-wait leg would run in whatever identity the suspended
+  // run carried, which for the common path is none.
+  runAs: 'system',
 
   variables: [],
 

--- a/src/flows/case-escalation.flow.ts
+++ b/src/flows/case-escalation.flow.ts
@@ -11,6 +11,24 @@ export const CaseEscalationFlow: Flow = {
   description: 'Automatically escalate high-priority cases',
   type: 'record_change',
   status: 'active',
+  // A record-change flow fired by a SYSTEM write carries no trigger user
+  // either — the user-less exposure is NOT schedule-only (ADR-0049, #1888,
+  // #3760), and the platform's own build-time lint cannot see this shape
+  // because it is only knowable at run time. Measured on 17.0.0-rc.2: a
+  // user-less run refuses the very first data node — "[runAs] refusing a data
+  // operation (object 'crm_case', event 'record-after-update')" — so a case
+  // raised by the seed loader, an integration, or another runAs:'system'
+  // flow's write silently keeps its critical priority forever.
+  //
+  // Elevating the USER-driven runs too is correct here: escalation is a
+  // service-level policy, not the writer's own edit. Both data nodes are keyed
+  // to `{record.id}` — the row that just fired the trigger — so user scope
+  // buys no restriction that matters, while it does add a failure mode: an
+  // agent may legitimately raise a case without holding edit rights on the
+  // escalation lifecycle fields (`is_escalated` / `escalated_date` / `status`).
+  // This also puts the flow on the same footing as `case_sla_monitor`, which
+  // performs the same escalation on a schedule under `runAs: 'system'`.
+  runAs: 'system',
 
   variables: [
     { name: 'caseId', type: 'text', isInput: true, isOutput: false },

--- a/src/flows/contact-welcome.flow.ts
+++ b/src/flows/contact-welcome.flow.ts
@@ -25,6 +25,25 @@ export const ContactWelcomeFlow: Flow = {
   description: 'On new contact: prompt the owner to welcome them.',
   type: 'record_change',
   status: 'active',
+  // A record-change flow fired by a SYSTEM write carries no trigger user
+  // either (ADR-0049, #1888, #3760) — and this flow exists FOR that
+  // population: the start condition below already documents the seeded /
+  // integration-written contacts whose `owner_id` the security middleware
+  // never stamped because the write carried no session (#548).
+  //
+  // Measured honestly on 17.0.0-rc.2: this flow has NO data node today (start
+  // → notify → end), the runAs refusal covers get/create/update/delete only,
+  // and `notify` dispatches through the messaging service without a run data
+  // context — so a user-less run completes and delivers today, and this
+  // declaration changes nothing observable right now. It is declared anyway
+  // because the decision being recorded is "record-change automation runs as
+  // the platform", not "this flow currently happens to have no data node".
+  // The day a data node is added — or a start-node `config.expand`, which is
+  // the remedy the notify node's own error message recommends and which reads
+  // through the same guarded path — the elevation has already been reasoned
+  // about here rather than discovered as a refusal in production. Elevation is
+  // harmless for the user-driven runs: there is no data operation to scope.
+  runAs: 'system',
   variables: [],
   nodes: [
     {

--- a/src/flows/lead-assignment.flow.ts
+++ b/src/flows/lead-assignment.flow.ts
@@ -31,6 +31,19 @@ export const LeadAssignmentFlow: Flow = {
   description: 'On new lead: set a rating-based follow-up SLA and alert the lead owner.',
   type: 'record_change',
   status: 'active',
+  // A record-change flow fired by a SYSTEM write carries no trigger user
+  // either (ADR-0049, #1888, #3760). This is the population the flow is FOR:
+  // leads arrive from web-to-lead, a CSV import, a partner integration or a
+  // seed load, none of which carry a user session. Measured on 17.0.0-rc.2, a
+  // user-less run refuses `sla_hot` / `sla_std` outright, so the lead lands
+  // with no follow-up SLA and no alert at all — silently, since the refusal
+  // surfaces only in the server log.
+  //
+  // Elevating the USER-driven runs too is correct: the SLA stamp is the
+  // platform's routing decision about the row that just fired the trigger
+  // (keyed to `{record.id}`), not the submitting rep's own edit, and a rep who
+  // may create a lead is not thereby guaranteed edit rights on it.
+  runAs: 'system',
 
   variables: [],
 

--- a/src/flows/opportunity-approval.flow.ts
+++ b/src/flows/opportunity-approval.flow.ts
@@ -35,6 +35,24 @@ export const OpportunityApprovalFlow: Flow = {
   description: 'Tiered approval for opportunities: manager review > $100K, director sign-off > $500K.',
   type: 'record_change',
   status: 'active',
+  // Same user-less exposure as every record-change flow (ADR-0049, #1888,
+  // #3760) — and the one with teeth. Measured on 17.0.0-rc.2: a $150K renewal
+  // created by the `runAs: 'system'` contract_renewal sweep fired this flow
+  // with no trigger user, and the run died at `get_opportunity`. The deal sat
+  // at `approval_status: 'not_required'`, unlocked, with no approval request
+  // ever opened — the gate was bypassed by the writer simply not carrying a
+  // session. An approval control that only engages for logged-in writers is
+  // not a control.
+  //
+  // Elevating the USER-driven runs too is not merely acceptable here, it is
+  // required. This gate exists to CONSTRAIN the submitter, so the submitter's
+  // own scope is the wrong identity to evaluate it under; and
+  // `mark_approved` / `mark_rejected` stamp `approval_status` on a record the
+  // approval node holds locked (`lockRecord: true`), which only a platform
+  // write may land. The approval node itself already opens its request under
+  // the platform identity while re-attaching the deciding user for
+  // attribution, so this declaration aligns the flow with the node it drives.
+  runAs: 'system',
 
   variables: [
     { name: 'opportunityId', type: 'text', isInput: true, isOutput: false },

--- a/src/flows/opportunity-won-alert.flow.ts
+++ b/src/flows/opportunity-won-alert.flow.ts
@@ -21,6 +21,18 @@ export const OpportunityWonAlertFlow: Flow = {
   description: 'On closed_won opportunities over $100K: notify owner + manager.',
   type: 'record_change',
   status: 'active',
+  // A record-change flow fired by a SYSTEM write carries no trigger user
+  // either (ADR-0049, #1888, #3760). Deals reach `closed_won` through
+  // machinery as well as through a rep's own save — `lead_conversion` and the
+  // `contract_renewal` sweep both write opportunities, and the latter is
+  // itself `runAs: 'system'`.
+  //
+  // Measured honestly on 17.0.0-rc.2: this flow has NO data node (start →
+  // notify → end), so the refusal does not reach it today and declaring
+  // `system` changes nothing observable. Declared for the same reason as
+  // `contact_welcome` — see the fuller note there. Nothing to scope, so
+  // elevating the user-driven runs costs nothing.
+  runAs: 'system',
   variables: [],
   nodes: [
     {

--- a/src/flows/task-urgent-alert.flow.ts
+++ b/src/flows/task-urgent-alert.flow.ts
@@ -17,6 +17,21 @@ export const TaskUrgentAlertFlow: Flow = {
   description: 'On new urgent task: notify the owner.',
   type: 'record_change',
   status: 'active',
+  // A record-change flow fired by a SYSTEM write carries no trigger user
+  // either (ADR-0049, #1888, #3760), and most urgent tasks in this app are
+  // machine-written: `case_status_side_effects` opens the escalation follow-up
+  // task, and the scheduled sweeps create their own — none of those writes
+  // carries a session.
+  //
+  // Measured honestly on 17.0.0-rc.2: this flow has NO data node (start →
+  // notify → end), so the refusal does not reach it today and declaring
+  // `system` changes nothing observable. Declared for the same reason as
+  // `contact_welcome` — see the fuller note there: the recorded decision is
+  // that record-change automation runs as the platform, so a data node added
+  // later inherits an elevation that was reasoned about rather than one
+  // discovered as a production refusal. No data operation exists to scope, so
+  // elevating the user-driven runs costs nothing.
+  runAs: 'system',
   variables: [],
   nodes: [
     {

--- a/test/actions-flows-integrity.test.ts
+++ b/test/actions-flows-integrity.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
+import { readdirSync, readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import stack from '../objectstack.config';
 
@@ -372,4 +373,96 @@ describe('case escalation trigger does not fight the close action', () => {
       expect(condition).toContain('record.status != "resolved"');
     },
   );
+});
+
+/**
+ * Execution identity of the RECORD-CHANGE flows (#684).
+ *
+ * `runAs` decides who a run's data operations execute as. Under the schema
+ * default `'user'` a run that resolved NO trigger user has no identity to
+ * scope to, so the engine REFUSES its data operations rather than letting them
+ * run unscoped — the fail-open ADR-0049 forbids (#1888, #3760).
+ *
+ * The trap this guard exists for is that "no trigger user" is NOT a
+ * schedule-only condition. A record-change flow is fired by a WRITE, and a
+ * write made without a session — seed loading, an integration, a webhook, or
+ * another `runAs:'system'` flow's own write — carries no user into the run it
+ * triggers. Ten scheduled flows had already been given `runAs:'system'`, each
+ * with an authored comment saying so; every record-change flow was left on the
+ * default, and on the 17.0 GA acceptance sweep that cost 12 failed runs on one
+ * boot plus a demonstrated approval bypass (a $150K renewal created by the
+ * contract_renewal sweep never opened its approval request).
+ *
+ * The platform's build-time lint (`flow-runas-unscoped`) rejects the
+ * statically-decidable shapes — schedule, time-relative, api — but explicitly
+ * NOT this one, because whether a record-change trigger carries a user is only
+ * knowable at run time. So the app owns the invariant, and this is it.
+ *
+ * Enumerated from the COMPILED STACK, not from a hand-maintained import list:
+ * a new record-change flow registered in `src/flows/index.ts` is covered the
+ * moment it is registered, which is the only way this guard cannot go stale.
+ */
+describe('record-change flows declare their execution identity (#684)', () => {
+  const recordChangeFlows = flows.filter((f) => f.type === 'record_change');
+
+  it('there are record-change flows to check (the filter still matches)', () => {
+    // Cheap canary: if `type` were ever renamed or the flows re-typed, every
+    // assertion below would pass vacuously over an empty list.
+    expect(recordChangeFlows.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it.each(recordChangeFlows.map((f) => f.name))(
+    '%s declares runAs:"system"',
+    (name) => {
+      const f = flow(name)!;
+      expect(
+        f.runAs,
+        `flow '${name}' is record-change but leaves runAs at the default 'user'. ` +
+          'A write that carries no session (seed, integration, webhook, or another ' +
+          "runAs:'system' flow) fires it with no trigger user, and its data operations " +
+          'are then REFUSED at run time — silently, in the server log. Declare ' +
+          "runAs:'system' to make the elevation explicit, or, if this flow genuinely " +
+          "must act as the triggering user, exempt it here with the reasoning written down.",
+      ).toBe('system');
+    },
+  );
+
+  it('the insert-time twins inherit the parent’s identity rather than restating it', () => {
+    // Both twins are built by spreading their parent, so `runAs` rides along.
+    // Pinning it keeps a future refactor from turning the spread into an
+    // explicit field list that quietly drops it.
+    for (const [twin, parent] of [
+      ['case_escalation_on_create', 'case_escalation'],
+      ['opportunity_approval_on_create', 'opportunity_approval'],
+    ] as const) {
+      expect(flow(twin)!.runAs, `${twin} drifted from ${parent}`).toBe(flow(parent)!.runAs);
+    }
+  });
+
+  it('every record-change flow explains its elevation in the source', () => {
+    // The ten scheduled flows each carry an authored rationale beside their
+    // `runAs`. An undocumented `runAs:'system'` is indistinguishable from a
+    // copy-paste, and elevation is exactly the decision that must not be made
+    // by copy-paste: it applies to the USER-driven runs too, which today
+    // execute scoped to the triggering user.
+    const missing: string[] = [];
+    for (const file of readdirSync(new URL('../src/flows/', import.meta.url))) {
+      if (!file.endsWith('.flow.ts')) continue;
+      const lines = readFileSync(new URL(`../src/flows/${file}`, import.meta.url), 'utf8').split('\n');
+      if (!lines.some((l) => /^\s*type:\s*'record_change'\s*,?\s*$/.test(l))) continue;
+      // The DECLARATION line, not a mention of `runAs: 'system'` in prose —
+      // these rationales cite each other and every scheduled precedent, so a
+      // substring search lands inside a comment and reports the file as
+      // undocumented (it did, on four of the seven, first run).
+      const at = lines.findIndex((l) => /^\s*runAs:\s*'system'\s*,\s*$/.test(l));
+      if (at < 0) { missing.push(`${file}: no runAs: 'system' declaration`); continue; }
+      // Walk back over the contiguous comment block directly above it.
+      let comment = 0;
+      for (let i = at - 1; i >= 0 && /^\s*(\/\/|\*|\/\*)/.test(lines[i]); i--) comment++;
+      if (comment < 3) {
+        missing.push(`${file}: runAs: 'system' carries ${comment} line(s) of rationale above it, expected >= 3`);
+      }
+    }
+    expect(missing, missing.join('\n')).toEqual([]);
+  });
 });

--- a/test/flow-record-change.test.ts
+++ b/test/flow-record-change.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { CaseCsatFollowupFlow } from '../src/flows/case-csat-followup.flow';
 import { CaseEscalationFlow, CaseEscalationOnCreateFlow } from '../src/flows/case-escalation.flow';
 import { ContactWelcomeFlow } from '../src/flows/contact-welcome.flow';
 import { LeadAssignmentFlow } from '../src/flows/lead-assignment.flow';
@@ -358,5 +359,181 @@ describe('insert-time twin flows', () => {
     };
     expect(startConditionHolds(OpportunityApprovalOnCreateFlow as unknown as Rec, pending))
       .toBe(startConditionHolds(OpportunityApprovalFlow as unknown as Rec, pending));
+  });
+});
+
+/**
+ * Execution identity under a USER-LESS trigger (#684).
+ *
+ * The metadata side of this invariant — every record-change flow declares
+ * `runAs: 'system'` — lives in `actions-flows-integrity.test.ts`, enumerated
+ * from the compiled stack so a new flow cannot slip past it. What that guard
+ * cannot show is WHY, so these run the real engine on the real flows with no
+ * trigger user and assert on what comes out.
+ *
+ * `makeFlowHarness().trigger()` always supplies `userId: 'user_1'`, which is
+ * exactly the healthy path the 17.0 acceptance sweep found working. The broken
+ * path is the other one, so these call `engine.execute` directly and omit
+ * `userId` — the shape of a write made by seed loading, an integration, or
+ * another `runAs:'system'` flow.
+ *
+ * Direction of the counter-proof, decided before running it: with `runAs`
+ * stripped back to the schema default the run must FAIL at its first data node
+ * with the engine's `[runAs]` refusal, and the record must be untouched. That
+ * is the pre-fix behaviour reproduced on demand — not a hypothetical — so the
+ * assertions below cannot pass vacuously by producing nothing.
+ */
+describe('record-change flows under a user-less trigger (#684)', () => {
+  type Run = { success: boolean; error?: string; summary?: { nodes?: Rec[] } };
+
+  /** Fire `flow` with NO trigger user, the way a system write does. */
+  async function fire(name: string, flow: Rec, record: Rec, previous: Rec, seed: Record<string, Rec[]> = {}) {
+    const h = makeFlowHarness({ [name]: flow as never }, seed);
+    const result = (await (h.engine as unknown as {
+      execute(n: string, c: Rec): Promise<Run>;
+    }).execute(name, { params: {}, event: 'record_change', record, previous })) as Run;
+    return { h, result };
+  }
+
+  const nodeStatus = (r: Run, id: string) =>
+    (r.summary?.nodes ?? []).find((n) => n.nodeId === id)?.status;
+
+  /** The flow as it was authored before #684: `runAs` back at its default. */
+  const withoutRunAs = (flow: Rec): Rec => {
+    const { runAs: _dropped, ...rest } = flow;
+    return rest;
+  };
+
+  const critical = (over: Rec = {}): Rec => ({
+    id: 'c1', case_number: 'CASE-1', priority: 'critical', status: 'new',
+    escalated_date: null, owner_id: 'agent1', ...over,
+  });
+
+  it('case_escalation escalates a case written with no session', async () => {
+    const { h, result } = await fire(
+      'case_escalation', CaseEscalationFlow as unknown as Rec,
+      critical(), {}, { crm_case: [critical()] },
+    );
+    expect(String(result.error ?? ''), 'the runAs refusal is back').not.toContain('[runAs]');
+    expect(result.success).toBe(true);
+    expect(h.store.crm_case[0].status).toBe('escalated');
+    expect(h.store.crm_case[0].is_escalated).toBe(true);
+    expect(h.notifications).toHaveLength(1);
+  });
+
+  it('…and REFUSES the same write once runAs is dropped (the shape #684 fixed)', async () => {
+    const { h, result } = await fire(
+      'case_escalation', withoutRunAs(CaseEscalationFlow as unknown as Rec),
+      critical(), {}, { crm_case: [critical()] },
+    );
+    expect(result.success).toBe(false);
+    expect(String(result.error)).toContain('[runAs] refusing a data operation');
+    // It dies at the FIRST data node, before anything is written — which is
+    // why a freshly seeded org had never once run this automation.
+    expect(nodeStatus(result, 'get_case')).toBe('failure');
+    expect(h.store.crm_case[0].status, 'the case was escalated despite the refusal').toBe('new');
+    expect(h.notifications).toHaveLength(0);
+  });
+
+  it('opportunity_approval reaches its approval node for a system-created deal', async () => {
+    // The governance hole the acceptance sweep demonstrated: a $150K renewal
+    // created by the runAs:'system' contract_renewal sweep fired this flow
+    // user-less and died at `get_opportunity`, leaving the deal unlocked at
+    // approval_status 'not_required' with no request ever opened.
+    const deal = {
+      id: 'o1', name: 'Acme Renewal', amount: 150_000, stage: 'negotiation',
+      approval_status: 'not_required', owner_id: 'rep1',
+    };
+    const { result } = await fire(
+      'opportunity_approval', OpportunityApprovalFlow as unknown as Rec,
+      deal, { ...deal, amount: 50_000 }, { crm_opportunity: [{ ...deal }] },
+    );
+    expect(String(result.error ?? ''), 'the deal is bypassing approval again').not.toContain('[runAs]');
+    expect(nodeStatus(result, 'get_opportunity')).toBe('success');
+    // The run then stops at `manager_review` for a harness-only reason: the
+    // approval node ships in @objectstack/plugin-approvals, which this
+    // in-memory harness does not install. That is NOT a runAs failure, and it
+    // is asserted here so a future reader does not read it as one.
+    expect(nodeStatus(result, 'manager_review')).toBe('failure');
+    expect(String(result.error)).toContain("No executor registered for node type 'approval'");
+  });
+
+  it('…and never gets that far once runAs is dropped', async () => {
+    const deal = {
+      id: 'o1', name: 'Acme Renewal', amount: 150_000, stage: 'negotiation',
+      approval_status: 'not_required', owner_id: 'rep1',
+    };
+    const { result } = await fire(
+      'opportunity_approval', withoutRunAs(OpportunityApprovalFlow as unknown as Rec),
+      deal, { ...deal, amount: 50_000 }, { crm_opportunity: [{ ...deal }] },
+    );
+    expect(String(result.error)).toContain('[runAs] refusing a data operation');
+    expect(nodeStatus(result, 'get_opportunity')).toBe('failure');
+    expect(nodeStatus(result, 'manager_review'), 'approval was never requested').toBeUndefined();
+  });
+
+  it('lead_assignment stamps the SLA on an integration-written lead', async () => {
+    const lead = {
+      id: 'l1', company: 'Acme', rating: 5, owner_id: 'rep1',
+      first_name: 'Ada', last_name: 'Lovelace',
+    };
+    const { h, result } = await fire(
+      'lead_assignment', LeadAssignmentFlow as unknown as Rec,
+      lead, {}, { crm_lead: [{ ...lead }] },
+    );
+    expect(String(result.error ?? '')).not.toContain('[runAs]');
+    expect(h.store.crm_lead[0].next_followup_date, 'hot lead got no SLA date').toBeTruthy();
+    expect(h.notifications).toHaveLength(1);
+  });
+
+  it('…and gets neither SLA nor alert once runAs is dropped', async () => {
+    const lead = {
+      id: 'l1', company: 'Acme', rating: 5, owner_id: 'rep1',
+      first_name: 'Ada', last_name: 'Lovelace',
+    };
+    const { h, result } = await fire(
+      'lead_assignment', withoutRunAs(LeadAssignmentFlow as unknown as Rec),
+      lead, {}, { crm_lead: [{ ...lead }] },
+    );
+    expect(String(result.error)).toContain('[runAs] refusing a data operation');
+    expect(h.store.crm_lead[0].next_followup_date).toBeUndefined();
+    expect(h.notifications).toHaveLength(0);
+  });
+
+  /**
+   * MEASURED, and deliberately recorded because the issue that prompted #684
+   * over-stated it: the four notify-only record-change flows
+   * (`contact_welcome`, `task_urgent_alert`, `opportunity_won_alert`,
+   * `case_csat_followup`) were NOT refused on 17.0.0-rc.2. The guard fires at
+   * `get_record` / `create_record` / `update_record` / `delete_record`, and
+   * `notify` dispatches through the messaging service without a run data
+   * context, so a user-less run of these completes and delivers.
+   *
+   * They carry `runAs: 'system'` anyway — the declaration records that
+   * record-change automation runs as the platform, so a data node added later
+   * inherits a reasoned elevation instead of a production refusal. This case
+   * pins the measurement so nobody "fixes" a break that was never there, and
+   * so the day it DOES start being refused, we hear about it here.
+   */
+  it('the notify-only siblings deliver either way (they were never the broken ones)', async () => {
+    const closed = { id: 'c2', case_number: 'CASE-2', status: 'closed', owner_id: 'agent1' };
+    for (const flow of [CaseCsatFollowupFlow, withoutRunAs(CaseCsatFollowupFlow as unknown as Rec)]) {
+      const { h, result } = await fire(
+        'case_csat_followup', flow as unknown as Rec, closed, { status: 'open' },
+      );
+      expect(String(result.error ?? '')).not.toContain('[runAs]');
+      // The run suspends at the P1D timer; the notify is on the other side.
+      expect(h.notifications).toHaveLength(0);
+    }
+
+    const contact = {
+      id: 'ct1', first_name: 'Ada', last_name: 'Lovelace',
+      owner_id: 'rep1', email_opt_out: false,
+    };
+    for (const flow of [ContactWelcomeFlow, withoutRunAs(ContactWelcomeFlow as unknown as Rec)]) {
+      const { h, result } = await fire('contact_welcome', flow as unknown as Rec, contact, {});
+      expect(String(result.error ?? '')).not.toContain('[runAs]');
+      expect(h.notifications, 'a notify-only flow was refused — the guard widened').toHaveLength(1);
+    }
   });
 });

--- a/test/runtime-coverage.test.ts
+++ b/test/runtime-coverage.test.ts
@@ -53,9 +53,13 @@ const RUNTIME_TEST_FILES = [
  * shortcut — and a stale entry (a flow that has since gained coverage) fails
  * the suite too, so it cannot rot.
  */
-const PENDING_FLOWS = new Set([
-  // Spans a 24h `wait` node; needs timer-resume support in the harness.
-  'case_csat_followup',
+const PENDING_FLOWS = new Set<string>([
+  // Empty, and the "no stale entries" case below is what emptied it.
+  // `case_csat_followup` was pending because it spans a 24h `wait` node — but
+  // the part of it that needed proving turned out to be reachable without
+  // timer-resume support: #684's user-less run drives it through the real
+  // engine as far as the suspension, which is where its execution identity is
+  // decided. See test/flow-record-change.test.ts.
 ]);
 
 const testSource = (() => {


### PR DESCRIPTION
Fixes #684

## 前提核对（先于实现）

按 origin/main `0899b4f` 逐条核对，issue 的核心前提**成立**，但**范围被高估了**，这里如实记录：

- ✅ 7 个 record-change flow 确实都没有 `runAs` 声明；`contact-welcome.flow.ts` 里的 `runAs` grep 命中只是注释。10 个 schedule flow + `case-actions.flow.ts` 的 `CloseCaseFlow` 已声明。PR #677 今天改过全部 flow 文件，行号已变，本 PR 基于合并后的代码。
- ✅ 平台侧的 build-time lint `flow-runas-unscoped` **不覆盖** record-change 这一形态（`userLessTriggerKind()` 只认 schedule / time-relative / api），引擎注释里也写明「only knowable at run time」。所以这个不变量只能由 app 侧自己守住 —— 与「不做平台侧 workaround」的约束一致，本 PR 只改 hotcrm 元数据与测试。
- ❌ **「七个 record-change flow 全部暴露」不成立。** 实测（17.0.0-rc.2，真实 `AutomationEngine`，不带 trigger user）只有 3 个真的被拒：`case_escalation`、`opportunity_approval`（各含其 insert-time twin）、`lead_assignment`。拒绝守卫的作用面是 `DATA_NODE_TYPES` = get/create/update/delete record；`notify` 节点直接调 `messaging.emit`，不经过 `resolveRunDataContext`。
- ❌ **验收补充评论里「`case_csat_followup` 潜在会被拒」也不成立。** 我把它跑通到 P1D wait 挂起、再 resume 过 wait，`notify` 正常投递，全程没有 `[runAs]`。

三个真实失败的实测输出（`summary.nodes`）：

| flow | 无用户运行（修改前） | 无用户运行（修改后） |
| --- | --- | --- |
| `case_escalation` | `get_case` = `failure`，case 仍是 `status: 'new'` | 全绿，case 变 `escalated`，1 条通知 |
| `opportunity_approval` | `get_opportunity` = `failure`，`manager_review` 从未到达 | `get_opportunity` = `success`（随后停在 approval 节点，见下） |
| `lead_assignment` | `sla_hot` 被拒，`next_followup_date` 为空、0 条通知 | SLA 落库 + 1 条告警 |

`opportunity_approval` 修改后停在 `manager_review`，报的是 `No executor registered for node type 'approval'` —— 这是 in-memory harness 没装 `@objectstack/plugin-approvals`，**不是 runAs 问题**，测试里显式断言了这一点，免得后来人误读。

## 逐 flow 的授权判断（不做无差别套用）

声明 `runAs: 'system'` 会**连带抬升用户驱动的那些 run**（今天走的是健康的 scoped-as-user 路径），所以逐个论证。共同的结构性事实：**这 7 个 flow 的每一个数据节点都以 `{record.id}` 为键**，也就是刚刚触发 trigger 的那一行 —— 用户作用域换不来任何有意义的限制（记录已经在 run 手里），只会多出一种失败模式。没有任何一个 flow 依赖触发用户的受限作用域，因此不存在需要 needs_decision 的分叉。

**真实被拒的三个：**

1. **`case_escalation`（+ `case_escalation_on_create`）** —— 升级是服务级策略，不是写入者自己的编辑。抬升同时修掉一个真实场景：坐席可以合法「建案」而不一定持有升级生命周期字段（`is_escalated` / `escalated_date` / `status`）的编辑权。这也让它和 `case_sla_monitor` 站到同一基准上 —— 后者在调度里做同一件升级，早就是 `runAs: 'system'`。
2. **`opportunity_approval`（+ twin）** —— 抬升在这里不只是可接受，而是**必须**。这道闸的存在就是为了**约束提交者**，用提交者自己的作用域去评估它方向就是反的；而且 `mark_approved` / `mark_rejected` 要往一条被 approval 节点 `lockRecord: true` 锁住的记录上盖 `approval_status`，只有平台写入落得下去。approval 节点本身也已经是以平台身份开请求、再回挂决策人做归属。
3. **`lead_assignment`** —— SLA 戳是平台对刚触发 trigger 那一行的路由决策，不是提交销售自己的编辑；线索来自 web-to-lead / CSV 导入 / 伙伴集成 / seed，本来就不带 session。

**实测未被拒的四个（`contact_welcome`、`task_urgent_alert`、`opportunity_won_alert`、`case_csat_followup`）** 仍然声明，理由写在各自文件里，并且**明确写清今天它是 inert 的**：

- 它们都是 notify-only，没有数据节点，所以拒绝够不着；声明不改变任何当下可观测的行为，也没有数据操作可供作用域约束，抬升成本为零。
- 之所以还是声明：要记录下来的决定是「**record-change 自动化以平台身份运行**」，而不是「这个 flow 恰好现在没有数据节点」。哪天加了数据节点（或加了 start 节点的 `config.expand` —— 那正是 notify 节点自己的报错信息推荐的补救手段，且走同一条受守卫的读取路径），继承到的是一个**已经论证过**的抬升，而不是在生产里撞出来的一次拒绝。
- `case_csat_followup` 还多一层：它的 run 由 `close_case`（本身就是 `runAs: 'system'`）派生，所以从 Close Case 按钮来的 run 天生无用户；而且它跨 P1D 挂起后才恢复，wait 之后那一段将来加的任何数据节点，用的都是挂起时携带的身份 —— 常见路径上就是「没有」。

注释风格沿用 10 个调度流的写法（共享段 + 每个 flow 自己的「这里为什么 load-bearing」），按 record-change 的语义改写。

## 测试

两处钉死，一处是枚举、一处是行为：

- **`test/actions-flows-integrity.test.ts`** —— 从**编译后的 stack** 枚举 record-change flow（不是手维护的 import 列表），要求每个都声明 `runAs: 'system'`，并且声明行上方带 >= 3 行的作者论证。新 flow 一注册就被覆盖，这是唯一不会腐坏的枚举方式。附带一个 canary，防止 `type` 改名后断言在空列表上空转。
- **`test/flow-record-change.test.ts`** —— 用真实引擎、**不带 `userId`** 跑真实 flow（harness 的 `trigger()` 恒定注入 `user_1`，那正是验收确认健康的那条路径，所以这些用例直接调 `engine.execute`）。并且把**修改前的形态按需重现**（剥掉 `runAs`），断言它以 `[runAs] refusing a data operation` 死在第一个数据节点、记录纹丝未动 —— 这样上面的断言不可能因为「什么都没产出」而空转通过。
- 还钉了一条**实测事实**：notify-only 的四个 flow 剥不剥 `runAs` 都照常投递。这样既不会有人去「修」一个根本不存在的破损，将来它真的开始被拒时也会在这里叫出来。

反向验证（**方向在跑之前就定好**：剥掉声明 → 三道守卫同时转红）：从 `lead-assignment.flow.ts` 删掉 `runAs: 'system'` 后实际结果 —

```
× lead_assignment stamps the SLA on an integration-written lead
× lead_assignment declares runAs:"system"
× every record-change flow explains its elevation in the source
AssertionError: expected '[runAs] refusing a data operation (ev…' not to contain '[runAs]'
Tests  3 failed | 71 passed (74)
```

随后已还原。

`test/runtime-coverage.test.ts` 的 `PENDING_FLOWS` 清空了一项：新用例把 `case_csat_followup` 真跑进引擎（跑到挂起点，也正是它执行身份被决定的地方），该 ledger 的「no stale entries」用例本身要求移除 —— 不是顺手改的无关测试。

全量验证：

```
pnpm typecheck   → tsc --noEmit，无输出
pnpm validate    → ✓ Validation passed (956ms)   （5 条 warning 均为存量：approval 空审批人槽位 / campaign_member 字段组）
pnpm lint        → 13 warning(s), 14 suggestion(s)  存量，无新增
pnpm hygiene     → ✓ source hygiene clean
pnpm build       → ✓ Build complete，Logic: 24 Flows
pnpm test        → Test Files  55 passed (55)
                   Tests  1338 passed | 1 skipped (1339)
```

`node -e` 级别的控制字符自查也已做：`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 扫过全部改动文件，clean。

## 范围与约束

- 平台依赖保持 `@objectstack/* 17.0.0-rc.2`，未做任何版本改动。
- 未触碰 `src/flows/demo-bootstrap.flow.ts`（#708 在飞）、调度流、screen 流。
- 未改 issue 的 assignee，未动 `content/docs/releases/`。
- changeset：`.changeset/record-change-flows-run-as-system.md`。

## 越界发现

re-entrancy / loop-breaker 那条（#507 形态）**不在本 PR 修**。搜索后确认 #701 已经开着且已交叉引用 #684，所以按归档纪律**没有另开重复 issue**，只在 #701 追加了一条本次实现带出的新交互事实：修完 #684 之后，这两个 flow 的自身写入变成 system 写入，重入分派因此不再带用户 —— 而在 #684 之前，`[runAs]` 拒绝**碰巧**在 seed / 系统写入路径上充当了重入的第二道防线（代价是这些 flow 在该路径上压根跑不起来）。#684 正当地移除了这个副产品，于是 loop-breaker 成为这两个 flow 的唯一防线，#701 的风险论据不降反升。引擎护栏 `activeRecordFlows` 以 `flowName::recordId` 为键、与 `runAs` 无关，护栏本身行为未变。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_