### PR TITLE
fix(hooks): 被拦下的删除要指名真正拦它的那条记录 (#693)

### DIFF
--- a/.changeset/cascade-guard-messages-name-the-blocker.md
+++ b/.changeset/cascade-guard-messages-name-the-blocker.md
@@ -1,0 +1,52 @@
+---
+'hotcrm': patch
+---
+
+Make a blocked delete name the record that actually blocked it. A cascade guard
+answered with the child's own point of view, so the refusal named an object — and
+sometimes an operation — the caller had never touched:
+
+```
+DELETE /api/v1/data/crm_account/<id>
+→ 400 "Cannot delete contact: still referenced by 1 open opportunity(ies), …"
+
+DELETE /api/v1/data/crm_opportunity/<id>
+→ 400 "Cannot edit a converted lead (attempted: converted_opportunity).
+        Make changes on the converted records instead."
+```
+
+Both refusals were correct — the records really were still referenced — but the
+first told an account deleter they had asked to delete a contact, and the second
+reported a *delete* of an *opportunity* as an *edit* of a *lead*, advising the
+caller to go and change the record they had just tried to remove. Either way the
+reader went looking at the wrong record.
+
+Each guard has two invocation contexts and no way to tell them apart. The contact
+delete guard runs on a direct delete **and** as a cascade child of an account
+delete; the converted-lead, closed-opportunity and frozen-quote locks run on a
+hand edit **and** on the engine's referential clear, which implements `set_null`
+by *updating* the row that holds the lookup. Measured on 17.0.0-rc.2, the hook
+context carries no cascade marker at all — so every refusal is now phrased from
+the **blocking relationship**, which is true in both contexts:
+
+```
+Contact Ada Lovelace (<id>) is still referenced by 1 open opportunity(ies),
+0 active quote(s), 0 active contract(s), so it cannot be deleted — and neither
+can its account, because deleting an account deletes its contacts. Close or
+reassign those records first.
+
+Converted lead Bo Chen (<id>) is locked, so its link(s) converted_opportunity
+cannot be cleared — which also blocks deleting the record(s) they point at.
+Delete the lead first, or have an admin clear the link with a system write.
+```
+
+The same construction was found on two guards the report did not cover, both
+reachable with the same two REST calls: deleting a contact that a **closed**
+opportunity names as its primary contact, and deleting an opportunity an
+**accepted** quote references. Those refusals now name the frozen record and the
+link too, and every lock still names the record it refuses plus the fields that
+were attempted when the write really was an edit.
+
+**Nothing about what is refused changes** — the same deletes are still blocked,
+for the same reasons, and the same records survive. This is wording only. Refs
+#693.

--- a/src/objects/contact.hook.ts
+++ b/src/objects/contact.hook.ts
@@ -66,8 +66,24 @@ const contactHook: Hook = {
       ]);
       const total = openOpps + openQuotes + activeContracts;
       if (total > 0) {
+        // Phrase the refusal as the BLOCKING RELATIONSHIP, not as the caller's
+        // operation (#693). This hook fires on a direct
+        // `DELETE /crm_contact/<id>` AND as a cascade child of
+        // `DELETE /crm_account/<id>` (`crm_contact.crm_account` is a
+        // master-detail with `deleteBehavior: 'cascade'`), and the hook context
+        // carries nothing that distinguishes the two — measured on 17.0.0-rc.2,
+        // a cascaded `beforeDelete` ctx holds exactly
+        // {api,event,input,object,previous,provenance,ql,session,transaction,user}
+        // with no cascade marker. So "Cannot delete contact" told an account
+        // deleter that they had asked to delete a contact, and sent them
+        // looking for the wrong record. Naming the contact and both
+        // consequences is true in either context.
+        const name = [ctx.previous?.first_name, ctx.previous?.last_name]
+          .filter((part) => typeof part === 'string' && part.trim() !== '')
+          .join(' ');
+        const subject = name ? `Contact ${name} (${id})` : `Contact ${id}`;
         throw new Error(
-          `Cannot delete contact: still referenced by ${openOpps} open opportunity(ies), ${openQuotes} active quote(s), ${activeContracts} active contract(s). Reassign first.`,
+          `${subject} is still referenced by ${openOpps} open opportunity(ies), ${openQuotes} active quote(s), ${activeContracts} active contract(s), so it cannot be deleted — and neither can its account, because deleting an account deletes its contacts. Close or reassign those records first.`,
         );
       }
     }

--- a/src/objects/lead.hook.ts
+++ b/src/objects/lead.hook.ts
@@ -192,8 +192,8 @@ const leadHook: Hook = {
     // `cannot_edit_converted` script validation over the four identity fields,
     // documented as the friendlier half of a two-layer design; #575 B1 removed
     // it because this throw always won the race, so the second layer was a
-    // second implementation that could only drift. The message below therefore
-    // has to carry the whole story — hence the attempted-field list.
+    // second implementation that could only drift. The messages below therefore
+    // have to carry the whole story — hence the attempted-field list.
     if (event === 'beforeUpdate' && ctx.user?.id) {
       const previous = ctx.previous;
       const wasConverted = previous?.is_converted === true || previous?.status === 'converted';
@@ -208,8 +208,44 @@ const leadHook: Hook = {
           (k) => !ALLOWED.has(k) && input[k] !== previous?.[k],
         );
         if (violating.length > 0) {
+          // Every lookup on `crm_lead` a referential clear can attack. The
+          // engine's `cascadeDeleteRelations` pass clears a `set_null` lookup
+          // by UPDATING the row that holds it, so deleting the account /
+          // contact / opportunity a converted lead points at (or the lead /
+          // contact it was flagged as a duplicate of) arrives here as an
+          // ordinary `beforeUpdate` — and nothing in the hook context says the
+          // write came from a cascade (measured on 17.0.0-rc.2: the ctx carries
+          // no cascade marker, and `session` is the caller's own). So a delete
+          // of an opportunity was reported as an *edit* of a *lead* (#693).
+          // Both messages below therefore describe the LOCK and the LINK rather
+          // than assuming which record the caller addressed.
+          const REFERENCE_FIELDS = new Set([
+            'converted_account', 'converted_contact', 'converted_opportunity',
+            'duplicate_of_lead', 'duplicate_of_contact',
+          ]);
+          const person = [previous?.first_name, previous?.last_name]
+            .filter((part) => typeof part === 'string' && part.trim() !== '')
+            .join(' ');
+          const name = person || (typeof previous?.company === 'string' ? previous.company : '');
+          const leadId =
+            (typeof previous?.id === 'string' && previous.id) ||
+            (typeof input.id === 'string' && input.id) ||
+            '';
+          const label = [name, leadId ? `(${leadId})` : ''].filter(Boolean).join(' ');
+
+          // A refusal made up ENTIRELY of links being cleared is the shape a
+          // delete of the linked record produces — describe it that way. A
+          // user nulling the same field by hand gets the same (true) sentence.
+          const detached = violating.filter(
+            (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous?.[k] != null,
+          );
+          if (detached.length === violating.length) {
+            throw new Error(
+              `${label ? `Converted lead ${label}` : 'A converted lead'} is locked, so its link(s) ${detached.join(', ')} cannot be cleared — which also blocks deleting the record(s) they point at. Delete the lead first, or have an admin clear the link with a system write.`,
+            );
+          }
           throw new Error(
-            `Cannot edit a converted lead (attempted: ${violating.join(', ')}). Make changes on the converted records instead.`,
+            `Cannot edit ${label ? `converted lead ${label}` : 'a converted lead'} (attempted: ${violating.join(', ')}). Make changes on the converted records instead.`,
           );
         }
       }

--- a/src/objects/opportunity.hook.ts
+++ b/src/objects/opportunity.hook.ts
@@ -84,8 +84,33 @@ const opportunityValidationHook: Hook = {
           (k) => !NARRATIVE_FIELDS.has(k) && !SYSTEM_FIELDS.has(k) && !APPROVAL_FIELDS.has(k) && input[k] !== previous[k],
         );
         if (violating.length > 0) {
+          // Same defect class as #693's two reported cases: this freeze also
+          // fires from a write the caller never made. Deleting a contact or a
+          // campaign a CLOSED opportunity references makes the engine clear
+          // that lookup, which arrives here as an ordinary `beforeUpdate` —
+          // measured: `DELETE /crm_contact/<id>` answered
+          // "Opportunity is closed (closed_won); … Attempted: primary_contact."
+          // The hook cannot tell a cascade from a hand edit (no marker in the
+          // context), so the refusal names the frozen record and the link
+          // instead of assuming the caller addressed the opportunity.
+          const REFERENCE_FIELDS = new Set(['crm_account', 'primary_contact', 'crm_campaign']);
+          const name = typeof previous.name === 'string' ? previous.name : '';
+          const oppId =
+            (typeof previous.id === 'string' && previous.id) ||
+            (typeof input.id === 'string' && input.id) ||
+            '';
+          const label = [name, oppId ? `(${oppId})` : ''].filter(Boolean).join(' ');
+          const subject = label ? `Opportunity ${label}` : 'Opportunity';
+          const detached = violating.filter(
+            (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous[k] != null,
+          );
+          if (detached.length === violating.length) {
+            throw new Error(
+              `${subject} is closed (${prevStage}) and frozen, so its link(s) ${detached.join(', ')} cannot be cleared — which also blocks deleting the record(s) they point at. Delete the opportunity first, or have an admin clear the link with a system write.`,
+            );
+          }
           throw new Error(
-            `Opportunity is closed (${prevStage}); only ${[...NARRATIVE_FIELDS].join(', ')} may be edited. Attempted: ${violating.join(', ')}.`,
+            `${subject} is closed (${prevStage}); only ${[...NARRATIVE_FIELDS].join(', ')} may be edited. Attempted: ${violating.join(', ')}.`,
           );
         }
       }

--- a/src/objects/quote.hook.ts
+++ b/src/objects/quote.hook.ts
@@ -59,8 +59,32 @@ const quoteValidation: Hook = {
           (k) => !allowed.has(k) && !SYSTEM_FIELDS.has(k) && input[k] !== previous[k],
         );
         if (changed.length > 0) {
+          // Same defect class as #693: the freeze also fires from a write the
+          // caller never made. Deleting an opportunity (or a contact) an
+          // ACCEPTED quote references makes the engine clear that lookup, and
+          // the clear arrives here as an ordinary `beforeUpdate` — measured:
+          // `DELETE /crm_opportunity/<id>` answered "Quote is accepted; only
+          // internal_notes may be edited. Attempted: crm_opportunity.", naming
+          // an object the caller never addressed. Nothing in the hook context
+          // marks a cascade, so the refusal names the frozen quote and the link.
+          const REFERENCE_FIELDS = new Set(['crm_account', 'crm_contact', 'crm_opportunity']);
+          const name = typeof previous.name === 'string' ? previous.name : '';
+          const quoteId =
+            (typeof previous.id === 'string' && previous.id) ||
+            (typeof input.id === 'string' && input.id) ||
+            '';
+          const label = [name, quoteId ? `(${quoteId})` : ''].filter(Boolean).join(' ');
+          const subject = label ? `Quote ${label}` : 'Quote';
+          const detached = changed.filter(
+            (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous[k] != null,
+          );
+          if (detached.length === changed.length) {
+            throw new Error(
+              `${subject} is ${previous.status as string} and frozen, so its link(s) ${detached.join(', ')} cannot be cleared — which also blocks deleting the record(s) they point at. Delete the quote first, or have an admin clear the link with a system write.`,
+            );
+          }
           throw new Error(
-            `Quote is ${previous.status as string}; only internal_notes may be edited. Attempted: ${changed.join(', ')}.`,
+            `${subject} is ${previous.status as string}; only internal_notes may be edited. Attempted: ${changed.join(', ')}.`,
           );
         }
       }

--- a/test/cascade-guard-messages.test.ts
+++ b/test/cascade-guard-messages.test.ts
@@ -1,0 +1,321 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { DefaultDatasourcePlugin, AppPlugin } from '@objectstack/runtime';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { MetadataPlugin } from '@objectstack/metadata';
+import stack from '../objectstack.config';
+
+/**
+ * A guard's refusal must name the record that is refusing — never the record
+ * the caller "must have" addressed (#693).
+ *
+ * ### What went wrong
+ *
+ * Found in the 17.0 GA acceptance sweep, tearing down a converted-lead chain:
+ *
+ *     DELETE /api/v1/data/crm_account/<id>
+ *     → 400 "Cannot delete contact: still referenced by 1 open opportunity(ies),
+ *            0 active quote(s), 0 active contract(s)"
+ *
+ *     DELETE /api/v1/data/crm_opportunity/<id>
+ *     → 400 "Cannot edit a converted lead (attempted: converted_opportunity).
+ *            Make changes on the converted record…"
+ *
+ * Both refusals are CORRECT — and both describe a different object, and in the
+ * second case a different operation, than the caller performed. The reader is
+ * sent to the wrong record, and the second one advises editing the very record
+ * the caller asked to delete.
+ *
+ * ### Why the hooks cannot simply say "delete"
+ *
+ * Each guard has TWO invocation contexts and no way to tell them apart:
+ *
+ * - `contact_integrity`'s `beforeDelete` runs on a direct contact delete AND as
+ *   a cascade child of an account delete (`crm_contact.crm_account` is a
+ *   master-detail with `deleteBehavior: 'cascade'`).
+ * - The `beforeUpdate` locks (`lead_automation`, `opportunity_stage_automation`,
+ *   `quote_workflow`) run on a hand edit AND on the engine's referential clear:
+ *   `cascadeDeleteRelations` implements `set_null` by UPDATING the row that
+ *   holds the lookup, so deleting the referenced record arrives at the guard as
+ *   `{ <field>: null }`.
+ *
+ * Measured on 17.0.0-rc.2 (pinned by the first test below), the hook context in
+ * the cascade case carries no marker at all: the same keys, and a `session`
+ * that is the caller's own. So the fix is not to detect the cascade — it is to
+ * phrase every refusal from the BLOCKING RELATIONSHIP, which is true in both
+ * contexts. The messages name the refusing record, the link or the references
+ * that block, and what to do.
+ *
+ * ### Why this file boots a real kernel
+ *
+ * `test/hooks-runtime*.test.ts` call the handlers directly, which proves the
+ * wording but not that a cascade produces it. Only the engine's own referential
+ * pass can show that `DELETE crm_account` ends in the contact guard — and it is
+ * the engine that decides which guard gets there first. Everything below is the
+ * message a real `DELETE` returns.
+ */
+
+type AnyRec = Record<string, any>;
+
+// The object registry announces every registered object on stdout at `info`;
+// the kernel logger is silenced the same way. Both are noise here.
+process.env.OS_REGISTRY_LOG ??= 'silent';
+
+const SYS = { isSystem: true } as AnyRec;
+
+let kernel: AnyRec;
+let ql: AnyRec;
+/** The context a REST `DELETE` runs under: a real user id. */
+let userCtx: AnyRec;
+
+const insert = (object: string, doc: AnyRec): Promise<AnyRec> =>
+  ql.insert(object, doc, { context: SYS });
+
+/** Delete as the user and return the refusal message (or `null` if it went through). */
+const deleteAndCatch = async (object: string, id: string): Promise<string | null> => {
+  try {
+    await ql.delete(object, { where: { id }, context: userCtx });
+    return null;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+const rowsOf = (object: string, id: string): Promise<AnyRec[]> =>
+  ql.find(object, { where: { id } }, { context: SYS });
+
+/** A unique suffix per fixture — `crm_contact.email` is globally unique. */
+let seq = 0;
+const uniq = (): string => `${++seq}`;
+
+beforeAll(async () => {
+  kernel = new ObjectKernel({ logger: { level: 'silent' } } as never);
+  await kernel.use(new DefaultDatasourcePlugin({ driver: 'memory', config: {} } as never));
+  await kernel.use(new MetadataPlugin({ watch: false, artifactWatch: false, environmentId: 'proj_693' } as never));
+  await kernel.use(new ObjectQLPlugin({ environmentId: 'proj_693' } as never));
+  // The app's own metadata is the subject — objects and hooks exactly as
+  // `objectstack.config.ts` declares them. Seed data is skipped; each test
+  // builds the population it needs.
+  await kernel.use(new AppPlugin(stack as never, undefined as never, { skipSeedData: true } as never));
+  await kernel.bootstrap();
+  ql = kernel.getService('objectql');
+
+  const user = await insert('sys_user', { name: 'Acceptance Rep', email: 'rep@cascade-guards.test' });
+  // `isSystem` keeps the fixture out of the sharing model (not what this file
+  // measures); `userId` is what matters — every guard here is deliberately a
+  // USER-write guard and stands down without it.
+  userCtx = { userId: user.id, isSystem: true } as AnyRec;
+}, 180_000);
+
+afterAll(async () => {
+  await kernel?.shutdown?.();
+});
+
+/** An account with one contact on it. */
+const accountWithContact = async (label: string) => {
+  const n = uniq();
+  const account = await insert('crm_account', {
+    name: `${label} ${n}`, type: 'customer', industry: 'technology',
+  });
+  const contact = await insert('crm_contact', {
+    first_name: 'Ada', last_name: 'Lovelace',
+    crm_account: account.id, email: `ada.${n}@cascade-guards.test`,
+  });
+  return { account, contact };
+};
+
+// ────────────────────────────── the premise: no cascade marker in the ctx ──
+
+describe('a guard cannot tell a cascade from a direct write', () => {
+  /**
+   * The measurement the whole fix rests on. If a future platform version starts
+   * marking referential writes, this test fails — and the messages below can be
+   * re-taken as "…so this ACCOUNT cannot be deleted", which is strictly better.
+   * Treat a failure here as news, not as a regression to paper over.
+   */
+  it('carries no cascade flag on a cascaded beforeDelete or referential update', async () => {
+    const seen: AnyRec[] = [];
+    ql.registerHook('beforeDelete', async (ctx: AnyRec) => {
+      if (ctx.object !== 'crm_contact') return;
+      seen.push({ where: 'contact.beforeDelete', keys: Object.keys(ctx), session: ctx.session ?? {} });
+    }, { object: 'crm_contact', priority: 1 });
+
+    const { account } = await accountWithContact('Marker Probe');
+    // Nothing blocks this one — the cascade runs to completion.
+    expect(await deleteAndCatch('crm_account', account.id)).toBeNull();
+
+    expect(seen, 'the cascade never reached the contact guard').toHaveLength(1);
+    const [probe] = seen;
+    const marker = /cascade|referential|__/i;
+    expect(probe.keys.filter((k: string) => marker.test(k))).toEqual([]);
+    expect(Object.keys(probe.session).filter((k: string) => marker.test(k))).toEqual([]);
+    // Positively: the session is the CALLER's, which is exactly why it cannot
+    // be used to tell the two invocations apart.
+    expect(probe.session.userId).toBe(userCtx.userId);
+  });
+});
+
+// ─────────────────────────────────────────── symptom 1: the account delete ──
+
+describe('deleting an account whose contact is still referenced', () => {
+  const build = async () => {
+    const { account, contact } = await accountWithContact('Acme Corp');
+    // The blocking opportunity sits on ANOTHER account, so the platform's own
+    // restrict on the required `crm_opportunity.crm_account` does not fire
+    // first — the contact guard is what answers, which is the reported case.
+    const elsewhere = await insert('crm_account', {
+      name: `Elsewhere ${uniq()}`, type: 'customer', industry: 'technology',
+    });
+    await insert('crm_opportunity', {
+      name: 'Acme Renewal', crm_account: elsewhere.id, primary_contact: contact.id,
+      stage: 'negotiation', amount: 1000, close_date: '2026-12-01',
+    });
+    return { account, contact };
+  };
+
+  it('names the contact that blocks, and says the account delete is blocked with it', async () => {
+    const { account, contact } = await build();
+    const message = await deleteAndCatch('crm_account', account.id);
+
+    expect(message, 'the account delete must still be refused').toBeTruthy();
+    expect(message).toContain(`Contact Ada Lovelace (${contact.id})`);
+    expect(message).toContain('1 open opportunity(ies)');
+    expect(message).toContain('neither can its account');
+    // The reported symptom: a caller who addressed an ACCOUNT was told they
+    // could not delete a CONTACT.
+    expect(message).not.toContain('Cannot delete contact');
+  });
+
+  it('refuses, and leaves the whole chain in place (semantics unchanged)', async () => {
+    const { account, contact } = await build();
+    await deleteAndCatch('crm_account', account.id);
+    expect(await rowsOf('crm_account', account.id)).toHaveLength(1);
+    expect(await rowsOf('crm_contact', contact.id)).toHaveLength(1);
+  });
+
+  it('says the same thing when the contact is addressed directly', async () => {
+    // The point of the phrasing: it does not depend on which record the caller
+    // named, so both invocations get one accurate sentence.
+    const { contact } = await build();
+    const message = await deleteAndCatch('crm_contact', contact.id);
+    expect(message).toContain(`Contact Ada Lovelace (${contact.id})`);
+    expect(message).toContain('1 open opportunity(ies)');
+  });
+
+  it('still deletes an account whose contact nothing references', async () => {
+    const { account, contact } = await accountWithContact('Quiet Corp');
+    expect(await deleteAndCatch('crm_account', account.id)).toBeNull();
+    expect(await rowsOf('crm_account', account.id)).toHaveLength(0);
+    expect(await rowsOf('crm_contact', contact.id)).toHaveLength(0);
+  });
+});
+
+// ────────────────────────────────────── symptom 2: the opportunity delete ──
+
+describe('deleting an opportunity a converted lead points at', () => {
+  const build = async () => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Globex ${n}`, type: 'customer', industry: 'technology',
+    });
+    const contact = await insert('crm_contact', {
+      first_name: 'Bo', last_name: 'Chen', crm_account: account.id,
+      email: `bo.${n}@cascade-guards.test`,
+    });
+    const opportunity = await insert('crm_opportunity', {
+      name: 'Globex New Business', crm_account: account.id, primary_contact: contact.id,
+      stage: 'negotiation', amount: 5000, close_date: '2026-12-01',
+    });
+    const lead = await insert('crm_lead', {
+      first_name: 'Bo', last_name: 'Chen', company: 'Globex', status: 'new',
+      lead_source: 'web', email: `bo.${n}@cascade-guards.test`,
+    });
+    // The conversion itself is a SYSTEM write (the flow's), which the lock lets
+    // through by design — it is user edits that are refused.
+    await ql.update('crm_lead', {
+      id: lead.id, is_converted: true, status: 'converted',
+      converted_account: account.id, converted_contact: contact.id,
+      converted_opportunity: opportunity.id, converted_date: '2026-02-01',
+    }, { context: SYS });
+    return { lead, opportunity };
+  };
+
+  it('names the lead and the link, not an edit of the lead', async () => {
+    const { lead, opportunity } = await build();
+    const message = await deleteAndCatch('crm_opportunity', opportunity.id);
+
+    expect(message, 'the opportunity delete must still be refused').toBeTruthy();
+    expect(message).toContain(`Converted lead Bo Chen (${lead.id})`);
+    expect(message).toContain('its link(s) converted_opportunity cannot be cleared');
+    expect(message).toContain('blocks deleting the record(s) they point at');
+    // The reported symptom: a DELETE of an OPPORTUNITY reported as an EDIT of a
+    // LEAD, advising the caller to go and change the record they just tried to
+    // delete.
+    expect(message).not.toContain('Cannot edit');
+    expect(message).not.toContain('Make changes on the converted records');
+  });
+
+  it('refuses, and leaves both records in place (semantics unchanged)', async () => {
+    const { lead, opportunity } = await build();
+    await deleteAndCatch('crm_opportunity', opportunity.id);
+    expect(await rowsOf('crm_opportunity', opportunity.id)).toHaveLength(1);
+    expect(await rowsOf('crm_lead', lead.id)).toHaveLength(1);
+    // And the message's own advice works: delete the lead, then the
+    // opportunity — the order the acceptance sweep had to discover by hand.
+    expect(await deleteAndCatch('crm_lead', lead.id)).toBeNull();
+    expect(await deleteAndCatch('crm_opportunity', opportunity.id)).toBeNull();
+  });
+});
+
+// ───────────────────────────── the same defect class on the sibling guards ──
+
+/**
+ * Neither of these is in #693's report, and both are reachable with the same
+ * two REST calls the sweep made. They are the same construction — a lock whose
+ * message assumed the caller had addressed the locked record — so they are
+ * fixed here rather than left to be re-found.
+ */
+describe('sibling guards reached the same way', () => {
+  it('a closed opportunity blocking a contact delete names the opportunity and the link', async () => {
+    const { contact } = await accountWithContact('Frozen Corp');
+    const elsewhere = await insert('crm_account', {
+      name: `Elsewhere ${uniq()}`, type: 'customer', industry: 'technology',
+    });
+    // CLOSED, so `contact_integrity` does not count it (it counts OPEN work)
+    // and the delete reaches the opportunity's own freeze.
+    const opportunity = await insert('crm_opportunity', {
+      name: 'Closed Deal', crm_account: elsewhere.id, primary_contact: contact.id,
+      stage: 'closed_won', win_reason: 'better_price', amount: 1000, close_date: '2026-01-01',
+    });
+
+    const message = await deleteAndCatch('crm_contact', contact.id);
+    expect(message).toContain(`Opportunity Closed Deal (${opportunity.id})`);
+    expect(message).toContain('its link(s) primary_contact cannot be cleared');
+    expect(message).toContain('blocks deleting the record(s) they point at');
+    expect(message).not.toContain('may be edited');
+  });
+
+  it('an accepted quote blocking an opportunity delete names the quote and the link', async () => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Quoted Corp ${n}`, type: 'customer', industry: 'technology',
+    });
+    const opportunity = await insert('crm_opportunity', {
+      name: 'Quoted Deal', crm_account: account.id,
+      stage: 'negotiation', amount: 1000, close_date: '2026-12-01',
+    });
+    const quote = await insert('crm_quote', {
+      name: `Q-${n}`, crm_account: account.id, crm_opportunity: opportunity.id,
+      status: 'draft', quote_date: '2026-01-01', expiration_date: '2026-02-01',
+    });
+    await ql.update('crm_quote', { id: quote.id, status: 'accepted' }, { context: SYS });
+
+    const message = await deleteAndCatch('crm_opportunity', opportunity.id);
+    expect(message).toContain(`Quote Q-${n} (${quote.id})`);
+    expect(message).toContain('its link(s) crm_opportunity cannot be cleared');
+    expect(message).toContain('blocks deleting the record(s) they point at');
+    expect(message).not.toContain('may be edited');
+  });
+});

--- a/test/converted-lead-guard.test.ts
+++ b/test/converted-lead-guard.test.ts
@@ -83,7 +83,7 @@ describe('the hook is the guard that actually speaks', () => {
     'rejects an edit to %s — the fields the deleted validation covered',
     async (field) => {
       await expect(editConverted({ [field]: 'changed' })).rejects.toThrow(
-        /Cannot edit a converted lead/,
+        /Cannot edit converted lead/,
       );
     },
   );
@@ -92,6 +92,77 @@ describe('the hook is the guard that actually speaks', () => {
     // The deleted validation's whole claim was a friendlier message. Nothing
     // gets a turn after this throw, so the diagnostic has to live here.
     await expect(editConverted({ company: 'Globex' })).rejects.toThrow(/attempted: company/);
+  });
+
+  it('names the LEAD as well as the field (#693)', async () => {
+    // The lock fires on writes the caller never made (a cascade clearing a
+    // conversion link), so "a converted lead" was not enough to find the
+    // record that refused. The label falls back to the company when the lead
+    // carries no personal name, and to the bare id when it carries neither.
+    await expect(editConverted({ company: 'Globex' })).rejects.toThrow(
+      /Cannot edit converted lead Ada Lovelace \(lead_1\)/,
+    );
+    await expect(
+      guard.handler(
+        makeCtx({
+          event: 'beforeUpdate',
+          input: { id: 'lead_2', rating: 5 },
+          previous: { id: 'lead_2', is_converted: true, company: 'Initech', rating: 1 },
+          user: { id: 'usr_1' },
+          api: makeHarness().api,
+        }),
+      ),
+    ).rejects.toThrow(/Cannot edit converted lead Initech \(lead_2\)/);
+  });
+
+  /**
+   * #693's second symptom, at the unit level: the engine clears a `set_null`
+   * lookup by UPDATING the row that holds it, so `DELETE /crm_opportunity/<id>`
+   * reaches this guard as `{ converted_opportunity: null }` on the lead. The
+   * old message reported that as "Cannot edit a converted lead … Make changes
+   * on the converted records instead" — a delete of an opportunity described
+   * as an edit of a lead, advising the caller to go and edit the very record
+   * they had asked to delete.
+   *
+   * The guard cannot know it is inside a cascade (measured on 17.0.0-rc.2: the
+   * hook context carries no cascade marker), so the refusal is phrased from the
+   * LINK, which is true whether the null came from the engine or from a hand
+   * edit. The end-to-end proof that this is the message a real cascade produces
+   * lives in `test/cascade-guard-messages.test.ts`.
+   */
+  describe('a cleared conversion link is described as a link, not as an edit', () => {
+    it.each([
+      ['converted_opportunity', 'opp_1'],
+      ['converted_account', 'acc_1'],
+      ['converted_contact', 'con_1'],
+    ])('%s', async (field, previousValue) => {
+      const err = await editConverted({ [field]: null }, { [field]: previousValue }).then(
+        () => null,
+        (e: Error) => e,
+      );
+      expect(err, `clearing ${field} was allowed`).toBeInstanceOf(Error);
+      expect(err!.message).toContain(`its link(s) ${field} cannot be cleared`);
+      expect(err!.message).toContain('blocks deleting the record(s) they point at');
+      // The sentence that sent readers to the wrong record must be gone from
+      // this branch: the caller may never have edited anything.
+      expect(err!.message).not.toContain('Cannot edit');
+      expect(err!.message).not.toContain('Make changes on the converted records');
+    });
+
+    it('falls back to the edit wording when the write is not only a link clear', async () => {
+      // A hand edit that also touches a business field is an edit, and saying
+      // so stays correct — the link branch must not swallow it.
+      await expect(
+        editConverted({ converted_opportunity: null, company: 'Globex' }, { converted_opportunity: 'opp_1' }),
+      ).rejects.toThrow(/Cannot edit converted lead/);
+    });
+
+    it('is not reached when the link is merely re-stated', async () => {
+      // `input[k] === previous[k]` is not a change at all, so nothing refuses.
+      await expect(
+        editConverted({ converted_opportunity: 'opp_1' }, { converted_opportunity: 'opp_1' }),
+      ).resolves.toBeUndefined();
+    });
   });
 
   it('still rejects fields the deleted validation never covered', async () => {

--- a/test/hooks-runtime-sales.test.ts
+++ b/test/hooks-runtime-sales.test.ts
@@ -105,6 +105,37 @@ describe('opportunity_lifecycle', () => {
     ).rejects.toThrow(/closed \(closed_won\)/);
   });
 
+  /**
+   * #693's defect class, on this guard: deleting a contact or a campaign a
+   * CLOSED opportunity references makes the engine clear that lookup, which
+   * arrives here as an ordinary `beforeUpdate`. Measured end-to-end,
+   * `DELETE /crm_contact/<id>` used to answer "Opportunity is closed
+   * (closed_won); … Attempted: primary_contact." — an object the caller never
+   * addressed, described as an edit they never made.
+   */
+  it('describes a cleared link as a link, and names the opportunity', async () => {
+    const previous: Rec = { id: 'o1', name: 'Acme Renewal', stage: 'closed_won', primary_contact: 'c1' };
+    const err = await hook
+      .handler(makeCtx({
+        event: 'beforeUpdate', input: { primary_contact: null }, previous, user: USER,
+      }))
+      .then(() => null, (e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain('Opportunity Acme Renewal (o1)');
+    expect(err!.message).toContain('its link(s) primary_contact cannot be cleared');
+    expect(err!.message).toContain('blocks deleting the record(s) they point at');
+    expect(err!.message).not.toContain('may be edited');
+  });
+
+  it('still reports a mixed write as the edit it is', async () => {
+    const previous: Rec = { id: 'o1', name: 'Acme Renewal', stage: 'closed_won', primary_contact: 'c1', amount: 10 };
+    await expect(
+      hook.handler(makeCtx({
+        event: 'beforeUpdate', input: { primary_contact: null, amount: 1 }, previous, user: USER,
+      })),
+    ).rejects.toThrow(/Opportunity Acme Renewal \(o1\) is closed \(closed_won\); only .* may be edited/);
+  });
+
   it('allows narrative, approval and system fields on a closed opportunity', async () => {
     const previous: Rec = { stage: 'closed_lost', amount: 100 };
     for (const input of [
@@ -222,6 +253,35 @@ describe('quote_workflow', () => {
         event: 'beforeUpdate', input: { total_price: 1 }, previous, user: USER,
       })),
     ).rejects.toThrow(new RegExp(`Quote is ${status}`));
+  });
+
+  /**
+   * #693's defect class, on this guard: deleting the opportunity (or contact) a
+   * frozen quote references makes the engine clear that lookup. Measured
+   * end-to-end, `DELETE /crm_opportunity/<id>` used to answer "Quote is
+   * accepted; only internal_notes may be edited. Attempted: crm_opportunity."
+   */
+  it('describes a cleared link as a link, and names the quote', async () => {
+    const previous: Rec = { id: 'q1', name: 'Q-1001', status: 'accepted', crm_opportunity: 'o1' };
+    const err = await hook
+      .handler(makeCtx({
+        event: 'beforeUpdate', input: { crm_opportunity: null }, previous, user: USER,
+      }))
+      .then(() => null, (e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain('Quote Q-1001 (q1)');
+    expect(err!.message).toContain('its link(s) crm_opportunity cannot be cleared');
+    expect(err!.message).toContain('blocks deleting the record(s) they point at');
+    expect(err!.message).not.toContain('may be edited');
+  });
+
+  it('still reports a mixed write as the edit it is', async () => {
+    const previous: Rec = { id: 'q1', name: 'Q-1001', status: 'accepted', crm_opportunity: 'o1', total_price: 100 };
+    await expect(
+      hook.handler(makeCtx({
+        event: 'beforeUpdate', input: { crm_opportunity: null, total_price: 1 }, previous, user: USER,
+      })),
+    ).rejects.toThrow(/Quote Q-1001 \(q1\) is accepted; only internal_notes may be edited/);
   });
 
   it('allows internal_notes and framework columns on a frozen quote', async () => {
@@ -575,6 +635,43 @@ describe('contact_integrity', () => {
         event: 'beforeDelete', previous: { id: 'c1' }, user: USER, api: h.api,
       })),
     ).rejects.toThrow(/still referenced by 1 open opportunity\(ies\), 1 active quote\(s\), 1 active contract\(s\)/);
+  });
+
+  /**
+   * #693: this guard also runs as a CASCADE child of an account delete
+   * (`crm_contact.crm_account` is master-detail / cascade), and the hook cannot
+   * tell the two apart. "Cannot delete contact" therefore told an account
+   * deleter they had asked to delete a contact. The refusal now names the
+   * contact and both consequences, which is true in either context.
+   */
+  it('names the contact it refuses, and says the account delete is blocked too', async () => {
+    const h = makeHarness({
+      crm_opportunity: [{ id: 'o1', primary_contact: 'c1', stage: 'proposal' }],
+    });
+    const err = await hook
+      .handler(makeCtx({
+        event: 'beforeDelete',
+        previous: { id: 'c1', first_name: 'Ada', last_name: 'Lovelace' },
+        user: USER,
+        api: h.api,
+      }))
+      .then(() => null, (e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain('Contact Ada Lovelace (c1)');
+    expect(err!.message).toContain('neither can its account');
+    // The old wording claimed an operation the caller may not have performed.
+    expect(err!.message).not.toContain('Cannot delete contact');
+  });
+
+  it('falls back to the bare id when the contact carries no name', async () => {
+    const h = makeHarness({
+      crm_contract: [{ id: 'k1', crm_contact: 'c1', status: 'activated' }],
+    });
+    await expect(
+      hook.handler(makeCtx({
+        event: 'beforeDelete', previous: { id: 'c1' }, user: USER, api: h.api,
+      })),
+    ).rejects.toThrow(/^Contact c1 is still referenced by/);
   });
 
   it('allows deleting a contact whose references are all settled', async () => {

--- a/test/hooks-runtime-service.test.ts
+++ b/test/hooks-runtime-service.test.ts
@@ -503,9 +503,12 @@ describe('lead_automation', () => {
 
   it('locks identity fields on a converted lead but leaves notes editable', async () => {
     const previous: Rec = { id: 'l1', is_converted: true, company: 'Acme' };
+    // The refusal NAMES the lead (#693) — a converted-lead lock also fires on
+    // writes the caller never made, so "a converted lead" left the reader with
+    // no way to tell which record refused.
     await expect(
       hook.handler(makeCtx({ event: 'beforeUpdate', input: { company: 'Other' }, previous, user: USER })),
-    ).rejects.toThrow(/Cannot edit a converted lead/);
+    ).rejects.toThrow(/Cannot edit converted lead Acme \(l1\)/);
     await expect(
       hook.handler(makeCtx({ event: 'beforeUpdate', input: { description: 'note' }, previous, user: USER })),
     ).resolves.toBeUndefined();


### PR DESCRIPTION
Fixes #693

## 先复现，再动手

在真实内核上（`ObjectKernel` + `ObjectQLPlugin` + `AppPlugin`，跑本仓自己的
`objectstack.config.ts`，平台 17.0.0-rc.2）把 issue 的两条现象原样跑了出来，
一个字都没改之前：

```
DELETE crm_account/{id}
→ "Cannot delete contact: still referenced by 1 open opportunity(ies), 0 active quote(s), 0 active contract(s). Reassign first."

DELETE crm_opportunity/{id}
→ "Cannot edit a converted lead (attempted: converted_opportunity). Make changes on the converted records instead."
```

前提成立：两条文案就是 `contact.hook.ts` / `lead.hook.ts` 里的守卫抛出来的，
经由平台的级联层原样上浮。**拒绝本身是对的**，本 PR 一个拒绝语义都没有动。

## 为什么不能靠“检测级联”来修

每个守卫都有两种被调用的方式，而它分不出自己身处哪一种：

- `contact_integrity` 的 `beforeDelete`：直接删联系人会走到，删客户时也会走到
  （`crm_contact.crm_account` 是 `deleteBehavior: 'cascade'` 的主从关系）。
- 三个 `beforeUpdate` 锁（转换线索锁、已关闭商机冻结、已接受报价冻结）：手工编辑
  会走到，引擎的引用清理也会走到 —— `cascadeDeleteRelations` 实现 `set_null` 的
  方式就是**去 UPDATE 持有该 lookup 的那一行**，所以“删掉被引用的记录”会以
  `{ 字段: null }` 的形状抵达守卫。

实测（17.0.0-rc.2）：级联情形下 hook 上下文里**没有任何级联标记**，键集合与直接
写入完全一致，`session` 就是调用者本人的。这条测量本身被 `cascade-guard-messages.test.ts`
的第一个用例钉住了 —— 将来平台若真加了标记，这个用例会红，那时可以把文案升级成
“所以这个**客户**不能删”，比现在更好。

因此改的是**说法**：每条拒绝都从**阻塞关系**出发陈述，这在两种调用方式下都成立。

## 改完之后（真实级联产生的原文）

```
Contact Ada Lovelace (crm_contact-…) is still referenced by 1 open opportunity(ies),
0 active quote(s), 0 active contract(s), so it cannot be deleted — and neither can
its account, because deleting an account deletes its contacts. Close or reassign
those records first.

Converted lead Bo Chen (crm_lead-…) is locked, so its link(s) converted_opportunity
cannot be cleared — which also blocks deleting the record(s) they point at. Delete
the lead first, or have an admin clear the link with a system write.
```

## 顺带扫出的同类缺陷（同一构造，issue 未报）

按“同一类构造”扫了 `src/objects/*.hook.ts`，发现另外两处，用同样两个 REST 调用就能
撞上，因此一并改文案：

| 调用 | 旧文案 | 新文案指名 |
| --- | --- | --- |
| `DELETE crm_contact/{id}`（被某个**已关闭**商机当 `primary_contact`） | `Opportunity is closed (closed_won); … Attempted: primary_contact.` | 商机名 + id + `primary_contact` 这条链接 |
| `DELETE crm_opportunity/{id}`（被某张**已接受**报价引用） | `Quote is accepted; only internal_notes may be edited. Attempted: crm_opportunity.` | 报价名 + id + `crm_opportunity` 这条链接 |

`account.hook.ts` / `product.hook.ts` 的删除守卫查过了：没有任何对象级联进
`crm_account` / `crm_product`，它们永远只在被直接寻址时触发，文案本来就对，未改。

## 判定规则

只有当被拒绝的字段**全部**是该对象上的引用字段、且都是从有值改成 `null` 时，才走
“链接被清空”那一支；混着业务字段的写入仍旧按“编辑”报，并照旧列出 `attempted:` 字段。
手工把同一个字段置空得到的是同一句话 —— 因为那句话在两种情况下都为真。

## 验证

- `pnpm test` → `57 files / 1368 passed | 1 skipped`
- `pnpm typecheck` → 干净
- `pnpm validate` → `✓ Validation passed`；`pnpm build` → 产物含新文案（L2 body 已下沉）
- `pnpm lint` / `pnpm hygiene` → 仅既有告警

**反向验证（方向先定后跑）**：预测“把四个 hook 还原 → 文案类断言变红、语义类断言保持绿”。
实跑：端到端 9 个用例红 5 绿 4（绿的是无级联标记探针、两个“拒绝且链路原样保留”、以及
“无人引用时客户仍可删”），单测另有 16 条断言变红。语义断言与本改动无关这一点，是它们绿着
证明的。

## 平台侧的一个问题（未改，留给维护者）

`converted_*` 链接的清理来自引擎维护引用完整性，并不是“用户在编辑线索”。转换线索锁
是否本就不该拦这一类写入（拦了会让被引用的商机在线索删除前无法删除），属于拒绝语义，
本 PR 按约定不动，已在报告里作为待决问题提出。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_