### PR TITLE
fix(forecast): 当季只留一个写入者，并把 crm_forecast 补进认领清单 (#702)

### DIFF
--- a/.changeset/forecast-current-quarter-single-producer.md
+++ b/.changeset/forecast-current-quarter-single-producer.md
@@ -1,0 +1,36 @@
+---
+"hotcrm": patch
+---
+
+Forecasts: the current quarter now has exactly one writer, so re-seeded orgs stop growing a phantom ownerless row
+
+On every boot the demo seeds are replayed, and until now they included a
+current-quarter `crm_forecast` row. Seeded rows arrive with no owner — a seed
+cannot name a user — while the nightly `forecast_snapshot` sweep looks for the
+current-quarter row **by owner**. The sweep therefore never saw the seeded row,
+concluded the period was missing, and opened a second row spanning the same
+quarter. Anything that groups forecasts by owner — the Sales dashboard's *Quota
+Attainment by Rep* table above all — then showed a duplicate current-quarter
+entry with a blank Owner, after every re-seeded boot.
+
+The seeds now stop at that window's edge: they ship **settled quarters only**,
+plus the current month, which no automation writes. The current quarter belongs
+to `forecast_snapshot` alone — one producer per window, whichever order the two
+scheduled sweeps happen to run in.
+
+`demo_bootstrap` additionally claims `crm_forecast`, the one owner-scoped seeded
+object it had been skipping. Forecasts are `private` and sales reps read only
+their own, so an ownerless snapshot was not merely blank on the owner axis — it
+was invisible to every rep and editable by nobody. Settled demo snapshots now
+belong to the first user, like every other seeded record.
+
+What this changes for a demo org: on a freshly seeded database the *Quota
+Attainment by Rep* table is empty until the 03:00 sweep opens the quarter's
+rows, and their **Quota** stays blank until someone sets one. Quota has no
+automated writer by design — it is the hand-maintained denominator of
+attainment — and an empty table is the same honest state that widget already
+shows at a quarter boundary. What it replaces is a row attributed to nobody,
+carrying a quota no rep was on the hook for.
+
+Existing databases: run `pnpm demo:reset` to drop the stale demo row, or delete
+the ownerless current-quarter forecast by hand. No user-authored data changes.

--- a/src/data/revenue.seed.ts
+++ b/src/data/revenue.seed.ts
@@ -231,8 +231,43 @@ export const quoteLineItems = defineSeed(QuoteLineItem, {
 // ─── Forecasts ────────────────────────────────────────────────────────
 // `owner_id` is left unset: a seed cannot name a user and seed writes run
 // `isSystem`, so nothing stamps it — ownership is backfilled by
-// `demo_bootstrap` once a real user exists (same as every other CRM object).
-// See the note at the foot of `src/data/index.ts`.
+// `demo_bootstrap`, which claims `crm_forecast` alongside the other
+// owner-scoped objects (#702). See the note at the foot of `src/data/index.ts`.
+//
+// ─── ONE PRODUCER PER WINDOW (#702) ───────────────────────────────────
+//
+// `forecast_snapshot` (#590) upserts the row whose window contains today, and
+// its lookup is OWNER-SCOPED:
+//
+//     { owner_id: '{currentOwner.id}', period: 'quarter',
+//       period_start: { $lte: '{TODAY()}' }, period_end: { $gte: '{TODAY()}' } }
+//
+// A seeded row in that same window can never satisfy that filter at the moment
+// the sweep reads it — the seed writes no owner, and the claim is a separate,
+// later sweep — so the flow concludes the period is missing and opens a SECOND
+// row beside it. Both span the same quarter; one has an owner and one does not.
+// Every owner-grouped consumer then renders a phantom, ownerless duplicate for
+// the current quarter, on every re-seeded dev boot (`quota_attainment_by_rep`
+// most visibly, since it pins exactly that window).
+//
+// Claiming the row does not fix that, it only re-labels the phantom: whichever
+// of the two scheduled sweeps reaches the window first decides whether the
+// second one adopts the row or duplicates it, and a duplicate never heals.
+//
+// So the seeds stop at the window's edge. They ship SETTLED quarters only, plus
+// the current MONTH — a window no runtime writer touches, since the sweep's
+// period is fixed to `quarter`. The current quarter belongs to
+// `forecast_snapshot` alone. `test/forecast-seeds.test.ts` derives the
+// forbidden window from the flow's own lookup filter and fails on any seeded
+// row that lands inside it.
+//
+// The cost, stated rather than hidden: on a freshly seeded org the Sales
+// dashboard's *Quota Attainment by Rep* table is empty until the 03:00 sweep
+// opens the quarter's rows, and their `quota` stays blank until someone sets
+// one by hand (`quota` has no automated writer — see `forecast.object.ts`).
+// That is the same honest-empty state the widget already chooses at a quarter
+// boundary; the alternative was a row attributed to nobody, carrying a quota no
+// rep is on the hook for.
 //
 // Periods are REAL calendar periods, labelled exactly the way
 // forecast.hook.ts derives them ('Q3 2026' / 'Aug 2026') — hooks don't run
@@ -254,16 +289,17 @@ const forecastNow = new Date();
 const forecastYear = forecastNow.getUTCFullYear();
 const forecastMonth = forecastNow.getUTCMonth();
 const forecastQuarterMonth = Math.floor(forecastMonth / 3) * 3;
-const thisQuarterStart = new Date(Date.UTC(forecastYear, forecastQuarterMonth, 1));
-const thisQuarterEnd = new Date(Date.UTC(forecastYear, forecastQuarterMonth + 3, 0));
+// No `thisQuarterStart` / `thisQuarterEnd`: that window is `forecast_snapshot`'s
+// and nothing here may open a row in it (#702, note above).
 const thisMonthStart = new Date(Date.UTC(forecastYear, forecastMonth, 1));
 const thisMonthEnd = new Date(Date.UTC(forecastYear, forecastMonth + 1, 0));
 const lastQuarterStart = new Date(Date.UTC(forecastYear, forecastQuarterMonth - 3, 1));
 const lastQuarterEnd = new Date(Date.UTC(forecastYear, forecastQuarterMonth, 0));
 // Deeper history: quota-attainment and coverage trends need more than a single
 // prior period to plot (#591). These are all SETTLED periods — deliberately so:
-// the forecast snapshot sweep upserts on (owner, period) for the CURRENT
-// period, so historical rows can never collide with what it writes.
+// the forecast snapshot sweep upserts the CURRENT quarter, so historical rows
+// can never collide with what it writes. That rule is now the whole rule for
+// quarters (#702): every quarterly seed below is settled.
 const quarterStartAgo = (n: number) => new Date(Date.UTC(forecastYear, forecastQuarterMonth - 3 * n, 1));
 const quarterEndAgo = (n: number) => new Date(Date.UTC(forecastYear, forecastQuarterMonth - 3 * (n - 1), 0));
 const monthStartAgo = (n: number) => new Date(Date.UTC(forecastYear, forecastMonth - n, 1));
@@ -302,31 +338,21 @@ const closedPeriod = (
 // (owner, period, period_start) identity or an insert-once mode: see the
 // `seed_key` declaration in `src/objects/forecast.object.ts`.
 //
-// The keys are POSITIONAL ('current quarter', 'two quarters back'), not
-// calendar values, because the records are positional — recomputed against
-// `new Date()` on every import. A positional key keeps the demo at exactly
-// these eight rows as the calendar rolls forward, re-pointing each at its new
-// period; a calendar-derived key would strand last quarter's demo row and add
-// one row per re-seed.
+// The keys are POSITIONAL ('current month', 'two quarters back'), not calendar
+// values, because the records are positional — recomputed against `new Date()`
+// on every import. A positional key keeps the demo at exactly these seven rows
+// as the calendar rolls forward, re-pointing each at its new period; a
+// calendar-derived key would strand last quarter's demo row and add one row per
+// re-seed.
+//
+// There is no `demo_quarter_current`: the current quarter is the one window
+// `forecast_snapshot` writes, and two producers in one window is what #702 was.
+// The current MONTH stays — the sweep's period is `quarter`, so no runtime
+// writer opens a monthly row.
 export const forecasts = defineSeed(Forecast, {
   mode: 'upsert',
   externalId: 'seed_key',
   records: [
-    {
-      seed_key: 'demo_quarter_current',
-      period: 'quarter',
-      period_label: forecastQuarterLabel(thisQuarterStart),
-      period_start: forecastIsoDate(thisQuarterStart),
-      period_end: forecastIsoDate(thisQuarterEnd),
-      snapshot_date: cel`today()`,
-      quota: 1500000,
-      pipeline_amount: 2400000,
-      best_case_amount: 1800000,
-      commit_amount: 1100000,
-      closed_amount: 820000,
-      source: 'scheduled',
-      notes: 'On track — commit + closed covers 64% of quota with the quarter still open.',
-    },
     {
       seed_key: 'demo_month_current',
       period: 'month',

--- a/src/flows/demo-bootstrap.flow.ts
+++ b/src/flows/demo-bootstrap.flow.ts
@@ -151,6 +151,21 @@ const claim = (key: string, objectName: string, label: string) => ({
  * quote_expiration notifies address a null owner and reach nobody (the exact
  * failure this flow exists to fix), and they additionally stay uneditable for
  * everyone under a `private` OWD (#622).
+ *
+ * `crm_forecast` is here for the same reason plus one sharper one (#702). A
+ * forecast row IS a per-owner object — `sharingModel: 'private'`, and
+ * `sales_rep` reads it with `readScope: 'own'` — so an ownerless snapshot is
+ * not merely blank on the owner axis of `forecast_metrics` and absent from "My
+ * Forecast": it is invisible to every rep and editable by nobody, admin
+ * included. It was the one owner-scoped seeded object this list omitted.
+ *
+ * Claiming it is only CORRECT because the seeds no longer ship a row in the
+ * window `forecast_snapshot` owns (`src/data/revenue.seed.ts`). While they did,
+ * stamping an owner here would have moved the phantom onto the first user
+ * rather than removing it — and left a permanent duplicate on any boot where
+ * the 03:00 sweep reached the window before this ten-minute sweep did. Order
+ * independence comes from the seeds staying out of that window, not from this
+ * claim; the claim only settles who owns the SETTLED periods.
  */
 const CLAIMED_OBJECTS: ReadonlyArray<[key: string, objectName: string, label: string]> = [
   ['leads', 'crm_lead', 'Leads'],
@@ -161,6 +176,7 @@ const CLAIMED_OBJECTS: ReadonlyArray<[key: string, objectName: string, label: st
   ['tasks', 'crm_task', 'Tasks'],
   ['quotes', 'crm_quote', 'Quotes'],
   ['contracts', 'crm_contract', 'Contracts'],
+  ['forecasts', 'crm_forecast', 'Forecasts'],
 ];
 
 /** One pass per object. */

--- a/test/flow-scheduled.test.ts
+++ b/test/flow-scheduled.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { CrmSeedData } from '../src/data/index';
 import { CampaignCompletionFlow } from '../src/flows/campaign-completion.flow';
 import { CaseSlaMonitorFlow } from '../src/flows/case-sla-monitor.flow';
 import { ContractExpirationFlow } from '../src/flows/contract-expiration.flow';
@@ -664,6 +665,190 @@ describe('forecast_snapshot — nightly per-owner pipeline snapshot', () => {
 });
 
 /**
+ * Re-seed × snapshot: one row per (owner, period, window) — #702.
+ *
+ * The reported defect needs three ordinary behaviours and no bug in any of
+ * them: seeds land ownerless (seed writes are `isSystem`, so the platform's
+ * `owner_id` stamp never fires), a warm boot replays them, and the sweep's
+ * current-window lookup is owner-scoped. Put a seeded row in the window the
+ * sweep writes and the sweep cannot see it — so it opens a SECOND row beside
+ * it, and every owner-grouped consumer shows a phantom ownerless duplicate for
+ * the current quarter after every re-seeded boot.
+ *
+ * The fix is in the seed data — the current quarter is no longer seeded — and
+ * this file's job is to show that the invariant survives the two scheduled
+ * sweeps in EITHER ORDER. That matters because the obvious alternative fix
+ * (claim `crm_forecast` and let the sweep adopt the claimed row) holds only
+ * while `demo_bootstrap` reaches the window before `forecast_snapshot` does,
+ * and a duplicate opened by losing that race never heals. Both orders are run
+ * below over the REAL seed records; the last case restores a current-quarter
+ * seed row and reproduces the duplicate, so a green run here can never be green
+ * for want of a mechanism.
+ */
+describe('re-seed × snapshot leaves one row per (owner, period, window) (#702)', () => {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const isoUtc = (d: Date) => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+  const nowUtc = new Date();
+  const qStart = new Date(Date.UTC(nowUtc.getUTCFullYear(), Math.floor(nowUtc.getUTCMonth() / 3) * 3, 1));
+  const qEnd = new Date(Date.UTC(qStart.getUTCFullYear(), qStart.getUTCMonth() + 3, 0));
+  const today = isoUtc(nowUtc);
+
+  /** The forecast rows the seed loader actually ships, read from the app. */
+  const seedRecords = ((CrmSeedData as unknown as Array<{ object: string; records: Rec[] }>)
+    .find((d) => d.object === 'crm_forecast')?.records ?? []);
+
+  const users = (): Rec[] => [
+    // `get_user` takes an unordered first row; the demo's first user is the
+    // dev admin, and `demo_bootstrap` claims every ownerless row for them.
+    { id: 'usr_admin', name: 'Dev Admin' },
+    { id: 'rep_two', name: 'Rep Two' },
+    { id: 'rep_idle', name: 'No Deals At All' },
+  ];
+
+  /** Two active deal owners and one user the sweep must skip. */
+  const opps = (): Rec[] => [
+    { id: 'o1', owner_id: 'usr_admin', stage: 'negotiation', forecast_category: 'commit', amount: 200_000, close_date: isoUtc(qStart) },
+    { id: 'o2', owner_id: 'rep_two', stage: 'proposal', forecast_category: 'commit', amount: 90_000, close_date: isoUtc(qStart) },
+  ];
+
+  /**
+   * One seed-loader pass, faithful to what the loader does rather than to what
+   * "re-seed" sounds like: `mode: 'upsert'` on `seed_key` resolves to
+   * `engine.update({ ...record, id })` for a row that already exists — a
+   * PARTIAL write over the columns the seed declares — and to an insert
+   * otherwise (`@objectstack/metadata-protocol`, `SeedLoaderService.writeRecord`).
+   *
+   * Partial is the load-bearing word: the seeds declare no `owner_id`, so a
+   * claimed owner SURVIVES a warm-boot replay. If it did not, the ownerless
+   * state would return on every boot and no claim could ever settle it.
+   *
+   * A fresh insert lands with `owner_id: null`, not with the key absent: the
+   * registry injects the column into every user-owned object, and the seed
+   * write only skips the security plugin's insert-time STAMP. The distinction
+   * decides whether `demo_bootstrap` can see the row at all — its filter is
+   * `{ owner_id: null }`, and an absent key is not null.
+   */
+  const loadSeeds = (store: Record<string, Rec[]>) => {
+    const rows = (store.crm_forecast ??= []);
+    for (const rec of seedRecords) {
+      const existing = rows.find((r) => r.seed_key === rec.seed_key);
+      if (existing) Object.assign(existing, rec);
+      else rows.push({ id: `seed_${String(rec.seed_key)}`, owner_id: null, ...rec });
+    }
+  };
+
+  const makeHarness = (forecasts: Rec[] = []) =>
+    makeFlowHarness(
+      { demo_bootstrap: DemoBootstrapFlow, forecast_snapshot: ForecastSnapshotFlow },
+      { sys_user: users(), crm_opportunity: opps(), crm_forecast: forecasts },
+      { hooks: [forecastDerive] },
+    );
+
+  /** A cold boot and a warm one, both running the sweeps in `order`. */
+  const boot = async (order: readonly string[]) => {
+    const h = makeHarness();
+    loadSeeds(h.store);
+    for (const flow of order) await h.run(flow, {}, { event: 'schedule' });
+    loadSeeds(h.store);
+    for (const flow of order) await h.run(flow, {}, { event: 'schedule' });
+    return h;
+  };
+
+  const inCurrentQuarter = (r: Rec) =>
+    r.period === 'quarter' && String(r.period_start) <= today && today <= String(r.period_end);
+
+  const ORDERINGS = [
+    ['claim first — the ten-minute sweep reaches the window first', ['demo_bootstrap', 'forecast_snapshot']],
+    ['sweep first — a boot minutes before 03:00', ['forecast_snapshot', 'demo_bootstrap']],
+  ] as const;
+
+  for (const [label, order] of ORDERINGS) {
+    describe(label, () => {
+      let h: Awaited<ReturnType<typeof boot>>;
+      beforeAll(async () => { h = await boot(order); });
+
+      it('leaves no forecast row owned by nobody', async () => {
+        const ownerless = h.store.crm_forecast
+          .filter((r) => r.owner_id == null)
+          .map((r) => `${String(r.seed_key ?? r.id)} (${String(r.period)} ${String(r.period_start)})`);
+        expect(
+          ownerless,
+          'these rows render with a blank Owner in every owner-grouped surface, and\n'
+            + "under sharingModel:'private' are readable by no rep at all:\n  "
+            + ownerless.join('\n  '),
+        ).toEqual([]);
+      });
+
+      it('leaves exactly one row per (owner, period, period_start)', async () => {
+        const keys = h.store.crm_forecast.map(
+          (r) => `${String(r.owner_id)}|${String(r.period)}|${String(r.period_start)}`,
+        );
+        const dupes = [...new Set(keys.filter((k, i) => keys.indexOf(k) !== i))];
+        expect(
+          dupes,
+          `two rows share one snapshot identity — a quota/closed double count:\n  ${dupes.join('\n  ')}`,
+        ).toEqual([]);
+      });
+
+      it('gives the current quarter one row per ACTIVE deal owner and no other', async () => {
+        const current = h.store.crm_forecast.filter(inCurrentQuarter);
+        expect(current.map((r) => String(r.owner_id)).sort()).toEqual(['rep_two', 'usr_admin']);
+        expect(
+          current.map((r) => r.seed_key).filter(Boolean),
+          'a seeded row opened in the window forecast_snapshot writes',
+        ).toEqual([]);
+      });
+
+      it('leaves the current-quarter numbers the sweep computed, not seeded ones', async () => {
+        // The other half of the warm-boot story: the replay must not stomp a
+        // runtime writer's row. It cannot, because the seeds no longer declare
+        // one in this window — this asserts the outcome rather than the reason.
+        const admin = h.store.crm_forecast.find((r) => inCurrentQuarter(r) && r.owner_id === 'usr_admin')!;
+        expect(admin, 'no current-quarter row for the admin').toBeTruthy();
+        expect(Number(admin.commit_amount)).toBe(200_000);
+        expect(Number(admin.pipeline_amount)).toBe(200_000);
+        expect(admin.period_start).toBe(isoUtc(qStart));
+        expect(admin.period_end).toBe(isoUtc(qEnd));
+      });
+
+      it('claims every settled seed row for the first user', async () => {
+        const seeded = h.store.crm_forecast.filter((r) => r.seed_key != null);
+        expect(seeded, 'the seed replay inserted duplicates').toHaveLength(seedRecords.length);
+        expect(seeded.map((r) => String(r.owner_id))).toEqual(seedRecords.map(() => 'usr_admin'));
+      });
+    });
+  }
+
+  it('reproduces the phantom when a current-quarter row IS seeded', async () => {
+    // Non-vacuity, and the reported mechanism end to end. Restore the row the
+    // seeds used to ship and run the sweep before the claim: the sweep's
+    // owner-scoped lookup cannot match an ownerless row, so it opens a second
+    // one; the claim then stamps the first, leaving TWO rows for ONE owner in
+    // ONE window. Predicted direction, and the one that makes the guards above
+    // meaningful — the duplicate is what they would report.
+    const phantom: Rec = {
+      id: 'seed_demo_quarter_current', seed_key: 'demo_quarter_current', owner_id: null,
+      period: 'quarter', period_start: isoUtc(qStart), period_end: isoUtc(qEnd),
+      snapshot_date: today, source: 'scheduled', quota: 1_500_000, closed_amount: 820_000,
+    };
+    const h = makeHarness([phantom]);
+    await h.run('forecast_snapshot', {}, { event: 'schedule' });
+    await h.run('demo_bootstrap', {}, { event: 'schedule' });
+
+    const adminRows = h.store.crm_forecast.filter((r) => inCurrentQuarter(r) && r.owner_id === 'usr_admin');
+    expect(adminRows, 'the sweep adopted the ownerless row instead of duplicating it').toHaveLength(2);
+    // And it is terminal: the sweep's findOne refreshes whichever row it
+    // reaches first and never sees, let alone merges, the other.
+    await h.run('forecast_snapshot', {}, { event: 'schedule' });
+    await h.run('demo_bootstrap', {}, { event: 'schedule' });
+    expect(
+      h.store.crm_forecast.filter((r) => inCurrentQuarter(r) && r.owner_id === 'usr_admin'),
+      'a later pass healed the duplicate — then the seed guard would be optional',
+    ).toHaveLength(2);
+  });
+});
+
+/**
  * Regression guard — a bare string condition inside a `loop` body WAS inert.
  *
  * `AutomationEngine.registerFlow` runs `applyConversionsToFlow`, which rewrites
@@ -844,6 +1029,11 @@ describe('demo_bootstrap — post-seed ownership claim', () => {
     for (const object of [
       'crm_lead', 'crm_account', 'crm_contact', 'crm_opportunity',
       'crm_case', 'crm_task', 'crm_quote', 'crm_contract',
+      // #702: `crm_forecast` is `private` and `sales_rep` reads it with
+      // `readScope: 'own'`, so an ownerless snapshot row is invisible to every
+      // rep and editable by nobody — the same defect as the eight above, on the
+      // one owner-scoped seeded object this list used to omit.
+      'crm_forecast',
     ]) {
       expect(claimed, `demo_bootstrap never claims ${object}`).toContain(object);
     }

--- a/test/forecast-period-scope.test.ts
+++ b/test/forecast-period-scope.test.ts
@@ -201,7 +201,23 @@ const makeEngine = () =>
     } as never,
   });
 
-describe('quota_attainment_by_rep over the real seeds (#614)', () => {
+/**
+ * The current-quarter quota, as it reaches a live table.
+ *
+ * Not from the seeds, and that is the point (#702): the seeds ship SETTLED
+ * quarters only, because `forecast_snapshot` owns the current-quarter window
+ * and two producers in one window is what left a phantom ownerless duplicate
+ * there. So the current-quarter row in the fixture below is the one the SWEEP
+ * opens — and the sweep never writes `quota` (see the flow header), which
+ * leaves it exactly where `crm_forecast` says it lives: maintained by hand
+ * until a quota model exists.
+ *
+ * A number, then, rather than a seeded value — and one that has to be here
+ * regardless, because the widget's whole subject is quota vs. closed.
+ */
+const CURRENT_QUARTER_QUOTA = 1_500_000;
+
+describe('quota_attainment_by_rep over the real seeds plus one sweep (#614)', () => {
   let ql: Awaited<ReturnType<typeof makeEngine>>;
   let analytics: AnalyticsService;
   /** Every filter the analytics service handed the engine, in order. */
@@ -225,17 +241,21 @@ describe('quota_attainment_by_rep over the real seeds (#614)', () => {
       }
     }
 
-    // "…plus one sweep run": `forecast_snapshot` upserts the CURRENT-period row
-    // and rewrites its amounts; it never writes `quota` (see the flow header).
-    // Modelled here as the write itself rather than by re-running the flow —
-    // `test/flow-scheduled.test.ts` owns the flow's behaviour; this file owns
-    // what the dashboard reads afterwards.
+    // "…plus one sweep run": `forecast_snapshot` OPENS the current-quarter row
+    // — the seeds no longer ship one (#702) — and writes the four amounts into
+    // it, never `quota`. Modelled here as the write itself rather than by
+    // re-running the flow: `test/flow-scheduled.test.ts` owns the flow's
+    // behaviour, this file owns what the dashboard reads afterwards. The quota
+    // arrives the only way it can, by hand.
     for (const rep of REPS) {
-      // `(document, options)` — the engine's real repo-facade shape (#616).
-      await api.object('crm_forecast').update(
-        { closed_amount: 900000, pipeline_amount: 2500000, commit_amount: 1200000 },
-        { where: { owner_id: rep, period: 'quarter', period_start: currentQuarterStart }, multi: true },
-      );
+      await api.object('crm_forecast').insert({
+        owner_id: rep,
+        period: 'quarter',
+        period_label: 'current quarter',
+        period_start: currentQuarterStart,
+        quota: CURRENT_QUARTER_QUOTA,
+        closed_amount: 900000, pipeline_amount: 2500000, commit_amount: 1200000,
+      });
     }
 
     filtersSeen = [];
@@ -274,44 +294,47 @@ describe('quota_attainment_by_rep over the real seeds (#614)', () => {
       { isSystem: true } as never,
     )).rows as AnyRec[];
 
-  /** The seeds' own current-quarter numbers — the answer the table must show. */
-  const currentQuarterSeed = () =>
-    (forecastSeed?.records ?? []).find(
-      (r) => r.period === 'quarter' && r.period_start === currentQuarterStart,
-    );
-
-  it('the seeds really do hold several periods for one owner', () => {
-    // The premise of the whole issue. If the seeds ever ship a single period,
-    // the assertions below would pass for the wrong reason.
+  it('the table really does hold several periods for one owner', () => {
+    // The premise of the whole issue. If the fixture ever collapsed to a single
+    // period, the assertions below would pass for the wrong reason.
     expect((forecastSeed?.records ?? []).length).toBeGreaterThan(1);
-    expect(currentQuarterSeed(), 'no current-quarter seed row').toBeDefined();
+  });
+
+  it('the seeds contribute no current-quarter row — the sweep owns that window (#702)', () => {
+    // The other premise, and the one that changed. A seeded row here could not
+    // be matched by the sweep's owner-scoped lookup, so the sweep would open a
+    // second row beside it and this table would show a phantom, ownerless
+    // duplicate for the current quarter after every re-seeded boot.
+    const trespassers = (forecastSeed?.records ?? [])
+      .filter((r) => r.period === 'quarter' && r.period_start === currentQuarterStart)
+      .map((r) => String(r.seed_key));
+    expect(trespassers, `seeded current-quarter rows: ${trespassers.join(', ')}`).toEqual([]);
   });
 
   it('unpinned, the measures add every snapshot together — the #614 defect', async () => {
     const rows = await runWidget();
     const alice = rows.find((r) => r.owner === 'rep_alice')!;
-    const seededQuotaTotal = (forecastSeed?.records ?? [])
-      .reduce((sum, r) => sum + Number(r.quota ?? 0), 0);
+    const quotaAcrossPeriods =
+      (forecastSeed?.records ?? []).reduce((sum, r) => sum + Number(r.quota ?? 0), 0)
+      + CURRENT_QUARTER_QUOTA;
 
     expect(rows).toHaveLength(REPS.length);
-    expect(alice.quota_sum).toBe(seededQuotaTotal);
+    expect(alice.quota_sum).toBe(quotaAcrossPeriods);
     // Concretely, and this is the number the dashboard used to print: every
     // period's quota stacked into one "Quota" cell.
-    expect(alice.quota_sum).toBeGreaterThan(Number(currentQuarterSeed()!.quota));
+    expect(alice.quota_sum).toBeGreaterThan(CURRENT_QUARTER_QUOTA);
   });
 
   it('the shipped widget filter yields the rep\'s quarterly quota, not the sum of snapshots', async () => {
-    const seedRow = currentQuarterSeed()!;
     const rows = await runWidget(quotaWidget.filter);
 
     expect(rows).toHaveLength(REPS.length);
     for (const rep of REPS) {
       const row = rows.find((r) => r.owner === rep)!;
-      expect(row.quota_sum, `${rep} quota`).toBe(Number(seedRow.quota));
-      // The sweep's write, not the seeded placeholder — the widget reads the
-      // refreshed current-quarter row.
+      expect(row.quota_sum, `${rep} quota`).toBe(CURRENT_QUARTER_QUOTA);
+      // The sweep's row, and only it — one snapshot per owner in this window.
       expect(row.closed_sum, `${rep} closed`).toBe(900000);
-      expect(row.attainment, `${rep} attainment`).toBeCloseTo(900000 / Number(seedRow.quota), 10);
+      expect(row.attainment, `${rep} attainment`).toBeCloseTo(900000 / CURRENT_QUARTER_QUOTA, 10);
     }
   });
 

--- a/test/forecast-seeds.test.ts
+++ b/test/forecast-seeds.test.ts
@@ -107,16 +107,20 @@ describe('forecast seed periods are calendar-true (#530)', () => {
     expect(bad, bad.join('\n')).toEqual([]);
   });
 
-  it('a quarterly snapshot exists for the current calendar quarter', () => {
-    // The row a "this quarter" equals-filter must be able to hit.
+  it('a monthly snapshot exists for the current calendar month', () => {
+    // The row a "this period" equals-filter must be able to hit. This was
+    // asserted on the current QUARTER until #702 moved that window out of the
+    // seeds entirely (see the #702 block below) — the property #530 is about is
+    // "a calendar-true current-period row exists to be matched", and the
+    // monthly row carries it now. The quarter's counterpart is written by
+    // `forecast_snapshot`, and `test/flow-scheduled.test.ts` pins that it lands
+    // on the same exact boundary.
     const now = new Date();
-    const currentQuarterStart = isoDate(
-      new Date(Date.UTC(now.getUTCFullYear(), Math.floor(now.getUTCMonth() / 3) * 3, 1)),
-    );
-    const hit = quarterRecs.find((r) => r.period_start === currentQuarterStart);
+    const currentMonthStart = isoDate(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)));
+    const hit = monthRecs.find((r) => r.period_start === currentMonthStart);
     expect(
       hit,
-      `no quarter snapshot with period_start ${currentQuarterStart}; got: ${quarterRecs
+      `no month snapshot with period_start ${currentMonthStart}; got: ${monthRecs
         .map((r) => r.period_start)
         .join(', ')}`,
     ).toBeDefined();
@@ -137,6 +141,112 @@ describe('forecast seed periods are calendar-true (#530)', () => {
     const labels = records.map((r) => String(r.period_label));
     const dupes = labels.filter((l, i) => labels.indexOf(l) !== i);
     expect(dupes, `two seeded forecasts render the same period: ${dupes.join(', ')}`).toEqual([]);
+  });
+});
+
+/**
+ * One producer per window (#702).
+ *
+ * `forecast_snapshot` upserts the row whose window contains today, keyed by
+ * OWNER. A seeded row in that same window cannot satisfy that lookup at the
+ * moment the sweep reads it — a seed writes no owner, and `demo_bootstrap`'s
+ * claim is a separate, later sweep — so the flow reports the period missing and
+ * opens a SECOND row beside it. Both span the quarter; one is ownerless. Every
+ * owner-grouped consumer then shows a phantom duplicate for the current
+ * quarter, on every re-seeded dev boot.
+ *
+ * Claiming `crm_forecast` (which `demo_bootstrap` now does, for the settled
+ * rows) does NOT make that safe: it only decides which of the two scheduled
+ * sweeps reaches the window first, and a duplicate opened by losing that race
+ * never heals. The invariant has to hold whatever the order, so it is enforced
+ * where order cannot reach it — in the seed data.
+ *
+ * The forbidden window is derived from the flow's own lookup filter rather than
+ * restated here: change `SNAPSHOT_PERIOD` and this guard follows.
+ */
+describe('the seeds stay out of the window forecast_snapshot owns (#702)', () => {
+  /** Any node in the flow, loop bodies included. */
+  const findNode = (id: string): Record<string, any> | undefined => {
+    const walk = (nodes: any[]): any => {
+      for (const node of nodes ?? []) {
+        if (node?.id === id) return node;
+        const hit = walk(node?.config?.body?.nodes ?? []);
+        if (hit) return hit;
+      }
+      return undefined;
+    };
+    return walk(((ForecastSnapshotFlow as any).nodes ?? []) as any[]);
+  };
+
+  const sweepLookup = (findNode('find_forecast')?.config?.filter ?? {}) as Record<string, any>;
+  const sweptPeriod = String(sweepLookup.period ?? '');
+  const today = isoDate(new Date());
+
+  /** Does `r` span today, in the period the sweep writes? */
+  const inSweptWindow = (r: SeedRec) =>
+    r.period === sweptPeriod
+    && String(r.period_start) <= today
+    && today <= String(r.period_end);
+
+  it('the sweep still claims the current window by an OWNER-SCOPED lookup', () => {
+    // The premise of everything below, and every part of it is load-bearing.
+    // Drop the owner key and the sweep would find the seeded row and adopt it,
+    // making this guard unnecessary; widen the window operators and it would
+    // match a different set of rows than the ones checked here. Either way the
+    // guard must be re-derived rather than left passing for a stale reason.
+    expect(findNode('find_forecast'), 'forecast_snapshot has no find_forecast node').toBeDefined();
+    expect(sweptPeriod, 'the sweep writes no fixed period any more').toMatch(/^(month|quarter)$/);
+    expect(String(sweepLookup.owner_id), 'the sweep lookup is no longer owner-scoped')
+      .toMatch(/\{currentOwner\.\w+\}/);
+    expect(sweepLookup.period_start).toEqual({ $lte: '{TODAY()}' });
+    expect(sweepLookup.period_end).toEqual({ $gte: '{TODAY()}' });
+  });
+
+  it('no seeded forecast row lands inside that window', () => {
+    const trespassers = records
+      .filter(inSweptWindow)
+      .map((r) => `${String(r.seed_key)} (${String(r.period_start)} → ${String(r.period_end)})`);
+    expect(
+      trespassers,
+      `these seeds open a ${sweptPeriod} row in the window forecast_snapshot writes.\n`
+        + 'The sweep cannot see them (its lookup is owner-scoped) so it opens a second,\n'
+        + 'owner-keyed row beside each — the #702 phantom. Seed settled periods only:\n  '
+        + trespassers.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('still seeds a CURRENT-period row for the period the sweep does not write', () => {
+    // The removal is scoped, not a blanket "no current periods". A monthly
+    // window has exactly one producer — the seed — so keeping it costs nothing
+    // and keeps the demo's current-period story alive. If this ever fails
+    // because the sweep took over months too, the seed has to give that window
+    // up as well rather than be quietly re-added.
+    const otherPeriod = sweptPeriod === 'quarter' ? 'month' : 'quarter';
+    const current = records.filter(
+      (r) =>
+        r.period === otherPeriod
+        && String(r.period_start) <= today
+        && today <= String(r.period_end),
+    );
+    expect(
+      current.map((r) => String(r.seed_key)),
+      `no seeded ${otherPeriod} row covers today — the demo has no current-period forecast at all`,
+    ).not.toEqual([]);
+  });
+
+  it(`every seeded row in the swept period is SETTLED — it ended before today`, () => {
+    // The same fact from the other side, and the one a reader checks by eye.
+    // Stated separately because the window guard above passes for a seeded
+    // FUTURE quarter, which the sweep will collide with the day it arrives
+    // rather than today — a bug that would sit dormant for up to three months.
+    const unsettled = records
+      .filter((r) => r.period === sweptPeriod && !(String(r.period_end) < today))
+      .map((r) => `${String(r.seed_key)} ends ${String(r.period_end)}`);
+    expect(
+      unsettled,
+      `these ${sweptPeriod} seeds are not settled — forecast_snapshot owns every\n`
+        + `${sweptPeriod} window from today onwards:\n  ${unsettled.join('\n  ')}`,
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Fixes #702

## 前提核对（先于实现）

issue 的证据采自验收线的 pinned baseline `5a78f88`，早于 PR #677。按 origin/main `59282895` 逐条重核，**三条促成因素在当前 main 上全部仍然成立**，只有措辞过时：

| issue 的说法 | 当前 main 实测 | 结论 |
| --- | --- | --- |
| (a) `demo_bootstrap` 认领清单不含 `crm_forecast` | `CLAIMED_OBJECTS` 是 lead / account / contact / opportunity / case / task / quote / contract 八项，**无 forecast** | ✅ 成立 |
| (b) 种子 forecast 行不带 owner | `src/data/revenue.seed.ts` 八条记录均未声明 `owner_id`，注释也写明「a seed cannot name a user」 | ✅ 成立 |
| (c) 快照流按 owner 键控当季查找 | `CURRENT_PERIOD_FILTER` = `owner_id: '{currentOwner.id}'` + `period: 'quarter'` + period_start ≤ TODAY ≤ period_end | ✅ 成立 |
| 「8 objects × 2 columns」 | 过时。#677 已把两列并成单列 `owner_id`，认领谓词是 `{owner_id: null}` | ⚠️ 措辞过时，机理不变 |

碰撞发生在 `demo_quarter_current` 这**一条**记录上：`demo_month_current` 是 month 期，而 sweep 的 `SNAPSHOT_PERIOD` 固定为 `quarter`，两者不同窗。

平台侧的 upsert 语义也实测过（`@objectstack/metadata-protocol` 的 `SeedLoaderService.writeRecord`）：`mode: 'upsert'` 命中已有行时走 `engine.update({ ...record, id })` —— **部分写**，只覆盖种子声明的列。所以一旦 `owner_id` 被盖上，热启动重播种不会把它抹掉。这条事实决定了下面方案的可行性，因此单独验证而非假设。

## 三个方向的取舍（选 2 + 1，理由如下）

### 方向 1 单用（只把 crm_forecast 加进认领清单）：**order-dependent，实测证明**

PM 提示要核实「认领到底去重了，还是只是换了幻影的 owner」。实测答案是：**看两个调度流谁先到窗口**。我在 `test/flow-scheduled.test.ts` 里把两种顺序都跑了一遍，并把当季种子行放回去做反向验证：

- `demo_bootstrap` 先跑 → sweep 认出已被认领的行并 adopt，**不产生重复**，方向 1 看起来「修好了」；
- `forecast_snapshot` 先跑（冷启动在 03:00 前十分钟内）→ sweep 看不见还没被认领的行，另开一条；随后认领又把种子行盖上 owner，于是**同一个 owner 在同一窗口有两行**：

```
AssertionError: two rows share one snapshot identity — a quota/closed double count:
  usr_admin|quarter|2026-07-01: expected [ 'usr_admin|quarter|2026-07-01' ] to deeply equal []
```

而且不自愈：sweep 的 `find_forecast` 是 findOne，只刷新先碰到的那一条，另一条永远留着。第一个用户如果本身不是 deal owner，方向 1 还会让幻影行**看起来更合法**（挂在 admin 名下、带 1.5M quota），与 issue 里那条空 owner 的行并排。

### 方向 3（让 sweep 收养无 owner 行）：不成立

flow 的 lookup 是纯 metadata filter。要表达「我的 或 无主」只能写 `owner_id: { $in: ['{currentOwner.id}', null] }`，但语义是错的：多个 deal owner 会**争抢同一条无主行**，谁先跑谁收养，其余人还是各自新建。这不是「宽松一点」，是把不确定性写进契约。按 contract-first，producer 侧修。

### 方向 2（+ 方向 1 作为独立修复）：采用

- **种子只写已结算的季度**：当季窗口交给 `forecast_snapshot` 独占。碰撞从源头消失，与调度顺序无关 —— 上面那条反向验证在两种顺序下都变红，就是这个性质的证据。
- **`crm_forecast` 补进认领清单**，理由与幻影无关、是另一个真实缺陷：该对象 `sharingModel: 'private'`，`sales_rep` 以 `readScope: 'own'` 读它，所以一条无主快照**不只是 owner 轴上空白**，而是对每个 rep 都不可见、对所有人（含 admin）都不可编辑。它是认领清单里唯一漏掉的 owner-scoped 已 seed 对象。

两者的依赖方向写进了源码注释：认领之所以**正确**，是因为种子已经退出了 sweep 的窗口；顺序无关性来自种子退让，不来自认领。

### 明说代价（不藏）

新装/重置的 demo org 上，Sales dashboard 的 *Quota Attainment by Rep* 表在 03:00 sweep 之前是**空的**，之后 `quota` 也是空的（`quota` 按设计没有自动写入者，是 attainment 的手工分母）。

这不是回归的净损失，因为**今天这个「demo 故事」本来就是坏的**：sweep 一旦跑过，归到 Dev Admin 名下的是 sweep 那行（quota 为空），种子那条 1.5M quota 挂在**空 owner** 上。换句话说，被删掉的不是一个能用的 quota 故事，而是一条不属于任何人的行。而「空」正是该 widget 在季度切换时**已经选择过**的诚实状态（见 `sales.dashboard.ts` 里 `quota_attainment_by_rep` 的既有注释）。

## 改动

- `src/data/revenue.seed.ts` —— 删除 `demo_quarter_current`（八条 → 七条），连带删掉只服务于它的 `thisQuarterStart` / `thisQuarterEnd`。新增「ONE PRODUCER PER WINDOW」注释块，写清机理、为什么认领不足以修、以及上面那条代价。
- `src/flows/demo-bootstrap.flow.ts` —— `CLAIMED_OBJECTS` 增加 `['forecasts', 'crm_forecast', 'Forecasts']`，附作者论证。
- `.changeset/forecast-current-quarter-single-producer.md`。

未触碰 #684 在飞的七个 record-change flow，未改 `forecast-snapshot.flow.ts`（方向 2 不需要动它），未改 `content/docs/releases/`。

## 测试

**`test/forecast-seeds.test.ts`** —— 新增 describe「the seeds stay out of the window forecast_snapshot owns (#702)」。禁区**从 flow 自身的 lookup filter 推导**（走节点树找 `find_forecast`，读 `config.filter`），所以 `SNAPSHOT_PERIOD` 一改守卫就跟着改，不会在陈旧前提上空转。四条：

1. sweep 仍然以 owner 键控当季（premise 守卫：owner_id 模板、period 标量、两个窗口算子都断言到）；
2. 没有任何种子行落在该窗口内；
3. 仍然为 sweep **不写**的那个 period 保留一条当期行（说明这是定向删除，不是「一刀切掉所有当期」）；
4. sweep 所属 period 的种子行必须**已结算**（`period_end` 早于今天）—— 单独一条，因为 (2) 对「种子了一个未来季度」是放行的，那种缺陷会潜伏最多三个月。

同时把原先的 `a quarterly snapshot exists for the current calendar quarter` 改指到**当月**：#530 要保的性质是「存在一条日历真值的当期行可被等值过滤命中」，那条性质现在由 month 行承载，季度那条由 sweep 产出（`flow-scheduled` 里已钉死它落在同样精确的边界上）。这属于 fixture 三种处置里的「改指」，不是删覆盖。

**`test/flow-scheduled.test.ts`** —— 新增端到端 describe：用**真实种子记录**在同一 store 上跑 `demo_bootstrap` + `forecast_snapshot`，冷启动一轮、模拟热启动重播种再跑一轮，**两种调度顺序各跑一遍**，断言无无主行、`(owner, period, period_start)` 唯一、当季每个活跃 deal owner 恰好一行、当季数字来自 sweep 而非种子、七条种子行全部归到第一个用户。

重播种按 loader 的真实语义模拟（按 `seed_key` 匹配 + 部分写），并且新插入的行带 `owner_id: null` 而非缺键 —— 这个区别是 load-bearing 的：`demo_bootstrap` 的过滤器是 `{owner_id: null}`，缺键匹配不上。第一版就是在这里红的。

最后一条用例把当季种子行**放回去**并按 sweep-先跑的顺序执行，断言重复行确实出现、且后续再跑也不自愈 —— 保证上面那组守卫不会因为「什么都没产出」而空转通过。

`demo_bootstrap` 的显式认领清单加上 `crm_forecast`。

**`test/forecast-period-scope.test.ts`** —— #614 的 runtime 半场原本直接从种子里取当季行做 fixture，现在改成生产形态：种子（已结算阶梯）+ sweep 新开的当季行 + 手工设的 quota（常量 `CURRENT_QUARTER_QUOTA`，注释说明 quota 没有自动写入者所以只能这样来）。新增一条断言：种子里不含当季行。#614 的结构守卫（不跨期求和）未动。

### 反向验证（方向在跑之前就定好：把删掉的种子行放回去 → 转红）

```
FAIL test/forecast-seeds.test.ts > ... > no seeded forecast row lands inside that window
FAIL test/forecast-seeds.test.ts > ... > every seeded row in the swept period is SETTLED
FAIL test/flow-scheduled.test.ts > ... > sweep first > leaves exactly one row per (owner, period, period_start)
FAIL test/flow-scheduled.test.ts > ... > sweep first > gives the current quarter one row per ACTIVE deal owner
FAIL test/flow-scheduled.test.ts > ... > claim first > gives the current quarter one row per ACTIVE deal owner
```

值得单独指出的**非对称**：`claim first` 那一栏只红了一条（「当季出现了种子行」），**重复行没有出现** —— 这正是方向 1 单用会「看起来修好了」的原因；`sweep first` 那一栏才红出重复。这条不对称就是选方向 2 而不是方向 1 的实测依据，随后已还原。

### 全量

```
pnpm typecheck   → tsc --noEmit，无输出
pnpm validate    → ✓ Validation passed (965ms)   （5 条 warning 均为存量：approval 空审批人槽位 / campaign_member 字段组）
pnpm lint        → 13 warning(s), 14 suggestion(s)   与 main 基线逐字相同（stash 对比过）
pnpm hygiene     → ✓ source hygiene clean
pnpm build       → ✓ Build complete，Logic: 24 Flows
pnpm test        → Test Files  56 passed (56)
                   Tests  1363 passed | 1 skipped (1364)
```

控制字符自查：`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 扫过全部改动文件（含 changeset），clean。

## 范围与约束

- 平台依赖保持 `@objectstack/* 17.0.0-rc.2`，未做任何版本改动。
- 无平台侧 workaround：无主种子与热启动重播种都按文档化行为对待，修在 app 的 producer 侧。
- 未改 issue 的 assignee。

## 越界发现

已按归档纪律搜过 open issue（关键词 + 文件路径），无重复，另开 **#716**（未指派）：`demo_bootstrap` 同样不认领 `crm_campaign` 与 `crm_knowledge_article`。这两个是 `public_read`，所以不是不可见，但 OWD baseline 只放开读 —— 而 `marketing_user.crm_campaign` 与 `service_agent.crm_knowledge_article` 都是 `allowEdit: true, modifyAllRecords: false`，种子行无主导致这两个岗位**授权表上写着能编辑、实际改不动**（#622 的形态，换了两个对象）。没有在本 PR 顺手改：`crm_knowledge_article` 的 owner 语义（作者？维护人？把全部种子文章归到第一个用户是否合适）需要维护者拍板，属于 #702 范围之外。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_