### PR TITLE
docs(analytics): retranslate the zh dashboards pages, and let the tile guard read them (#685)

### DIFF
--- a/.changeset/dashboards-docs-zh-retranslation.md
+++ b/.changeset/dashboards-docs-zh-retranslation.md
@@ -1,0 +1,41 @@
+---
+'hotcrm': patch
+---
+
+Retranslates the Chinese dashboards pages against the corrected English page, and
+extends the CI tile guard to cover them.
+
+`content/docs/analytics/dashboards.mdx` was rewritten in #610 to describe the five
+dashboards the app actually registers. The two locale copies were left behind and
+still carried the whole of the original defect for every zh reader:
+
+- "四个仪表盘 / 四個儀表板" — five are registered. `sales_activity_dashboard`
+  (added in #592) had no section at all in either locale.
+- Tiles that do not exist, in both files: `Slipping Deals`, `Cases Approaching SLA`,
+  `Customer Satisfaction (CSAT)`, `Net New ARR`, `CSAT and NPS`, `Forecast vs Quota`,
+  `Pipeline Coverage`, `Customer Acquisition Cost` and the rest of the invented
+  lists — none of them a widget any dashboard ships, several of them not even a
+  measure any dataset defines.
+- A fabricated usage statistic: "*Cases Approaching SLA* 磁贴是此仪表盘上点击最多的
+  小部件". The tile does not exist, and this repo collects no click telemetry, so
+  the sentence was a confident quantitative claim measured by nothing. It is
+  deleted, not softened.
+- Trend claims ("过去 30 天，趋势", "与上周对比的趋势") that no tile makes — the
+  renderer shows no period-over-period delta on any KPI tile.
+
+Both pages are now a translation of the current English text: the five real
+dashboards and their real widget titles, the real controls (no date picker on
+Sales Activity or Customer Service, and why), and the shared-definition and
+opt-out notes. Terminology follows the neighbouring zh analytics pages
+(多维数据集 / 多維資料集, 磁贴 / 磁貼, 小部件 / 小工具); the zh-Hant page also drops the
+mis-converted 磚貼 for 磁貼, the form the rest of the zh-Hant docs already use.
+
+The guard is what keeps this from happening a third time:
+`test/docs-drift.test.ts` now reads all three pages, not just the English one. Its
+extraction was already locale-agnostic — the section headings carry each
+dashboard's own English `label` and the bold tile names stay in English in every
+locale — so both rules now bite per locale. A tile named in a zh page that no
+dashboard ships fails the build, and registering a sixth dashboard fails until all
+three pages document it.
+
+Fixes #685. Follows #610.

--- a/content/docs/analytics/dashboards.zh-Hans.mdx
+++ b/content/docs/analytics/dashboards.zh-Hans.mdx
@@ -1,124 +1,156 @@
 ---
 title: 仪表盘
-description: 四个开箱即用的仪表盘——CRM 概览、销售管道、服务运营和高管记分卡。
+description: 五个开箱即用的仪表盘——CRM 概览、销售业绩、销售活动、客户服务和高管概览。
 ---
 
 # 仪表盘
 
-HotCRM 内置四个仪表盘。每个都为特定角色而构建，回答该角色每天提出的问题。
+HotCRM 内置五个仪表盘。每个都为特定角色而构建，回答该角色每天提出的问题。
 
-## 四个仪表盘
+本页列出的每一个磁贴，都是应用真正发布的磁贴。这些清单会在 CI 里与仪表盘元数据逐条比对（`test/docs-drift.test.ts`），所以产品中的磁贴一旦被改名、新增或删除，本页就会直接让构建失败，而不是悄悄开始说假话。
+
+## 五个仪表盘
 
 | 仪表盘 | 面向 | 回答 |
 | --- | --- | --- |
 | 🏠 **CRM Overview** | 所有人 | "今天整个业务发生了什么？" |
-| 📈 **Sales Dashboard** | 销售代表、经理 | "我的管道健康状况如何？" |
-| 🎧 **Service Dashboard** | 服务客服、经理 | "我们在工单和 SLA 上表现如何？" |
-| 👔 **Executive Scorecard** | 高管、财务 | "我们达成目标了吗？" |
+| 📈 **Sales Performance** | 销售代表、经理 | "我的管道健康状况如何？我们赢单了吗？" |
+| ☎️ **Sales Activity** | 销售经理、客户团队 | "谁在和客户打交道？哪些客户已经没了动静？" |
+| 🎧 **Customer Service** | 服务客服、经理 | "我们在工单和 SLA 上表现如何？" |
+| 👔 **Executive Overview** | 高管、财务 | "我们达成目标了吗？" |
 
-四者都遵守 [共享规则](/zh-Hans/docs/administration/sharing-and-security)——你看到的内容取决于你的角色。
+五者都遵守 [共享规则](/zh-Hans/docs/administration/sharing-and-security)——你看到的内容取决于你的角色。
+
+### 没有任何磁贴显示趋势箭头
+
+在任何一个仪表盘上，KPI 磁贴都不显示"对比上期"的涨跌幅。跨期对比是一次测量：它必须来自一次真实的对比查询。在渲染器能为数据集绑定的指标跑出这样一次查询之前，磁贴上的百分比只会是手工敲进去的数字，没有任何数据能改变它——数据库塞得满满的时候和一条记录都没有的时候，它读起来一模一样。所以磁贴只呈现真正查询出来的那个数，此外什么都不加。
 
 ## 🏠 CRM Overview
 
-跨职能的主页仪表盘，默认对所有用户可见。
+跨职能的主页仪表盘——收入、管道和交易构成集中在一页上。
 
 **磁贴**：
 
-- **Open Leads** — 数量，按状态。
-- **New Leads This Week** — 与上周对比的趋势。
-- **My Open Opportunities** — 数量和价值。
-- **Cases Awaiting Response** — 数量，并突出 SLA 风险。
-- **Top 5 Accounts by Pipeline** — 柱状图。
-- **Recent Activity** — 过去 24 小时的通话、会议、电子邮件（你的）。
+- **Total Revenue** — 所选周期内的成交赢单收入。
+- **Active Deals** — 管道中进行中的商机。
+- **Won Deals** — 所选周期内成交赢单的交易。
+- **Avg Deal Size** — 成交赢单交易的平均金额。
+- **Revenue Trends** — 近 12 个月的成交赢单收入（面积图）。
+- **Lead Source** — 按获客渠道统计的管道金额（环形图）。
+- **Pipeline by Stage** — 各销售阶段的进行中商机金额（漏斗图）。
+- **Top Products** — 按产品类别统计的标价收入合计（柱状图）。
+- **Pipeline by Owner** — 每位销售代表的进行中管道金额、交易数和平均交易规模（表格）。
+
+**控件**：一个基于商机预计成交日期的日期范围选择器（默认本季度），以及一个 Owner 筛选器。
 
 非常适合作为每天开始时的着陆页。
 
-## 📈 Sales Dashboard
+## 📈 Sales Performance
 
 销售团队的日常运营仪表盘。
 
 **磁贴**：
 
-- **Pipeline by Stage** — 显示各阶段 $ 的漏斗图。
-- **Forecast vs Quota** — 仪表盘图。
-- **Closed Won this Quarter** — 带目标线的累计总额。
-- **Win Rate (12M)** — 近 12 个月内**已结案**（赢单 + 丢单）商机中的赢单占比，旁边同时展示 **Deals Won** 与 **Deals Lost**，让分子分母始终可见。进行中的管道不计入分母。
-- **Win / Loss by Rep** 与 **Win / Loss by Lead Source** — 同一比值的拆分表：每行给出赢单数、丢单数、已结案数、赢率与赢单金额。
-- **Why We Lose** — 按丢单原因统计的丢单数。每条丢单商机都必须填写原因（[关单时强制](/docs/sales/opportunities)），因此图中不存在“未归因”切片——图为空表示该时间窗内没有丢单，而不是没人填字段。
-- **Average Deal Size** — 本季度对比上季度。
-- **Average Sales Cycle** — 从创建到成交的天数（赢单交易）。
-- **Top 10 Open Deals** — 可排序的表格。
-- **Slipping Deals** — 本周成交日期被推后的商机。
-- **Activity Heatmap** — 每位销售代表每天的通话 + 会议 + 电子邮件。
+- **Total Pipeline** — 进行中商机金额合计。
+- **Closed Won (QTD)** — 本季度已成交的收入。
+- **Open Opportunities** — 正在推进中的交易。
+- **Avg Deal Size** — 本季度成交赢单交易的平均金额。
+- **Win Rate (12M)** — 近 12 个月内*已结案*（赢单 + 丢单）商机中的赢单占比。进行中的管道不计入分母。
+- **Deals Won (12M)** — 这个百分比背后的分子。
+- **Deals Lost (12M)** — 分母的另一半，好让分子和分母始终陈列在赢率旁边。
+- **Pipeline by Stage** — 各销售阶段的进行中商机金额（漏斗图）。
+- **Monthly Revenue Trend** — 近 12 个月的成交赢单收入。
+- **Pipeline by Forecast Category** — 按预测类别分组的进行中管道。
+- **Lead Source** — 管道是从哪里来的（环形图）。
+- **Open Pipeline by Owner** — 每位销售代表进行中的金额、交易数和平均赢单概率（表格）。
+- **Quota Attainment by Rep** — 每位销售代表当季的配额、已成交收入与达成率，读取自预测快照。
+- **Win / Loss by Rep** — 每位销售代表的赢单数、丢单数、已结案数、赢率和赢单金额（表格）。
+- **Win / Loss by Lead Source** — 同一份拆分换成按获客渠道来看：哪些来源带来的商机真正能成交。
+- **Why We Lose** — 按丢单原因统计的丢单数。每条丢单商机都必须填写原因（[关单时强制](/zh-Hans/docs/sales/opportunities)），因此图中不存在"未归因"切片——图为空表示该时间窗内没有丢单，而不是没人填字段。
+- **Pipeline by Stage × Lead Source** — 进行中商机金额按阶段与来源的交叉统计（透视表）。
 
-角色感知：销售代表看到自己的，经理看到团队的，总监看到汇总。
+**控件**：一个基于成交日期的日期范围选择器（默认本季度），外加 Sales Rep 和 Deal Type 筛选器。Quota Attainment by Rep 固定在当前季度，两者都不作用于它——配额是为某个周期定义的，用任意范围去重新切分它，等于拿完整的目标对比不完整的收入。
 
-## 🎧 Service Dashboard
+角色感知：销售代表看到自己的记录，经理看到团队的，遵循共享规则。
+
+## ☎️ Sales Activity
+
+覆盖度与客户健康视图：谁在和客户打交道、打交道有多频繁，以及沉默出现在哪里。
+
+**磁贴**：
+
+- **Interactions Logged** — 真正发生过的通话和会议。
+- **Meetings Booked** — 已排进日历、但还没有发生的会议。
+- **Customer Minutes** — 面对客户的总时长。
+- **Tasks Completed** — 已经收尾的跟进事项，活动量的另一半。
+- **Activity by Rep** — 按负责人统计的已记录互动数（柱状图）。
+- **Activity Volume by Week** — 每周互动数：团队是在提速，还是在变安静？
+- **Activity Mix** — 通话、会议与演示各占多少（环形图）。
+- **Where the Activity Lands** — 漏斗的哪一段拿到了注意力。
+- **Interactions on Deals** — 关联到商机的已记录互动数。
+- **Open Deals** — 仍在推进中的商机，用来给上一个磁贴当参照。
+- **Quiet 30+ Days** — 一个月内没有任何已记录互动的活跃客户。
+- **Quiet 60+ Days** — 沉默两个月，风险阈值。
+- **Quiet 90+ Days** — 整整一个季度没有联系：要么介入，要么放弃。
+
+**控件**：一个 Rep 筛选器。这里**故意没有**日期范围选择器——互动日期是 datetime 列，而平台的 datetime 筛选器转换目前会在这类列上套用范围时把每个小部件都清零。时间改由坐标轴承载：Activity Volume by Week 按周分桶，三个沉默客户磁贴各自框住自己的 30 / 60 / 90 天阈值。
+
+## 🎧 Customer Service
 
 服务团队的日常运营视图。
 
 **磁贴**：
 
-- **Open Cases by Priority** — 柱状图。
-- **Cases Approaching SLA** — 按距违约时间排序的表格。
-- **Cases Breached** — 过去 7 天（含工单所有者）。
-- **First Response Time** — 平均值对比目标。
-- **Resolution Time** — 平均值对比目标。
-- **Customer Satisfaction (CSAT)** — 过去 30 天，趋势。
-- **Case Volume by Origin** — Email / Phone / Web / Chat / Portal。
-- **Top Case Categories** — 用于发现产品问题。
-- **Agent Workload** — 每位客服的未结工单数。
+- **Open Cases** — 尚未关闭的工单。
+- **Critical Cases** — 优先级为 critical 的未结工单。
+- **Avg Resolution Time** — 平均关单时长（小时）。
+- **SLA Violations** — 违反了 SLA 的工单。
+- **Cases by Status** — 工作量在流程各状态上的分布（环形图）。
+- **Cases by Priority** — 未结工单按紧急程度的构成（饼图）。
+- **Cases by Origin** — Email / Phone / Web / Chat / Portal（柱状图）。
+- **Daily Case Volume** — 近 30 天每天新建的工单数。
+- **SLA Compliance** — 在 SLA 内解决的工单占比，对比 95% 的目标线（仪表图）。
+- **Open Cases by Priority** — 每个优先级的未结工单数及其 SLA 违约率（表格）。
 
-*Cases Approaching SLA* 磁贴是此仪表盘上点击最多的小部件——它是客服确定优先级的方式。
+**控件**：Agent 和 Priority 筛选器，外加每分钟一次的刷新——服务台需要新鲜的数字。和 Sales Activity 一样，这里同样故意没有日期范围选择器，原因是同一个 datetime 筛选器问题；Daily Case Volume 自带 30 天的时间窗。
 
-## 👔 Executive Scorecard
+## 👔 Executive Overview
 
 业务的高管 / 财务视图。
 
 **磁贴**：
 
-- **Bookings This Quarter** — 成交赢单，对比计划和去年同期。
-- **Pipeline Coverage** — 管道 ÷ 剩余配额。
-- **Forecast Confidence** — 承诺 + 最佳情况对比目标。
-- **Net New ARR** — 适用于订阅业务。
-- **Renewals This Quarter** — 即将到来、已续约、已流失。
-- **CSAT and NPS** — 客户健康度。
-- **Customer Acquisition Cost** — 营销活动支出 ÷ 新客户数。
-- **Top 10 Accounts by ACV** — 年度合同价值排行榜。
-- **Pipeline Trend** — 4 周管道价值图表。
+- **Total Revenue (YTD)** — 今年的成交赢单收入。
+- **Active Accounts** — 至少还有一段有效关系的客户。
+- **Total Contacts** — 通讯录里的人。
+- **Open Leads** — 漏斗中尚未转化的线索。
+- **Revenue Trend** — 近 12 个月的成交赢单收入。
+- **Revenue by Industry** — 年初至今的成交赢单收入按客户行业拆分（环形图）。
+- **Pipeline by Stage** — 各销售阶段的进行中商机金额（漏斗图）。
+- **New Accounts** — 近 6 个月的客户新建节奏。
+- **Accounts by Industry** — 每个行业的年收入合计与客户数（表格）。
+
+**控件**：一个基于成交日期的日期范围选择器（默认本季度），外加 Owner 和 Lead Source 筛选器。四个 KPI 磁贴各自声明了自己的周期（年初至今、"活跃"、"未转化"），不会被这个选择器收窄。
 
 此仪表盘是每周领导层评审的基础。
 
-## 个性化和创建仪表盘
+## 你可以改什么
 
-每位用户都可以：
+- **日期范围** — CRM Overview、Sales Performance 和 Executive Overview 各带一个基于商机预计成交日期的选择器，默认本季度。Sales Activity 和 Customer Service 没有，原因见上面各自的章节。
+- **筛选器** — 每个仪表盘声明自己的一套：Owner 各处都有，另外 Sales Performance 有 Deal Type、Customer Service 有 Priority、Executive Overview 有 Lead Source。
+- **刷新** — Customer Service 每分钟刷新一次，Sales Performance 每三分钟，其余三个每五分钟。
 
-- 将任何仪表盘**固定**为着陆页。
-- 按日期范围、团队、地区、产品**筛选**仪表盘。
-- **下钻**到任何磁贴以查看底层记录。
-- 将任何磁贴**导出**为图片或 PDF。
-- **订阅**以通过电子邮件接收每周 PDF。
+有些磁贴刻意不接受所在仪表盘的筛选器。12 个月的收入趋势、Top Products 和 Quota Attainment by Rep 都保持自己标题上写明的那个时间窗，这样更窄的日期选择器就无法在标题不变的情况下悄悄改掉数字的定义。
 
-管理员可以：
+## 数字是从哪里来的
 
-- 从 **Analytics › Dashboards › New** 菜单创建新仪表盘。
-- 从标准库选择小部件，或从 [多维数据集](/zh-Hans/docs/analytics/cubes) 构建自定义小部件。
-- 设置受众——谁默认看到每个仪表盘。
-- 安排快照（例如自动生成的季度 QBR 演示文稿）。
+每个磁贴都绑定到一个数据集——正是这一层语义把"管道""已结案交易""SLA 违约"各定义一次，供用到它们的每个磁贴和报表共用。可用的度量和维度见 [数据集与多维数据集](/zh-Hans/docs/analytics/cubes)，聚合数字背后的记录级视图见 [报表](/zh-Hans/docs/analytics/reports)。
 
-## 给经理的提示
+出现在不止一个仪表盘上的定义是共享的，而不是重新敲一遍：Pipeline by Stage 和 Avg Deal Size 各自只有一份定义，分别被三个和两个仪表盘使用，所以"进行中管道"不会在不同页面上变成不同的意思。
 
-- ✅ 为你的团队**订阅仪表盘 PDF**——周一早上 8 点是很好的节奏。
-- ✅ 每周五使用 **Slipping Deals** 磁贴来规划下周的交易评审通话。
-- ✅ 不要从电子邮件管理——从仪表盘管理。电子邮件用于采取行动；仪表盘用于呈现事实。
+## 提示
 
-## 给高管的提示
-
-- ✅ 从多维数据集构建一个**董事会视图**仪表盘——成交、管道、流失、CSAT——一页搞定。
-- ✅ 设置**阈值告警**（例如管道覆盖率 &lt;2.5×），以便在问题出现前得到提醒。
-
-## 给管理员的提示
-
-- ✅ 构建仪表盘时，**从多维数据集开始**而非临时查询——它们更快也更一致。
-- ✅ 鼓励用户**克隆并个性化**，而非从头重建。
-- ✅ 每季度审计仪表盘使用情况——淘汰无人打开的仪表盘。
+- ✅ 管道评审之前，把 **Win / Loss by Rep** 和 **Why We Lose** 放在一起读——前者说谁在转化，后者说是什么在打败你。
+- ✅ 每周都处理一次 **Quiet 90+ Days** 磁贴。一个季度都没有任何已记录互动的客户，要么已经休眠，要么早就走了；而这个磁贴的价值上限，就是你的团队真正记录下来的互动量。
+- ✅ 在服务台，把 **SLA Violations**（违约的绝对条数）和 **SLA Compliance** 磁贴（对比目标的达标率）一起看——小基数上的一个小数字，和一个健康的达标率不是一回事。
+- ✅ 把 **Interactions on Deals** 对着 **Open Deals** 读：覆盖度问题的答案是这两者的比值，而不是其中任何一个单独的数字。

--- a/content/docs/analytics/dashboards.zh-Hant.mdx
+++ b/content/docs/analytics/dashboards.zh-Hant.mdx
@@ -1,124 +1,156 @@
 ---
 title: 儀表板
-description: 四個開箱即用的儀表板——CRM 概覽、銷售管道、服務營運和高階主管記分卡。
+description: 五個開箱即用的儀表板——CRM 概覽、銷售績效、銷售活動、客戶服務和高階主管概覽。
 ---
 
 # 儀表板
 
-HotCRM 內建四個儀表板。每個都為特定角色而建構，回答該角色每天提出的問題。
+HotCRM 內建五個儀表板。每個都為特定角色而建構，回答該角色每天提出的問題。
 
-## 四個儀表板
+本頁列出的每一個磁貼，都是應用真正發布的磁貼。這些清單會在 CI 裡與儀表板中繼資料逐條比對（`test/docs-drift.test.ts`），所以產品中的磁貼一旦被改名、新增或刪除，本頁就會直接讓建構失敗，而不是悄悄開始說假話。
+
+## 五個儀表板
 
 | 儀表板 | 面向 | 回答 |
 | --- | --- | --- |
 | 🏠 **CRM Overview** | 所有人 | "今天整個業務發生了什麼？" |
-| 📈 **Sales Dashboard** | 業務代表、經理 | "我的管道健康狀況如何？" |
-| 🎧 **Service Dashboard** | 服務客服、經理 | "我們在工單和 SLA 上表現如何？" |
-| 👔 **Executive Scorecard** | 高階主管、財務 | "我們達成目標了嗎？" |
+| 📈 **Sales Performance** | 銷售代表、經理 | "我的管道健康狀況如何？我們贏單了嗎？" |
+| ☎️ **Sales Activity** | 銷售經理、客戶團隊 | "誰在和客戶往來？哪些客戶已經沒了動靜？" |
+| 🎧 **Customer Service** | 服務客服、經理 | "我們在工單和 SLA 上表現如何？" |
+| 👔 **Executive Overview** | 高階主管、財務 | "我們達成目標了嗎？" |
 
-四者都遵守 [共享規則](/zh-Hant/docs/administration/sharing-and-security)——你看到的內容取決於你的角色。
+五者都遵守 [共享規則](/zh-Hant/docs/administration/sharing-and-security)——你看到的內容取決於你的角色。
+
+### 沒有任何磁貼顯示趨勢箭頭
+
+在任何一個儀表板上，KPI 磁貼都不顯示"對比上期"的漲跌幅。跨期對比是一次測量：它必須來自一次真實的對比查詢。在渲染器能為綁定資料集的指標跑出這樣一次查詢之前，磁貼上的百分比只會是手動敲進去的數字，沒有任何資料能改變它——資料庫塞得滿滿的時候和一筆記錄都沒有的時候，它讀起來一模一樣。所以磁貼只呈現真正查詢出來的那個數，此外什麼都不加。
 
 ## 🏠 CRM Overview
 
-跨職能的首頁儀表板，預設對所有使用者可見。
+跨職能的首頁儀表板——收入、管道和交易組成集中在一頁上。
 
-**磚貼**：
+**磁貼**：
 
-- **Open Leads** — 數量，按狀態。
-- **New Leads This Week** — 與上週對比的趨勢。
-- **My Open Opportunities** — 數量和價值。
-- **Cases Awaiting Response** — 數量，並突出 SLA 風險。
-- **Top 5 Accounts by Pipeline** — 長條圖。
-- **Recent Activity** — 過去 24 小時的通話、會議、電子郵件（你的）。
+- **Total Revenue** — 所選週期內的成交贏單收入。
+- **Active Deals** — 管道中進行中的商機。
+- **Won Deals** — 所選週期內成交贏單的交易。
+- **Avg Deal Size** — 成交贏單交易的平均金額。
+- **Revenue Trends** — 近 12 個月的成交贏單收入（面積圖）。
+- **Lead Source** — 按獲客通路統計的管道金額（環圈圖）。
+- **Pipeline by Stage** — 各銷售階段的進行中商機金額（漏斗圖）。
+- **Top Products** — 按產品類別統計的標價收入合計（長條圖）。
+- **Pipeline by Owner** — 每位銷售代表的進行中管道金額、交易數和平均交易規模（表格）。
+
+**控制項**：一個以商機預計成交日期為準的日期範圍選擇器（預設本季），以及一個 Owner 篩選器。
 
 非常適合作為每天開始時的著陸頁。
 
-## 📈 Sales Dashboard
+## 📈 Sales Performance
 
-業務團隊的日常營運儀表板。
+銷售團隊的日常營運儀表板。
 
-**磚貼**：
+**磁貼**：
 
-- **Pipeline by Stage** — 顯示各階段 $ 的漏斗圖。
-- **Forecast vs Quota** — 量表圖。
-- **Closed Won this Quarter** — 帶目標線的累計總額。
-- **Win Rate (12M)** — 近 12 個月內**已結案**（贏單 + 丟單）商機中的贏單占比，旁邊同時顯示 **Deals Won** 與 **Deals Lost**，讓分子分母始終可見。進行中的管道不計入分母。
-- **Win / Loss by Rep** 與 **Win / Loss by Lead Source** — 同一比值的拆分表：每列給出贏單數、丟單數、已結案數、贏率與贏單金額。
-- **Why We Lose** — 按丟單原因統計的丟單數。每筆丟單商機都必須填寫原因（[結案時強制](/docs/sales/opportunities)），因此圖中不存在「未歸因」切片——圖為空表示該時間窗內沒有丟單，而不是沒人填欄位。
-- **Average Deal Size** — 本季對比上一季。
-- **Average Sales Cycle** — 從建立到成交的天數（贏單交易）。
-- **Top 10 Open Deals** — 可排序的表格。
-- **Slipping Deals** — 本週成交日期被推後的商機。
-- **Activity Heatmap** — 每位業務代表每天的通話 + 會議 + 電子郵件。
+- **Total Pipeline** — 進行中商機金額合計。
+- **Closed Won (QTD)** — 本季已成交的收入。
+- **Open Opportunities** — 正在推進中的交易。
+- **Avg Deal Size** — 本季成交贏單交易的平均金額。
+- **Win Rate (12M)** — 近 12 個月內*已結案*（贏單 + 丟單）商機中的贏單占比。進行中的管道不計入分母。
+- **Deals Won (12M)** — 這個百分比背後的分子。
+- **Deals Lost (12M)** — 分母的另一半，好讓分子和分母始終陳列在贏率旁邊。
+- **Pipeline by Stage** — 各銷售階段的進行中商機金額（漏斗圖）。
+- **Monthly Revenue Trend** — 近 12 個月的成交贏單收入。
+- **Pipeline by Forecast Category** — 按預測類別分組的進行中管道。
+- **Lead Source** — 管道是從哪裡來的（環圈圖）。
+- **Open Pipeline by Owner** — 每位銷售代表進行中的金額、交易數和平均贏單機率（表格）。
+- **Quota Attainment by Rep** — 每位銷售代表當季的配額、已成交收入與達成率，讀取自預測快照。
+- **Win / Loss by Rep** — 每位銷售代表的贏單數、丟單數、已結案數、贏率和贏單金額（表格）。
+- **Win / Loss by Lead Source** — 同一份拆分換成按獲客通路來看：哪些來源帶來的商機真正能成交。
+- **Why We Lose** — 按丟單原因統計的丟單數。每筆丟單商機都必須填寫原因（[結案時強制](/zh-Hant/docs/sales/opportunities)），因此圖中不存在"未歸因"切片——圖為空表示該時間窗內沒有丟單，而不是沒人填欄位。
+- **Pipeline by Stage × Lead Source** — 進行中商機金額按階段與來源的交叉統計（樞紐分析表）。
 
-角色感知：業務代表看到自己的，經理看到團隊的，總監看到彙總。
+**控制項**：一個以成交日期為準的日期範圍選擇器（預設本季），外加 Sales Rep 和 Deal Type 篩選器。Quota Attainment by Rep 固定在當季，兩者都不作用於它——配額是為某個週期定義的，用任意範圍去重新切分它，等於拿完整的目標對比不完整的收入。
 
-## 🎧 Service Dashboard
+角色感知：銷售代表看到自己的記錄，經理看到團隊的，遵循共享規則。
+
+## ☎️ Sales Activity
+
+覆蓋度與客戶健康檢視：誰在和客戶往來、往來有多頻繁，以及沉默出現在哪裡。
+
+**磁貼**：
+
+- **Interactions Logged** — 真正發生過的通話和會議。
+- **Meetings Booked** — 已排進行事曆、但還沒有發生的會議。
+- **Customer Minutes** — 面對客戶的總時長。
+- **Tasks Completed** — 已經收尾的跟進事項，活動量的另一半。
+- **Activity by Rep** — 按負責人統計的已記錄互動數（長條圖）。
+- **Activity Volume by Week** — 每週互動數：團隊是在提速，還是在變安靜？
+- **Activity Mix** — 通話、會議與示範各占多少（環圈圖）。
+- **Where the Activity Lands** — 漏斗的哪一段拿到了注意力。
+- **Interactions on Deals** — 關聯到商機的已記錄互動數。
+- **Open Deals** — 仍在推進中的商機，用來給上一個磁貼當參照。
+- **Quiet 30+ Days** — 一個月內沒有任何已記錄互動的活躍客戶。
+- **Quiet 60+ Days** — 沉默兩個月，風險閾值。
+- **Quiet 90+ Days** — 整整一季沒有聯絡：要麼介入，要麼放棄。
+
+**控制項**：一個 Rep 篩選器。這裡**刻意沒有**日期範圍選擇器——互動日期是 datetime 欄，而平台的 datetime 篩選器轉換目前會在這類欄位上套用範圍時把每個小工具都歸零。時間改由座標軸承載：Activity Volume by Week 按週分桶，三個沉默客戶磁貼各自框住自己的 30 / 60 / 90 天閾值。
+
+## 🎧 Customer Service
 
 服務團隊的日常營運檢視。
 
-**磚貼**：
+**磁貼**：
 
-- **Open Cases by Priority** — 長條圖。
-- **Cases Approaching SLA** — 按距違約時間排序的表格。
-- **Cases Breached** — 過去 7 天（含工單擁有者）。
-- **First Response Time** — 平均值對比目標。
-- **Resolution Time** — 平均值對比目標。
-- **Customer Satisfaction (CSAT)** — 過去 30 天，趨勢。
-- **Case Volume by Origin** — Email / Phone / Web / Chat / Portal。
-- **Top Case Categories** — 用於發現產品問題。
-- **Agent Workload** — 每位客服的未結工單數。
+- **Open Cases** — 尚未結案的工單。
+- **Critical Cases** — 優先順序為 critical 的未結工單。
+- **Avg Resolution Time** — 平均結案時長（小時）。
+- **SLA Violations** — 違反了 SLA 的工單。
+- **Cases by Status** — 工作量在流程各狀態上的分布（環圈圖）。
+- **Cases by Priority** — 未結工單按緊急程度的組成（圓餅圖）。
+- **Cases by Origin** — Email / Phone / Web / Chat / Portal（長條圖）。
+- **Daily Case Volume** — 近 30 天每天新建的工單數。
+- **SLA Compliance** — 在 SLA 內解決的工單占比，對比 95% 的目標線（量表圖）。
+- **Open Cases by Priority** — 每個優先順序的未結工單數及其 SLA 違約率（表格）。
 
-*Cases Approaching SLA* 磚貼是此儀表板上點擊最多的小工具——它是客服確定優先順序的方式。
+**控制項**：Agent 和 Priority 篩選器，外加每分鐘一次的重新整理——服務台需要新鮮的數字。和 Sales Activity 一樣，這裡同樣刻意沒有日期範圍選擇器，原因是同一個 datetime 篩選器問題；Daily Case Volume 自帶 30 天的時間窗。
 
-## 👔 Executive Scorecard
+## 👔 Executive Overview
 
 業務的高階主管 / 財務檢視。
 
-**磚貼**：
+**磁貼**：
 
-- **Bookings This Quarter** — 成交贏單，對比計畫和去年同期。
-- **Pipeline Coverage** — 管道 ÷ 剩餘配額。
-- **Forecast Confidence** — 承諾 + 最佳情況對比目標。
-- **Net New ARR** — 適用於訂閱業務。
-- **Renewals This Quarter** — 即將到來、已續約、已流失。
-- **CSAT and NPS** — 客戶健康度。
-- **Customer Acquisition Cost** — 行銷活動支出 ÷ 新客戶數。
-- **Top 10 Accounts by ACV** — 年度合約價值排行榜。
-- **Pipeline Trend** — 4 週管道價值圖表。
+- **Total Revenue (YTD)** — 今年的成交贏單收入。
+- **Active Accounts** — 至少還有一段有效關係的客戶。
+- **Total Contacts** — 通訊錄裡的人。
+- **Open Leads** — 漏斗中尚未轉換的潛在客戶。
+- **Revenue Trend** — 近 12 個月的成交贏單收入。
+- **Revenue by Industry** — 年初至今的成交贏單收入按客戶產業拆分（環圈圖）。
+- **Pipeline by Stage** — 各銷售階段的進行中商機金額（漏斗圖）。
+- **New Accounts** — 近 6 個月的客戶新建節奏。
+- **Accounts by Industry** — 每個產業的年收入合計與客戶數（表格）。
+
+**控制項**：一個以成交日期為準的日期範圍選擇器（預設本季），外加 Owner 和 Lead Source 篩選器。四個 KPI 磁貼各自宣告了自己的週期（年初至今、"活躍"、"未轉換"），不會被這個選擇器收窄。
 
 此儀表板是每週領導層評審的基礎。
 
-## 個人化和建立儀表板
+## 你可以改什麼
 
-每位使用者都可以：
+- **日期範圍** — CRM Overview、Sales Performance 和 Executive Overview 各帶一個以商機預計成交日期為準的選擇器，預設本季。Sales Activity 和 Customer Service 沒有，原因見上面各自的章節。
+- **篩選器** — 每個儀表板宣告自己的一套：Owner 各處都有，另外 Sales Performance 有 Deal Type、Customer Service 有 Priority、Executive Overview 有 Lead Source。
+- **重新整理** — Customer Service 每分鐘重新整理一次，Sales Performance 每三分鐘，其餘三個每五分鐘。
 
-- 將任何儀表板**釘選**為著陸頁。
-- 按日期範圍、團隊、地區、產品**篩選**儀表板。
-- **下鑽**到任何磚貼以檢視底層記錄。
-- 將任何磚貼**匯出**為圖片或 PDF。
-- **訂閱**以透過電子郵件接收每週 PDF。
+有些磁貼刻意不接受所在儀表板的篩選器。12 個月的收入趨勢、Top Products 和 Quota Attainment by Rep 都保持自己標題上寫明的那個時間窗，這樣更窄的日期選擇器就無法在標題不變的情況下悄悄改掉數字的定義。
 
-管理員可以：
+## 數字是從哪裡來的
 
-- 從 **Analytics › Dashboards › New** 選單建立新儀表板。
-- 從標準庫選擇小工具，或從 [多維資料集](/zh-Hant/docs/analytics/cubes) 建構自訂小工具。
-- 設定受眾——誰預設看到每個儀表板。
-- 安排快照（例如自動產生的季度 QBR 簡報）。
+每個磁貼都綁定到一個資料集——正是這一層語意把"管道""已結案交易""SLA 違約"各定義一次，供用到它們的每個磁貼和報表共用。可用的度量和維度見 [資料集與多維資料集](/zh-Hant/docs/analytics/cubes)，彙總數字背後的記錄層級檢視見 [報表](/zh-Hant/docs/analytics/reports)。
 
-## 給經理的提示
+出現在不只一個儀表板上的定義是共享的，而不是重新敲一遍：Pipeline by Stage 和 Avg Deal Size 各自只有一份定義，分別被三個和兩個儀表板使用，所以"進行中管道"不會在不同頁面上變成不同的意思。
 
-- ✅ 為你的團隊**訂閱儀表板 PDF**——週一早上 8 點是很好的節奏。
-- ✅ 每週五使用 **Slipping Deals** 磚貼來規劃下週的交易評審通話。
-- ✅ 不要從電子郵件管理——從儀表板管理。電子郵件用於採取行動；儀表板用於呈現事實。
+## 提示
 
-## 給高階主管的提示
-
-- ✅ 從多維資料集建構一個**董事會檢視**儀表板——成交、管道、流失、CSAT——一頁搞定。
-- ✅ 設定**閾值告警**（例如管道覆蓋率 &lt;2.5×），以便在問題出現前得到提醒。
-
-## 給管理員的提示
-
-- ✅ 建構儀表板時，**從多維資料集開始**而非臨時查詢——它們更快也更一致。
-- ✅ 鼓勵使用者**複製並個人化**，而非從頭重建。
-- ✅ 每季稽核儀表板使用情況——淘汰無人開啟的儀表板。
+- ✅ 管道評審之前，把 **Win / Loss by Rep** 和 **Why We Lose** 放在一起讀——前者說誰在轉化，後者說是什麼在打敗你。
+- ✅ 每週都處理一次 **Quiet 90+ Days** 磁貼。一季都沒有任何已記錄互動的客戶，要麼已經休眠，要麼早就走了；而這個磁貼的價值上限，就是你的團隊真正記錄下來的互動量。
+- ✅ 在服務台，把 **SLA Violations**（違約的絕對筆數）和 **SLA Compliance** 磁貼（對比目標的達標率）一起看——小基數上的一個小數字，和一個健康的達標率不是一回事。
+- ✅ 把 **Interactions on Deals** 對著 **Open Deals** 讀：覆蓋度問題的答案是這兩者的比值，而不是其中任何一個單獨的數字。

--- a/test/docs-drift.test.ts
+++ b/test/docs-drift.test.ts
@@ -340,16 +340,29 @@ describe('documented agent names resolve to a platform agent', () => {
  * page from silently omitting a whole dashboard, which is the case that actually
  * bit.
  *
- * Locale note: `dashboards.zh-Hans.mdx` / `.zh-Hant.mdx` carry the same tile
- * lists — the bold names are left in English there — so they can join `DOC_PAGES`
- * unchanged once their prose is retranslated against the current dashboards.
- * They are out of this rule's scope only because they still hold the old text.
+ * Locale note (#685): `dashboards.zh-Hans.mdx` / `.zh-Hant.mdx` were retranslated
+ * against the current English page and now sit in `DOC_PAGES` alongside it. The
+ * extraction is locale-agnostic on purpose — the section headings carry each
+ * dashboard's own English `label` and the bold tile names are left in English in
+ * every locale, so the same two regexes resolve all three files. That is what
+ * makes the section-coverage rule bite per locale: registering a sixth dashboard
+ * now fails until all three pages document it, which is the shape #592 needed.
+ *
+ * One asymmetry to know about: the `**Name** tile` prose rule below keys on the
+ * English word "tile", so it only ever fires on the English page — the zh pages
+ * say `**Quiet 90+ Days** 磁贴 / 磁貼`. Their tile LISTS are fully checked; a
+ * stray tile name in their running prose is not. Widen `TILE_REFERENCE` if that
+ * becomes a real defect, rather than assuming it is already covered.
  */
 describe('the dashboards docs page lists tiles that exist', () => {
   type AnyRec = Record<string, any>;
   const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
 
-  const DOC_PAGES = ['content/docs/analytics/dashboards.mdx'];
+  const DOC_PAGES = [
+    'content/docs/analytics/dashboards.mdx',
+    'content/docs/analytics/dashboards.zh-Hans.mdx',
+    'content/docs/analytics/dashboards.zh-Hant.mdx',
+  ];
 
   /** `## 🏠 CRM Overview` → heading text + everything up to the next `## `. */
   const sectionsOf = (text: string): { heading: string; body: string }[] => {


### PR DESCRIPTION
Fixes #685

## 前提复核（对照 origin/main，实测）

三条前提逐条成立：

1. **英文页已定稿** —— `content/docs/analytics/dashboards.mdx` 在 origin/main 上就是 #610 / PR #677 的重写结果（五个仪表盘、真实磁贴、无编造统计）。
2. **两个语言页仍是旧文** —— 逐字仍写「四个仪表盘 / 四個儀表板」、`Slipping Deals`、`Cases Approaching SLA`、`Net New ARR`、`CSAT and NPS`，以及那句编造的点击统计。
3. **守卫只读英文页** —— `test/docs-drift.test.ts` 的 `DOC_PAGES` 在 origin/main 上是单元素数组。

另外，我没有相信任何一份文档，而是把五个仪表盘和它们的真实 widget title 直接从 `src/dashboards/` 的元数据里跑出来对照（`stack.dashboards` 逐个 dump）。结果与当前英文页 **逐条一致**：

| `name` | `label` | widgets | dateRange | refresh |
| --- | --- | --- | --- | --- |
| `crm_overview_dashboard` | CRM Overview | 9 | close_date / this_quarter | 300s |
| `sales_dashboard` | Sales Performance | 17 | close_date / this_quarter | 180s |
| `sales_activity_dashboard` | Sales Activity | 13 | 无 | 300s |
| `service_dashboard` | Customer Service | 10 | 无 | 60s |
| `executive_dashboard` | Executive Overview | 9 | close_date / this_quarter | 300s |

`sales_activity_dashboard`（#592 / PR #670 注册）在两个语言页里此前**完全没有章节**。

## 改了什么

### 两个语言页：重译，不是替换

按当前英文页重写，而不是把假磁贴名机械换成真磁贴名。五个仪表盘各自的章节、真实 widget 标题、真实控件（Sales Activity 与 Customer Service **刻意没有**日期范围选择器，以及原因）、「没有任何磁贴显示趋势箭头」一节、共享定义与 filter opt-out 的说明，全部译出。

那句编造的定量统计（「*Cases Approaching SLA* 磁贴是此仪表盘上点击最多的小部件」）是**删除**，不是软化 —— 磁贴不存在，本仓也不采集任何点击遥测，这句话没有可被弱化的真值内核。旧页里的趋势断言（「与上周对比的趋势」「过去 30 天，趋势」）同样删除：#587 之后没有任何磁贴显示同环比。

术语对齐邻近的 zh 分析页（`cubes` / `reports` / `faq`）：多维数据集 / 多維資料集、磁贴 / 磁貼、小部件 / 小工具、线索来源 / 潛在客戶來源、行业 / 產業。zh-Hant 页顺带把误转换的 **磚貼**（「砖」）改回 **磁貼** —— 这是 `faq.zh-Hant.mdx` 等其余 zh-Hant 文档已经在用的写法。链接改用 `/zh-Hans/` `/zh-Hant/` 前缀，与该目录 219 处既有链接一致（旧页里 `Why We Lose` 那条漏了前缀）。

结构上守住守卫需要的两点：**章节标题带各仪表盘自己的英文 `label`**（emoji 前缀不计），**加粗磁贴名保持英文**。

### 守卫：`DOC_PAGES` 加两条路径（同 PR）

抽取逻辑本来就与语言无关，所以两个路径直接加进数组即可，两条规则随即按语言各自生效。**必须与重译同 PR** —— 先加会直接红 CI，这也是 #610 当时把它留下的唯一原因。

同时更新了紧邻的那段 Locale note 注释：它原文写着两个语言页 out of this rule's scope only because they still hold the old text，在本 PR 之后就是假话了。

## 反向验证（先定方向，再跑）

方向是**标准红向**：守卫是「listed ⇒ exists」，本 PR 新增的是文件面而非判据，所以往 zh 页注入一个假磁贴，改动前应绿、改动后应红。两个方向都实测：

**A. 注入假磁贴 → 红，且点名 zh 文件**（在 zh-Hans 的 Sales Performance 里加回 `- **Slipping Deals** — …`）：

```
× Sales Performance: every tile the page lists is a widget on this dashboard
  content/docs/analytics/dashboards.zh-Hans.mdx: "Sales Performance" lists a tile
  "Slipping Deals" that sales_dashboard does not ship (widgets: Total Pipeline | ...)
  Tests  1 failed | 28 passed (29)
```

**B. 同一处注入保留，`DOC_PAGES` 回退为改动前的单元素数组 → 绿**，证明这份覆盖确实是本 PR 新增的、而不是本来就在：

```
Test Files  1 passed (1)
     Tests  29 passed (29)
```

**C. 章节覆盖那一半（这才是 #592 真正踩到的形状）**：把 zh-Hant 的 `## ☎️ Sales Activity` 标题本地化掉，模拟「某语言页漏掉一个已注册仪表盘」：

```
× every registered dashboard has a section on the page
  content/docs/analytics/dashboards.zh-Hant.mdx has no section for: Sales Activity.
  Tests  1 failed | 28 passed (29)
```

三处注入均已还原。

## 一处如实记录的不对称（没有隐瞒，也没有顺手扩大改动）

`TILE_REFERENCE` 正则匹配的是英文单词 `tile` / `tiles`，而 zh 页写的是 `**Quiet 90+ Days** 磁贴 / 磁貼`。所以：两个语言页的**磁贴清单**被完整检查，但它们**正文散文里**的磁贴引用不被检查 —— 这条规则事实上只在英文页上开火。

我没有顺手改正则：本单的文件面明确限定为「`DOC_PAGES` 增两路径」，而放宽 `TILE_REFERENCE` 是一个判据变更，属于另一次决定。这一点已写进测试文件的注释里，免得下一个读者以为已经覆盖。本 PR 里 zh 页正文引用的每个磁贴（`Win / Loss by Rep`、`Why We Lose`、`Quiet 90+ Days`、`SLA Violations`、`SLA Compliance`、`Interactions on Deals`、`Open Deals`）都是真实 widget，人工逐条核过。

## 验证

```
npx vitest run test/docs-drift.test.ts   →  Test Files 1 passed (1) / Tests 29 passed (29)
pnpm typecheck                           →  exit 0
node scripts/check-source-hygiene.mjs    →  source hygiene clean (237 files)
npx vitest run --maxWorkers=2            →  Test Files 58 passed (58)
                                            Tests 1397 passed | 1 skipped (1398)
```

守卫现在覆盖三份文件：`every registered dashboard has a section on the page`，以及五个按 label 参数化的 `每个仪表盘: every tile the page lists is a widget on this dashboard`，全部对三份文件逐一断言。

（注：上一版正文里这句写作反尖括号包裹的 label 占位符，被 GitHub 的正文清洗器当成 HTML 标签吞掉了 —— 已改写为不含裸尖括号的形式。）

平台依赖未动，仍固定在 `@objectstack/*` 17.0.0-rc.2。未触碰 `content/docs/releases/`、英文 `dashboards.mdx`、`src/views/**`、`src/flows/**`。

https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa
