### PR TITLE
fix(demo-bootstrap): claim crm_campaign 与 crm_knowledge_article 的种子行 (#716)

### DIFF
--- a/.changeset/claim-campaign-and-knowledge-seeds.md
+++ b/.changeset/claim-campaign-and-knowledge-seeds.md
@@ -1,0 +1,34 @@
+---
+"hotcrm": patch
+---
+
+Demo campaigns and knowledge articles now get an owner, so the marketing and service edit grants actually work
+
+Seeded rows arrive owned by nobody — a seed cannot name a user — and the
+`demo_bootstrap` sweep is what gives them one on first boot. It claimed nine
+objects and skipped two: `crm_campaign` and `crm_knowledge_article`.
+
+Those two hid longer than the rest because their org-wide default is
+`public_read`. Their rows read normally for everybody, so nothing looked wrong —
+no empty list, no error, no blank page. But `public_read` opens the read
+baseline only; a **write** still needs the caller to own the record or hold a
+share. `marketing_user` is granted `crm_campaign` edit and `service_agent` is
+granted `crm_knowledge_article` edit, both without *Modify All Records*, which
+means their write reach is "records I own". Against a permanently ownerless row
+that is no records at all: every seeded campaign and every seeded article
+answered **403 on save** for everyone except a system administrator, while the
+permission screen said the edit was allowed. The same rows also stayed out of
+every "My …" list, rendered a blank owner on any owner-grouped report, and could
+not receive an owner-addressed notification.
+
+Both objects are now claimed alongside the other nine, so a demo org comes up
+with no seeded row left ownerless. Ownership of demo seed data goes to the org's
+first user, the same convention every other seeded object already follows —
+whether a real deployment's article owner should mean its *author* or its
+*maintainer* is a product question this does not answer, and real deployments
+assign ownership through import or territory rules before the sweep has anything
+to pick up.
+
+Existing demo databases heal themselves: the sweep runs every ten minutes and
+claims whatever is still ownerless on its next pass — no reset required. Records
+that already have an owner are never reassigned.

--- a/src/flows/demo-bootstrap.flow.ts
+++ b/src/flows/demo-bootstrap.flow.ts
@@ -166,6 +166,57 @@ const claim = (key: string, objectName: string, label: string) => ({
  * the 03:00 sweep reached the window before this ten-minute sweep did. Order
  * independence comes from the seeds staying out of that window, not from this
  * claim; the claim only settles who owns the SETTLED periods.
+ *
+ * `crm_campaign` and `crm_knowledge_article` close the list (#716). Cross the
+ * registered objects three ways — seeded × declares `owner_id` × claimed here —
+ * and after these two the "seeded and owner-scoped but unclaimed" cell is
+ * EMPTY. `test/flow-scheduled.test.ts` computes that cross-table rather than
+ * reading a hand-written roster, so the next seeded owner-scoped object cannot
+ * be forgotten the way these two were.
+ *
+ * What hid them is their OWD. The nine above are `private` (or
+ * `controlled_by_parent`), where an ownerless row is INVISIBLE and the defect
+ * announces itself on the first list view. These two are `public_read`, so
+ * their seeded rows read fine for everybody and look perfectly healthy. But
+ * `public_read` opens the read baseline only — the platform's write filter
+ * applies to it exactly as it does to `private`: "public_read is read-open but
+ * write-owned; only a fully public object is write-open"
+ * (`@objectstack/plugin-sharing` 17.0.0-rc.2, `buildWriteFilter`). A write
+ * still needs owner-match, or a share at a write level.
+ *
+ * Which turns two GRANTED permissions into permanent 403s. `marketing_user`
+ * holds `crm_campaign` at `allowEdit: true, modifyAllRecords: false`, and
+ * `service_agent` holds `crm_knowledge_article` the same way. With
+ * `modifyAllRecords: false` and no `writeScope`, the effective write depth is
+ * `own`, whose filter is `owner_id == caller` — a predicate no null-owner row
+ * can ever satisfy. So the permission table says "can edit" while every seeded
+ * row answers 403 for everyone but `system_admin`. That is #622's failure shape
+ * on two more objects, and it is why this is worth fixing past the cosmetic
+ * complaint of a blank owner column (empty "My …" lists, an empty owner axis in
+ * the campaign analytics, owner-addressed `notify` reaching nobody).
+ *
+ * The `campaign_leadership_*` criteria shares (`src/sharing/campaign.sharing.ts`)
+ * are not a substitute: they widen edit to two marketing POSITIONS and only
+ * while a campaign is `planning`/`in_progress`, so they cover neither the
+ * finished seeded campaigns nor any knowledge article, and nobody holding the
+ * plain `marketing_user` grant is reached by them at all.
+ *
+ * Both objects are owner-scoped by history rather than shared catalogue:
+ * `scripts/backfill-owner-id.ts` lists both in its `OBJECTS`, i.e. both carried
+ * the app-level `owner` lookup #548 retired. `crm_product` — the other seeded
+ * `public_read` object — declares no `owner_id` at all and stays OUT: it is a
+ * shared catalogue, and it is also the e2e ownership-blind probe, whose premise
+ * is "`public_read` AND swept by nothing" (`e2e/seed-precondition.ts`, pinned by
+ * `test/e2e-seed-precondition.test.ts`). Claiming these two leaves that premise
+ * untouched; claiming `crm_product` would break it.
+ *
+ * Who owns a seeded knowledge article, recorded rather than decided (#716, PM
+ * ruling): the first user, by the same demo convention every other object here
+ * follows. Whether a real deployment's article owner means its AUTHOR or its
+ * MAINTAINER is a product question, and this claim deliberately does not
+ * prejudge it — a real deployment assigns ownership through import or territory
+ * rules before this sweep has anything to pick up (see the header). The demo's
+ * job is only that no seeded row is left owned by nobody.
  */
 const CLAIMED_OBJECTS: ReadonlyArray<[key: string, objectName: string, label: string]> = [
   ['leads', 'crm_lead', 'Leads'],
@@ -177,6 +228,8 @@ const CLAIMED_OBJECTS: ReadonlyArray<[key: string, objectName: string, label: st
   ['quotes', 'crm_quote', 'Quotes'],
   ['contracts', 'crm_contract', 'Contracts'],
   ['forecasts', 'crm_forecast', 'Forecasts'],
+  ['campaigns', 'crm_campaign', 'Campaigns'],
+  ['knowledge', 'crm_knowledge_article', 'Knowledge Articles'],
 ];
 
 /** One pass per object. */

--- a/test/flow-scheduled.test.ts
+++ b/test/flow-scheduled.test.ts
@@ -8,6 +8,9 @@ import { ContractExpirationFlow } from '../src/flows/contract-expiration.flow';
 import { ContractRenewalFlow } from '../src/flows/contract-renewal.flow';
 import { DemoBootstrapFlow } from '../src/flows/demo-bootstrap.flow';
 import { ForecastSnapshotFlow } from '../src/flows/forecast-snapshot.flow';
+import * as CrmObjects from '../src/objects';
+import { MarketingUserProfile } from '../src/profiles/marketing-user.profile';
+import { ServiceAgentProfile } from '../src/profiles/service-agent.profile';
 import { OpportunityStagnationFlow } from '../src/flows/opportunity-stagnation.flow';
 import { QuoteExpirationFlow } from '../src/flows/quote-expiration.flow';
 import forecastDerive from '../src/objects/forecast.hook';
@@ -1034,9 +1037,83 @@ describe('demo_bootstrap — post-seed ownership claim', () => {
       // rep and editable by nobody — the same defect as the eight above, on the
       // one owner-scoped seeded object this list used to omit.
       'crm_forecast',
+      // #716: the last two, and the ones that hid longest. Both are seeded and
+      // both declare `owner_id`, but their OWD is `public_read` — so unlike the
+      // nine above their ownerless rows READ fine for everybody and nothing
+      // looked broken until somebody tried to WRITE one. `public_read` opens
+      // the read baseline only; the write filter still needs owner-match, so
+      // `marketing_user.crm_campaign.allowEdit` and
+      // `service_agent.crm_knowledge_article.allowEdit` (both at
+      // `modifyAllRecords: false`, i.e. write depth `own` → `owner_id ==
+      // caller`) were granted permissions that answered 403 on every seeded
+      // row for everyone but `system_admin`.
+      'crm_campaign',
+      'crm_knowledge_article',
     ]) {
       expect(claimed, `demo_bootstrap never claims ${object}`).toContain(object);
     }
+  });
+
+  /**
+   * The roster above is a list a human maintains, and #716 is what happens when
+   * one falls behind: `crm_campaign` and `crm_knowledge_article` sat seeded,
+   * owner-scoped and unclaimed for release after release because nothing ever
+   * COMPUTED the question — and their `public_read` OWD meant the omission
+   * showed up as a 403 on an edit nobody in a demo tries, rather than as an
+   * empty list somebody would have reported.
+   *
+   * So compute it, from the app's own metadata. An object that is SEEDED and
+   * declares `owner_id` reaches the database owned by nobody — seed writes run
+   * `{ isSystem: true }`, which skips the security middleware's insert-time
+   * stamp, and no seed can name a user — so this sweep is the ONLY thing that
+   * can give it an owner, and it belongs in the list. Objects with no
+   * `owner_id` (`crm_product`, and the `controlled_by_parent` children whose
+   * access derives from their master) have no ownership to claim and must stay
+   * out; `crm_product` in particular is the e2e ownership-blind probe, which
+   * `test/e2e-seed-precondition.test.ts` fails if this sweep ever touches it.
+   */
+  it('leaves no seeded owner-scoped object unclaimed — the cross-table, computed', () => {
+    const seeded = new Set(
+      (CrmSeedData as unknown as Array<{ object: string }>).map((d) => d.object),
+    );
+    const claimed = new Set(claimedObjects());
+    const objects = Object.values(CrmObjects as unknown as Record<string, Rec>).filter(
+      (o) => o != null && typeof o.name === 'string' && o.fields != null,
+    );
+    const ownerScoped = (o: Rec) =>
+      Object.prototype.hasOwnProperty.call(o.fields as Rec, PLATFORM_OWNER);
+
+    // Guard the guard: a broken walk would make every filter below empty and
+    // the whole case vacuous.
+    expect(objects.length, 'no objects read off the barrel — the walk broke').toBeGreaterThan(10);
+    expect(
+      objects.filter((o) => seeded.has(String(o.name)) && ownerScoped(o)).length,
+      'no seeded owner-scoped object found at all — the cross-table is empty',
+    ).toBeGreaterThan(5);
+
+    const unclaimed = objects
+      .filter((o) => seeded.has(String(o.name)) && ownerScoped(o) && !claimed.has(String(o.name)))
+      .map((o) => `${String(o.name)} (sharingModel: ${String(o.sharingModel)})`);
+    expect(
+      unclaimed,
+      'these objects ship seed records AND declare the ownership column, so their rows\n' +
+        'reach the database owned by nobody and nothing else can claim them. Under any\n' +
+        'OWD that leaves them uneditable by every user, `system_admin` aside — and under\n' +
+        '`public_read` it does so while the rows still read normally, so the only symptom\n' +
+        'is a 403 (#716). Add them to CLAIMED_OBJECTS:\n  ' + unclaimed.join('\n  '),
+    ).toEqual([]);
+
+    // The other direction: claiming an object with no ownership column would
+    // stamp a field it does not declare, on rows where ownership means nothing.
+    const byName = new Map(objects.map((o) => [String(o.name), o]));
+    const claimedWithoutOwner = [...claimed].filter((name) => {
+      const object = byName.get(name);
+      return object != null && !ownerScoped(object);
+    });
+    expect(
+      claimedWithoutOwner,
+      `these claimed objects declare no ${PLATFORM_OWNER}:\n  ` + claimedWithoutOwner.join('\n  '),
+    ).toEqual([]);
   });
 
   it('leaves no claimed object ownerless at the PLATFORM level', async () => {
@@ -1107,5 +1184,187 @@ describe('demo_bootstrap — post-seed ownership claim', () => {
       const unowned = (h.store[object] ?? []).find((r) => r.id === `${object}_unowned`);
       expect(unowned?.[PLATFORM_OWNER], `${object}: claimed with no user present`).toBeNull();
     }
+  });
+});
+
+/**
+ * #716 end to end: the two `public_read` families, over the records the seed
+ * loader actually ships.
+ *
+ * The block above runs on a synthetic two-row fixture per claimed object. That
+ * proves the sweep's MECHANICS and nothing about the real seed book — and #716
+ * was not a mechanics bug: the sweep worked perfectly, it simply never looked
+ * at these two objects. So this runs it over the actual `crm_campaign` and
+ * `crm_knowledge_article` seed records, read from `src/data/` rather than
+ * restated here, and asserts the outcome the issue is about.
+ *
+ * Why these two hid so long is worth keeping in the fixture: their OWD is
+ * `public_read`, so every one of these rows READS normally for every user even
+ * while owned by nobody. Nothing is empty, nothing errors, no list is short.
+ * The only symptom is a write — and a demo org is read almost exclusively.
+ */
+describe('demo_bootstrap claims the real campaign and knowledge seeds (#716)', () => {
+  const ADMIN = 'usr_admin';
+  const PLATFORM_OWNER = 'owner_id';
+
+  /** The two families, with the `externalId` their `defineSeed` upserts on. */
+  const FAMILIES = [
+    ['crm_campaign', 'name'],
+    ['crm_knowledge_article', 'title'],
+  ] as const;
+
+  const seedRecordsOf = (object: string): Rec[] =>
+    (CrmSeedData as unknown as Array<{ object: string; records: Rec[] }>).find(
+      (d) => d.object === object,
+    )?.records ?? [];
+
+  /**
+   * One seed-loader pass, faithful to what the loader does: `mode: 'upsert'` on
+   * the dataset's `externalId` resolves to a PARTIAL update over the columns
+   * the seed declares when the row already exists, and to an insert otherwise.
+   *
+   * Partial is load-bearing — the seeds declare no `owner_id`, so a claimed
+   * owner survives a warm-boot replay. And a fresh insert lands with
+   * `owner_id: null` rather than with the key absent: the registry injects the
+   * column into every user-owned object, and the seed write only skips the
+   * security plugin's insert-time STAMP. That distinction decides whether the
+   * sweep can see the row at all — its filter is `{ owner_id: null }`, and an
+   * absent key is not null.
+   */
+  const loadSeeds = (store: Record<string, Rec[]>) => {
+    for (const [object, externalId] of FAMILIES) {
+      const rows = (store[object] ??= []);
+      for (const rec of seedRecordsOf(object)) {
+        const key = String(rec[externalId]);
+        const existing = rows.find((r) => String(r[externalId]) === key);
+        if (existing) Object.assign(existing, rec);
+        else rows.push({ id: `seed_${object}_${key}`, [PLATFORM_OWNER]: null, ...rec });
+      }
+    }
+  };
+
+  const freshStore = (): Record<string, Rec[]> => {
+    const store: Record<string, Rec[]> = { sys_user: [{ id: ADMIN, email: 'admin@objectos.ai' }] };
+    loadSeeds(store);
+    return store;
+  };
+
+  const sweep = async (store: Record<string, Rec[]>) => {
+    const h = makeFlowHarness({ demo_bootstrap: DemoBootstrapFlow }, store);
+    await h.run('demo_bootstrap', {}, { event: 'schedule' });
+    return h;
+  };
+
+  const ownerless = (rows: Rec[]) => rows.filter((r) => r[PLATFORM_OWNER] == null);
+
+  it('the seed book actually ships rows for both, and ships them ownerless', () => {
+    // Guard the guard, twice over. An empty family makes every case below
+    // vacuous, and a family that arrived already owned would mean the fixture
+    // no longer presents the defect the sweep is supposed to fix.
+    const store = freshStore();
+    for (const [object] of FAMILIES) {
+      expect(seedRecordsOf(object).length, `${object} ships no seed records`).toBeGreaterThan(0);
+      expect(store[object].length, `${object} did not load`).toBe(seedRecordsOf(object).length);
+      expect(
+        ownerless(store[object]).length,
+        `${object}: seeds arrived owned — the fixture no longer shows the defect`,
+      ).toBe(store[object].length);
+    }
+  });
+
+  it('leaves no seeded campaign or article ownerless after one pass', async () => {
+    const h = await sweep(freshStore());
+
+    const stillOwnerless: string[] = [];
+    for (const [object, externalId] of FAMILIES) {
+      for (const row of ownerless(h.store[object] ?? [])) {
+        stillOwnerless.push(`${object}/${String(row[externalId])}`);
+      }
+    }
+    expect(
+      stillOwnerless,
+      'these seeded rows came out of demo_bootstrap owned by nobody. Their OWD is\n' +
+        '`public_read`, so they still READ fine — the failure is silent until an edit,\n' +
+        'which answers 403 for every user but system_admin (#716):\n  ' +
+        stillOwnerless.join('\n  '),
+    ).toEqual([]);
+
+    for (const [object] of FAMILIES) {
+      for (const row of h.store[object]) {
+        expect(row[PLATFORM_OWNER], `${object}/${String(row.id)}: wrong owner`).toBe(ADMIN);
+      }
+    }
+  });
+
+  /**
+   * The permission half of #716, as far as this repo can honestly take it.
+   *
+   * This is a MODEL of the platform's write gate, not the platform's own code —
+   * `@objectstack/plugin-security` is not a dependency of this app and standing
+   * one up would test the platform rather than us. The model is one line of
+   * documented behaviour: a grant with `modifyAllRecords: false` and no
+   * `writeScope` resolves to the `own` write depth, whose write filter is
+   * `owner_id == caller`, and `public_read` does NOT exempt writes from it
+   * ("public_read is read-open but write-owned; only a fully public object is
+   * write-open" — `@objectstack/plugin-sharing` 17.0.0-rc.2, `buildWriteFilter`).
+   *
+   * So what this pins is not "the 403 is gone" — only a running server shows
+   * that. It pins the single input the app controls and #716 got wrong: the row
+   * a granted editor is measured against has an owner at all. The grants are
+   * read from the real profile metadata, so the case fails loudly if the
+   * premise it reasons from (edit granted, `modifyAllRecords` off) ever moves.
+   */
+  it('turns a granted editor from zero editable rows into all of them', async () => {
+    const GRANTS = [
+      ['crm_campaign', (MarketingUserProfile.objects as Rec).crm_campaign, 'marketing_user'],
+      ['crm_knowledge_article', (ServiceAgentProfile.objects as Rec).crm_knowledge_article, 'service_agent'],
+    ] as const;
+
+    for (const [object, grant, profile] of GRANTS) {
+      expect(grant, `${profile} has no ${object} grant`).toBeTruthy();
+      expect(grant.allowEdit, `${profile}.${object}: edit grant gone`).toBe(true);
+      expect(grant.modifyAllRecords, `${profile}.${object}: now modifies all records`).toBe(false);
+      expect(grant.writeScope, `${profile}.${object}: gained a writeScope`).toBeUndefined();
+    }
+
+    // The `own`-depth write filter, applied to the rows a granted editor faces.
+    const editable = (rows: Rec[], userId: string) =>
+      rows.filter((r) => r[PLATFORM_OWNER] === userId);
+
+    const before = freshStore();
+    for (const [object] of GRANTS) {
+      expect(
+        editable(before[object], ADMIN).length,
+        `${object}: an editable row before the sweep — the fixture is wrong`,
+      ).toBe(0);
+    }
+
+    const h = await sweep(before);
+    for (const [object] of GRANTS) {
+      expect(
+        editable(h.store[object], ADMIN).length,
+        `${object}: rows a granted editor still cannot reach`,
+      ).toBe(seedRecordsOf(object).length);
+    }
+  });
+
+  it('survives a warm boot — the replayed seed does not blank the claim', async () => {
+    // The seeds re-run on every boot. They declare no `owner_id`, so the upsert
+    // is a partial write and the claim must persist; if it did not, the sweep
+    // would re-claim forever and any real reassignment would be undone by the
+    // next restart.
+    const h = await sweep(freshStore());
+    loadSeeds(h.store);
+
+    for (const [object] of FAMILIES) {
+      expect(ownerless(h.store[object]).length, `${object}: re-seed blanked the owner`).toBe(0);
+      expect(h.store[object].length, `${object}: re-seed duplicated rows`).toBe(
+        seedRecordsOf(object).length,
+      );
+    }
+
+    const settled = JSON.parse(JSON.stringify(h.store)) as Record<string, Rec[]>;
+    const again = await sweep(JSON.parse(JSON.stringify(settled)) as Record<string, Rec[]>);
+    expect(again.store).toEqual(settled);
   });
 });


### PR DESCRIPTION
Fixes #716

## 前提复核（先验证再动手）

issue 是线索不是规格，因此先对 `origin/main` `dae36503`（已含 PR #717 对 CLAIMED_OBJECTS 的重写与 crm_forecast 入列）逐条实测，交叉表由 app 自身 metadata 枚举生成，不是人工清单：

| object | seeded | 声明 owner_id | OWD | demo_bootstrap 认领 |
| --- | --- | --- | --- | --- |
| crm_lead / crm_account / crm_contact / crm_opportunity / crm_case / crm_task / crm_quote / crm_contract / crm_forecast | Y | Y | private / controlled_by_parent | Y |
| **crm_campaign** | Y | Y | public_read | **n** |
| **crm_knowledge_article** | Y | Y | public_read | **n** |
| crm_product | Y | **n** | public_read | n（共享目录，应当留在外面） |
| crm_campaign_member / crm_*_line_item / crm_event_attendee | Y | n | controlled_by_parent | n |

- seed 数据：`campaigns`（`src/data/marketing.seed.ts`）与 `knowledgeArticles`（`src/data/service.seed.ts`）都在 `CrmSeedData` 里；两个 seed 都没有任何一行声明 `owner_id`（全仓 `src/data/**` 无 `owner_id:` 赋值）。
- profile 授权原样成立：`marketing_user.crm_campaign` = `allowEdit: true, modifyAllRecords: false`；`service_agent.crm_knowledge_article` = `allowEdit: true, modifyAllRecords: false`。两处都没有 `writeScope`。
- 平台侧语义也实测过，不是转述 issue：`@objectstack/plugin-sharing` 17.0.0-rc.2 的 `buildWriteFilter` 自带注释 —— “public_read is read-open but write-owned; only a fully public object is write-open”，且 `effectiveSharingModel` 把 `public_read` 映射成 `read`（只有 `public_read_write` / `controlled_by_parent` 才是 `public`）。`plugin-security` 的 `getEffectiveScope` 里 `opClass === "write" && op.modifyAllRecords` 才返回 `org`，否则落到 `own`，写过滤器即 `owner_id == caller`。
- `scripts/backfill-owner-id.ts` 的 `OBJECTS` 里确实同时列着这两个对象 —— 它们在 #548 之前带 app 级 `owner` lookup，属 owner-scoped 一类。

**结论：premise 成立，且是当前唯一剩下的两个「已 seed + 声明 owner_id + 未认领」对象。**

## 为什么它们藏了这么久

已认领的九个是 `private` / `controlled_by_parent`：无 owner 的行**读都读不到**，第一个列表页就暴露了。这两个是 `public_read`，种子行对所有人读起来完全正常 —— 没有空列表、没有报错、没有短少的行。唯一症状是**写**：被明确授予了编辑权的 `marketing_user` / `service_agent` 保存时 403，除 `system_admin` 外无人改得动。授权表上写着“能编辑”，实际不能 —— 这正是 #622 的失败形态换了两个对象。

次级影响照旧：不进任何「My …」视图、owner 轴分组渲染空 owner、面向 owner 的 `notify` 到不了人。

`src/sharing/campaign.sharing.ts` 的 `campaign_leadership_*` 不构成替代：它只把 edit 放宽给两个 marketing **岗位**，且限 `planning` / `in_progress` 的活动 —— 既覆盖不到已结束的种子活动，也覆盖不到任何知识文章，更够不着只持有普通 `marketing_user` 授权的人。

## 改动

`src/flows/demo-bootstrap.flow.ts` 的 `CLAIMED_OBJECTS` 增两项，并按 #717 建立的注释风格补上论证（含平台侧原文引用、profile 授权链路、以及为什么 `crm_product` 必须留在外面）。

### 知识文章 owner 语义 —— 记录而非裁定

按 issue 分诊评论里 PM 的裁定：本单修的是 **demo 种子数据**的认领，demo org 里 owner-scoped 种子对象的既定处置就是归第一个用户（#622 先例，CLAIMED_OBJECTS 全表如此），知识文章遵循同一约定，不引入新契约。真实部署里文章 owner 到底指「作者」还是「维护人」是未来的产品问题，本 PR 明确不予预判 —— 真实部署在这个 sweep 有东西可捡之前，就已经通过 import 或 territory 规则分配好归属了（flow 头部注释原有的说明）。该判断已写进 flow 注释与 changeset。

## 测试

`test/flow-scheduled.test.ts`：

1. 显式认领清单加上两个对象（照 #717 加 crm_forecast 的写法）。
2. **新增计算式交叉表守卫** —— 这条是关键。原有的 outcome 用例（“leaves no claimed object ownerless”“claims the ownership column on every row it touches”）都是**从 flow 自身读认领清单再迭代**，所以对象没进清单时它们不是变红，而是因为“什么都没迭代”而保持绿 —— 正是这类空绿让 #716 藏了下来。新用例改从 app metadata 计算（seeded × 声明 `owner_id` × 已认领），并双向断言：既不许有「已 seed + owner-scoped 但未认领」，也不许认领没有 `owner_id` 的对象。附带 guard-the-guard，防止遍历坏掉后整条断言变空。
3. **新增端到端 describe**，跑真实 seed 记录（7 个 campaign + 4 个 knowledge article，从 `src/data/` 读，不在测试里重抄）：一次 sweep 后无一行无主；warm boot（seed 重放为 partial upsert）不会把认领抹掉且不重复插行；幂等。
4. 权限那一半按能诚实做到的程度做：本仓不依赖 `@objectstack/plugin-security`，硬起一个只会测到平台代码。所以写的是平台写门的**模型**（`modifyAllRecords: false` 且无 `writeScope` → `own` 深度 → `owner_id == caller`），授权本身从真实 profile metadata 读取（授权若消失用例即红）。它钉住的不是“403 没了”（那要跑起来的服务器才能证），而是 app 唯一能控、且 #716 搞错了的那个输入：被授权的编辑者面对的行**有 owner** —— 前 0 行可写，后全部可写。注释里如实标明了这层边界。

`test/e2e-seed-precondition.test.ts`：**未改动**，复核后确认无需改。它的 ownership-blind 探针前提（`crm_product` 是 `public_read` 且不被任何 sweep 扫到）**已经**被显式断言（`expect(swept.has(OWNERSHIP_BLIND_PROBE_OBJECT)).toBe(false)`，注释里写明“Adding crm_product to CLAIMED_OBJECTS must fail here”）。认领这两个对象不触及该前提；正反向跑都绿。

### 反向验证（方向先定后跑）

预判：把两项从 `CLAIMED_OBJECTS` 摘掉 → 显式清单用例红、计算式交叉表红、三条端到端红；而「seed book 确实发货且确实无主」那条 fixture guard 应当**保持绿**（它不依赖认领）；`e2e-seed-precondition` 应当**保持绿**。实测与预判一致 —— 5 red / 其余绿：

```
FAIL  claims every object the seed data ships an owner-scoped record for
FAIL  leaves no seeded owner-scoped object unclaimed — the cross-table, computed
        + "crm_campaign (sharingModel: public_read)"
        + "crm_knowledge_article (sharingModel: public_read)"
FAIL  leaves no seeded campaign or article ownerless after one pass   （11 行全部无主）
FAIL  turns a granted editor from zero editable rows into all of them  （expected 7, received 0）
FAIL  survives a warm boot — the replayed seed does not blank the claim
Test Files  1 failed | 1 passed (2)
```

同时确认了那条“空绿”：原有的 `leaves no claimed object ownerless at the PLATFORM level` 在摘掉之后**依旧是绿的**，因为它迭代的正是被摘掉的那份清单 —— 这就是新增计算式交叉表用例的理由。

### 全量

```
pnpm typecheck   → tsc --noEmit，无输出
pnpm validate    → ✓（5 条 author-time warning 均为既有，与 main 一致）
pnpm build       → ✓ Build complete，dist/objectstack.json 1877.4 KB
pnpm lint        → 13 warning(s), 14 suggestion(s) — 与 main 上 stash 后重跑的基线逐字相同
pnpm hygiene     → ✓ source hygiene clean（237 files，无文件超 100KB）
vitest run       → Test Files 58 passed (58) / Tests 1402 passed | 1 skipped (1403)
```

## 边界

只动了 `src/flows/demo-bootstrap.flow.ts`、`test/flow-scheduled.test.ts` 和一个 changeset。未触 `src/views/**`（#688 在飞）、`content/docs/**`（#685 在飞）、seed 数据文件、任何其他 flow，未改动任何 `@objectstack/*` 版本（保持 17.0.0-rc.2），无平台侧 workaround。

已有 demo 库自愈：sweep 每 10 分钟一轮，下一轮就会认领仍无主的行，不需要 reset；已有 owner 的记录永不被改写。

Refs #702 #622 #548


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_