### PR TITLE
fix(event-attendee): cascade the attendee row when its contact, lead or user is deleted (#711)

### DIFF
--- a/.changeset/event-attendee-cascade-on-party-delete.md
+++ b/.changeset/event-attendee-cascade-on-party-delete.md
@@ -1,0 +1,45 @@
+---
+'hotcrm': patch
+---
+
+Let a contact, lead or colleague who attended a meeting be deleted again. This is
+the second half of the defect fixed for campaign members: `crm_event_attendee`
+has the identical construction, and anyone who had ever been logged as a meeting
+attendee was **permanently undeletable** — through the API and through the UI —
+with a refusal naming an object the caller had not touched:
+
+```
+DELETE /api/v1/data/crm_lead/<id>
+→ 400 {"error":"An attendee must point at a Contact, a Lead, a User, or name an
+       external guest","code":"VALIDATION_FAILED","object":"crm_lead"}
+```
+
+The cause was a default nobody wrote down. The three party lookups
+(`crm_contact`, `crm_lead`, `sys_user`) declared no `deleteBehavior`, so all
+three took `Field.lookup`'s spec default of `set_null`. Deleting the person made
+the engine's referential pass clear that column, the cleared row instantly
+violated `attendee_resolves` — the rule the same object declares — and the whole
+delete rolled back. The rule's `external_name` escape hatch rescued nothing,
+because the activity actions that create attendees always write a party
+reference and never an external name. Since logging a meeting is an ordinary
+part of the sales flow, ordinary use reached it, and a GDPR-style "delete this
+person" request could not be served at all.
+
+All three party lookups now declare `deleteBehavior: 'cascade'`. An attendee row
+is a junction row whose whole meaning is "this person was in this room"; once the
+person is gone the row denotes nothing, so deleting a contact, a lead or a user
+now removes their attendance with them.
+
+**What changes for you:** deleting a contact, lead or user silently removes their
+`crm_event_attendee` rows, so a meeting's attendee list loses that person and
+attendance-based counts drop accordingly — deliberately, since the person is
+gone. The meeting itself is untouched, as are attendee rows naming anybody else
+and external-guest rows, which name no CRM record at all. The `sys_user` lookup
+gets the same treatment on purpose: account erasure runs through better-auth's
+`delete-user` / `admin/remove-user` routes onto the same delete path, and every
+other user reference in the app already degrades on deletion, so this junction is
+not the place to start vetoing it — deactivation (ban / unban), not deletion,
+remains the ordinary offboarding path and is unaffected. Deleting a **meeting**
+that still has attendees is still refused, now visibly the only refusal left, and
+it names the real obstacle: a meeting's attendee list is its historical record.
+Refs #711, #696.

--- a/src/objects/event_attendee.object.ts
+++ b/src/objects/event_attendee.object.ts
@@ -86,6 +86,17 @@ export const EventAttendee = ObjectSchema.create({
       format: 'EA-{00000}',
     }),
 
+    // Deliberately left on the spec default, and NOT cascaded with the party
+    // lookups below (#711). Because it is REQUIRED, the engine escalates the
+    // stored `set_null` to a refusal at delete time, with a message that names
+    // the real obstacle instead of an unrelated rule — measured on
+    // 17.0.0-rc.2: "Cannot delete crm_event (...): 3 dependent
+    // crm_event_attendee record(s) reference it via crm_event (crm_event is
+    // required, so it cannot be cleared)." That is the correct answer on this
+    // side, for the same reason `crm_campaign_member.crm_campaign` keeps it
+    // (#696): a meeting's attendee list is the meeting's historical record, not
+    // a per-person artefact. `test/event-attendee-cascade.test.ts` pins the
+    // resolved value so a copy-paste of the three cascades cannot reach here.
     crm_event: Field.lookup('crm_event', {
       group: 'basic',
       label: 'Event',
@@ -109,21 +120,77 @@ export const EventAttendee = ObjectSchema.create({
       ],
     }),
 
+    // `deleteBehavior: 'cascade'` on ALL THREE party lookups (#711, the same
+    // construction and the same defect as #696/`crm_campaign_member`). A lookup
+    // defaults to `set_null`, and that default made every person who had ever
+    // been logged as a meeting attendee permanently undeletable: deleting the
+    // party cleared this column, the row the engine had just edited instantly
+    // violated `attendee_resolves` below, and the whole delete rolled back with
+    // an error naming an object the caller never addressed. Measured on
+    // 17.0.0-rc.2, before the fix:
+    //
+    //   DELETE lead    -> "An attendee must point at a Contact, a Lead, a User,
+    //                      or name an external guest"  (lead survives)
+    //   DELETE contact -> same        DELETE user -> same
+    //
+    // `external_name` is the rule's fourth escape hatch, but it is blank on
+    // every row the product actually writes (`src/actions/global.actions.ts`
+    // logs attendees with a party reference and never an external name), so it
+    // rescues nothing in practice.
+    //
+    // Cascade rather than `restrict`: an attendee row is a JUNCTION whose whole
+    // meaning is "this person was in this room". Once the person is gone the
+    // row denotes nothing, and the query it exists to serve ("meetings this
+    // person attended") has lost its subject. `restrict` would produce an
+    // accurate message but keep the person undeletable until someone deleted
+    // their attendance by hand, and undeletable PEOPLE is the impact being
+    // fixed. Cascade also leaves no reachable state in which a stored attendee
+    // row breaks its own object's rule.
     crm_contact: Field.lookup('crm_contact', {
       group: 'basic',
       label: 'Contact',
+      deleteBehavior: 'cascade',
       description: 'Set when the attendee is an existing customer contact',
     }),
 
     crm_lead: Field.lookup('crm_lead', {
       group: 'basic',
       label: 'Lead',
+      deleteBehavior: 'cascade',
       description: 'Set when the attendee is still an unconverted lead',
     }),
 
+    // `sys_user` gets the SAME answer as the two CRM parties, and it was the one
+    // worth a second look rather than a copy-paste (#711 raises it explicitly).
+    // What decided it, measured rather than assumed:
+    //
+    //  · Deleting a user is a real, reachable operation. Generic CRUD delete on
+    //    the identity table is off (`sys_user` ships `apiMethods: ['get',
+    //    'list', 'update', 'bulk']`), but better-auth's own routes —
+    //    `/api/v1/auth/delete-user`, which the platform's `sys_user` object
+    //    surfaces as the "Delete My Account" record action, and
+    //    `/api/v1/auth/admin/remove-user` — resolve `user` to `sys_user` and
+    //    land on `dataEngine.delete(...)`, i.e. the SAME ObjectQL delete that
+    //    runs the referential pass. So `set_null` here is not dormant: it broke
+    //    account erasure for any colleague who had ever attended a meeting.
+    //  · The app's shipped stance is already "a deleted user's references
+    //    degrade". HotCRM holds 15 lookups on `sys_user`; the other 14 (every
+    //    `owner_id`, `renewal_owner`, `product_manager`) are `set_null` and no
+    //    validation rule anywhere reads a user reference. `restrict` here would
+    //    make this junction the ONE app row able to veto a platform identity
+    //    erasure — an app object holding a `protection: { lock: 'full' }`,
+    //    better-auth-managed table hostage, surfacing as an opaque failure from
+    //    an auth route. That is the layering inversion, not the fix.
+    //  · The cost of cascade is bounded and is the right half to lose: the
+    //    meeting itself (`crm_event` — subject, times, outcome notes) survives
+    //    untouched; only the per-person row goes, and it goes because the
+    //    person's identity record was erased. Deactivation, not deletion, is
+    //    the ordinary offboarding path (the platform ships ban/unban for that),
+    //    and it touches nothing here.
     sys_user: Field.lookup('sys_user', {
       group: 'basic',
       label: 'User',
+      deleteBehavior: 'cascade',
       description: 'Set when the attendee is a colleague',
     }),
 

--- a/src/objects/event_attendee.object.ts
+++ b/src/objects/event_attendee.object.ts
@@ -175,12 +175,14 @@ export const EventAttendee = ObjectSchema.create({
     //    account erasure for any colleague who had ever attended a meeting.
     //  · The app's shipped stance is already "a deleted user's references
     //    degrade". HotCRM holds 15 lookups on `sys_user`; the other 14 (every
-    //    `owner_id`, `renewal_owner`, `product_manager`) are `set_null` and no
-    //    validation rule anywhere reads a user reference. `restrict` here would
-    //    make this junction the ONE app row able to veto a platform identity
-    //    erasure — an app object holding a `protection: { lock: 'full' }`,
-    //    better-auth-managed table hostage, surfacing as an opaque failure from
-    //    an auth route. That is the layering inversion, not the fix.
+    //    `owner_id`, plus `renewal_owner` and `product_manager`) are `set_null`
+    //    and NO validation rule reads any of them — the rule below is the only
+    //    one in the app that reads a user reference at all, which is precisely
+    //    why this is the only lookup where the default misbehaved. `restrict`
+    //    here would make this junction the ONE app row able to veto a platform
+    //    identity erasure — an app object holding a `protection: { lock:
+    //    'full' }`, better-auth-managed table hostage, surfacing as an opaque
+    //    failure from an auth route. That is the layering inversion, not the fix.
     //  · The cost of cascade is bounded and is the right half to lose: the
     //    meeting itself (`crm_event` — subject, times, outcome notes) survives
     //    untouched; only the per-person row goes, and it goes because the

--- a/test/event-attendee-cascade.test.ts
+++ b/test/event-attendee-cascade.test.ts
@@ -62,11 +62,15 @@ import stack from '../objectstack.config';
  *  2. **"A deleted user's references degrade" is already this app's stance.**
  *     HotCRM holds 15 lookups on `sys_user`; the other 14 — every `owner_id`,
  *     plus `crm_account.renewal_owner` and `crm_product.product_manager` — are
- *     `set_null`, and no validation rule in the app reads a user reference.
- *     `restrict` would make this junction the ONE app row able to veto a
- *     platform identity erasure, on a `protection: { lock: 'full' }`,
- *     better-auth-managed table, surfacing as an opaque failure from an auth
- *     route. That is a layering inversion, not a fix.
+ *     `set_null`, and NO validation rule reads any of them. Swept over the
+ *     built stack (rule conditions are `{ dialect, source }`, so the source
+ *     string is what has to be searched): `attendee_resolves` is the only rule
+ *     in the app that reads a user reference at all, which is exactly why this
+ *     is the only lookup where the `set_null` default misbehaved. `restrict`
+ *     would make this junction the ONE app row able to veto a platform identity
+ *     erasure, on a `protection: { lock: 'full' }`, better-auth-managed table,
+ *     surfacing as an opaque failure from an auth route. That is a layering
+ *     inversion, not a fix.
  *  3. **The cost of cascade is the right half to lose.** The meeting itself
  *     survives untouched — only the per-person row goes, because the person's
  *     identity record was erased. Deactivation, not deletion, is the ordinary
@@ -82,6 +86,17 @@ import stack from '../objectstack.config';
  *
  * The `crm_event` side is deliberately NOT cascaded; see the last structural
  * test and the last end-to-end test for what it does instead, and why.
+ *
+ * ### The family is closed
+ *
+ * The construction — a severity `error` rule reading an OPTIONAL lookup that
+ * takes the `set_null` default — was swept across the built stack after this
+ * change. It now returns nothing: `crm_campaign_member` (#696) and
+ * `crm_event_attendee` (this) were the only two, and both cascade. The sweep
+ * was run non-vacuous first (the same query against `cascade` lists exactly
+ * those two objects), because the naive version silently matches nothing: a
+ * rule's `condition` is a `{ dialect, source }` object, so `String(condition)`
+ * is `"[object Object]"` and every `includes()` on it is false.
  */
 
 type AnyRec = Record<string, any>;

--- a/test/event-attendee-cascade.test.ts
+++ b/test/event-attendee-cascade.test.ts
@@ -1,0 +1,437 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import { SysUser } from '@objectstack/platform-objects';
+import stack from '../objectstack.config';
+
+/**
+ * Deleting a person who attended a meeting must work (#711).
+ *
+ * ### The bug this file exists to keep dead
+ *
+ * `crm_event_attendee` is the same construction as `crm_campaign_member` and
+ * carried the same defect (#696 / `test/campaign-member-cascade.test.ts`) — it
+ * was simply outside that fix's file surface. The object declares a severity
+ * `error` rule, `attendee_resolves`, that rejects an attendee row naming
+ * neither a Contact, a Lead, a User, nor an external guest; all three party
+ * lookups used to take `Field.lookup`'s SPEC DEFAULT for `deleteBehavior`,
+ * which is `set_null`.
+ *
+ * So the engine's own referential pass turned every party delete into a
+ * self-defeating sequence: `cascadeDeleteRelations` cleared the attendee row's
+ * party column, the row it had just edited instantly broke the rule the same
+ * object declares, and the whole delete rolled back. Measured before the fix on
+ * 17.0.0-rc.2, on this exact harness:
+ *
+ *     DELETE lead    ERROR: An attendee must point at a Contact, a Lead,
+ *                           a User, or name an external guest
+ *     lead survives? true
+ *     DELETE contact ERROR: (same)      contact survives? true
+ *     DELETE user    ERROR: (same)      user survives?    true
+ *
+ * `external_name` gives the rule a fourth escape hatch, but it rescues nothing
+ * in practice: `src/actions/global.actions.ts` logs attendees with a party
+ * reference and never with an external name, so every row the product actually
+ * writes has it blank. Anyone logged as a meeting attendee was therefore
+ * undeletable, with an error naming an object the caller never addressed — the
+ * same GDPR "delete this person" impact as #696.
+ *
+ * ### The fix, and why cascade on the USER lookup too
+ *
+ * `deleteBehavior: 'cascade'` on all three party lookups. An attendee row is a
+ * JUNCTION whose whole meaning is "this person was in this room"; once the
+ * person is gone the row denotes nothing and the query it exists to serve
+ * ("meetings this person attended") has lost its subject.
+ *
+ * `sys_user` was the one worth deciding rather than copying, and three measured
+ * facts decided it:
+ *
+ *  1. **Deleting a user is reachable.** Generic CRUD delete on the identity
+ *     table is off — the platform's `sys_user` ships
+ *     `apiMethods: ['get', 'list', 'update', 'bulk']` and `userActions:
+ *     { edit: true }` — but better-auth's own routes are not generic CRUD.
+ *     `plugin-auth`'s ObjectQL adapter maps the `user` model to `sys_user` and
+ *     implements `delete` as `dataEngine.delete(...)`, i.e. the same ObjectQL
+ *     delete that runs the referential pass. `/api/v1/auth/delete-user` (which
+ *     the platform object surfaces as its "Delete My Account" record action)
+ *     and `/api/v1/auth/admin/remove-user` both land there. `set_null` here was
+ *     not dormant: it broke account erasure for any colleague who had ever sat
+ *     in a logged meeting.
+ *  2. **"A deleted user's references degrade" is already this app's stance.**
+ *     HotCRM holds 15 lookups on `sys_user`; the other 14 — every `owner_id`,
+ *     plus `crm_account.renewal_owner` and `crm_product.product_manager` — are
+ *     `set_null`, and no validation rule in the app reads a user reference.
+ *     `restrict` would make this junction the ONE app row able to veto a
+ *     platform identity erasure, on a `protection: { lock: 'full' }`,
+ *     better-auth-managed table, surfacing as an opaque failure from an auth
+ *     route. That is a layering inversion, not a fix.
+ *  3. **The cost of cascade is the right half to lose.** The meeting itself
+ *     survives untouched — only the per-person row goes, because the person's
+ *     identity record was erased. Deactivation, not deletion, is the ordinary
+ *     offboarding path (the platform ships ban / unban for that) and it touches
+ *     nothing here.
+ *
+ * `restrict` was the serious alternative on all three lookups: it produces an
+ * accurate message (the platform's own "N dependent record(s) reference it"),
+ * and it removes the broken state just as cascade does, since the parent delete
+ * is refused before any row is edited. It was rejected because the impact being
+ * fixed is undeletable PEOPLE, not confusing text — `restrict` trades one
+ * undeletable person for a manual delete-their-attendance chore.
+ *
+ * The `crm_event` side is deliberately NOT cascaded; see the last structural
+ * test and the last end-to-end test for what it does instead, and why.
+ */
+
+type AnyRec = Record<string, any>;
+
+const objects: AnyRec[] = (stack as any).objects ?? [];
+const byName = (n: string) => objects.find((o) => o.name === n) as AnyRec;
+
+const EVENT_ATTENDEE = byName('crm_event_attendee');
+
+/** The rule's exact text, so a reworded message cannot quietly pass. */
+const RULE_MESSAGE = /must point at a Contact, a Lead, a User, or name an external guest/i;
+
+// ───────────────────────────────────────────────── the declaration ──
+
+describe('crm_event_attendee declares cascade on all three party lookups', () => {
+  /**
+   * A structural pin, deliberately kept next to the end-to-end run below: the
+   * hazard is a MISSING key, and a missing key is invisible in review because
+   * the spec quietly fills in `set_null`. Asserting the RESOLVED value catches
+   * both a deletion of the declaration and a future spec default flip.
+   */
+  it.each(['crm_contact', 'crm_lead', 'sys_user'])('%s cascades', (field) => {
+    expect(EVENT_ATTENDEE.fields[field].type).toBe('lookup');
+    expect(EVENT_ATTENDEE.fields[field].deleteBehavior).toBe('cascade');
+  });
+
+  it('still declares the rule that the cascade keeps satisfiable', () => {
+    const rule = (EVENT_ATTENDEE.validations ?? []).find(
+      (v: AnyRec) => v.name === 'attendee_resolves',
+    );
+    expect(rule).toBeDefined();
+    expect(rule.severity).toBe('error');
+  });
+
+  /**
+   * The EVENT side is deliberately not cascade. `crm_event` is a REQUIRED
+   * lookup, and the engine escalates a `set_null` default on a required lookup
+   * to a refusal at delete time — with a message that names the real obstacle
+   * (see the last end-to-end test). That is the correct answer there, for the
+   * same reason `crm_campaign_member.crm_campaign` keeps it (#696): a meeting's
+   * attendee list is the meeting's historical record, not a per-person
+   * artefact. Pinned so a copy-paste of the three lines above cannot reach here
+   * and start shredding meeting history.
+   */
+  it('leaves the required event lookup on the default', () => {
+    expect(EVENT_ATTENDEE.fields.crm_event.required).toBe(true);
+    expect(EVENT_ATTENDEE.fields.crm_event.deleteBehavior).toBe('set_null');
+  });
+});
+
+// ─────────────────────────────────────────── on the real engine ──
+
+/**
+ * End-to-end over a real ObjectQL — the only place the interaction is visible.
+ * `cascadeDeleteRelations` is engine behaviour driven by metadata; no
+ * metadata-only assertion can show that a delete now succeeds, and no hook
+ * harness runs the referential pass at all.
+ *
+ * `InMemoryDriver` is used for the same reason `object-validation-predicates`
+ * uses it: it stores only the columns a row was written with, so the merged
+ * record handed to the validator has ABSENT keys — the shape that made the rule
+ * fire in the first place.
+ *
+ * `sys_user` is the PLATFORM object, imported rather than stubbed: the whole
+ * user-side decision rests on a real account erasure reaching this same delete
+ * path, so a local stand-in would be assuming what the test is meant to show.
+ * (It resolves at the repo root because `.npmrc` pins `node-linker=hoisted`;
+ * `test/parent-derived-reach.test.ts` reaches for platform packages the same
+ * way.)
+ */
+describe('deleting a person who attended a meeting', () => {
+  let ql: AnyRec;
+  let api: AnyRec;
+
+  beforeEach(async () => {
+    ql = (await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: {
+        crm_event_attendee: EVENT_ATTENDEE,
+        crm_event: byName('crm_event'),
+        crm_contact: byName('crm_contact'),
+        crm_lead: byName('crm_lead'),
+        crm_account: byName('crm_account'),
+        sys_user: SysUser,
+      } as never,
+    })) as never;
+    api = ql.createContext({ isSystem: true });
+  });
+  afterEach(async () => {
+    await ql?.close();
+  });
+
+  const newEvent = (subject = 'Quarterly Business Review') =>
+    api.object('crm_event').insert({
+      subject,
+      type: 'meeting',
+      status: 'planned',
+      start_datetime: '2026-02-01T09:00:00.000Z',
+      end_datetime: '2026-02-01T10:00:00.000Z',
+    });
+
+  const newLead = (email = 'wei.zhang@acme.test') =>
+    api.object('crm_lead').insert({
+      first_name: 'Wei',
+      last_name: 'Zhang',
+      company: 'ACME',
+      status: 'new',
+      lead_source: 'web',
+      email,
+    });
+
+  const newContact = async (email = 'li.wang@acme.test') => {
+    const account = await api.object('crm_account').insert({
+      name: `ACME ${email}`,
+      type: 'customer',
+      industry: 'technology',
+    });
+    return api.object('crm_contact').insert({
+      first_name: 'Li',
+      last_name: 'Wang',
+      crm_account: account.id,
+      email,
+    });
+  };
+
+  const newUser = (email = 'chen.hu@objectos.ai') =>
+    api.object('sys_user').insert({ name: 'Chen Hu', email });
+
+  const attendees = () => api.object('crm_event_attendee').find({ where: {} });
+
+  it('deletes a lead who attended several meetings, and takes their attendance with it', async () => {
+    const [qbr, demo] = await Promise.all([newEvent('QBR'), newEvent('Demo')]);
+    const lead = await newLead();
+    for (const event of [qbr, demo]) {
+      await api.object('crm_event_attendee').insert({
+        crm_event: event.id,
+        attendee_type: 'lead',
+        crm_lead: lead.id,
+        response: 'no_response',
+      });
+    }
+    expect(await attendees()).toHaveLength(2);
+
+    // The assertion that WAS the bug: this used to reject with
+    // "An attendee must point at a Contact, a Lead, a User, or name an
+    // external guest" — an object the caller never addressed.
+    await expect(
+      api.object('crm_lead').delete({ where: { id: lead.id } }),
+    ).resolves.not.toThrow();
+
+    expect(await api.object('crm_lead').find({ where: { id: lead.id } })).toHaveLength(0);
+    expect(await attendees()).toHaveLength(0);
+  });
+
+  it('deletes an attending contact the same way', async () => {
+    const event = await newEvent();
+    const contact = await newContact();
+    await api.object('crm_event_attendee').insert({
+      crm_event: event.id,
+      attendee_type: 'contact',
+      crm_contact: contact.id,
+      response: 'accepted',
+    });
+
+    await expect(
+      api.object('crm_contact').delete({ where: { id: contact.id } }),
+    ).resolves.not.toThrow();
+
+    expect(await api.object('crm_contact').find({ where: { id: contact.id } })).toHaveLength(0);
+    expect(await attendees()).toHaveLength(0);
+  });
+
+  /**
+   * The colleague case — the one #711 flagged for a second look. It is the same
+   * verdict as the two CRM parties, and it is pinned separately (not folded
+   * into an `it.each`) because it is the case a future reader is most likely to
+   * want to revisit: this is where a decision to switch `sys_user` to
+   * `restrict` would have to change a green test on purpose.
+   *
+   * `is_organizer: true` is on the row deliberately — organising the meeting is
+   * the strongest form of "their attendance is history worth keeping", and the
+   * answer is still that the row goes when the identity record is erased. The
+   * meeting itself survives, asserted below.
+   */
+  it('deletes a colleague who attended — and organised — a meeting, keeping the meeting', async () => {
+    const event = await newEvent('Internal sync');
+    const user = await newUser();
+    await api.object('crm_event_attendee').insert({
+      crm_event: event.id,
+      attendee_type: 'user',
+      sys_user: user.id,
+      response: 'accepted',
+      is_organizer: true,
+    });
+
+    await expect(
+      api.object('sys_user').delete({ where: { id: user.id } }),
+    ).resolves.not.toThrow();
+
+    expect(await api.object('sys_user').find({ where: { id: user.id } })).toHaveLength(0);
+    expect(await attendees()).toHaveLength(0);
+    // The bounded cost, asserted rather than asserted-about: the meeting record
+    // is untouched. Only the per-person row went.
+    expect(await api.object('crm_event').find({ where: { id: event.id } })).toHaveLength(1);
+  });
+
+  it('leaves every attendee row that named somebody else alone', async () => {
+    const event = await newEvent();
+    const lead = await newLead();
+    const bystanderLead = await newLead('bystander@acme.test');
+    const contact = await newContact();
+    const user = await newUser();
+
+    await api.object('crm_event_attendee').insert({
+      crm_event: event.id, attendee_type: 'lead', crm_lead: lead.id, response: 'no_response',
+    });
+    // The rows that must SURVIVE: the other two party TYPES, a different record
+    // of the SAME type, and the external guest who is in no CRM object at all.
+    // A cascade that keyed off the object rather than the id would take the
+    // same-type one; one that keyed off the object alone would take more.
+    const keepContact = await api.object('crm_event_attendee').insert({
+      crm_event: event.id, attendee_type: 'contact', crm_contact: contact.id, response: 'accepted',
+    });
+    const keepUser = await api.object('crm_event_attendee').insert({
+      crm_event: event.id, attendee_type: 'user', sys_user: user.id, response: 'accepted',
+    });
+    const keepLead = await api.object('crm_event_attendee').insert({
+      crm_event: event.id, attendee_type: 'lead', crm_lead: bystanderLead.id, response: 'tentative',
+    });
+    const keepGuest = await api.object('crm_event_attendee').insert({
+      crm_event: event.id, attendee_type: 'contact', external_name: "the prospect's lawyer",
+      response: 'no_response',
+    });
+
+    await api.object('crm_lead').delete({ where: { id: lead.id } });
+
+    const remaining = (await attendees()).map((r: AnyRec) => r.id).sort();
+    expect(remaining).toEqual(
+      [keepContact.id, keepUser.id, keepLead.id, keepGuest.id].sort(),
+    );
+  });
+
+  /**
+   * The rule's fourth branch, the one that makes this object differ from
+   * `crm_campaign_member` at all: a guest who is in no CRM object is named in
+   * free text. Two things are pinned — that such a row is ACCEPTED (the escape
+   * hatch is live, not decorative), and that it is untouched by any party
+   * delete (it references nothing to cascade from). It is also why the bug was
+   * never total: a hand-authored external-guest row was always deletable-around.
+   * `src/actions/global.actions.ts` never writes one, so no row the product
+   * produces was rescued by it.
+   */
+  it('accepts and keeps an external-guest row, which names no CRM record at all', async () => {
+    const event = await newEvent();
+    const lead = await newLead();
+    const contact = await newContact();
+    const user = await newUser();
+
+    const guest = await api.object('crm_event_attendee').insert({
+      crm_event: event.id,
+      attendee_type: 'contact',
+      external_name: 'Jane Roe (outside counsel)',
+      response: 'accepted',
+    });
+    for (const [type, key, party] of [
+      ['lead', 'crm_lead', lead],
+      ['contact', 'crm_contact', contact],
+      ['user', 'sys_user', user],
+    ] as const) {
+      await api.object('crm_event_attendee').insert({
+        crm_event: event.id, attendee_type: type, [key]: party.id, response: 'no_response',
+      });
+    }
+    expect(await attendees()).toHaveLength(4);
+
+    await api.object('crm_lead').delete({ where: { id: lead.id } });
+    await api.object('crm_contact').delete({ where: { id: contact.id } });
+    await api.object('sys_user').delete({ where: { id: user.id } });
+
+    expect((await attendees()).map((r: AnyRec) => r.id)).toEqual([guest.id]);
+  });
+
+  it('still refuses an attendee row that names nobody — the rule is intact, not neutered', async () => {
+    const event = await newEvent();
+    await expect(
+      api.object('crm_event_attendee').insert({
+        crm_event: event.id, attendee_type: 'contact', response: 'no_response',
+      }),
+    ).rejects.toThrow(RULE_MESSAGE);
+  });
+
+  /**
+   * The one semantic cost of cascading on all three lookups, measured and
+   * written down rather than left for the next reader to trip over: a row
+   * naming two parties is removed when EITHER is deleted, even though the other
+   * still exists.
+   *
+   * It is accepted because no such row is reachable today — the activity
+   * actions in `src/actions/global.actions.ts` push one party per attendee
+   * entry (`attendee_type` is the discriminator that says which lookup is the
+   * live one, and it holds exactly one value). If a future change starts
+   * writing two, this test is the place that says what has to be decided again.
+   */
+  it('removes a two-party row on either delete (documented consequence)', async () => {
+    const event = await newEvent();
+    const contact = await newContact();
+    const user = await newUser();
+    await api.object('crm_event_attendee').insert({
+      crm_event: event.id,
+      attendee_type: 'contact',
+      crm_contact: contact.id,
+      sys_user: user.id,
+      response: 'accepted',
+    });
+
+    await api.object('sys_user').delete({ where: { id: user.id } });
+
+    expect(await attendees()).toHaveLength(0);
+    expect(await api.object('crm_contact').find({ where: { id: contact.id } })).toHaveLength(1);
+  });
+
+  /**
+   * The event side, pinned end-to-end so the structural assertion above has a
+   * behaviour behind it. Deleting a meeting that still has attendees is
+   * REFUSED, and — the point of leaving it alone — the refusal names the real
+   * obstacle and the field it lives on, instead of an unrelated validation rule
+   * on an object the caller never addressed. Clear the attendees and the
+   * meeting deletes.
+   */
+  it('still refuses to delete a meeting that has attendees, naming the real obstacle', async () => {
+    const event = await newEvent();
+    const contact = await newContact();
+    const row = await api.object('crm_event_attendee').insert({
+      crm_event: event.id, attendee_type: 'contact', crm_contact: contact.id, response: 'accepted',
+    });
+
+    await expect(
+      api.object('crm_event').delete({ where: { id: event.id } }),
+    ).rejects.toThrow(/dependent crm_event_attendee record\(s\) reference it via crm_event/i);
+    // Not the party rule, which is what the caller used to be told.
+    await expect(
+      api.object('crm_event').delete({ where: { id: event.id } }),
+    ).rejects.not.toThrow(RULE_MESSAGE);
+
+    expect(await api.object('crm_event').find({ where: { id: event.id } })).toHaveLength(1);
+
+    await api.object('crm_event_attendee').delete({ where: { id: row.id } });
+    await expect(
+      api.object('crm_event').delete({ where: { id: event.id } }),
+    ).resolves.not.toThrow();
+    expect(await api.object('crm_event').find({ where: { id: event.id } })).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes #711
Related to #696 / #712

## 问题

任何"被记录参加过会议"的人——线索、联系人、同事——都**永久无法删除**,API 和 UI 都一样,而且拒绝信息指向调用方根本没碰过的对象:

```
DELETE /api/v1/data/crm_lead/{id}
→ 400 {"error":"An attendee must point at a Contact, a Lead, a User, or name an
       external guest","code":"VALIDATION_FAILED","object":"crm_lead"}
```

这与 #696 / #712(`crm_campaign_member`)是**同一构造的同一缺陷**,只是落在另一个对象上,不在那次修复的文件面内。

## 机制(在 17.0.0-rc.2 上实测)

`crm_event_attendee` 的三个 party lookup(`crm_contact` / `crm_lead` / `sys_user`)都没有声明 `deleteBehavior`,于是全部落到 `Field.lookup` 的 spec 默认值 `set_null` —— 解析后的字段字面量就是 `"deleteBehavior":"set_null"`。删除当事人时,引擎的 `cascadeDeleteRelations` 清空该列,它刚刚改过的那一行立刻违反同一对象声明的 `attendee_resolves`(severity `error`),整个删除回滚:

```
DELETE lead    ERROR: An attendee must point at a Contact, a Lead, a User,
                      or name an external guest        lead survives? true
DELETE contact ERROR: (同上)                            contact survives? true
DELETE user    ERROR: (同上)                            user survives?    true
```

规则的第四个逃生口 `external_name` 在实践中救不了任何一行:`src/actions/global.actions.ts` 写入参会人时永远带 party 引用、从不写外部姓名,所以产品真正产生的每一行该字段都是空的。记录一次会议是销售流程的日常动作,普通使用即可触达;GDPR 式的"删除这个人"请求根本无法完成。

## 修复

三个 party lookup 全部声明 `deleteBehavior: 'cascade'`。参会人行是**联结行**,全部含义就是"这个人在这个房间里过";人没了,这行什么也不指代,它存在的目的所服务的查询("这个人参加过哪些会议")也失去了主语。

`restrict` 是认真考虑过的替代方案:它给出的信息是准确的(平台自己的 "N dependent record(s) reference it"),而且同样消除了坏状态——父删除在任何行被改写之前就被拒绝。之所以否掉,是因为本次要修的影响是**人删不掉**,不是文案难懂;`restrict` 只是把"删不掉的人"换成"先手工删掉他的参会记录"这道工序。

### `sys_user` 那一路:三轴论证,不是照抄

Issue 明确要求这一路单独判断。三条**实测**依据决定了它取同一答案:

1. **删除用户是真实可达的操作。** 身份表上的通用 CRUD 删除是关闭的(平台 `sys_user` 声明 `apiMethods: ['get', 'list', 'update', 'bulk']`、`userActions: { edit: true }`),但 better-auth 自己的路由不是通用 CRUD:`plugin-auth` 的 ObjectQL adapter 把 `user` 模型映射到 `sys_user`,`delete` 实现就是 `dataEngine.delete(...)` —— 与上面那条引用传递路径完全相同。`/api/v1/auth/delete-user`(平台对象自身以 "Delete My Account" 记录动作暴露它)和 `/api/v1/auth/admin/remove-user` 都落在这里。所以 `set_null` 在这一路不是休眠代码:它让任何坐过一次会议的同事的账号注销失败。
2. **"被删用户的引用降级"本来就是本 app 的既有立场。** HotCRM 一共有 15 个指向 `sys_user` 的 lookup;另外 14 个(每个 `owner_id`,加 `crm_account.renewal_owner`、`crm_product.product_manager`)全是 `set_null`,**没有任何校验规则读它们**——扫描全栈的结果是:`attendee_resolves` 是全 app **唯一**读取用户引用的规则,这也正是为什么只有这一个 lookup 上的默认值会出事。在这里改 `restrict`,等于让这张联结表成为**唯一**能否决平台身份注销的业务行——挟持一张 `protection: { lock: 'full' }`、由 better-auth 托管的表,而且失败会从 auth 路由上以一个不透明错误冒出来。那是分层倒置,不是修复。
3. **cascade 的代价是有界的,而且丢掉的是该丢的那一半。** 会议记录本身(`crm_event`:主题、时间、纪要)原封不动,只有"某人出席"这一行消失,而它消失的原因正是这个人的身份记录被抹除了。日常离场路径是停用而非删除(平台提供 ban / unban),它完全不触及这里。

按三轴总结:**真实业务拉力**——有人真的会注销账号,没有任何业务场景需要"出席记录把已注销账号钉住";**长期正确性**——app 不该对平台身份表行使否决权,cascade 与本仓已有的 14 处立场一致;**让 AI 写的元数据不易出错**——三个 party lookup 一条规则("party 全 cascade,必填父 restrict"),而"两个 cascade 一个 restrict"正是后来者最容易抄错、且没有业务理由支撑的形状。

### `crm_event` 一侧刻意不动

它是**必填** lookup,引擎把 `set_null` 升级为删除时拒绝,并给出指向真正障碍的信息(实测):

```
Cannot delete crm_event (...): 3 dependent crm_event_attendee record(s)
reference it via crm_event (crm_event is required, so it cannot be cleared).
```

这一侧的正确答案与 `crm_campaign_member.crm_campaign`(#696)相同:会议的出席名单是会议的历史记录,不是某个人的附属物。PR 把这个解析值也钉住了,防止有人把三行 cascade 顺手复制到这里、开始铲会议历史。

### 这一族已经收口

把"severity `error` 的规则读一个取默认 `set_null` 的**可选** lookup"这个构造在全栈扫了一遍:本次修完后返回空集——`crm_campaign_member`(#696)与 `crm_event_attendee`(本 PR)是仅有的两个,现在都是 cascade。

扫描本身先做了**非空验证**才敢用:同一查询改问 `cascade`,恰好列出上述两个对象。原因是天真写法会静默匹配不到任何东西——规则的 `condition` 是 `{ dialect, source }` 对象,`String(condition)` 是 `"[object Object]"`,所有 `includes()` 都为假。第二个 commit 就是用正确的 `condition.source` 重跑后,把注释里"全 app 没有规则读用户引用"改成准确表述(是"只有本对象这一条")。结论方向不变,但事实必须准。

## 测试

新增 `test/event-attendee-cascade.test.ts`(13 个用例,结构对齐 #712 的 `campaign-member-cascade.test.ts`),用真实 ObjectQL 跑在 `InMemoryDriver` 上(稀疏行驱动,合并记录里的键是**缺失**而非 null,正是当初让规则触发的形状),并且用的是**平台的** `sys_user` 对象而不是本地桩——用户侧的整个判断依赖"真实账号注销会走到同一条删除路径",用桩就等于假设了待证之事。

钉住的事实:

- 三个 party lookup 的**解析后**值确为 `cascade`(缺键在评审里看不见,spec 会悄悄填 `set_null`);
- `attendee_resolves` 仍在、仍是 `error`;必填 `crm_event` 仍在默认值上;
- 参加过多场会议的线索能干净删除,并带走自己的出席行;联系人同理;**组织了会议的同事**(`is_organizer: true`)同理,且会议记录仍在;
- 指向其他人的参会行(另两种 party 类型、同类型的另一条记录、外部访客行)全部存活;
- 外部访客行(只有 `external_name`)被接受——规则第四个分支是活的——且不受任何 party 删除影响;
- 谁也不指的参会行仍被拒绝(规则没有被架空);
- 同时指两个 party 的行在任一方被删时消失(**书面记录的代价**,今天不可达:活动动作每条参会记录只写一个 party);
- 有参会人时删除会议仍被拒绝,且拒绝信息指向真正的障碍;清空参会人后会议可删。

### 反向验证(方向是先预测再执行的)

预测:删掉三行 `deleteBehavior: 'cascade'` 后,3 条解析值钉子 + 6 条端到端删除用例变红,4 条不依赖该改动的用例保持绿。实测完全一致:

```
Tests  9 failed | 4 passed (13)

× crm_contact cascades / crm_lead cascades / sys_user cascades
    AssertionError: expected 'set_null' to be 'cascade'
× deletes a lead ... / deletes an attending contact ... / deletes a colleague ...
    AssertionError: promise rejected "ValidationError: An attendee must point a…"
    { code: 'VALIDATION_FAILED', fields: [ { field: '_record',
      code: 'rule_violation', message: 'An attendee must point at a Contact,
      a Lead, a User, or name an external guest' } ] }
× leaves every attendee row that named somebody else alone
× accepts and keeps an external-guest row, which names no CRM record at all
× removes a two-party row on either delete (documented consequence)
    AssertionError: expected [ { …(10) } ] to have a length of +0 but got 1
```

最后一条的红法值得一提:两 party 的行在 `sys_user` 被清空后 `crm_contact` 仍在,规则因此**通过**,删除成功——但那一行留了下来(带一个悬空的用户引用)。这正好把 `set_null` 的另一面暴露出来。

保持绿的 4 条恰是不依赖本改动的:规则仍被声明、`crm_event` 仍在默认值、空参会人仍被拒绝、有参会人的会议仍删不掉。

### 本地全量

```
pnpm typecheck   → exit 0
pnpm validate    → exit 0(仅既有 warning)
pnpm lint        → exit 0(13 warning / 14 suggestion,均为既有)
pnpm hygiene     → ✓ source hygiene clean
pnpm build       → ✓ Build complete
pnpm test        → Test Files 57 passed (57) · Tests 1360 passed | 1 skipped (1361)
```

## 文件面

- `src/objects/event_attendee.object.ts` —— 三个 party lookup 加 `deleteBehavior: 'cascade'`,以及把上面的判断依据写进注释(含 `crm_event` 为何不动)
- `test/event-attendee-cascade.test.ts` —— 新增
- `.changeset/event-attendee-cascade-on-party-delete.md` —— 新增

未触碰 `campaign_member.object.ts`(#712 是先例不是修改对象)、`global.actions.ts`(可达性证据不是修复面)、`*.hook.ts`(#693 在飞)、`src/flows/**`(#702 在飞)。平台依赖仍固定在 `@objectstack/*` 17.0.0-rc.2,无任何平台侧规避。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changeset
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Linting passes / Build succeeds
- [x] My changes generate no new warnings
