### PR TITLE
fix(views): bind lead form predicates to `record` and make them total (#688)

### DIFF
--- a/.changeset/view-predicates-record-bound-and-total.md
+++ b/.changeset/view-predicates-record-bound-and-total.md
@@ -1,0 +1,35 @@
+---
+'hotcrm': patch
+---
+
+Leads can be created from the console again: every conditional field on the lead
+forms now hides when it should, instead of appearing as a mandatory field nobody
+can satisfy.
+
+Console → Leads → New was unusable. Submit was blocked client-side with five
+"required" errors — Disqualification Reason, Duplicate Of, Duplicate Of Lead,
+Duplicate Of Contact, Duplicate Status — and no write ever reached the server.
+The form was not merely annoying, it was **unsatisfiable**: `duplicate_of_lead`
+and `duplicate_of_contact` are mutually exclusive by design, so it demanded the
+new lead be a duplicate of an existing lead *and* of an existing contact at once.
+Creating a lead through the REST API worked (201) the whole time, because the
+object's `requiredWhen` predicates were already written correctly.
+
+The cause was the form predicates, in this app's own metadata. They were spelled
+with bare field names (`status == "unqualified"`), but the renderer binds field
+values under the `record` namespace, so a bare name is an unbound identifier and
+the predicate **never** evaluates — for any record, in any state. An
+unevaluable visibility predicate fails open: the field renders, and a rendered
+field enforces its `required` flag. Every such predicate in `src/views/` is
+rewritten to the `record.`-bound form the object files already use, and made
+total with `has(record.x)` guards (plus `!= null` on ordering comparisons) so it
+still answers on a brand-new record whose keys do not exist yet — prefixing alone
+would have left the same five fields failing on exactly the New form where the
+bug was reported. The `duplicate_of_lead` / `duplicate_of_contact` predicates are
+now character-for-character identical to the object's `requiredWhen`, so the form
+shows a lookup exactly when the server will demand it.
+
+No field, requirement or label changed — only the predicates that decide when a
+field is shown. `test/view-predicate-dialect.test.ts` enumerates every predicate
+from the compiled stack and fails on any that references an unbound namespace or
+cannot evaluate, so a bare-name predicate cannot land green again.

--- a/src/views/lead.view.ts
+++ b/src/views/lead.view.ts
@@ -1,7 +1,51 @@
-import { P } from '@objectstack/spec';
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
+import { P } from '@objectstack/spec';
 import { defineView } from '@objectstack/spec/ui';
+
+/**
+ * ═══ HOUSE RULE: form predicates are `record.`-bound AND TOTAL ═════════════
+ *
+ * Every `visibleOn` / `visibleWhen` below is a CEL predicate the *renderer*
+ * evaluates, and it must satisfy two properties. `test/view-predicate-dialect.test.ts`
+ * enforces both against the compiled stack, so you do not have to remember them.
+ *
+ * 1. **`record.`-bound.** The evaluation context binds field values under the
+ *    `record` namespace (`buildScope` in `@objectstack/formula` binds exactly
+ *    `record` / `previous` / `input` / `user` / `current_user` / `ctx` / `os`).
+ *    A bare field name is an unbound identifier, so it never evaluates:
+ *
+ *        evaluate('status == "unqualified"',        { record: { status: 'new' } })
+ *          → ok:false  type  "Unknown variable: status"       ← for EVERY record
+ *        evaluate('record.status == "unqualified"', { record: { status: 'new' } })
+ *          → ok:true   false
+ *
+ * 2. **TOTAL** — the same `has(record.x)` rule AGENTS.md states for
+ *    `validations[].condition` / `requiredWhen` / `readonlyWhen` / `visibleWhen`
+ *    (#630). Prefixing alone is not enough: on a *brand-new* record the key is
+ *    absent, and strict CEL aborts on the read:
+ *
+ *        evaluate('record.duplicate_of_type == "crm_lead"',                { record: {} })
+ *          → ok:false  "No such key: duplicate_of_type"
+ *        evaluate('has(record.duplicate_of_type) && record.duplicate_of_type == "crm_lead"',
+ *                                                                          { record: {} })
+ *          → ok:true   false
+ *
+ * Why both matter here and not only in theory (#688): the console's predicate
+ * evaluation **fails OPEN** — an unevaluable `visibleWhen` defaults the field to
+ * *visible*, with no diagnostic — and a visible field carries its `required: true`
+ * into client-side submit validation. So a predicate that cannot answer does not
+ * degrade to "shown but optional"; it makes the form unsatisfiable. On `crm_lead`
+ * this rendered all five conditional disqualification fields at once and demanded
+ * a new lead be a duplicate of *both* a lead and a contact — mutually exclusive by
+ * design — so no lead could be created through the UI at all. The fail-open half
+ * is tracked upstream at objectstack-ai/objectstack#5149; these predicates are the
+ * half this repo owns, and they must be able to answer.
+ *
+ * Numeric comparisons carry `!= null` on top of `has(...)`, matching the object
+ * files: `has(record.rating) && record.rating != null && record.rating >= 4`.
+ * Strict CEL aborts on `dyn<null> < int`, which `has()` alone does not prevent.
+ */
 
 /**
  * The duplicate-link block (#598), spread into every form that offers
@@ -17,28 +61,31 @@ import { defineView } from '@objectstack/spec/ui';
  * this shape is meant to make impossible.
  *
  * The two lookups mirror the object's `requiredWhen` predicates: each appears
- * only when `duplicate_of_type` names its object.
+ * only when `duplicate_of_type` names its object — and now says so in the same
+ * words, character for character as the `requiredWhen` on those two fields in
+ * `lead.object.ts`, so the form shows a lookup exactly when the server will
+ * demand it. `test/view-predicate-dialect.test.ts` pins the two together.
  */
 const DUPLICATE_LINK_FIELDS = [
   {
     field: 'duplicate_of_type',
     required: true,
-    visibleOn: 'disqualification_reason == "duplicate"',
+    visibleOn: P`has(record.disqualification_reason) && record.disqualification_reason == "duplicate"`,
   },
   {
     field: 'duplicate_of_lead',
     required: true,
-    visibleOn: 'duplicate_of_type == "crm_lead"',
+    visibleOn: P`has(record.duplicate_of_type) && record.duplicate_of_type == "crm_lead"`,
   },
   {
     field: 'duplicate_of_contact',
     required: true,
-    visibleOn: 'duplicate_of_type == "crm_contact"',
+    visibleOn: P`has(record.duplicate_of_type) && record.duplicate_of_type == "crm_contact"`,
   },
   {
     field: 'duplicate_status',
     required: true,
-    visibleOn: 'disqualification_reason == "duplicate"',
+    visibleOn: P`has(record.disqualification_reason) && record.disqualification_reason == "duplicate"`,
     helpText: 'Confirmed means a human checked the two records and they are the same person.',
   },
 ];
@@ -207,7 +254,7 @@ export const LeadViews = defineView({
           {
             field: 'disqualification_reason',
             required: true,
-            visibleOn: 'status == "unqualified"',
+            visibleOn: P`has(record.status) && record.status == "unqualified"`,
           },
           ...DUPLICATE_LINK_FIELDS,
         ],
@@ -470,7 +517,7 @@ export const LeadViews = defineView({
             {
               field: 'disqualification_reason',
               required: true,
-              visibleOn: 'status == "unqualified"',
+              visibleOn: P`has(record.status) && record.status == "unqualified"`,
             },
             ...DUPLICATE_LINK_FIELDS,
           ],
@@ -513,7 +560,7 @@ export const LeadViews = defineView({
             {
               field: 'disqualification_reason',
               required: true,
-              visibleOn: 'status == "unqualified"',
+              visibleOn: P`has(record.status) && record.status == "unqualified"`,
             },
             ...DUPLICATE_LINK_FIELDS,
           ],
@@ -584,14 +631,16 @@ export const LeadViews = defineView({
             {
               field: 'disqualification_reason',
               required: true,
-              visibleOn: 'status == "unqualified"',
+              visibleOn: P`has(record.status) && record.status == "unqualified"`,
             },
             ...DUPLICATE_LINK_FIELDS,
             { field: 'rating', widget: 'star_rating' },
             'lead_source',
             {
               field: 'owner_id',
-              visibleOn: 'rating >= 4', // Conditional visibility
+              // Conditional visibility. `!= null` on top of `has(...)`: strict
+              // CEL aborts on `dyn<null> < int`, which `has()` alone allows.
+              visibleOn: P`has(record.rating) && record.rating != null && record.rating >= 4`,
             },
           ],
         },
@@ -633,7 +682,7 @@ export const LeadViews = defineView({
             {
               field: 'disqualification_reason',
               required: true,
-              visibleOn: 'status == "unqualified"',
+              visibleOn: P`has(record.status) && record.status == "unqualified"`,
             },
             ...DUPLICATE_LINK_FIELDS,
           ],
@@ -680,13 +729,16 @@ export const LeadViews = defineView({
             'lead_source',
             {
               field: 'owner_id',
-              visibleOn: 'status != "new"', // Only show owner after initial contact
+              // Only show owner after initial contact. A record with no status
+              // yet has not been contacted, so `!isBlank` keeps the blank case
+              // on the "hidden" side rather than letting `null != "new"` show it.
+              visibleOn: P`has(record.status) && !isBlank(record.status) && record.status != "new"`,
             },
             // See the default form: `unqualified` requires a reason.
             {
               field: 'disqualification_reason',
               required: true,
-              visibleOn: 'status == "unqualified"',
+              visibleOn: P`has(record.status) && record.status == "unqualified"`,
             },
             ...DUPLICATE_LINK_FIELDS,
           ],
@@ -720,7 +772,8 @@ export const LeadViews = defineView({
             {
               field: 'rating',
               widget: 'star_rating',
-              visibleOn: 'status == "qualified"', // Only show rating for qualified leads
+              // Only show rating for qualified leads
+              visibleOn: P`has(record.status) && record.status == "qualified"`,
             },
             // The reason picklist, not just free-text notes: it is what the
             // `disqualification_reason_required` validation checks, and this
@@ -728,13 +781,14 @@ export const LeadViews = defineView({
             {
               field: 'disqualification_reason',
               required: true,
-              visibleOn: 'status == "unqualified"',
+              visibleOn: P`has(record.status) && record.status == "unqualified"`,
             },
             ...DUPLICATE_LINK_FIELDS,
             {
               field: 'notes',
               placeholder: 'Add notes about this status change',
-              visibleOn: 'status == "unqualified"', // Free-text context alongside the reason
+              // Free-text context alongside the reason
+              visibleOn: P`has(record.status) && record.status == "unqualified"`,
             },
           ],
         },
@@ -823,7 +877,9 @@ export const LeadViews = defineView({
             {
               field: 'rating',
               widget: 'star_rating',
-              visibleOn: 'status != "new"', // Only show after first contact
+              // Only show after first contact — see the drawer form's note on
+              // why blank stays on the "hidden" side.
+              visibleOn: P`has(record.status) && !isBlank(record.status) && record.status != "new"`,
             },
             {
               field: 'industry',
@@ -831,29 +887,31 @@ export const LeadViews = defineView({
             },
             {
               field: 'annual_revenue',
-              visibleOn: 'rating >= 3', // Only for qualified leads
+              // Only for qualified leads
+              visibleOn: P`has(record.rating) && record.rating != null && record.rating >= 3`,
             },
             {
               field: 'number_of_employees',
-              visibleOn: P`record.rating >= 3`,
+              visibleOn: P`has(record.rating) && record.rating != null && record.rating >= 3`,
             },
             {
               field: 'owner_id',
               required: true,
-              visibleOn: P`record.status == "contacted" || record.status == "qualified"`,
+              visibleOn: P`has(record.status) && (record.status == "contacted" || record.status == "qualified")`,
             },
             // See the default form: `unqualified` requires a reason.
             {
               field: 'disqualification_reason',
               required: true,
-              visibleOn: 'status == "unqualified"',
+              visibleOn: P`has(record.status) && record.status == "unqualified"`,
             },
             ...DUPLICATE_LINK_FIELDS,
             {
               field: 'notes',
               colSpan: 2,
               required: true,
-              visibleOn: 'status == "unqualified"', // Require explanation for unqualified
+              // Require explanation for unqualified
+              visibleOn: P`has(record.status) && record.status == "unqualified"`,
             },
           ],
         },

--- a/test/view-predicate-dialect.test.ts
+++ b/test/view-predicate-dialect.test.ts
@@ -1,0 +1,428 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { ExpressionEngine, buildScope, collectCelRootIdentifiers } from '@objectstack/formula';
+import stack from '../objectstack.config';
+import { REPO_ROOT } from './helpers/repo-root';
+
+/**
+ * ═══ HOUSE RULE: view predicates are `record.`-bound AND TOTAL ═════════════
+ *
+ * **Every predicate in `src/views/*.view.ts` reads its field values through the
+ * `record` namespace, and every `record.x` read carries a `has(record.x)`
+ * guard** (plus `!= null` when the comparison is an ordering one). A form
+ * predicate must return a verdict for every record shape the renderer can hand
+ * it — never abort. This file enforces it; you do not have to remember it.
+ *
+ * This is the SAME totality rule `test/object-validation-predicates.test.ts`
+ * states for object `validations[]` and `test/flow-condition-totality.test.ts`
+ * states for record-change flow conditions, applied to a **third surface with a
+ * third failure mode**. Per #633 the surfaces were measured separately rather
+ * than assumed alike, and this one is the worst of the three:
+ *
+ *   | surface                  | unevaluable predicate ⇒                      |
+ *   | ------------------------ | -------------------------------------------- |
+ *   | object `validations[]`   | write REJECTED, named rule (17.0.0-rc.2)     |
+ *   | flow condition           | run FAILS, logged at ERROR                   |
+ *   | view `visibleWhen` (here)| FAILS OPEN — field shown, no diagnostic      |
+ *
+ * A silently-visible field is not a cosmetic defect, because a *visible* field
+ * carries its `required: true` into the console's client-side submit check. So
+ * a predicate that cannot answer does not degrade to "shown but optional" — it
+ * makes the form unsatisfiable.
+ *
+ * ### What that cost, and the two measurements the rule rests on (#688)
+ *
+ * Console → Leads → New was unusable on 17.0.0-rc.2: submit was blocked with
+ * five "required" errors for fields that cannot apply to a brand-new lead, and
+ * zero network writes fired. `duplicate_of_lead` and `duplicate_of_contact` are
+ * mutually exclusive by design, so the form demanded something no input could
+ * satisfy. REST create returned 201 for the same payload — the object's
+ * `requiredWhen` predicates were already `record.`-bound AND guarded, so the
+ * server half was right the whole time. Only the form half was wrong.
+ *
+ * Both halves of the mechanism were measured on the platform's own engine
+ * (`ExpressionEngine` from `@objectstack/formula` — the evaluator the console
+ * bundle drives, per objectstack#5149's `a.evaluate(Ie(e), { record, previous, … })`):
+ *
+ *   1. **Namespace.** Values bind under `record`; a bare field name is an
+ *      unbound identifier, so it fails for EVERY record — the predicate is not
+ *      "sometimes wrong", it never evaluates at all:
+ *
+ *          evaluate('status == "unqualified"', { record: { status: 'unqualified' } })
+ *            → ok:false  kind=type  "Unknown variable: status"
+ *          evaluate('record.status == "unqualified"', { record: { status: 'new' } })
+ *            → ok:true   false
+ *          evaluate('record.status == "unqualified"', { record: { status: 'unqualified' } })
+ *            → ok:true   true
+ *
+ *   2. **Totality.** Prefixing alone does not finish the job. A *new* record has
+ *      no key for a field the user has not touched, and strict CEL aborts on the
+ *      read — which fails open again, for exactly the five fields in the report:
+ *
+ *          evaluate('record.duplicate_of_type == "crm_lead"', { record: {} })
+ *            → ok:false  "No such key: duplicate_of_type"
+ *          evaluate('has(record.duplicate_of_type) && record.duplicate_of_type == "crm_lead"',
+ *                                                            { record: {} })
+ *            → ok:true   false
+ *
+ * `!= null` is not a substitute for `has(...)`, and `isBlank(record.f)` /
+ * `coalesce(record.f, "")` abort on an absent key too — see the measured table
+ * in `test/object-validation-predicates.test.ts`. Ordering comparisons need
+ * both guards, because `has()` alone still admits `dyn<null> < int`.
+ *
+ * ### Scope of this file vs. the platform half
+ *
+ * The fail-open behaviour itself — an unevaluable `visibleWhen` defaulting to
+ * *visible*, with no diagnostic anywhere — is a platform question and stays
+ * upstream at objectstack-ai/objectstack#5149. It is deliberately NOT worked
+ * around here, and this file cannot reproduce it: the fail-open wrapper lives
+ * in the console bundle, not in `@objectstack/formula`. What this file pins is
+ * the half HotCRM owns and can keep true forever — that no predicate this app
+ * ships can fail to evaluate in the first place, whichever way the platform
+ * later decides to treat one that does.
+ */
+
+type AnyRec = Record<string, any>;
+
+/**
+ * The namespace roots the evaluator actually binds — read off `buildScope`
+ * rather than hand-listed, so this file tracks the platform instead of drifting
+ * from it. Measured on 17.0.0-rc.2:
+ * `record, previous, input, current_user, user, ctx, os`.
+ */
+const BOUND_ROOTS = new Set(
+  Object.keys(
+    buildScope({
+      record: {},
+      previous: {},
+      input: {},
+      user: { id: 'u' },
+      org: { id: 'o' },
+      env: 'test',
+    }),
+  ),
+);
+
+/**
+ * Every expression the compiled stack carries under `views`, enumerated by
+ * walking the artifact — NOT from a hand-kept list of view files or of
+ * predicate key names.
+ *
+ * Two reasons the walk collects *envelopes* (`{ dialect, source }`) rather than
+ * looking up known keys: `visibleOn` does not survive compilation (ADR-0089 D2
+ * folds it into `visibleWhen` at the schema boundary), and a key list cannot
+ * grow when the platform adds a predicate-bearing key. Anything expression-
+ * shaped anywhere under `stack.views` is in scope by construction. Measured on
+ * 17.0.0-rc.2: 49 envelopes, all of them `visibleWhen`, all `dialect: 'cel'`.
+ */
+function collectExpressions(root: unknown, path: string, out: { path: string; expr: AnyRec }[]) {
+  if (Array.isArray(root)) {
+    root.forEach((n, i) => collectExpressions(n, `${path}[${i}]`, out));
+    return;
+  }
+  if (!root || typeof root !== 'object') return;
+  const node = root as AnyRec;
+  if (typeof node.dialect === 'string' && ('source' in node || 'ast' in node)) {
+    out.push({ path, expr: node });
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) collectExpressions(value, `${path}.${key}`, out);
+}
+
+/** Object names referenced anywhere inside one view bundle — used for labels. */
+function objectsOf(view: unknown, found = new Set<string>()): Set<string> {
+  if (Array.isArray(view)) {
+    view.forEach((v) => objectsOf(v, found));
+    return found;
+  }
+  if (view && typeof view === 'object') {
+    const node = view as AnyRec;
+    if (typeof node.object === 'string') found.add(node.object);
+    Object.values(node).forEach((v) => objectsOf(v, found));
+  }
+  return found;
+}
+
+const viewBundles: AnyRec[] = ((stack as AnyRec).views ?? []) as AnyRec[];
+
+const predicates = viewBundles.flatMap((view, index) => {
+  const label = [...objectsOf(view)].filter((n) => n.startsWith('crm_'))[0] ?? `views[${index}]`;
+  const found: { path: string; expr: AnyRec }[] = [];
+  collectExpressions(view, `views[${index}]`, found);
+  return found.map(({ path, expr }) => ({
+    id: `${label} ${path.replace(`views[${index}]`, '')}`,
+    path,
+    dialect: String(expr.dialect),
+    source: String(expr.source ?? ''),
+  }));
+});
+
+/**
+ * A record shape with EVERY conditional field populated — the "shown" side of
+ * each predicate has to be reachable, or a rule that always answers `false`
+ * would pass the totality sweep while hiding the field forever.
+ */
+const POPULATED_LEAD = {
+  first_name: 'Ada',
+  last_name: 'Lovelace',
+  company: 'Analytical Engines',
+  email: 'ada@example.com',
+  status: 'unqualified',
+  rating: 5,
+  lead_source: 'web',
+  industry: 'technology',
+  owner_id: 'user-1',
+  notes: 'duplicate of an existing record',
+  disqualification_reason: 'duplicate',
+  duplicate_of_type: 'crm_lead',
+  duplicate_of_lead: 'lead-1',
+  duplicate_of_contact: null,
+  duplicate_status: 'confirmed',
+};
+
+function evaluatePredicate(source: string, record: AnyRec) {
+  return ExpressionEngine.evaluate({ dialect: 'cel', source }, { record });
+}
+
+describe('view predicates — the sweep itself', () => {
+  it('finds a predicate for every one authored in src/views', () => {
+    const viewsDir = join(REPO_ROOT, 'src', 'views');
+    const authored = readdirSync(viewsDir)
+      .filter((f) => f.endsWith('.view.ts'))
+      .reduce((total, file) => {
+        const src = readFileSync(join(viewsDir, file), 'utf8');
+        // Assignments only — the word also appears in prose comments.
+        return total + (src.match(/^\s*(visibleOn|visibleWhen):/gm) ?? []).length;
+      }, 0);
+
+    // Anti-vacuity. Every assertion below is `for (const p of predicates)`, so an
+    // enumeration that silently collected nothing would make this whole file
+    // pass by producing no verdicts at all. Tie it to the source of truth on
+    // disk: the compiled stack must carry at least as many predicates as the
+    // view files declare (`>=`, because one authored constant is spread into
+    // several forms).
+    expect(authored).toBeGreaterThan(0);
+    expect(predicates.length).toBeGreaterThanOrEqual(authored);
+  });
+
+  it('only produces predicates the CEL engine handles', () => {
+    for (const p of predicates) {
+      expect(p.dialect, `${p.id} — non-CEL dialect on a visibility predicate`).toBe('cel');
+      expect(p.source.trim(), `${p.id} — empty predicate source`).not.toBe('');
+    }
+  });
+});
+
+describe('view predicates are record-bound', () => {
+  it('references only namespaces the evaluator binds', () => {
+    const offenders: string[] = [];
+    for (const p of predicates) {
+      const roots = collectCelRootIdentifiers(p.source);
+      if (!roots.ok) {
+        offenders.push(`${p.id}: does not parse — ${roots.error}`);
+        continue;
+      }
+      const unbound = roots.roots.filter((r) => !BOUND_ROOTS.has(r));
+      if (unbound.length > 0) {
+        offenders.push(
+          `${p.id}: unbound root(s) ${unbound.join(', ')} in \`${p.source}\` — ` +
+            `field values bind under \`record\`, so write \`record.${unbound[0]}\``,
+        );
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([]);
+  });
+
+  it('a bare field name really is unbound — the premise this rule rests on', () => {
+    // Reverse verification, pinned rather than assumed. If a future platform
+    // release starts binding bare field names, this flips and the reader is
+    // told the rule's premise changed instead of quietly guarding nothing.
+    // Direction is deliberate: the bare spelling must fail even when the record
+    // DOES carry the field, because the identifier — not the value — is missing.
+    const bare = evaluatePredicate('status == "unqualified"', { status: 'unqualified' });
+    expect(bare.ok).toBe(false);
+    if (!bare.ok) expect(bare.error.message).toContain('Unknown variable: status');
+
+    const bound = evaluatePredicate('record.status == "unqualified"', { status: 'unqualified' });
+    expect(bound).toEqual({ ok: true, value: true });
+  });
+});
+
+describe('view predicates are TOTAL on the real engine', () => {
+  it('answers on a brand-new record with no keys at all', () => {
+    // The shape the console hands a `New` form. This is the assertion that
+    // would have caught #688: on 17.0.0-rc.2 every one of the five lead fields
+    // failed here, and a failed predicate is a VISIBLE, REQUIRED field.
+    const offenders: string[] = [];
+    for (const p of predicates) {
+      const result = evaluatePredicate(p.source, {});
+      if (!result.ok) {
+        offenders.push(`${p.id}: ${result.error.kind} — ${result.error.message.split('\n')[0]}`);
+      } else if (typeof result.value !== 'boolean') {
+        offenders.push(`${p.id}: returned ${typeof result.value}, not a boolean verdict`);
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([]);
+  });
+
+  it('answers on a fully populated record', () => {
+    const offenders: string[] = [];
+    for (const p of predicates) {
+      const result = evaluatePredicate(p.source, POPULATED_LEAD);
+      if (!result.ok) {
+        offenders.push(`${p.id}: ${result.error.kind} — ${result.error.message.split('\n')[0]}`);
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([]);
+  });
+
+  it('answers when every field is present but null', () => {
+    // `has()` is true for a present-but-null key, so this shape is what catches
+    // an ordering comparison guarded by `has()` alone (`dyn<null> < int`).
+    const allNull = Object.fromEntries(Object.keys(POPULATED_LEAD).map((k) => [k, null]));
+    const offenders: string[] = [];
+    for (const p of predicates) {
+      const result = evaluatePredicate(p.source, allNull);
+      if (!result.ok) {
+        offenders.push(`${p.id}: ${result.error.kind} — ${result.error.message.split('\n')[0]}`);
+      }
+    }
+    expect(offenders, offenders.join('\n')).toEqual([]);
+  });
+});
+
+/**
+ * The reported form, end to end at the metadata level (#688).
+ *
+ * Totality alone is not the acceptance criterion — a predicate hard-wired to
+ * `false` is total and useless. Each of the five fields is checked in BOTH
+ * directions: hidden on the new lead the report could not create, and shown in
+ * the state that is supposed to summon it.
+ */
+describe('crm_lead — the five fields that blocked lead creation', () => {
+  const leadView = viewBundles.find((v) => objectsOf(v).has('crm_lead'));
+
+  /** Field entries of the default form, keyed by field name, from the artifact. */
+  const formFields = new Map<string, AnyRec>();
+  for (const section of (leadView?.form?.sections ?? []) as AnyRec[]) {
+    for (const field of (section.fields ?? []) as unknown[]) {
+      if (field && typeof field === 'object' && typeof (field as AnyRec).field === 'string') {
+        formFields.set((field as AnyRec).field, field as AnyRec);
+      }
+    }
+  }
+
+  const NEW_LEAD = {
+    first_name: 'Grace',
+    last_name: 'Hopper',
+    company: 'UNIVAC',
+    email: 'grace@example.com',
+    status: 'new',
+  };
+
+  const CASES = [
+    {
+      field: 'disqualification_reason',
+      shownWhen: { ...NEW_LEAD, status: 'unqualified' },
+      why: 'status is Unqualified',
+    },
+    {
+      field: 'duplicate_of_type',
+      shownWhen: { ...NEW_LEAD, status: 'unqualified', disqualification_reason: 'duplicate' },
+      why: 'the reason is Duplicate',
+    },
+    {
+      field: 'duplicate_of_lead',
+      shownWhen: {
+        ...NEW_LEAD,
+        status: 'unqualified',
+        disqualification_reason: 'duplicate',
+        duplicate_of_type: 'crm_lead',
+      },
+      why: 'the survivor is a lead',
+    },
+    {
+      field: 'duplicate_of_contact',
+      shownWhen: {
+        ...NEW_LEAD,
+        status: 'unqualified',
+        disqualification_reason: 'duplicate',
+        duplicate_of_type: 'crm_contact',
+      },
+      why: 'the survivor is a contact',
+    },
+    {
+      field: 'duplicate_status',
+      shownWhen: { ...NEW_LEAD, status: 'unqualified', disqualification_reason: 'duplicate' },
+      why: 'the reason is Duplicate',
+    },
+  ] as const;
+
+  it('all five are still declared, still required, still conditional', () => {
+    // The fix is the predicate, not the requirement: dropping `required` would
+    // "fix" the report by letting a lead be saved in a state the server rejects.
+    for (const { field } of CASES) {
+      const entry = formFields.get(field);
+      expect(entry, `${field} missing from the crm_lead default form`).toBeDefined();
+      expect(entry!.required, `${field} lost its required flag`).toBe(true);
+      expect(entry!.visibleWhen?.source, `${field} lost its visibility predicate`).toBeTruthy();
+    }
+  });
+
+  it('is hidden on a brand-new lead, and shown in the state that summons it', () => {
+    for (const { field, shownWhen, why } of CASES) {
+      const source = String(formFields.get(field)!.visibleWhen.source);
+
+      const onNew = evaluatePredicate(source, NEW_LEAD);
+      expect(onNew, `${field}: predicate did not evaluate on a new lead`).toHaveProperty('ok', true);
+      expect((onNew as AnyRec).value, `${field} must be hidden on a brand-new lead`).toBe(false);
+
+      const onTrigger = evaluatePredicate(source, shownWhen);
+      expect(onTrigger, `${field}: predicate did not evaluate when ${why}`).toHaveProperty('ok', true);
+      expect((onTrigger as AnyRec).value, `${field} must be shown when ${why}`).toBe(true);
+    }
+  });
+
+  it('never demands both duplicate lookups at once', () => {
+    // The core of the report: the form asked for a lead that duplicates BOTH an
+    // existing lead AND an existing contact. They are mutually exclusive by
+    // design, so a form that shows both is unsatisfiable however it is filled.
+    const base = { ...NEW_LEAD, status: 'unqualified', disqualification_reason: 'duplicate' };
+    const lookups = ['duplicate_of_lead', 'duplicate_of_contact'] as const;
+
+    for (const record of [
+      base,
+      { ...base, duplicate_of_type: 'crm_lead' },
+      { ...base, duplicate_of_type: 'crm_contact' },
+    ]) {
+      const shown = lookups.filter((field) => {
+        const result = evaluatePredicate(String(formFields.get(field)!.visibleWhen.source), record);
+        return result.ok && result.value === true;
+      });
+      expect(
+        shown.length,
+        `both duplicate lookups visible at once for duplicate_of_type=${String(
+          (record as AnyRec).duplicate_of_type ?? '<unset>',
+        )} — the form cannot be satisfied`,
+      ).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('says the same thing the object says — form and server agree', () => {
+    // The lookups' `visibleWhen` and the object's `requiredWhen` must be the
+    // same predicate: a field the server will demand has to be reachable on the
+    // form, and a field the form demands has to be one the server wants. They
+    // drifted into different dialects once (#688); pin them together.
+    const leadObject = ((stack as AnyRec).objects ?? []).find((o: AnyRec) => o.name === 'crm_lead');
+    expect(leadObject, 'crm_lead object missing from the stack').toBeDefined();
+
+    for (const field of ['duplicate_of_lead', 'duplicate_of_contact'] as const) {
+      const declared = (leadObject.fields as AnyRec)[field];
+      expect(declared?.requiredWhen?.source, `${field} has no requiredWhen on the object`).toBeTruthy();
+      expect(String(formFields.get(field)!.visibleWhen.source)).toBe(String(declared.requiredWhen.source));
+    }
+  });
+});


### PR DESCRIPTION
Part of #688 — 本 PR 只修 **hotcrm 半侧**（应用元数据里的谓词方言）。平台半侧（求值失败 fail-open、无任何诊断）仍归 objectstack-ai/objectstack#5149，本单**保持 open**，请勿用本 PR 自动关闭。

## 症状与结论

Console → Leads → New 完全建不出线索：提交被客户端拦下，报五个 required 错误（Disqualification Reason / Duplicate Of / Duplicate Of Lead / Duplicate Of Contact / Duplicate Status），没有任何网络写入。这个表单**在逻辑上无法被满足**——`duplicate_of_lead` 与 `duplicate_of_contact` 按设计互斥，却被同时要求。同样的 payload 走 REST 建单返回 201。

原因在本仓库自己的元数据里：`src/views/lead.view.ts` 的可见性谓词写成了**裸字段名**（`status == "unqualified"`），而求值器把字段值绑定在 `record` 命名空间下。裸名是未绑定标识符，因此该谓词**对任何记录都求值失败**；求值失败在 console 侧 fail-open（字段照常渲染），而渲染出来的字段会强制执行它的 `required: true`。

## 机理实测（PR 立论所依据的那对测量）

直接驱动平台自己的求值器 `ExpressionEngine`（`@objectstack/formula` 17.0.0-rc.2，即 console bundle 所用的那个；objectstack#5149 引用为 `a.evaluate(Ie(e), { record, previous, … })`）：

**(a) 裸名谓词 —— 永远求值不出来，与记录取值无关**

```
evaluate('status == "unqualified"', { record: { status: 'new' } })
  -> ok:false  kind=type  "Unknown variable: status"
evaluate('status == "unqualified"', { record: { status: 'unqualified' } })
  -> ok:false  kind=type  "Unknown variable: status"
evaluate('rating >= 4',            { record: { status: 'new' } })
  -> ok:false  kind=type  "Unknown variable: rating"
```

`collectCelRootIdentifiers('status == "unqualified"')` → `roots: ['status']`；`collectCelRootIdentifiers('record.status == …')` → `roots: ['record']`。`buildScope` 实测绑定的根只有 `record / previous / input / current_user / user / ctx / os`。

**(b) 同一谓词写成 `record.` 前缀 —— true 与 false 两个方向都正确**

```
evaluate('record.status == "unqualified"', { record: { status: 'new' } })
  -> ok:true  false
evaluate('record.status == "unqualified"', { record: { status: 'unqualified' } })
  -> ok:true  true
```

**(c) 只加前缀还不够 —— 全新记录上仍然求值失败（这一点决定了本 PR 的最终写法）**

新建表单的记录里，用户没碰过的字段**键根本不存在**，严格 CEL 在读取时直接中止：

```
evaluate('record.duplicate_of_type == "crm_lead"',  { record: {} })
  -> ok:false  "No such key: duplicate_of_type"
evaluate('record.disqualification_reason == "duplicate"', { record: { status:'new' } })
  -> ok:false  "No such key: disqualification_reason"
evaluate('has(record.duplicate_of_type) && record.duplicate_of_type == "crm_lead"', { record: {} })
  -> ok:true   false
```

也就是说：只把裸名改成 `record.` 前缀，报单里那五个字段**在报单现场（New 表单）依旧会求值失败、依旧 fail-open 常显**，P0 不会解除。所以每个谓词还必须是 **TOTAL** 的——这正是 AGENTS.md 对 `validations[].condition` / `requiredWhen` / `readonlyWhen` / `visibleWhen` 已经写明的 `has(record.x)` 家规（#630）。序关系比较另外再带 `!= null`，因为 `has()` 挡不住 `dyn< null > < int`。

## 改动

- `src/views/lead.view.ts`：全部 **21 处** `visibleOn` 改写为 P 标签 + `record.` 前缀 + `has()` 守卫。其中 19 处原为裸名字符串；另外 2 处（`P record.rating >= 3`、`P record.status == "contacted" || …`）方言本已正确，但不是 total，一并补齐守卫。逻辑逐条保留，原有注释保留并补充理由。
  - `status != "new"` 一类写作 `has(record.status) && !isBlank(record.status) && record.status != "new"`：没有状态的记录属于「尚未接触」，空值应留在「隐藏」一侧，而不是被 `null != "new"` 判成显示。
  - 两个 duplicate lookup 的 `visibleOn` 现在与 `lead.object.ts` 上对应的 `requiredWhen` **逐字符相同**——表单显示某个 lookup 的时机，正好是服务端会要求它的时机。
- 文件顶部新增家规注释，写明两条性质、上面的实测输出，以及 fail-open 归属 objectstack#5149。
- **未改动**：字段声明、`required` 标志、label/helpText 等任何非谓词元数据；未改动对象/hook/flow/docs；未动任何 `@objectstack/*` 版本（保持 17.0.0-rc.2）；未在平台侧做任何绕过。

## 守卫测试 `test/view-predicate-dialect.test.ts`（新文件）

- 视图**从编译后的 stack 枚举**，而不是手工列表；收集的是任意 `{ dialect, source }` 表达式信封（`visibleOn` 经 ADR-0089 D2 在 schema 边界折叠成 `visibleWhen`，手写 key 列表会漏且会过期）。实测 17.0.0-rc.2 下 `stack.views` 共 49 个信封，全部是 `visibleWhen` / `dialect: 'cel'`。
- **防空转**：从磁盘上 `src/views/*.view.ts` 数出作者写了多少条谓词，断言编译枚举到的条数 `>=` 它。否则枚举一旦悄悄收集到 0 条，整个文件会因为「没有产出任何判定」而全绿。
- 断言 1（命名空间）：每条谓词的 CEL 根标识符必须落在 `buildScope` 实际绑定的集合内——集合是从 `buildScope` **读出来**的，不是手写常量，因此跟随平台而不会漂移。
- 断言 2（可求值 / totality）：每条谓词对 **空记录**（New 表单形态）、**全量填充记录**、**键全为 null 的记录** 三种形态都必须 `ok:true` 且返回 boolean。
- 断言 3（本单验收）：报单里那五个字段，从编译产物取出各自的谓词，逐一检查**两个方向**——在全新线索上为 `false`（隐藏），在触发状态下为 `true`（显示）；并单独断言两个 duplicate lookup **任何取值下都不会同时可见**，即表单不可能再退化成不可满足；再断言五个字段仍然声明存在、仍然 `required: true`、仍然带谓词（修法是谓词，不是把 required 拿掉）。
- 断言 4（前提固定）：正向 pin 住「裸名确实未绑定」这一前提——即便记录里带着该字段，裸名写法也必须 `ok:false`。将来平台若开始绑定裸名，这条会变红并明确告诉读者规则前提变了，而不是让规则静默地不再守护任何东西。

**反向验证**（方向为预先判定的「红」，实测吻合）：把 `src/views/lead.view.ts` 还原成裸名谓词后重跑，11 条中 6 条转红，诊断正是机理本身：

```
FAIL  view predicates are record-bound > references only namespaces the evaluator binds
  crm_lead .form.sections[1].fields[5].visibleWhen: unbound root(s) status in `status == "unqualified"`
FAIL  view predicates are TOTAL on the real engine > answers on a brand-new record with no keys at all
  crm_lead .form.sections[1].fields[5].visibleWhen: type — Unknown variable: status
FAIL  … > answers on a fully populated record
FAIL  … > answers when every field is present but null
FAIL  crm_lead — the five fields … > is hidden on a brand-new lead, and shown in the state that summons it
  disqualification_reason: predicate did not evaluate on a new lead
FAIL  crm_lead — the five fields … > says the same thing the object says — form and server agree
  expected 'duplicate_of_type == "crm_lead"' to be 'has(record.duplicate_of_type) && reco…'
Tests  6 failed | 5 passed (11)
```

顺带一提，还原版里出现了 `no such overload: dyn< null > >= int`——这条证明「键全为 null」那个形态的断言不是装饰，它抓的是 `has()` 单独挡不住的那类中止。

## 验证

```
pnpm validate    ✓ Validation passed (1117ms)
pnpm typecheck   ✓ (tsc --noEmit, 无输出)
pnpm build       ✓ Build complete — Artifact: dist/objectstack.json
pnpm lint        ✓ 13 warning(s), 14 suggestion(s)（均为既存项，与本改动无关）
pnpm hygiene     ✓ source hygiene clean
pnpm test        ✓ Test Files 59 passed (59) · Tests 1408 passed | 1 skipped (1409)
```

控制字符自扫：本仓库没有 `scripts/check-nul-bytes.mjs`（那是 objectstack 仓的门禁），所以只跑了更宽的手工扫描 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`，对本 PR 改动的两个文件均无命中。

## 附带说明（未改动，非缺陷）

`src/flows/lead-conversion.flow.ts` 的 screen field `visibleWhen: 'createOpportunity == true'` 同样是裸名，但那是**另一个语境**：flow screen 的谓词是对该 screen 自己的字段名求值、由客户端按已收集的值重算，文件内注释已写明这一点。不属于本单，未改动、也未另开单。
