### PR TITLE
feat(demo): seed the activity model and spread the churn clock (#671)

### DIFF
--- a/.changeset/activity-demo-seeds.md
+++ b/.changeset/activity-demo-seeds.md
@@ -1,0 +1,31 @@
+---
+'hotcrm': minor
+---
+
+Demo data for the activity model: the Sales Activity dashboard now has numbers behind it
+
+The activity model shipped with its objects, actions, cube and dashboard but no
+records, so a freshly seeded demo showed a complete Sales Activity dashboard
+reading zero on every widget, an empty calendar, empty interaction histories,
+and three "Quiet 30 / 60 / 90+ Days" tiles with nothing to count.
+
+The demo database now ships 27 interactions and their attendee rows, spread
+across leads, contacts, accounts, opportunities and cases, over roughly nine
+weeks and across calls, meetings, demos, webinars and an onsite visit. Both
+sides of the `held` / `planned` split are represented: interactions that
+happened, meetings that are merely booked, and a cancelled and a no-show row.
+Every timestamp is relative to the boot date, so the demo reads the same on any
+day it is installed.
+
+`crm_account.last_activity_date` is now laid out across the churn bands rather
+than clustered inside a fortnight: three accounts sit at 41, 72 and 104 days of
+silence, one per tile, and each has a re-engagement meeting on the calendar
+without its clock moving — which is what the `held` / `planned` distinction is
+for. The at-risk account's health score and its activity clock finally agree.
+
+Seeded interactions reach the database owned by nobody, as every seeded record
+does, so the demo bootstrap sweep now claims `crm_event` alongside the other
+owner-scoped objects. Without that, every interaction would be invisible to
+every rep, absent from the "Activity by Rep" breakdown and editable by no one.
+The attendee junction takes its access from the event it hangs off and is
+deliberately not claimed.

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -17,13 +17,20 @@
  *   - `_shared.ts`      seed doctrine + helpers used by more than one family
  *   - `catalog.seed.ts` products, and the catalogue price lookup
  *   - `sales.seed.ts`   accounts, contacts, leads, opportunities, opp lines
- *   - `service.seed.ts` tasks, cases, knowledge articles
+ *   - `service.seed.ts` tasks, cases, knowledge articles, events + attendees
  *   - `marketing.seed.ts` campaigns, campaign members
  *   - `revenue.seed.ts` contracts, quotes, quote lines, forecasts
  */
 import { products } from './catalog.seed';
 import { accounts, contacts, leads, opportunities, opportunityLineItems } from './sales.seed';
-import { tasks, cases, knowledgeArticles } from './service.seed';
+import {
+  tasks,
+  cases,
+  knowledgeArticles,
+  events,
+  eventAttendeesFromContacts,
+  eventAttendeesFromLeads,
+} from './service.seed';
 import { campaigns, campaignMembersFromLeads, campaignMembersFromContacts } from './marketing.seed';
 import { contracts, quotes, quoteLineItems, forecasts } from './revenue.seed';
 
@@ -64,6 +71,12 @@ export const CrmSeedData = [
   opportunityLineItems,
   tasks,
   cases,
+  // Events come after the five objects their `related_to_*` lookups resolve
+  // against (accounts, contacts, leads, opportunities, cases); the attendee
+  // junctions come after the events they hang off.
+  events,
+  eventAttendeesFromContacts,
+  eventAttendeesFromLeads,
   campaigns,
   campaignMembersFromLeads,
   campaignMembersFromContacts,

--- a/src/data/sales.seed.ts
+++ b/src/data/sales.seed.ts
@@ -50,6 +50,63 @@ import { lineItemRecords } from './catalog.seed';
 //
 // Phone numbers moved with the addresses: a Munich account answering a Denver
 // number is the kind of incoherence an evaluator notices before the feature.
+//
+// ─── `last_activity_date`: the churn clock, and who is allowed to set it ───
+//
+// The three "Quiet 30 / 60 / 90+ Days" tiles on the Sales Activity dashboard,
+// `at_risk_accounts` and `customer_churn_signals` all window this one column,
+// so the demo needs a real DISTRIBUTION across the three bands — not the
+// cluster inside a fortnight it used to be, which left every churn surface
+// empty while the data looked populated (#671).
+//
+// Authoring it here is legitimate, and the boundary is worth stating because it
+// is NOT the `billing_country` case three paragraphs up (doctrine rule 3 in
+// `./_shared.ts`). `billing_country` is `readonly` and DERIVED — the hook
+// recomputes it from `billing_address` on every write that carries one, so a
+// seeded copy would be a second source of truth for a value nothing else owns.
+// `last_activity_date` is neither: #592 removed the `readonly` flag precisely
+// so hooks could write it, and no hook derives it from anything on the account.
+// It is a HISTORICAL fact — "when did anyone last speak to this customer" — and
+// authoring history into a field whose writers only ever stamp the current date
+// is doctrine rule 1, the same licence `stage_entry_date` and `created_date`
+// already use.
+//
+// What the writers DO impose is a constraint on the events seeded beside these
+// rows, and it decides the whole layout below. Lifecycle hooks run over seed
+// writes (#617), and two of them stamp TODAY on an account:
+//
+//   · `event_activity_bubble` — on any `held` event, walking up from its
+//     contact / opportunity / case (`src/objects/event.hook.ts`);
+//   · `task_activity_bubble`  — on any task seeded already completed.
+//
+// Neither reads the activity's own timestamp: a `held` meeting seeded 45 days
+// ago still stamps the day the demo was seeded. So an account may carry an
+// authored age ONLY if nothing in the seed book bubbles to it; otherwise the
+// authored value is overwritten at seed time and the demo shows something
+// nobody wrote (doctrine rule 2). Hence the three-way split:
+//
+//   today()   Acme, Wayne, Vertex, Stark — every account something in the seed
+//             book bubbles to. Acme / Wayne / Vertex carry `held` events;
+//             Stark carries the completed welcome-package task, which has
+//             bubbled since long before this issue (its authored `daysAgo(5)`
+//             was being silently overwritten). Authored as today because that
+//             is exactly what the bubble writes, so the value is right whether
+//             or not hooks fire.
+//   6–8 days  Lattice, Globex — recency from channels this seed book does not
+//             model (an email thread, a signature). They carry only `planned`
+//             and `cancelled` events, neither of which bubbles.
+//   41/72/104 Northwind, Initech, Apex — one per churn band. Nothing held
+//             reaches them; each carries a BOOKED re-engagement meeting
+//             instead, which is #592's whole point: a meeting on the calendar
+//             is not an interaction that happened, and only `held` moves the
+//             clock. Internal pipeline motion (a `stage_entry_date`) is not
+//             customer contact either, which is why a stagnating deal can sit
+//             on a silent account — that pairing is what the stagnation sweep
+//             and the churn tiles are each looking at from one side.
+//
+// `test/activity-seed-coverage.test.ts` recomputes the bubble's reachability
+// from the seeds themselves and fails if a held event ever reaches one of the
+// three quiet accounts, so the split above cannot rot into a comment.
 export const accounts = defineSeed(Account, {
   mode: 'upsert',
   externalId: 'name',
@@ -67,7 +124,8 @@ export const accounts = defineSeed(Account, {
       segment: 'growth',
       health_score: 'healthy',
       next_renewal_date: cel`daysFromNow(45)`,
-      last_activity_date: cel`daysAgo(3)`,
+      // Held: workshop, demo, calls and an onsite visit — see `service.seed.ts`.
+      last_activity_date: cel`today()`,
       description: `**Strategic Customer · Enterprise Tier**
 
 Acme Corporation is a Series-C robotics & industrial automation
@@ -107,6 +165,8 @@ three regional teams (NA, EMEA, APAC).
       website: 'https://globex.example.com',
       tier: 'enterprise',
       segment: 'net_new',
+      // Only a booked demo and a cancelled review — neither bubbles, so this
+      // 8-day age survives the seed load and stays inside every churn window.
       last_activity_date: cel`daysAgo(8)`,
     },
     {
@@ -122,7 +182,11 @@ three regional teams (NA, EMEA, APAC).
       segment: 'at_risk',
       health_score: 'at_risk',
       next_renewal_date: cel`daysFromNow(75)`,
-      last_activity_date: cel`daysAgo(21)`,
+      // QUIET 60+ — the `at_risk` segment and health score, with a clock that
+      // finally agrees with them: ten weeks of silence against a renewal 75
+      // days out. A no-show call 55 days ago was the last attempt; the
+      // re-engagement call on the calendar is `planned`, so it moves nothing.
+      last_activity_date: cel`daysAgo(72)`,
     },
     {
       name: 'Stark Medical',
@@ -137,7 +201,10 @@ three regional teams (NA, EMEA, APAC).
       website: 'https://starkmed.example.com',
       tier: 'mid_market',
       segment: 'stable',
-      last_activity_date: cel`daysAgo(5)`,
+      // The completed 'Send welcome package' task bubbles here on every seed
+      // load, so this has ALWAYS resolved to today — the previous `daysAgo(5)`
+      // was authored and then overwritten before anyone could read it.
+      last_activity_date: cel`today()`,
     },
     {
       name: 'Wayne Enterprises',
@@ -152,7 +219,8 @@ three regional teams (NA, EMEA, APAC).
       segment: 'growth',
       health_score: 'healthy',
       next_renewal_date: cel`daysFromNow(28)`,
-      last_activity_date: cel`daysAgo(1)`,
+      // Held: negotiation meeting, security-addendum call, governance webinar.
+      last_activity_date: cel`today()`,
     },
     {
       name: 'Northwind Energy',
@@ -166,7 +234,10 @@ three regional teams (NA, EMEA, APAC).
       website: 'https://northwind.example.com',
       tier: 'enterprise',
       segment: 'net_new',
-      last_activity_date: cel`daysAgo(2)`,
+      // QUIET 30+ — the field-service pilot was lost 80 days ago and the grid
+      // program has not been worked since. The discovery workshop is booked,
+      // not held.
+      last_activity_date: cel`daysAgo(41)`,
       description: 'A regional energy provider evaluating a unified operations and customer-data platform.',
     },
     {
@@ -182,7 +253,8 @@ three regional teams (NA, EMEA, APAC).
       segment: 'growth',
       health_score: 'healthy',
       next_renewal_date: cel`daysFromNow(62)`,
-      last_activity_date: cel`daysAgo(4)`,
+      // Held: rollout meeting, analytics demo, committee call, retrospective.
+      last_activity_date: cel`today()`,
       description: 'An analytics SaaS customer expanding usage from the data team to its revenue organization.',
     },
     {
@@ -201,6 +273,8 @@ three regional teams (NA, EMEA, APAC).
       segment: 'stable',
       health_score: 'healthy',
       next_renewal_date: cel`daysFromNow(36)`,
+      // Signed the analytics expansion six days ago; the renewal review is
+      // booked, not held, so nothing bubbles and this age stands.
       last_activity_date: cel`daysAgo(6)`,
       description: 'A higher-education technology company consolidating admissions, student-success and alumni workflows.',
     },
@@ -218,7 +292,10 @@ three regional teams (NA, EMEA, APAC).
       website: 'https://apexlogistics.example.com',
       tier: 'enterprise',
       segment: 'net_new',
-      last_activity_date: cel`daysAgo(9)`,
+      // QUIET 90+ — a lost compliance deal 110 days ago and a data-hub
+      // evaluation that has been silent for a quarter. Only a booked
+      // re-engagement call.
+      last_activity_date: cel`daysAgo(104)`,
       description: 'A fast-growing logistics provider assessing a modern data hub for its operations and commercial teams.',
     },
   ]
@@ -376,7 +453,13 @@ export const leads = defineSeed(Lead, {
       industry: 'education',
       rating: 4,
       next_followup_date: cel`daysFromNow(1)`,
-      last_contacted_date: cel`daysAgo(3)`,
+      // A seeded `held` event names this lead, and `event_activity_bubble`
+      // stamps `last_contacted_date` with the SEED MOMENT rather than the
+      // event's own timestamp — so an authored age here would be overwritten
+      // the instant it was written (doctrine rule 2 in `./_shared.ts`). Day
+      // granularity is the honest match: the seed writes today's UTC midnight,
+      // the bubble writes today's instant, and both render as "today".
+      last_contacted_date: cel`today()`,
     },
     {
       first_name: 'Lisa',
@@ -395,7 +478,8 @@ export const leads = defineSeed(Lead, {
       // prevent (#591).
       rating: 5,
       next_followup_date: cel`daysFromNow(0)`,
-      last_contacted_date: cel`daysAgo(1)`,
+      // Same as David Kim above: a `held` qualification call names this lead.
+      last_contacted_date: cel`today()`,
     },
     // ─── Generated demo leads — spread across 6 months for monthly-bucket reports
     // (`LeadInflowByMonthSourceReport`). Each `last_contacted_date` lives in a

--- a/src/data/service.seed.ts
+++ b/src/data/service.seed.ts
@@ -1,11 +1,15 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * Service seeds — the task list, the case backlog and the knowledge base.
+ * Service seeds — the task list, the case backlog, the knowledge base, and the
+ * interaction log.
  *
  * Tasks live here rather than with the sales pipeline because they are the
  * activity layer over every object (accounts, opportunities AND cases), and the
- * case seeds are the records they most often hang off.
+ * case seeds are the records they most often hang off. `crm_event` and
+ * `crm_event_attendee` join them for exactly that reason (#671): an event is
+ * the same activity layer, over the same five parents, and it is the object the
+ * cases below are the other half of.
  *
  * Split out of the former monolithic `src/data/index.ts` (#635). Seed doctrine
  * lives in `./_shared.ts`.
@@ -15,6 +19,8 @@ import { cel } from '@objectstack/spec';
 import { Task } from '../objects/task.object';
 import { Case } from '../objects/case.object';
 import { KnowledgeArticle } from '../objects/knowledge_article.object';
+import { Event } from '../objects/event.object';
+import { EventAttendee } from '../objects/event_attendee.object';
 import { celDaysAgo, celDaysFromNow } from './_shared';
 
 // ─── Tasks ────────────────────────────────────────────────────────────
@@ -400,4 +406,440 @@ connector instead. Retained for customers still on the legacy stack.`,
       not_helpful_count: 9,
     },
   ]
+});
+
+// ─── Events & attendees: the interaction log ──────────────────────────
+//
+// #592 shipped the activity model — `crm_event`, `crm_event_attendee`, the
+// per-object log/schedule actions, the `event_metrics` cube and the Sales
+// Activity dashboard — and deliberately left the demo rows to this issue
+// (#671). Until now the demo booted with the whole model installed and not one
+// row in it: every widget on that dashboard read 0, the calendar and
+// interaction-history views were empty, and the three churn tiles had nothing
+// to stratify.
+//
+// # Time is authored in CEL, never in TypeScript
+//
+// `start_datetime` / `end_datetime` are `cel` expressions
+// (`daysAgo(12) + duration("9h0m")`), resolved by the seed loader at BOOT.
+// Plain-TS dates would freeze into `dist/objectstack.json` at BUILD time, and a
+// published artifact would ship a calendar that ages out — the same hazard
+// `test/analytics-integrity.test.ts` guards on report filters. `daysAgo()`
+// alone returns UTC midnight, which is why the duration term is there: a
+// calendar object whose every row starts at 00:00 is a calendar nobody would
+// demo.
+//
+// # A `held` event stamps TODAY on its account — that is the whole layout rule
+//
+// Lifecycle hooks run over seed writes (#617), so `event_activity_bubble` fires
+// on these inserts and stamps `crm_account.last_activity_date` /
+// `crm_contact.last_contacted_date` / `crm_lead.last_contacted_date` with the
+// SEED MOMENT — not with the event's own timestamp. Nothing here can make an
+// account look quiet AND give it a held interaction; the two are the same
+// column. So the quiet accounts of `sales.seed.ts` carry only `planned`,
+// `cancelled` and `no_show` rows, none of which bubble, and the accounts that
+// do carry held rows are authored at `today()` there. The long note beside the
+// account records states the boundary; `test/activity-seed-coverage.test.ts`
+// recomputes the bubble's own reachability over these rows and fails if a held
+// event ever reaches an account the churn tiles depend on.
+//
+// # Upsert identity is `subject`
+//
+// Same choice as `crm_task` and `crm_case` above, and it carries the same known
+// cost: a user who logs an interaction under a subject this file also uses
+// would have their row adopted (and overwritten) by the next re-seed. The
+// forecast seeds escape that with a dedicated `seed_key` column (#613), which
+// is an OBJECT change and out of this issue's scope; the subjects below are
+// long and account-specific so the collision needs deliberate effort, and the
+// two activity-shaped objects that came before already accept the same trade.
+// No collision exists with the runtime writer's own rows: `log_call` /
+// `log_meeting` / `schedule_meeting` insert with an explicit `owner_id`
+// (`src/actions/global.actions.ts`), so they are never ownerless and
+// `demo_bootstrap`'s claim sweep never sees them — the "one producer per
+// window" question #702 raised, answered for this object.
+
+/** Which `related_to_*` lookup carries each `related_to_type`. */
+const EVENT_RELATED_FIELD = {
+  crm_account: 'related_to_account',
+  crm_contact: 'related_to_contact',
+  crm_opportunity: 'related_to_opportunity',
+  crm_lead: 'related_to_lead',
+  crm_case: 'related_to_case',
+} as const;
+
+type EventRelatedType = keyof typeof EVENT_RELATED_FIELD;
+
+type AttendeeSpec = {
+  /** Contact email — the contact dataset's externalId. Exclusive with `lead`. */
+  readonly contact?: string;
+  /** Lead email — the lead dataset's externalId. */
+  readonly lead?: string;
+  readonly response: 'accepted' | 'declined' | 'tentative' | 'no_response';
+};
+
+type EventSpec = {
+  readonly subject: string;
+  readonly type: 'meeting' | 'call' | 'demo' | 'webinar' | 'onsite_visit' | 'other';
+  readonly status: 'held' | 'planned' | 'cancelled' | 'no_show';
+  /** Days before boot. NEGATIVE means that many days AFTER boot. */
+  readonly daysAgo: number;
+  /** UTC wall clock the slot opens at: `[hour, minute]`. */
+  readonly at: readonly [number, number];
+  /** Slot length in minutes — the gap between start and end on the calendar. */
+  readonly minutes: number;
+  readonly relatedType: EventRelatedType;
+  /** Natural key of the related record (that dataset's externalId). */
+  readonly relatedKey: string;
+  /**
+   * Account natural key, when the related record hangs off one. Authored on the
+   * event as well as implied through the parent — same shape the task seeds
+   * use, and it is what puts the row in the ACCOUNT's activity related list.
+   */
+  readonly account?: string;
+  readonly location?: string;
+  readonly description?: string;
+  readonly outcome?: string;
+  readonly attendees: readonly AttendeeSpec[];
+  /** Days before the event the invitation went out. Defaults to 3. */
+  readonly invitedDaysBefore?: number;
+};
+
+/**
+ * A wall-clock instant on a day relative to the boot date.
+ *
+ * `daysAgo(n)` / `daysFromNow(n)` both return UTC midnight of that calendar
+ * day, and CEL timestamp + duration arithmetic is what puts a real time on it.
+ */
+const celClock = (daysAgo: number, hour: number, minute: number) => {
+  const clock = `${hour}h${minute}m`;
+  return daysAgo >= 0
+    ? cel`daysAgo(${daysAgo}) + duration(${clock})`
+    : cel`daysFromNow(${-daysAgo}) + duration(${clock})`;
+};
+
+/**
+ * The interaction log.
+ *
+ * `held` rows span all five `related_to_type` values and five of the six
+ * `type` values across roughly nine weeks, because that is what the Sales
+ * Activity dashboard reads: the mix donut groups by `type`, the "where the
+ * activity lands" bar groups by `related_to_type`, and the volume area chart
+ * buckets `start_datetime` by week. A block of rows in one week on one parent
+ * would light every widget up while proving none of them.
+ */
+const EVENT_SPECS: readonly EventSpec[] = [
+  // ─── Acme Corporation — the hero account, worked across every parent ────
+  {
+    subject: 'Acme — Enterprise edition walkthrough',
+    type: 'demo', status: 'held', daysAgo: 2, at: [10, 0], minutes: 60,
+    relatedType: 'crm_opportunity', relatedKey: 'Acme Platform Upgrade', account: 'Acme Corporation',
+    location: 'Zoom',
+    outcome: 'Walked the Ops team through agent governance and the analytics seats. Revised proposal to follow this week.',
+    attendees: [{ contact: 'john.smith@acme.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Acme — proposal follow-up call',
+    type: 'call', status: 'held', daysAgo: 5, at: [15, 30], minutes: 25,
+    relatedType: 'crm_contact', relatedKey: 'john.smith@acme.example.com', account: 'Acme Corporation',
+    outcome: 'Procurement wants an 18-month term. Pricing to be re-cut before the governance workshop.',
+    attendees: [{ contact: 'john.smith@acme.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Acme — AI governance scoping session',
+    type: 'meeting', status: 'held', daysAgo: 12, at: [9, 0], minutes: 90,
+    relatedType: 'crm_account', relatedKey: 'Acme Corporation',
+    location: 'Google Meet',
+    outcome: 'Agreed the workshop agenda: data scoping, RBAC, audit trails, human-in-the-loop.',
+    attendees: [{ contact: 'john.smith@acme.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Acme — login incident status call',
+    type: 'call', status: 'held', daysAgo: 16, at: [8, 30], minutes: 20,
+    relatedType: 'crm_case', relatedKey: 'Login issues after platform upgrade', account: 'Acme Corporation',
+    outcome: 'Confirmed the EMEA SSO clock-skew hypothesis; engineering reproducing in staging.',
+    attendees: [{ contact: 'john.smith@acme.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Acme — renewal signature review',
+    type: 'meeting', status: 'held', daysAgo: 20, at: [14, 0], minutes: 45,
+    relatedType: 'crm_opportunity', relatedKey: 'Acme Annual Renewal 2025', account: 'Acme Corporation',
+    outcome: 'Signed two weeks ahead of the renewal date. Multi-year deferred to the upgrade decision.',
+    attendees: [{ contact: 'john.smith@acme.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Acme — San Francisco HQ business review',
+    type: 'onsite_visit', status: 'held', daysAgo: 33, at: [13, 0], minutes: 120,
+    relatedType: 'crm_account', relatedKey: 'Acme Corporation',
+    location: '500 Howard Street, Suite 400, San Francisco',
+    outcome: 'Quarterly review with the CTO org. Expansion into the EMEA team confirmed as the next motion.',
+    attendees: [{ contact: 'john.smith@acme.example.com', response: 'accepted' }],
+  },
+
+  // ─── Wayne Enterprises — a deal in negotiation ──────────────────────────
+  {
+    subject: 'Wayne — enterprise license negotiation',
+    type: 'meeting', status: 'held', daysAgo: 3, at: [16, 0], minutes: 60,
+    relatedType: 'crm_opportunity', relatedKey: 'Wayne Enterprise License', account: 'Wayne Enterprises',
+    location: 'Zoom',
+    outcome: 'Volume tier agreed at 20 tenants. Security addendum is the last open item.',
+    attendees: [{ contact: 'rwilson@wayne.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Wayne — security addendum walkthrough',
+    type: 'call', status: 'held', daysAgo: 8, at: [11, 0], minutes: 30,
+    relatedType: 'crm_contact', relatedKey: 'rwilson@wayne.example.com', account: 'Wayne Enterprises',
+    outcome: 'Legal to return redlines within the week.',
+    attendees: [{ contact: 'rwilson@wayne.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Wayne — platform governance webinar',
+    type: 'webinar', status: 'held', daysAgo: 26, at: [15, 0], minutes: 60,
+    relatedType: 'crm_account', relatedKey: 'Wayne Enterprises',
+    location: 'https://acme.example.com/webinars/governance',
+    outcome: 'Four business units attended; two asked for their own rollout plan.',
+    attendees: [{ contact: 'rwilson@wayne.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Wayne — bulk import rollout check-in',
+    type: 'call', status: 'held', daysAgo: 45, at: [10, 30], minutes: 25,
+    relatedType: 'crm_case', relatedKey: 'Request: bulk import via CSV', account: 'Wayne Enterprises',
+    outcome: 'CSV import shipped and documented; the customer closed the request out on the call.',
+    attendees: [{ contact: 'rwilson@wayne.example.com', response: 'accepted' }],
+  },
+
+  // ─── Vertex Analytics — expansion, then an enterprise rollout ───────────
+  {
+    subject: 'Vertex — rollout phasing and data residency',
+    type: 'meeting', status: 'held', daysAgo: 1, at: [9, 30], minutes: 75,
+    relatedType: 'crm_opportunity', relatedKey: 'Vertex Enterprise Rollout', account: 'Vertex Analytics',
+    location: 'Zoom',
+    outcome: 'Phase 1 scoped to four regions. Residency controls to be confirmed with their security team.',
+    attendees: [{ contact: 'ethan.brooks@vertex.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Vertex — revenue analytics demo',
+    type: 'demo', status: 'held', daysAgo: 10, at: [14, 30], minutes: 45,
+    relatedType: 'crm_opportunity', relatedKey: 'Vertex Analytics Expansion', account: 'Vertex Analytics',
+    location: 'Zoom',
+    outcome: 'Sales, marketing and service leads all asked for their own workspace — the expansion case makes itself.',
+    attendees: [{ contact: 'ethan.brooks@vertex.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Vertex — expansion buying committee call',
+    type: 'call', status: 'held', daysAgo: 19, at: [16, 30], minutes: 30,
+    relatedType: 'crm_contact', relatedKey: 'ethan.brooks@vertex.example.com', account: 'Vertex Analytics',
+    outcome: 'CRO owns the budget; the data team stays the technical sponsor.',
+    attendees: [{ contact: 'ethan.brooks@vertex.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'Vertex — developer platform retrospective',
+    type: 'meeting', status: 'held', daysAgo: 38, at: [11, 0], minutes: 60,
+    relatedType: 'crm_account', relatedKey: 'Vertex Analytics',
+    outcome: 'Three product teams live on the developer platform; usage analytics is the next ask.',
+    attendees: [{ contact: 'ethan.brooks@vertex.example.com', response: 'accepted' }],
+  },
+
+  // ─── Stark Medical — the partner motion ────────────────────────────────
+  {
+    subject: 'Stark Medical — Toronto clinical operations visit',
+    type: 'onsite_visit', status: 'held', daysAgo: 52, at: [9, 0], minutes: 180,
+    relatedType: 'crm_account', relatedKey: 'Stark Medical',
+    location: '181 Bay Street, Suite 2200, Toronto',
+    outcome: 'Two clinical service lines live on the pilot. Device-servicing expansion parked on budget.',
+    attendees: [{ contact: 'emily.d@starkmed.example.com', response: 'accepted' }],
+  },
+
+  // ─── Leads: the only held rows that touch a prospect's own clock ────────
+  {
+    subject: 'CloudFirst — qualification call with Lisa Thompson',
+    type: 'call', status: 'held', daysAgo: 1, at: [11, 0], minutes: 30,
+    relatedType: 'crm_lead', relatedKey: 'lisa.t@cloudfirst.example.com',
+    outcome: 'Budget confirmed and a technical evaluation agreed — qualified.',
+    attendees: [{ lead: 'lisa.t@cloudfirst.example.com', response: 'accepted' }],
+  },
+  {
+    subject: 'EduTech Labs — discovery call with David Kim',
+    type: 'call', status: 'held', daysAgo: 4, at: [13, 0], minutes: 30,
+    relatedType: 'crm_lead', relatedKey: 'dkim@edutechlabs.example.com',
+    outcome: 'Replacing spreadsheets across admissions. Referral source confirmed.',
+    attendees: [{ lead: 'dkim@edutechlabs.example.com', response: 'accepted' }],
+  },
+
+  // ─── Booked, not held: the calendar ahead ───────────────────────────────
+  // These are what `status` exists for. Not one of them moves a recency clock,
+  // and the three re-engagement rows below sit on the accounts the churn tiles
+  // count — which is the demonstration, not an oversight.
+  {
+    subject: 'Acme — AI agent governance workshop',
+    type: 'meeting', status: 'planned', daysAgo: -6, at: [9, 0], minutes: 90,
+    relatedType: 'crm_opportunity', relatedKey: 'Acme Platform Upgrade', account: 'Acme Corporation',
+    location: 'Google Meet',
+    description: 'Joint workshop with Acme compliance: data scoping, RBAC, audit trails, human-in-the-loop.',
+    attendees: [{ contact: 'john.smith@acme.example.com', response: 'tentative' }],
+    invitedDaysBefore: 9,
+  },
+  {
+    subject: 'Wayne — procurement signature call',
+    type: 'meeting', status: 'planned', daysAgo: -1, at: [11, 0], minutes: 30,
+    relatedType: 'crm_opportunity', relatedKey: 'Wayne Enterprise License', account: 'Wayne Enterprises',
+    description: 'Confirm the signature date once the security addendum is closed.',
+    attendees: [{ contact: 'rwilson@wayne.example.com', response: 'accepted' }],
+    invitedDaysBefore: 4,
+  },
+  {
+    subject: 'Globex — manufacturing suite demo',
+    type: 'demo', status: 'planned', daysAgo: -5, at: [15, 0], minutes: 60,
+    relatedType: 'crm_opportunity', relatedKey: 'Globex Manufacturing Suite', account: 'Globex Industries',
+    location: 'Zoom',
+    description: 'Plant-operations demo for the six-site rollout, ahead of the qualification review.',
+    attendees: [{ contact: 'sarah.j@globex.example.com', response: 'accepted' }],
+    invitedDaysBefore: 8,
+  },
+  {
+    subject: 'Lattice — renewal proposal review',
+    type: 'meeting', status: 'planned', daysAgo: -3, at: [10, 0], minutes: 45,
+    relatedType: 'crm_opportunity', relatedKey: 'Lattice Education Renewal', account: 'Lattice Education',
+    description: 'Walk procurement through the two-year option before the executive sponsor meeting.',
+    attendees: [{ contact: 'priya.shah@lattice.example.com', response: 'accepted' }],
+    invitedDaysBefore: 6,
+  },
+  {
+    subject: 'Initech — re-engagement call before renewal',
+    type: 'call', status: 'planned', daysAgo: -2, at: [14, 0], minutes: 30,
+    relatedType: 'crm_account', relatedKey: 'Initech Solutions',
+    description: 'Nobody has spoken to Initech in ten weeks and the renewal is 75 days out. Re-open the relationship.',
+    attendees: [{ contact: 'mchen@initech.example.com', response: 'no_response' }],
+    invitedDaysBefore: 5,
+  },
+  {
+    subject: 'Northwind — grid modernization discovery workshop',
+    type: 'meeting', status: 'planned', daysAgo: -7, at: [9, 30], minutes: 120,
+    relatedType: 'crm_opportunity', relatedKey: 'Northwind Grid Modernization', account: 'Northwind Energy',
+    location: 'Leopoldstrasse 21, Munich',
+    description: 'Confirm discovery participants and agree the operational-data assessment scope.',
+    attendees: [{ contact: 'olivia.chen@northwind.example.com', response: 'tentative' }],
+    invitedDaysBefore: 10,
+  },
+  {
+    subject: 'Apex Logistics — data hub re-engagement call',
+    type: 'call', status: 'planned', daysAgo: -4, at: [16, 0], minutes: 30,
+    relatedType: 'crm_account', relatedKey: 'Apex Logistics',
+    description: 'The data-hub evaluation has been silent for a quarter. Re-establish the commercial sponsor.',
+    attendees: [{ contact: 'marcus.reed@apexlogistics.example.com', response: 'no_response' }],
+    invitedDaysBefore: 6,
+  },
+  {
+    subject: 'NextGen Retail — first discovery call with Alice Martinez',
+    type: 'call', status: 'planned', daysAgo: -2, at: [15, 0], minutes: 30,
+    relatedType: 'crm_lead', relatedKey: 'alice@nextgenretail.example.com',
+    description: 'Inbound web lead, booked on her follow-up date.',
+    attendees: [{ lead: 'alice@nextgenretail.example.com', response: 'no_response' }],
+    invitedDaysBefore: 3,
+  },
+
+  // ─── Neither held nor booked ────────────────────────────────────────────
+  // `duration_minutes` is 0 on both, exactly as `event_schedule_derive`
+  // recomputes it: a meeting nobody attended occupies nobody's time, while the
+  // calendar slot it was booked into stays on the record as evidence of the
+  // attempt.
+  {
+    subject: 'Globex — line expansion review',
+    type: 'meeting', status: 'cancelled', daysAgo: 30, at: [14, 0], minutes: 60,
+    relatedType: 'crm_opportunity', relatedKey: 'Globex Line Expansion (Lost)', account: 'Globex Industries',
+    description: 'Cancelled by the customer: the incumbent MES vendor had already bundled the two lines.',
+    attendees: [{ contact: 'sarah.j@globex.example.com', response: 'declined' }],
+    invitedDaysBefore: 7,
+  },
+  {
+    subject: 'Initech — SSO configuration check-in',
+    type: 'call', status: 'no_show', daysAgo: 55, at: [10, 0], minutes: 30,
+    relatedType: 'crm_account', relatedKey: 'Initech Solutions',
+    description: 'Customer did not join. The last attempt to reach Initech before the account went quiet.',
+    attendees: [{ contact: 'mchen@initech.example.com', response: 'no_response' }],
+    invitedDaysBefore: 4,
+  },
+];
+
+/** `[hour, minute]` plus `minutes`, as the end-of-slot wall clock. */
+const endClock = (spec: EventSpec): readonly [number, number] => {
+  const total = spec.at[0] * 60 + spec.at[1] + spec.minutes;
+  return [Math.floor(total / 60), total % 60];
+};
+
+export const events = defineSeed(Event, {
+  mode: 'upsert',
+  externalId: 'subject',
+  records: EVENT_SPECS.map((spec) => {
+    const [endHour, endMinute] = endClock(spec);
+    return {
+      subject: spec.subject,
+      type: spec.type,
+      status: spec.status,
+      start_datetime: celClock(spec.daysAgo, spec.at[0], spec.at[1]),
+      end_datetime: celClock(spec.daysAgo, endHour, endMinute),
+      // Authored rather than left to the hook, and authored to the value the
+      // hook computes: `event_schedule_derive` measures the gap between the two
+      // timestamps above, then zeroes it for a cancelled / no-show row. Both
+      // branches agree with this literal, so the figure is right whether or not
+      // hooks fire over the seed write (`./_shared.ts`, doctrine rule 2).
+      duration_minutes: spec.status === 'cancelled' || spec.status === 'no_show' ? 0 : spec.minutes,
+      all_day: false,
+      related_to_type: spec.relatedType,
+      [EVENT_RELATED_FIELD[spec.relatedType]]: spec.relatedKey,
+      // The account link is authored on every row that has one, including rows
+      // whose `related_to_type` is the contact / opportunity / case — the same
+      // shape the task seeds use, and what fills the ACCOUNT's activity list.
+      ...(spec.account && spec.relatedType !== 'crm_account'
+        ? { related_to_account: spec.account }
+        : {}),
+      ...(spec.location ? { location: spec.location } : {}),
+      ...(spec.description ? { description: spec.description } : {}),
+      ...(spec.outcome ? { outcome_notes: spec.outcome } : {}),
+      // No `owner_id`: a seed cannot name a user (see `src/data/index.ts`), so
+      // these rows land ownerless and `demo_bootstrap` claims them — which is
+      // why `crm_event` is in that flow's CLAIMED_OBJECTS (#671).
+    };
+  }),
+});
+
+/**
+ * Attendees, seeded as TWO datasets over one object, split by which party
+ * lookup is populated — the same construction, for the same reason, as
+ * `campaignMembersFromLeads` / `campaignMembersFromContacts`: the loader's
+ * composite key is EMPTY when any component is null, which silently disables
+ * dedupe and re-inserts every row on each replay boot.
+ *
+ * There is no third dataset for `sys_user` attendees, and no `is_organizer:
+ * true` row anywhere below. The organiser of every one of these meetings is the
+ * rep — a `sys_user` — and a seed cannot name a user: lookup values resolve
+ * against the target's externalId, which only works inside the app's own
+ * object graph. `global.actions.ts` adds the organiser row at runtime, where
+ * the id exists. Nothing is invented here to stand in for it.
+ */
+const attendeeRecords = (kind: 'contact' | 'lead') =>
+  EVENT_SPECS.flatMap((spec) =>
+    spec.attendees
+      .filter((a) => (kind === 'lead' ? a.lead : a.contact))
+      .map((a) => ({
+        crm_event: spec.subject,
+        attendee_type: kind,
+        ...(kind === 'lead' ? { crm_lead: a.lead } : { crm_contact: a.contact }),
+        response: a.response,
+        is_organizer: false,
+        // The invitation predates the slot. Clamped at 0 so a meeting booked
+        // for the day after tomorrow was invited today, never tomorrow.
+        invited_date: celDaysAgo(Math.max(spec.daysAgo + (spec.invitedDaysBefore ?? 3), 0)),
+      })),
+  );
+
+export const eventAttendeesFromContacts = defineSeed(EventAttendee, {
+  mode: 'upsert',
+  externalId: ['crm_event', 'crm_contact'],
+  records: attendeeRecords('contact'),
+});
+
+export const eventAttendeesFromLeads = defineSeed(EventAttendee, {
+  mode: 'upsert',
+  externalId: ['crm_event', 'crm_lead'],
+  records: attendeeRecords('lead'),
 });

--- a/src/flows/demo-bootstrap.flow.ts
+++ b/src/flows/demo-bootstrap.flow.ts
@@ -167,12 +167,13 @@ const claim = (key: string, objectName: string, label: string) => ({
  * independence comes from the seeds staying out of that window, not from this
  * claim; the claim only settles who owns the SETTLED periods.
  *
- * `crm_campaign` and `crm_knowledge_article` close the list (#716). Cross the
+ * `crm_campaign` and `crm_knowledge_article` came next (#716). Cross the
  * registered objects three ways — seeded × declares `owner_id` × claimed here —
- * and after these two the "seeded and owner-scoped but unclaimed" cell is
+ * and after those two the "seeded and owner-scoped but unclaimed" cell was
  * EMPTY. `test/flow-scheduled.test.ts` computes that cross-table rather than
  * reading a hand-written roster, so the next seeded owner-scoped object cannot
- * be forgotten the way these two were.
+ * be forgotten the way these two were — and `crm_event` at the foot of this
+ * list is that mechanism paying out for the first time (see below).
  *
  * What hid them is their OWD. The nine above are `private` (or
  * `controlled_by_parent`), where an ownerless row is INVISIBLE and the defect
@@ -217,6 +218,30 @@ const claim = (key: string, objectName: string, label: string) => ({
  * prejudge it — a real deployment assigns ownership through import or territory
  * rules before this sweep has anything to pick up (see the header). The demo's
  * job is only that no seeded row is left owned by nobody.
+ *
+ * `crm_event` joins the list the day the activity model gets demo rows (#671),
+ * and it is the computed cross-table above doing its job rather than an
+ * obstacle: `crm_event` declares `owner_id`, so the moment `src/data/` shipped
+ * events the "seeded AND owner-scoped AND unclaimed" cell stopped being empty
+ * and `test/flow-scheduled.test.ts` went red. Its OWD is `private` and
+ * `sales_rep` reads it `own`-only, which is #702's shape exactly: an ownerless
+ * interaction is invisible to every rep, absent from the owner axis of
+ * `event_metrics` (the Sales Activity dashboard's "Activity by Rep" bar) and
+ * editable by nobody, `system_admin` aside.
+ *
+ * `crm_event_attendee` is seeded alongside it and deliberately stays OUT. It
+ * declares no `owner_id` at all — `sharingModel: 'controlled_by_parent'`, its
+ * access derived from the event it hangs off — so there is no ownership to
+ * claim, and stamping one would write a column the object does not have. That
+ * is the cross-table's OTHER direction, which the same test asserts.
+ *
+ * No collision with the runtime writer, the question #702 taught us to ask
+ * before claiming anything: `log_call` / `log_meeting` / `schedule_meeting`
+ * insert their `crm_event` row with an explicit `owner_id` (an action body runs
+ * `isSystem`, so it stamps ownership itself — see `src/actions/global.actions.ts`),
+ * which means a rep's own interactions are never ownerless and this sweep never
+ * selects them. Unlike `crm_forecast` there is no shared window to keep clear:
+ * seeds and the actions write disjoint rows, not two producers of one row.
  */
 const CLAIMED_OBJECTS: ReadonlyArray<[key: string, objectName: string, label: string]> = [
   ['leads', 'crm_lead', 'Leads'],
@@ -230,6 +255,7 @@ const CLAIMED_OBJECTS: ReadonlyArray<[key: string, objectName: string, label: st
   ['forecasts', 'crm_forecast', 'Forecasts'],
   ['campaigns', 'crm_campaign', 'Campaigns'],
   ['knowledge', 'crm_knowledge_article', 'Knowledge Articles'],
+  ['events', 'crm_event', 'Events'],
 ];
 
 /** One pass per object. */

--- a/test/activity-seed-coverage.test.ts
+++ b/test/activity-seed-coverage.test.ts
@@ -1,0 +1,622 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import { AnalyticsService } from '@objectstack/service-analytics';
+import { resolveSeedRecord } from '@objectstack/formula';
+import stack from '../objectstack.config';
+import { CrmSeedData } from '../src/data/index';
+
+/**
+ * The activity model's demo data (#671).
+ *
+ * #592 / PR #670 shipped `crm_event`, `crm_event_attendee`, the per-object
+ * activity actions, the `event_metrics` cube and the Sales Activity dashboard —
+ * and no rows. Every widget on that dashboard read 0, the calendar and
+ * interaction-history views were empty, and the three churn tiles had nothing
+ * to stratify because `crm_account.last_activity_date` was null on every seeded
+ * customer. The acceptance criterion for this issue is a BROWSER one ("every
+ * widget non-zero after `pnpm demo:reset && pnpm dev`"), so this file translates
+ * it into the two things a test can actually hold:
+ *
+ *   1. the seed book's own structure — every event resolves to a real parent,
+ *      the churn bands are each populated, and (the load-bearing one) no `held`
+ *      event bubbles onto an account the churn tiles depend on;
+ *   2. the dashboard's own widget bindings, executed through the real dataset
+ *      compiler, the real filter-token resolver and a real engine over the real
+ *      seed records — which is the same harness `forecast-period-scope.test.ts`
+ *      uses, for the same reason: "the filter is present" is not the claim, "a
+ *      non-zero number comes back" is.
+ *
+ * # Why the bubble invariant is the important half
+ *
+ * Lifecycle hooks run over seed writes (#617). `event_activity_bubble` stamps
+ * `crm_account.last_activity_date` with the SEED MOMENT on any `held` event,
+ * walking up from the event's contact / opportunity / case — it never reads the
+ * event's own timestamp. `task_activity_bubble` does the same for a task seeded
+ * already completed. So a `held` interaction and an account that looks quiet
+ * are mutually exclusive by construction, and an author who adds one held event
+ * to the wrong parent silently empties a churn tile — with the seed file still
+ * saying 104 days. Nothing else in the suite can see that, so it is recomputed
+ * here from the hooks' own reachability rule.
+ */
+
+type AnyRec = Record<string, any>;
+type Dataset = { object: string; externalId: string | string[]; mode: string; records: AnyRec[] };
+
+const datasets = CrmSeedData as unknown as Dataset[];
+const recordsOf = (object: string): AnyRec[] =>
+  datasets.filter((d) => d.object === object).flatMap((d) => d.records);
+
+/**
+ * Seed records with their `cel` expressions resolved, exactly as the loader
+ * resolves them at boot. Every date in this file goes through here rather than
+ * being re-derived, so a change of expression cannot pass a test that reads the
+ * old intent.
+ */
+const resolve = (rows: AnyRec[]): AnyRec[] =>
+  rows.map((r) => {
+    const out = resolveSeedRecord(r, {} as never) as { ok: boolean; value?: AnyRec; error?: AnyRec };
+    if (!out.ok) throw new Error(`seed record does not resolve: ${JSON.stringify(out.error)}`);
+    return out.value as AnyRec;
+  });
+
+const eventRows = resolve(recordsOf('crm_event'));
+const attendeeRows = resolve(recordsOf('crm_event_attendee'));
+const accountRows = resolve(recordsOf('crm_account'));
+const contactRows = recordsOf('crm_contact');
+const leadRows = recordsOf('crm_lead');
+const opportunityRows = recordsOf('crm_opportunity');
+const caseRows = recordsOf('crm_case');
+const taskRows = resolve(recordsOf('crm_task'));
+
+/** `related_to_type` → the lookup that carries the record, as the hooks read it. */
+const RELATED_FIELD: Record<string, string> = {
+  crm_account: 'related_to_account',
+  crm_contact: 'related_to_contact',
+  crm_opportunity: 'related_to_opportunity',
+  crm_lead: 'related_to_lead',
+  crm_case: 'related_to_case',
+};
+
+/** Natural keys per object — each dataset's own `externalId`. */
+const KEYS = {
+  crm_account: new Set(accountRows.map((r) => String(r.name))),
+  crm_contact: new Set(contactRows.map((r) => String(r.email))),
+  crm_lead: new Set(leadRows.map((r) => String(r.email))),
+  crm_opportunity: new Set(opportunityRows.map((r) => String(r.name))),
+  crm_case: new Set(caseRows.map((r) => String(r.subject))),
+} as const;
+
+/**
+ * `resolveSeedRecord` hands a CEL temporal back as a real `Date`, not a string
+ * — `String(date)` is "Wed Aug 05 2026 …", which slices into nonsense and makes
+ * a date comparison pass for the wrong reason. Everything below goes through
+ * these two.
+ */
+const isoOf = (value: unknown): string =>
+  value instanceof Date ? value.toISOString() : String(value);
+const isoDay = (value: unknown): string => isoOf(value).slice(0, 10);
+const dayOffset = (days: number): string =>
+  new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
+
+// ─── 1. The seed book's structure ───────────────────────────────────────
+
+describe('the activity seeds resolve against real records (#671)', () => {
+  it('ships events and attendees at all', () => {
+    // Guard the guard: every case below iterates these, so an empty set would
+    // make the whole file vacuously green — which is precisely the state #671
+    // exists to end.
+    expect(eventRows.length, 'no crm_event seed records').toBeGreaterThanOrEqual(20);
+    expect(attendeeRows.length, 'no crm_event_attendee seed records').toBeGreaterThanOrEqual(20);
+  });
+
+  it('gives every event a related record that the loader can resolve', () => {
+    const bad: string[] = [];
+    for (const e of eventRows) {
+      const type = String(e.related_to_type ?? '');
+      const field = RELATED_FIELD[type];
+      if (!field) {
+        bad.push(`${e.subject}: related_to_type "${type}" is not one of ${Object.keys(RELATED_FIELD).join(', ')}`);
+        continue;
+      }
+      const key = e[field];
+      if (typeof key !== 'string' || !key) {
+        bad.push(`${e.subject}: related_to_type is ${type} but ${field} is empty`);
+        continue;
+      }
+      if (!(KEYS as Record<string, Set<string>>)[type].has(key)) {
+        bad.push(`${e.subject}: ${field} "${key}" matches no seeded ${type}`);
+      }
+      // The account link is optional, but when present it must resolve too —
+      // an unresolvable natural key is stored verbatim and silently links to
+      // nothing.
+      if (e.related_to_account && !KEYS.crm_account.has(String(e.related_to_account))) {
+        bad.push(`${e.subject}: related_to_account "${e.related_to_account}" matches no seeded account`);
+      }
+    }
+    expect(bad, `events whose parent does not resolve:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('keys every event on a unique subject — the upsert identity', () => {
+    // `externalId: 'subject'`. Two rows sharing one means the second overwrites
+    // the first on every boot, and the demo silently loses an interaction.
+    const seen = new Map<string, number>();
+    for (const e of eventRows) seen.set(String(e.subject), (seen.get(String(e.subject)) ?? 0) + 1);
+    const dupes = [...seen].filter(([, n]) => n > 1).map(([s]) => s);
+    expect(dupes, `duplicate event subjects: ${dupes.join(', ')}`).toEqual([]);
+  });
+
+  it('never authors owner_id — a seed cannot name a user', () => {
+    const authored = [...eventRows, ...attendeeRows].filter((r) => 'owner_id' in r);
+    expect(
+      authored.map((r) => String(r.subject ?? r.crm_event)),
+      'ownership is demo_bootstrap\'s job (src/data/index.ts); an authored owner_id would ' +
+        'store a literal string, not an id',
+    ).toEqual([]);
+  });
+
+  it('hangs every attendee off a seeded event and a seeded person', () => {
+    const subjects = new Set(eventRows.map((r) => String(r.subject)));
+    const bad: string[] = [];
+    for (const a of attendeeRows) {
+      if (!subjects.has(String(a.crm_event))) bad.push(`attendee of unknown event "${a.crm_event}"`);
+      if (a.attendee_type === 'contact' && !KEYS.crm_contact.has(String(a.crm_contact))) {
+        bad.push(`attendee "${a.crm_contact}" on "${a.crm_event}" matches no seeded contact`);
+      }
+      if (a.attendee_type === 'lead' && !KEYS.crm_lead.has(String(a.crm_lead))) {
+        bad.push(`attendee "${a.crm_lead}" on "${a.crm_event}" matches no seeded lead`);
+      }
+      // `attendee_resolves` (an ERROR-severity rule) rejects a row that points
+      // at nobody, so a blank party would be refused at seed time.
+      if (!a.crm_contact && !a.crm_lead && !a.sys_user && !a.external_name) {
+        bad.push(`attendee on "${a.crm_event}" resolves to nobody`);
+      }
+    }
+    expect(bad, `attendee rows that do not resolve:\n  ${bad.join('\n  ')}`).toEqual([]);
+
+    // Both halves of the split are populated: two datasets exist only because
+    // the loader's composite key is empty when a component is null, and a
+    // lead-less book would leave the second one unexercised.
+    expect(attendeeRows.filter((a) => a.attendee_type === 'contact').length).toBeGreaterThan(0);
+    expect(attendeeRows.filter((a) => a.attendee_type === 'lead').length).toBeGreaterThan(0);
+  });
+
+  it('gives every event a duration that equals its own start/end gap', () => {
+    // `event_schedule_derive` MEASURES the duration when both ends are known,
+    // then zeroes it for cancelled / no-show. A seeded figure that disagrees is
+    // rewritten at seed time and the demo shows something nobody authored
+    // (`src/data/_shared.ts`, doctrine rule 2).
+    const bad: string[] = [];
+    for (const e of eventRows) {
+      const start = new Date(isoOf(e.start_datetime)).getTime();
+      const end = new Date(isoOf(e.end_datetime)).getTime();
+      expect(Number.isFinite(start) && Number.isFinite(end), `${e.subject}: unparseable timestamps`).toBe(true);
+      const measured = Math.max(0, Math.round((end - start) / 60000));
+      const expectedDuration =
+        e.status === 'cancelled' || e.status === 'no_show' ? 0 : measured;
+      if (e.duration_minutes !== expectedDuration) {
+        bad.push(`${e.subject}: authored ${e.duration_minutes}, hook computes ${expectedDuration}`);
+      }
+      if (end < start) bad.push(`${e.subject}: ends before it starts — end_after_start rejects it`);
+    }
+    expect(bad, `durations the hook would rewrite:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('puts a real wall clock on every slot, not UTC midnight', () => {
+    // `daysAgo(n)` alone returns midnight, which would make the calendar view —
+    // one of the two surfaces #671 is about — a column of 00:00 rows. The
+    // duration term in the seed expression is what avoids that.
+    const midnight = eventRows.filter((e) => isoOf(e.start_datetime).slice(11, 16) === '00:00');
+    expect(midnight.map((e) => String(e.subject)), 'events starting at UTC midnight').toEqual([]);
+  });
+
+  it('covers both statuses, all five parents and a spread of types and weeks', () => {
+    const held = eventRows.filter((e) => e.status === 'held');
+    const planned = eventRows.filter((e) => e.status === 'planned');
+    expect(held.length, 'no held events — "Interactions Logged" reads 0').toBeGreaterThan(0);
+    expect(planned.length, 'no planned events — "Meetings Booked" reads 0').toBeGreaterThan(0);
+
+    // The dashboard groups HELD interactions by `related_to_type` and by `type`.
+    expect(new Set(held.map((e) => String(e.related_to_type)))).toEqual(
+      new Set(Object.keys(RELATED_FIELD)),
+    );
+    expect(new Set(held.map((e) => String(e.type))).size, 'the activity mix donut needs more than a couple of slices')
+      .toBeGreaterThanOrEqual(4);
+
+    // The volume chart buckets by week; a single week draws a spike, not a trend.
+    const weeks = new Set(
+      held.map((e) => Math.floor(new Date(isoOf(e.start_datetime)).getTime() / (7 * 86_400_000))),
+    );
+    expect(weeks.size, 'held interactions all land in one or two weeks').toBeGreaterThanOrEqual(5);
+
+    // A booked MEETING specifically — "Meetings Booked" filters on the pair.
+    expect(planned.filter((e) => e.type === 'meeting').length).toBeGreaterThan(0);
+  });
+});
+
+// ─── 2. The churn bands, and the bubble that can empty them ─────────────
+
+/**
+ * The accounts a seeded activity stamps `last_activity_date` on, recomputed the
+ * way `event_activity_bubble` / `task_activity_bubble` compute it: the directly
+ * named account, plus the walk-up through the contact / opportunity / case the
+ * activity names. Anything in this set is at TODAY after a seed load, whatever
+ * the account record says.
+ */
+const bubbleTargets = (): Set<string> => {
+  const accountOfContact = new Map(contactRows.map((c) => [String(c.email), String(c.crm_account)]));
+  const accountOfOpportunity = new Map(opportunityRows.map((o) => [String(o.name), String(o.crm_account)]));
+  const accountOfCase = new Map(caseRows.map((c) => [String(c.subject), String(c.crm_account)]));
+
+  const out = new Set<string>();
+  const walk = (r: AnyRec) => {
+    if (r.related_to_account) out.add(String(r.related_to_account));
+    const viaContact = accountOfContact.get(String(r.related_to_contact));
+    if (viaContact) out.add(viaContact);
+    const viaOpportunity = accountOfOpportunity.get(String(r.related_to_opportunity));
+    if (viaOpportunity) out.add(viaOpportunity);
+    const viaCase = accountOfCase.get(String(r.related_to_case));
+    if (viaCase) out.add(viaCase);
+  };
+
+  // Only `held` moves the clock — that is the whole point of the status split.
+  for (const e of eventRows) if (e.status === 'held') walk(e);
+  // A task that arrives already completed bubbles on insert, exactly like a
+  // held event. This has been true since before #671 and is why Stark Medical
+  // is authored at today().
+  for (const t of taskRows) if (t.status === 'completed' || t.is_completed === true) walk(t);
+  return out;
+};
+
+describe('the churn tiles have something to count (#671)', () => {
+  // `last_activity_date` comes back from `resolveSeedRecord` as a `Date`, so
+  // the presence test is a null check, not a `typeof … === 'string'` one.
+  const withDate = accountRows.filter((a) => a.last_activity_date != null);
+
+  it('gives every seeded account a last_activity_date', () => {
+    // A null column matches no `$lt` window at all, so a missing value hides an
+    // account from all three tiles rather than putting it in the oldest one.
+    const missing = accountRows.filter((a) => !a.last_activity_date).map((a) => String(a.name));
+    expect(missing, `accounts with no last_activity_date: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('populates each of the 30 / 60 / 90-day bands', () => {
+    const bands = {
+      '30-60': withDate.filter((a) => isoDay(a.last_activity_date) < dayOffset(30) && isoDay(a.last_activity_date) >= dayOffset(60)),
+      '60-90': withDate.filter((a) => isoDay(a.last_activity_date) < dayOffset(60) && isoDay(a.last_activity_date) >= dayOffset(90)),
+      '90+': withDate.filter((a) => isoDay(a.last_activity_date) < dayOffset(90)),
+    };
+    const summary = Object.entries(bands)
+      .map(([k, v]) => `${k}=[${v.map((a) => String(a.name)).join(', ')}]`)
+      .join(' · ');
+
+    // The three tiles are CUMULATIVE (`< 30 days ago` contains everything older),
+    // so one 90-day account would light all three while showing 1 / 1 / 1. A
+    // member per band is what makes them read 3 / 2 / 1 — the layering the
+    // dashboard is for.
+    for (const [band, members] of Object.entries(bands)) {
+      expect(members.length, `churn band ${band} is empty — ${summary}`).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps every held interaction away from the quiet accounts', () => {
+    // The invariant this whole file exists for. An author who hangs one held
+    // event off (say) an Initech opportunity moves Initech to today, empties the
+    // 60-day band, and leaves `daysAgo(72)` sitting in the seed file as a
+    // comment about something that is no longer true.
+    const targets = bubbleTargets();
+    const quiet = withDate
+      .filter((a) => isoDay(a.last_activity_date) < dayOffset(30))
+      .map((a) => String(a.name));
+    const contradicted = quiet.filter((name) => targets.has(name));
+    expect(
+      contradicted,
+      'these accounts are authored as quiet but a seeded `held` event (or completed task)\n' +
+        'bubbles onto them, so `event_activity_bubble` stamps them with TODAY at seed time and\n' +
+        'the churn tile they were authored for comes up empty:\n  ' + contradicted.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('authors today() on every account a seeded activity does bubble to', () => {
+    // The other direction, and the one that keeps the file honest rather than
+    // merely non-empty: an account the bubble reaches ends at today whatever the
+    // seed says, so any other authored value is a number nobody will ever see.
+    const today = dayOffset(0);
+    const targets = bubbleTargets();
+    const stale = accountRows
+      .filter((a) => targets.has(String(a.name)) && isoDay(a.last_activity_date) !== today)
+      .map((a) => `${String(a.name)}: authored ${isoDay(a.last_activity_date)}, bubble writes ${today}`);
+    expect(
+      stale,
+      'a seeded held event / completed task bubbles onto these accounts, so the authored age is\n' +
+        'overwritten at seed time (src/data/_shared.ts, doctrine rule 2):\n  ' + stale.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('books a re-engagement meeting on each quiet account — planned, not held', () => {
+    // #592's semantic, shown rather than asserted: these three accounts have
+    // something on the calendar and their clock has not moved.
+    const quiet = new Set(
+      withDate.filter((a) => isoDay(a.last_activity_date) < dayOffset(30)).map((a) => String(a.name)),
+    );
+    const accountOfOpportunity = new Map(opportunityRows.map((o) => [String(o.name), String(o.crm_account)]));
+    const booked = new Set(
+      eventRows
+        .filter((e) => e.status === 'planned')
+        .flatMap((e) => [
+          e.related_to_account ? String(e.related_to_account) : '',
+          accountOfOpportunity.get(String(e.related_to_opportunity)) ?? '',
+        ]),
+    );
+    const unbooked = [...quiet].filter((name) => !booked.has(name));
+    expect(unbooked, `quiet accounts with nothing on the calendar: ${unbooked.join(', ')}`).toEqual([]);
+  });
+
+  it('keeps the leads a held event names at today, and the rest historical', () => {
+    // `event_activity_bubble` stamps `crm_lead.last_contacted_date` too, and the
+    // generated leads' ages are what `lead_inflow_by_month_source` buckets by
+    // month — so a held event on the wrong lead silently moves a report cell.
+    const today = dayOffset(0);
+    const named = new Set(
+      eventRows.filter((e) => e.status === 'held' && e.related_to_lead).map((e) => String(e.related_to_lead)),
+    );
+    expect(named.size, 'no held event names a lead — the crm_lead bar is missing from the dashboard').toBeGreaterThan(0);
+
+    const resolvedLeads = resolve(leadRows);
+    const drifted = resolvedLeads
+      .filter((l) => named.has(String(l.email)) && isoDay(l.last_contacted_date) !== today)
+      .map((l) => `${String(l.email)}: authored ${isoDay(l.last_contacted_date)}`);
+    expect(drifted, `leads a held event bubbles to, authored with a stale age:\n  ${drifted.join('\n  ')}`).toEqual([]);
+
+    // And the history the monthly report needs is still there.
+    const historical = resolvedLeads.filter(
+      (l) => l.last_contacted_date != null && isoDay(l.last_contacted_date) < dayOffset(60),
+    );
+    expect(historical.length, 'every lead now reads as freshly contacted — the inflow report flattens')
+      .toBeGreaterThan(3);
+  });
+});
+
+// ─── 3. The dashboard's own widgets, over the real seeds ────────────────
+
+const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
+const datasetDefs: AnyRec[] = (stack as any).datasets ?? [];
+const objects: AnyRec[] = (stack as any).objects ?? [];
+
+const activityDashboard = dashboards.find((d) => d.name === 'sales_activity_dashboard') as AnyRec;
+const datasetByName = new Map(datasetDefs.map((d) => [String(d.name), d]));
+const objectByName = new Map(objects.map((o) => [String(o.name), o]));
+
+/**
+ * The claim `demo_bootstrap` performs on first boot, modelled as the one thing
+ * this file needs from it: a seeded event reaches the database ownerless, and
+ * the sweep stamps the first user onto it (#671 added `crm_event` to
+ * CLAIMED_OBJECTS — `test/flow-scheduled.test.ts` owns the sweep's behaviour).
+ * Without it the "Activity by Rep" bar groups every interaction under a null
+ * owner, which is the defect that claim exists to prevent.
+ */
+const OWNER = 'usr_first';
+
+/** `crm_account.is_active` is not authored in the seeds; the field default is. */
+const accountIsActiveDefault = (): boolean => {
+  const field = objectByName.get('crm_account')?.fields?.is_active as AnyRec | undefined;
+  expect(field, 'crm_account declares no is_active field — the churn tiles filter on it').toBeTruthy();
+  return field!.defaultValue === true;
+};
+
+const makeEngine = () =>
+  ObjectQL.create({
+    datasources: { default: new InMemoryDriver({ persistence: false }) },
+    objects: {
+      // Only the columns the four datasets read. The object suite owns the full
+      // schemas; the contract under test here is "which rows do the widget
+      // filters select, and what do they sum to".
+      crm_event: {
+        name: 'crm_event',
+        fields: {
+          id: { type: 'text' },
+          owner_id: { type: 'text' },
+          subject: { type: 'text' },
+          type: { type: 'text' },
+          status: { type: 'text' },
+          start_datetime: { type: 'datetime' },
+          duration_minutes: { type: 'number' },
+          related_to_type: { type: 'text' },
+        },
+      },
+      crm_account: {
+        name: 'crm_account',
+        fields: {
+          id: { type: 'text' },
+          name: { type: 'text' },
+          is_active: { type: 'boolean' },
+          last_activity_date: { type: 'date' },
+          annual_revenue: { type: 'number' },
+          industry: { type: 'text' },
+          type: { type: 'text' },
+        },
+      },
+      crm_task: {
+        name: 'crm_task',
+        fields: {
+          id: { type: 'text' },
+          subject: { type: 'text' },
+          status: { type: 'text' },
+          is_completed: { type: 'boolean' },
+          progress_percent: { type: 'number' },
+        },
+      },
+      crm_opportunity: {
+        name: 'crm_opportunity',
+        fields: {
+          id: { type: 'text' },
+          name: { type: 'text' },
+          stage: { type: 'text' },
+          amount: { type: 'number' },
+        },
+      },
+    } as never,
+  });
+
+describe('every Sales Activity widget returns a number over the shipped seeds (#671)', () => {
+  let ql: Awaited<ReturnType<typeof makeEngine>>;
+  let analytics: AnalyticsService;
+
+  beforeAll(async () => {
+    ql = await makeEngine();
+    const api = ql.createContext({ isSystem: true });
+
+    const isActive = accountIsActiveDefault();
+    for (const a of accountRows) {
+      await api.object('crm_account').insert({
+        name: a.name,
+        // Mirrors the schema default rather than restating it — the seeds do
+        // not author `is_active`, so the engine's default is what the tiles see.
+        is_active: a.is_active ?? isActive,
+        last_activity_date: isoDay(a.last_activity_date),
+        annual_revenue: a.annual_revenue ?? 0,
+        industry: a.industry ?? null,
+        type: a.type ?? null,
+      });
+    }
+    for (const e of eventRows) {
+      await api.object('crm_event').insert({
+        // The sweep's stamp — see OWNER above.
+        owner_id: OWNER,
+        subject: e.subject,
+        type: e.type,
+        status: e.status,
+        start_datetime: isoOf(e.start_datetime),
+        duration_minutes: e.duration_minutes ?? 0,
+        related_to_type: e.related_to_type ?? null,
+      });
+    }
+    for (const t of taskRows) {
+      await api.object('crm_task').insert({
+        subject: t.subject,
+        status: t.status,
+        is_completed: t.is_completed === true,
+        progress_percent: t.progress_percent ?? 0,
+      });
+    }
+    for (const o of opportunityRows) {
+      await api.object('crm_opportunity').insert({
+        name: o.name,
+        stage: o.stage,
+        amount: o.amount ?? 0,
+      });
+    }
+
+    analytics = new AnalyticsService({
+      // The same bridge `AnalyticsServicePlugin` auto-wires at boot, so the
+      // filter observed here is the filter the engine really receives.
+      executeAggregate: async (objectName, { groupBy, aggregations, filter, timezone, context }) =>
+        (ql as any).aggregate(objectName, {
+          where: filter,
+          groupBy,
+          aggregations: aggregations?.map((a: AnyRec) => ({
+            function: a.method, field: a.field, alias: a.alias,
+          })),
+          timezone,
+          context,
+        }),
+      queryCapabilities: () => ({ nativeSql: false, objectqlAggregate: true, inMemory: false }),
+    });
+  });
+
+  afterAll(async () => {
+    await ql?.close();
+  });
+
+  /** One widget, executed exactly as the dashboard declares it. */
+  const runWidget = async (widget: AnyRec): Promise<AnyRec[]> => {
+    const dataset = datasetByName.get(String(widget.dataset));
+    expect(dataset, `widget ${widget.id} names an undeclared dataset "${widget.dataset}"`).toBeTruthy();
+    const result = await analytics.queryDataset(
+      dataset as never,
+      {
+        ...(widget.dimensions ? { dimensions: widget.dimensions } : {}),
+        measures: widget.values,
+        ...(widget.filter ? { runtimeFilter: widget.filter as never } : {}),
+      },
+      { isSystem: true } as never,
+    );
+    return result.rows as AnyRec[];
+  };
+
+  const totalOf = (rows: AnyRec[], measure: string): number =>
+    rows.reduce((sum, r) => sum + (Number(r[measure]) || 0), 0);
+
+  it('the dashboard is the one this file thinks it is', () => {
+    expect(activityDashboard, 'sales_activity_dashboard is not registered').toBeTruthy();
+    expect((activityDashboard.widgets ?? []).length).toBeGreaterThanOrEqual(12);
+  });
+
+  it('returns a non-zero total for every widget on the dashboard', async () => {
+    const zero: string[] = [];
+    for (const widget of activityDashboard.widgets as AnyRec[]) {
+      const rows = await runWidget(widget);
+      const total = (widget.values as string[]).reduce(
+        (sum, measure) => sum + totalOf(rows, measure),
+        0,
+      );
+      if (total <= 0) {
+        zero.push(`${widget.id} (${widget.dataset} ${JSON.stringify(widget.values)}): ${total}`);
+      }
+    }
+    expect(
+      zero,
+      'these widgets read zero over the shipped seed data — the exact state #671 was filed for:\n  ' +
+        zero.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('groups the charted widgets across more than one column', async () => {
+    // A one-bar bar chart is technically non-zero and useless. The three
+    // grouped widgets are the ones a demo is actually read from.
+    const grouped = (activityDashboard.widgets as AnyRec[]).filter((w) => (w.dimensions ?? []).length > 0);
+    expect(grouped.length).toBeGreaterThanOrEqual(4);
+
+    for (const widget of grouped) {
+      const rows = await runWidget(widget);
+      // `activity_by_rep` groups by owner, and every seeded row is claimed by
+      // the same first user, so ONE row is the correct answer there.
+      const floor = widget.id === 'activity_by_rep' ? 1 : 3;
+      expect(rows.length, `${widget.id} groups into ${rows.length} column(s)`).toBeGreaterThanOrEqual(floor);
+    }
+  });
+
+  it('lands every interaction under a real owner — the demo_bootstrap claim', async () => {
+    const rows = await runWidget(
+      (activityDashboard.widgets as AnyRec[]).find((w) => w.id === 'activity_by_rep')!,
+    );
+    const ownerless = rows.filter((r) => r.owner == null || r.owner === '');
+    expect(
+      ownerless,
+      'the "Activity by Rep" bar has a null-owner column: a seeded event that demo_bootstrap ' +
+        'never claimed (#671 added crm_event to CLAIMED_OBJECTS)',
+    ).toEqual([]);
+  });
+
+  it('stratifies the three churn tiles instead of repeating one number', async () => {
+    const tile = async (id: string) => {
+      const widget = (activityDashboard.widgets as AnyRec[]).find((w) => w.id === id)!;
+      return totalOf(await runWidget(widget), 'account_count');
+    };
+    const [q30, q60, q90] = await Promise.all([
+      tile('quiet_accounts_30'),
+      tile('quiet_accounts_60'),
+      tile('quiet_accounts_90'),
+    ]);
+    const summary = `30+=${q30} 60+=${q60} 90+=${q90}`;
+
+    // Each tile non-empty is the issue's acceptance criterion; the strict
+    // ordering is what proves the seeds SPAN the bands rather than piling one
+    // very old account into all three.
+    expect(q90, `the 90-day tile is empty — ${summary}`).toBeGreaterThan(0);
+    expect(q60, `the 60-day tile does not exceed the 90-day one — ${summary}`).toBeGreaterThan(q90);
+    expect(q30, `the 30-day tile does not exceed the 60-day one — ${summary}`).toBeGreaterThan(q60);
+  });
+});

--- a/test/flow-scheduled.test.ts
+++ b/test/flow-scheduled.test.ts
@@ -1049,9 +1049,29 @@ describe('demo_bootstrap — post-seed ownership claim', () => {
       // row for everyone but `system_admin`.
       'crm_campaign',
       'crm_knowledge_article',
+      // #671: the activity model got demo rows, and `crm_event` declares
+      // `owner_id` under a `private` OWD — so an unclaimed seeded interaction
+      // is invisible to every rep (`sales_rep` reads it `own`-only), missing
+      // from the owner axis of `event_metrics`, and editable by nobody. This is
+      // the cross-table below going red the day the seeds landed, which is the
+      // mechanism working.
+      'crm_event',
     ]) {
       expect(claimed, `demo_bootstrap never claims ${object}`).toContain(object);
     }
+  });
+
+  /**
+   * The other half of #671, and the direction that is easy to get wrong by
+   * copying the line above: `crm_event_attendee` is seeded in the same commit
+   * as `crm_event` but declares NO `owner_id` — its access derives from the
+   * event it hangs off (`sharingModel: 'controlled_by_parent'`). Claiming it
+   * would stamp a column the object does not have, on rows where ownership
+   * means nothing. The computed cross-table below asserts this as a general
+   * rule; this case names the record so a future edit cannot quietly add it.
+   */
+  it('does not claim the attendee junction — it has no ownership to claim', () => {
+    expect(claimedObjects()).not.toContain('crm_event_attendee');
   });
 
   /**


### PR DESCRIPTION
Fixes #671

#592 / PR #670 把活动模型的元数据、动作、语义层和 Sales Activity 仪表盘全部装好了，但演示库里一行 `crm_event` 都没有：每个 widget 读 0,日历视图与互动历史为空,三个流失 tile 没有可分层的数据。本 PR 补上种子,并把 `crm_account.last_activity_date` 铺开成真正的 30/60/90 分布。

## 前提复核（issue 是线索,不是规格）

按 origin/main 逐条核对过,前提**成立**:`src/data/` 下确实没有任何 `crm_event` / `crm_event_attendee` 记录;`sales.seed.ts` 里九个客户的 `last_activity_date` 全部落在 1–21 天内,所以三个 tile 的 `$lt` 窗口一个也匹配不到;#635 拆分后的家族模块布局与 `_shared.ts` 的种子教条也都如 issue 所述。

## 做了什么

### 1. 27 条互动记录 + 参会人（`src/data/service.seed.ts`）

事件放在 service 家族,和 `crm_task` 并排 —— 该模块的抬头本来就写着"任务放这里是因为它是覆盖所有对象的活动层",事件是同一个活动层、同样的五个父对象。

- 17 条 `held` / 8 条 `planned` / 1 条 `cancelled` / 1 条 `no_show`;
- `held` 覆盖全部五种 `related_to_type`（account / contact / opportunity / lead / case）和五种 `type`（meeting / call / demo / webinar / onsite_visit）,横跨约九周,让周趋势面积图有曲线而不是一根柱子;
- 参会人按 `campaignMembersFromLeads` / `FromContacts` 的同一构造拆成两个 dataset —— 复合 externalId 只要有一个分量为 null,loader 生成的 key 就是空的,replay boot 会重复插入。没有 `sys_user` 参会人、也没有 `is_organizer: true` 的行:组织者是 rep,而**种子不能命名用户**,运行时的 `log_meeting` 会补上那一行。

时间全部是 CEL:`daysAgo(2) + duration("10h0m")`。用 TypeScript 在模块加载期算 ISO 会被冻进 `dist/objectstack.json`（已验证 artifact 里保留的是 CEL 表达式,不是日期字符串）;而单用 `daysAgo(n)` 只能得到 UTC 午夜 —— 一个每行都从 00:00 开始的日历没法拿去演示,duration 项就是为此。

### 2. 流失时钟的分布（`src/data/sales.seed.ts`）

实测落库结果:

```
Apex Logistics    2026-04-23  (104 天)  → 90+ tile
Initech Solutions 2026-05-25  ( 72 天)  → 60+ tile
Northwind Energy  2026-06-25  ( 41 天)  → 30+ tile
Globex 07-28 · Lattice 07-30 · Acme / Stark / Wayne / Vertex = today
```

三个 tile 因此读 3 / 2 / 1 而不是三个相同的数字。三个沉默客户各自都有一场**已预约**的重启会议 —— 时钟没动,这正是 #592 状态语义的演示。

### 边界确认（issue 第 2 点要求的那个）

种子直接写 `last_activity_date` 是允许的,但它**不是** `billing_country` 那一类,注释里写清了区别:`billing_country` 是 `readonly` + 派生,种子抄一份就是第二个真相来源(教条第 3 条);`last_activity_date` 既不 readonly(#592 去掉的)也不从账户上的任何列派生,它是历史事实,而它的写入方只会盖当天日期 —— 想让 demo 展示 90 天沉默就只能授权写入(教条第 1 条)。

真正的硬约束在另一边,而且它决定了整个布局:**hooks 会在种子写入时运行(#617)**,`event_activity_bubble` 对任何 `held` 事件都盖"种子那一刻",它从不读事件自己的时间戳。所以一个账户能带着"已授权的历史年龄"存在,当且仅当种子书里没有任何东西 bubble 到它。顺带查出一处既有漂移:Stark Medical 的 `daysAgo(5)` 一直在被那条已完成的 welcome-package 任务覆写(`task_activity_bubble` 同理),现在按事实改成 `today()`。

### 3. `demo_bootstrap` 认领 `crm_event`

**这是 #722 的计算式交叉表在正常工作,不是障碍。** `crm_event` 声明了 `owner_id`,所以种子一发事件行,"已播种 × 有 owner_id × 未认领"这一格就不再为空,`test/flow-scheduled.test.ts` 立刻转红。已按既有风格补上认领项和成文理由。`crm_event_attendee` **没有** `owner_id`（`controlled_by_parent`,访问从父事件派生）,故不认领 —— 交叉表的另一个方向会因此转红,新增用例点名钉住这一点。

顺带回答 #702 立下的"一个窗口一个生产者"问题:`log_call` / `log_meeting` / `schedule_meeting` 插入 `crm_event` 时会显式写 `owner_id`(action body 以 isSystem 运行,自己盖所有权),所以 rep 的互动记录永远不是无主的,这个 sweep 看不到它们;与 `crm_forecast` 不同,这里没有共享窗口需要让开,种子和 action 写的是不相交的行。

## 验收怎么转译的（跑不了浏览器）

`test/activity-seed-coverage.test.ts` 复用 `forecast-period-scope.test.ts` 的 harness（ObjectQL + InMemoryDriver + AnalyticsService）,把仪表盘**自己声明的 widget 绑定**送进真实的 dataset 编译器、真实的 filter token 解析器和真实引擎,数据是真实种子记录:

- 12 个 widget 逐个跑,合计度量必须 > 0;
- 分组类 widget 至少 3 列（`activity_by_rep` 例外,种子被同一个 first user 认领,1 行才是正确答案 —— 并顺带断言不存在 null-owner 列,即认领确实必要）;
- 三个 tile 断言 `30+ > 60+ > 90+ > 0`,即"各覆盖至少一个客户"且真的分层;
- 结构层:每个事件的父记录都能被 loader 解析、subject 唯一（upsert 身份）、`duration_minutes` 等于自己 start/end 的间隔（`event_schedule_derive` 会重算,不等就是被改写)、没有一行 start 在 UTC 午夜、没有一行授权 `owner_id`;
- **最吃重的一条**:按 hook 自己的可达规则重算 bubble 目标集合（直连 account + 经 contact/opportunity/case 上溯 + 已完成任务）,断言它与"被授权为沉默"的账户集合不相交,反向也断言 bubble 能到的账户必须授权成 `today()`。

## 反向验证（先定方向再跑）

**方向一(预测转红)**:把 `Initech — SSO configuration check-in` 从 `no_show` 翻成 `held` —— 预测"held 事件不得触及沉默账户"和"bubble 能到的账户必须是 today"两条转红。实测正是这两条红,其余 17 条绿。

**并且方向二(预测保持绿,这一点才是重点)**:同一次改动下"三个 band 各自非空"**仍然通过** —— 因为它读的是被授权的值,而数据库里的值已经被 bubble 改成今天了。种子文件会继续写着 72 天,tile 却空掉。这正是那条 bubble 不变式不冗余的原因,如果只写 band 断言,这个回归是看不见的。

**方向三**:从 `CLAIMED_OBJECTS` 里去掉 `crm_event` —— 预测 `flow-scheduled` 的名册断言与计算式交叉表双双转红,实测 `2 failed | 60 passed`,报错正是 `crm_event (sharingModel: private)`。

## 验证输出

```
pnpm test        →  Test Files 60 passed (60) · Tests 1433 passed | 1 skipped (1434)
pnpm typecheck   →  clean
pnpm validate    →  ✓ Validation passed (957ms)   （5 条既有 author-time warning,与本 PR 无关）
pnpm build       →  ✓ Build complete · Artifact: dist/objectstack.json (1910.0 KB)
node scripts/check-source-hygiene.mjs → clean（service.seed.ts 40KB,远低于 100KB 上限）
```

真机启动一次（`objectstack start` + 直接读 SQLite）确认落库,而不是只信单测:

```
events:      held 17 · planned 8 · cancelled 1 · no_show 1
attendees:   contact 24 · lead 3
held minutes: 985
held by related_to_type: account 5 · case 2 · contact 3 · lead 2 · opportunity 5
每个账户都有事件（活动相关列表处处非空）；没有一条事件缺父记录
start_datetime 落库为 2026-08-03T10:00:00.000Z 一类的真实时刻，duration 与间隔一致
四个被 bubble 到的账户落库为 2026-08-05 = 授权值 today()，证明 bubble 确实跑了且与授权一致
两个被 held 事件点名的 lead，last_contacted_date 被 bubble 改写成种子那一刻（同一日历日）
```

`test/territory-seed-coverage.test.ts` 一类既有种子守卫全绿,其中"每个家族模块的 dataset 都必须接进 `CrmSeedData`,且一个不多"那条在本 PR 里正好覆盖了新增的三个 dataset。

## 范围外发现

- 新开 #740（`finding` 标签,未指派）:`crm_event_attendee.external_name` 在 `attendee_type` 里没有对应选项,只填外部姓名的与会人只能被存成 `attendee_type: 'contact'` 却指不到任何联系人。用户可达但当前休眠(没有写入方会写 `external_name`)。本 PR 因此没有播任何 external-only 参会人 —— 那样做只能在 `attendee_type` 上撒谎。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_