### PR TITLE
fix(views): scope the "This Quarter" forecast view to the current quarter (#730)

### DIFF
--- a/.changeset/quarterly-forecast-view-scope.md
+++ b/.changeset/quarterly-forecast-view-scope.md
@@ -1,0 +1,13 @@
+---
+"hotcrm": patch
+---
+
+Forecast "This Quarter" list view now actually shows this quarter
+
+Opening **Forecasts → This Quarter** returned every quarterly snapshot ever taken — every settled quarter of every year — with the current one merely sorted to the top. All four locales named it "This Quarter" / 本季度 / Este trimestre / 今四半期, so anyone who trusted the heading and read the Quota column down was adding one quarter's target to another's.
+
+The view is now filtered to the current quarter (`period = quarter` **and** `period_start = {current_quarter_start}`), which is the same period key the Sales dashboard's *Quota Attainment by Rep* table pins. Both halves are needed: the period type alone spans years, and the start date alone merges the quarter row with the month row that opens the same quarter.
+
+The restriction had been removed on the ground that the list data path could not resolve a date macro. That was true on ObjectStack 16.1.0 and is no longer: filter placeholders have been resolved on the server's read path since 17.0.0-rc.0, which is what this app has been running for several releases.
+
+**What you will notice:** the view is empty until the nightly forecast sweep has opened the current quarter — the same honest-empty state the quota table already shows at a quarter boundary. It now says so, in every language, instead of showing a blank grid. Settled quarters are on the **All** tab.

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -320,7 +320,13 @@ export const en: TranslationData = {
       },
       _views: {
         all_forecasts: { label: 'All Forecasts' },
-        this_quarter_forecasts: { label: 'This Quarter' },
+        this_quarter_forecasts: {
+          label: 'This Quarter',
+          emptyState: {
+            title: 'This Quarter Has No Snapshots Yet',
+            message: 'Quarterly snapshots are written by the nightly forecast sweep. Until it has run once for the current quarter this view is empty — settled quarters are on the All tab.',
+          },
+        },
         my_forecast: { label: 'My Forecast' },
       },
       _sections: {

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -324,7 +324,13 @@ export const esES: TranslationData = {
       },
       _views: {
         all_forecasts: { label: 'Todas las previsiones' },
-        this_quarter_forecasts: { label: 'Este trimestre' },
+        this_quarter_forecasts: {
+          label: 'Este trimestre',
+          emptyState: {
+            title: 'Aún no hay instantáneas de este trimestre',
+            message: 'Las instantáneas trimestrales las escribe el barrido nocturno de previsiones. Hasta que se ejecute una vez para el trimestre actual, esta vista está vacía; los trimestres cerrados están en la pestaña Todas.',
+          },
+        },
         my_forecast: { label: 'Mi previsión' },
       },
       _sections: {

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -353,7 +353,13 @@ export const jaJP: TranslationData = {
       },
       _views: {
         all_forecasts: { label: 'すべてのフォーキャスト' },
-        this_quarter_forecasts: { label: '今四半期' },
+        this_quarter_forecasts: {
+          label: '今四半期',
+          emptyState: {
+            title: '今四半期のスナップショットはまだありません',
+            message: '四半期スナップショットは夜間のフォーキャスト集計が書き込みます。今四半期分が一度実行されるまでこのビューは空です。確定済みの四半期は「すべて」タブにあります。',
+          },
+        },
         my_forecast: { label: '自分のフォーキャスト' },
       },
       _sections: {

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -295,7 +295,13 @@ export const zhCN: TranslationData = {
       },
       _views: {
         all_forecasts: { label: '全部预测' },
-        this_quarter_forecasts: { label: '本季度' },
+        this_quarter_forecasts: {
+          label: '本季度',
+          emptyState: {
+            title: '本季度尚无快照',
+            message: '季度快照由每晚的预测扫描任务写入。在它为当前季度首次跑完之前，本视图为空——已结束的季度请见“全部”标签页。',
+          },
+        },
         my_forecast: { label: '我的预测' },
       },
       _sections: {

--- a/src/views/forecast.view.ts
+++ b/src/views/forecast.view.ts
@@ -39,7 +39,7 @@ export const ForecastViews = defineView({
     appearance: { allowedVisualizations: ['grid'] },
     tabs: [
       { name: 'all',          label: 'All',           view: 'all_forecasts',  isDefault: true, pinned: true },
-      { name: 'this_quarter', label: 'Quarterly',     icon: 'calendar',       view: 'this_quarter_forecasts' },
+      { name: 'this_quarter', label: 'This Quarter',  icon: 'calendar',       view: 'this_quarter_forecasts' },
       { name: 'mine',         label: 'My Forecast',   icon: 'user',           view: 'my_forecast' },
     ],
   },
@@ -48,26 +48,62 @@ export const ForecastViews = defineView({
     this_quarter_forecasts: {
       name: 'this_quarter_forecasts',
       type: 'grid',
-      // Operator-only filter: the list data path resolves no date macro (the
-      // old `{this_quarter_start}` — not even a valid token — reached the
-      // query as a literal string and matched nothing; the valid spelling
-      // `{current_quarter_start}` would ALSO ship unresolved). Newest quarter
-      // sorts first, so the current quarter is the top group.
-      label: 'Quarterly · Latest First',
+      // The label promises the CURRENT quarter, and the filter delivers it.
+      //
+      // The restriction was dropped in #515 on the measurement that "the list
+      // data path resolves no date macro". That measurement was taken on
+      // @objectstack 16.1.0 and has since expired: `resolveFilterTokens()` was
+      // wired into the ObjectQL READ path in 17.0.0-rc.0 (objectql
+      // `feat(filters): evaluate {filter-token} placeholders server-side`,
+      // #3582) — `find`/`findOne`/`count`/`aggregate`, ahead of the middleware
+      // chain, which is the one gate every server-side read passes through,
+      // saved-view filters included. Measured on the pinned 17.0.0-rc.2 rather
+      // than inferred; `test/forecast-current-quarter-view.test.ts` runs THIS
+      // filter through a real engine and pins the three-way outcome (one
+      // quarter selected, not zero and not all of them).
+      //
+      // Both halves of the key are load-bearing, same as the quota-attainment
+      // widget in `src/dashboards/sales.dashboard.ts`: `period: 'quarter'`
+      // alone returns every quarter ever snapshotted (the #730 defect), and
+      // `period_start` alone merges the quarter row with the MONTH row that
+      // opens the same quarter — Q3 and July both start on the 1st.
+      //
+      // The old `{this_quarter_start}` spelling is not merely unresolved now,
+      // it is rejected: the resolver throws `Unresolvable filter placeholder`
+      // and names `{current_quarter_start}` as the fix, so the silent-empty
+      // failure mode that removal was reacting to is no longer reachable.
+      label: 'This Quarter',
       data: { provider: 'object', object: 'crm_forecast' },
       columns: ['owner_id', 'quota', 'closed_amount', 'commit_amount', 'best_case_amount', 'pipeline_amount', 'attainment_pct', 'coverage_ratio'],
       filter: [
         { field: 'period', operator: 'equals', value: 'quarter' },
+        { field: 'period_start', operator: 'equals', value: '{current_quarter_start}' },
       ],
-      // The tiebreaker was `attainment_pct desc`, which is a FORMULA — the
+      // One sort key, because the filter pins `period_start` to a single value
+      // — the `period_start desc` key that ranked quarters against each other
+      // existed only to float the current quarter to the top of an unscoped
+      // list, and is provably inert now that the list holds one quarter.
+      //
+      // The tiebreaker is NOT `attainment_pct desc`, which is a FORMULA — the
       // engine computes it in JS after the query, so the data engine never saw
       // that sort key and the ordering within a quarter was arbitrary (same
       // class of defect as #489's `days_in_stage` filter). `closed_amount` is
       // the stored numerator behind attainment and ranks the same direction.
       sort: [
-        { field: 'period_start', order: 'desc' },
         { field: 'closed_amount', order: 'desc' },
       ],
+      // Empty is the honest state, and it needs to say so. The seeds ship no
+      // current-quarter row on purpose (#702 — the sweep owns that window, and
+      // two producers in one window is what left a phantom ownerless
+      // duplicate), so on a fresh install this view is empty until the 03:00
+      // `forecast_snapshot` sweep has run once. That is the same trade the
+      // quota-attainment widget already takes; without this copy the user
+      // cannot tell it apart from a broken view.
+      emptyState: {
+        title: 'This Quarter Has No Snapshots Yet',
+        message: 'Quarterly snapshots are written by the nightly forecast sweep. Until it has run once for the current quarter this view is empty — settled quarters are on the All tab.',
+        icon: 'calendar',
+      },
     },
     my_forecast: {
       name: 'my_forecast',

--- a/test/forecast-current-quarter-view.test.ts
+++ b/test/forecast-current-quarter-view.test.ts
@@ -1,0 +1,362 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import stack from '../objectstack.config';
+
+/**
+ * ═══ HOUSE RULE: a view label may not promise a time scope its filter does
+ *     not express ═══════════════════════════════════════════════════════════
+ *
+ * A list view is named twice — once in metadata (`label`) and once per locale
+ * (`objects.<object>._views.<view>.label`) — and the name a user reads is the
+ * translated one. Neither spelling is decoration: "This Quarter" is a claim
+ * about WHICH ROWS come back, and the only thing that can honour it is the
+ * view's `filter`.
+ *
+ * `crm_forecast` holds one row per owner PER PERIOD and deliberately holds
+ * several periods at once, so a quarter-labelled view whose filter says only
+ * `period = 'quarter'` returns every quarterly snapshot ever taken — every
+ * settled quarter of every year, with the current one merely sorted to the
+ * top. That was #730: four locales said "This Quarter" / 本季度 / Este
+ * trimestre / 今四半期 over an unscoped list, and a reader who trusted the
+ * label and summed the Quota column got the same cross-period addition #614
+ * fixed on the dashboard.
+ *
+ * ### Why the scope is expressible again (the premise that expired)
+ *
+ * The restriction was removed in #515 on a measurement that was true then and
+ * is false now: on @objectstack 16.1.0 nothing on the server substituted
+ * `{date_macro}` placeholders, so a `period_start = '{current_quarter_start}'`
+ * filter reached the driver as a literal string and matched nothing — an empty
+ * grid indistinguishable from "no data yet". `resolveFilterTokens()` was wired
+ * into the ObjectQL READ path in **17.0.0-rc.0** (objectql `feat(filters):
+ * evaluate {filter-token} placeholders server-side`, #3582), ahead of the
+ * middleware chain, covering `find` / `findOne` / `count` / `aggregate` — the
+ * one gate every server-side read passes through, saved-view filters included.
+ *
+ * This file does not take that on faith. The RUNTIME block below runs the
+ * shipped filter through a real engine on the pinned 17.0.0-rc.2 and pins a
+ * THREE-way outcome, because two of the three look alike from a screenshot:
+ *
+ *   | rows back | meaning                                              |
+ *   | --------- | ---------------------------------------------------- |
+ *   | 0         | the macro shipped unresolved — the #515 failure mode  |
+ *   | all       | the filter is unscoped — the #730 defect             |
+ *   | 1 quarter | resolved AND scoped — the contract                    |
+ *
+ * The STRUCTURAL block is the one that stops the lie coming back: it re-derives
+ * the claim from the labels themselves, in all four locales, so a view renamed
+ * "This Month" without a matching filter fails on the day it is renamed.
+ */
+
+type AnyRec = Record<string, any>;
+
+const views: AnyRec[] = (stack as any).views ?? [];
+const localePacks: [string, AnyRec][] = ((stack as any).translations ?? []).flatMap(
+  (bundle: AnyRec) => Object.entries(bundle) as [string, AnyRec][],
+);
+
+/**
+ * Phrases that claim a CURRENT calendar period, per period and per locale, and
+ * the `{token}` a filter must carry to honour the claim.
+ *
+ * Deliberately a claim vocabulary rather than a regex over "quarter": "All
+ * Forecasts" and "Quarterly Subscriptions" name no period and must not be
+ * dragged in, while "This Quarter" and 今四半期 do. `_start` is the token that
+ * pins a period on this schema — `period_start` stores the period's first day,
+ * so equality against `{current_*_start}` selects exactly one period.
+ */
+const CURRENT_PERIOD_CLAIMS: Array<{ period: string; token: string; phrases: RegExp[] }> = [
+  {
+    period: 'quarter',
+    token: '{current_quarter_start}',
+    phrases: [/this quarter/i, /current quarter/i, /本季度|本季報|本季$/, /este trimestre/i, /今四半期/],
+  },
+  {
+    period: 'month',
+    token: '{current_month_start}',
+    phrases: [/this month/i, /current month/i, /本月/, /este mes/i, /今月/],
+  },
+  {
+    period: 'week',
+    token: '{current_week_start}',
+    phrases: [/this week/i, /current week/i, /本周|本週/, /esta semana/i, /今週/],
+  },
+  {
+    period: 'year',
+    token: '{current_year_start}',
+    phrases: [/this year/i, /current year/i, /本年度/, /este año/i, /今年度/],
+  },
+];
+
+/**
+ * KNOWN DEBT — surfaces in breach of the rule above, with the issue that owns
+ * the fix. NOT a suppression list: each entry is asserted to be STILL in
+ * breach, so the day one is fixed this file goes red and tells you to delete
+ * the line. An exemption that quietly outlives its defect is how a guard
+ * becomes decoration.
+ *
+ * `crm_opportunity.closing_this_quarter` was found BY this guard on the run
+ * that introduced it: labelled "Closing This Quarter" in all four locales with
+ * no `close_date` condition of any kind, so it returns deals closing next year.
+ * It is a different object and a different view from #730's, and it needs a
+ * RANGE (`close_date` between quarter start and end) rather than the equality
+ * pin that fits `crm_forecast.period_start` — so it is filed, not folded in.
+ */
+const KNOWN_DEBT: Record<string, string> = {
+  'crm_opportunity.closing_this_quarter': '#743',
+};
+
+/** Every list view in the stack, flattened with the object it reads. */
+const listViews: Array<{ object: string; name: string; view: AnyRec }> = views.flatMap((record) => {
+  const containers: Array<[string, AnyRec]> = [
+    ...(record.list ? ([['list', record.list]] as Array<[string, AnyRec]>) : []),
+    ...Object.entries<AnyRec>(record.listViews ?? {}),
+  ];
+  return containers.map(([key, view]) => ({
+    object: view?.data?.object ?? record.list?.data?.object ?? record.object,
+    name: view?.name ?? key,
+    view,
+  }));
+});
+
+/** Metadata label + every locale label, i.e. every name a user can read. */
+const namesOf = (object: string, name: string, view: AnyRec): Array<[string, string]> => {
+  const out: Array<[string, string]> = [];
+  if (typeof view?.label === 'string') out.push(['metadata', view.label]);
+  for (const [locale, pack] of localePacks) {
+    const label = pack.objects?.[object]?._views?.[name]?.label;
+    if (typeof label === 'string') out.push([locale, label]);
+  }
+  return out;
+};
+
+/** The `{token}` values a view's filter actually carries. */
+const filterTokens = (view: AnyRec): string[] =>
+  (view?.filter ?? [])
+    .map((rule: AnyRec) => rule?.value)
+    .filter((v: unknown): v is string => typeof v === 'string' && /^\{.+\}$/.test(v));
+
+describe('no view label promises a time scope its filter does not express (#730)', () => {
+  it('the locale bundles this guard reads are actually loaded', () => {
+    // Without this, a bundle rename would silently reduce the guard to the
+    // metadata label alone — and the metadata label is the half that was RIGHT
+    // in #730. The lie lived exclusively in the translated half.
+    expect(localePacks.map(([l]) => l).sort()).toEqual(['en', 'es-ES', 'ja-JP', 'zh-CN']);
+  });
+
+  it('the forecast quarter view is one of the surfaces under guard', () => {
+    // Vacuity: this rule exists because of exactly one view. If the derivation
+    // stops finding it, the suite must fail rather than pass on an empty set.
+    const claims = listViews.filter(({ object, name, view }) =>
+      CURRENT_PERIOD_CLAIMS.some((c) =>
+        namesOf(object, name, view).some(([, label]) => c.phrases.some((p) => p.test(label)))));
+    expect(claims.map((c) => `${c.object}.${c.name}`)).toContain('crm_forecast.this_quarter_forecasts');
+  });
+
+  /** Every (view, claimed period) pair whose filter does not pin that period. */
+  const breaches = (): string[] => {
+    const out: string[] = [];
+    for (const { object, name, view } of listViews) {
+      const labels = namesOf(object, name, view);
+      const tokens = filterTokens(view);
+      for (const claim of CURRENT_PERIOD_CLAIMS) {
+        const claiming = labels.filter(([, label]) => claim.phrases.some((p) => p.test(label)));
+        if (claiming.length === 0) continue;
+        if (tokens.includes(claim.token)) continue;
+        out.push(
+          `${object}.${name} is labelled ${claiming.map(([l, v]) => `${l}:"${v}"`).join(', ')} `
+          + `but its filter carries no ${claim.token} — it returns every ${claim.period}, `
+          + `not the current one (filter tokens: ${tokens.join(', ') || 'none'})`,
+        );
+      }
+    }
+    return out;
+  };
+
+  it('every current-period label is backed by a filter that pins that period', () => {
+    const bad = breaches().filter((line) => !Object.keys(KNOWN_DEBT).some((k) => line.startsWith(`${k} `)));
+    expect(
+      bad,
+      'these view names promise a time scope the filter does not apply. Either pin '
+        + `the period in the filter, or rename the view so it stops claiming one:\n  ${bad.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('every KNOWN_DEBT exemption is still needed', () => {
+    const stale = Object.entries(KNOWN_DEBT)
+      .filter(([key]) => !breaches().some((line) => line.startsWith(`${key} `)))
+      .map(([key, issue]) => `${key} (${issue})`);
+    expect(
+      stale,
+      'these views no longer breach the rule — delete their KNOWN_DEBT entries so the '
+        + `guard covers them again:\n  ${stale.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('the quarter view pins BOTH halves of the period key', () => {
+    // `period_start` alone merges the quarter row with the MONTH row that opens
+    // the same quarter (Q3 and July both start on the 1st); `period` alone is
+    // the #730 defect. Only the pair names one snapshot per owner — the same
+    // pair `sales_dashboard/quota_attainment_by_rep` pins.
+    const view = listViews.find((v) => v.name === 'this_quarter_forecasts')!.view;
+    const pairs = (view.filter ?? []).map((r: AnyRec) => [r.field, r.operator, r.value]);
+    expect(pairs).toEqual([
+      ['period', 'equals', 'quarter'],
+      ['period_start', 'equals', '{current_quarter_start}'],
+    ]);
+  });
+
+  it('the empty state is authored and translated in all four locales', () => {
+    // Scoping to the current quarter makes "empty" a state a real user meets:
+    // the seeds ship no current-quarter row (#702 — the sweep owns that
+    // window), so a fresh install shows nothing here until the 03:00 sweep runs
+    // once. Untranslated, that reads as a broken view.
+    const view = listViews.find((v) => v.name === 'this_quarter_forecasts')!.view;
+    expect(view.emptyState?.title, 'authored empty-state title').toBeTruthy();
+    expect(view.emptyState?.message, 'authored empty-state message').toBeTruthy();
+    const missing: string[] = [];
+    for (const [locale, pack] of localePacks) {
+      const t = pack.objects?.crm_forecast?._views?.this_quarter_forecasts?.emptyState;
+      if (!t?.title) missing.push(`${locale}: title`);
+      if (!t?.message) missing.push(`${locale}: message`);
+    }
+    expect(missing, `untranslated empty-state copy:\n  ${missing.join('\n  ')}`).toEqual([]);
+  });
+});
+
+// ─── Runtime: the rows the shipped filter actually selects ─────────────────
+
+const pad = (n: number) => String(n).padStart(2, '0');
+const isoDate = (d: Date) => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+const now = new Date();
+const currentQuarterStart = isoDate(
+  new Date(Date.UTC(now.getUTCFullYear(), Math.floor(now.getUTCMonth() / 3) * 3, 1)),
+);
+const lastQuarterStart = isoDate(
+  new Date(Date.UTC(now.getUTCFullYear(), Math.floor(now.getUTCMonth() / 3) * 3 - 3, 1)),
+);
+
+/**
+ * Translate a view `filter` (the authored `[{field, operator, value}]` shape)
+ * into an engine `where`.
+ *
+ * Only the operators the shipped view uses are implemented, and an unknown one
+ * THROWS rather than being dropped: a silently-dropped condition widens the
+ * result set, which is the very failure this file exists to catch. It would
+ * turn a red test green.
+ */
+const whereFromViewFilter = (filter: AnyRec[]): AnyRec => {
+  const where: AnyRec = {};
+  for (const rule of filter ?? []) {
+    if (rule.operator !== 'equals') {
+      throw new Error(
+        `view filter operator "${rule.operator}" is not implemented by this test's `
+        + 'translator — implement it rather than letting the condition vanish',
+      );
+    }
+    where[rule.field] = rule.value;
+  }
+  return where;
+};
+
+describe('this_quarter_forecasts returns the current quarter, on the real engine (#730)', () => {
+  let ql: Awaited<ReturnType<typeof ObjectQL.create>>;
+  let api: AnyRec;
+  const view = listViews.find((v) => v.name === 'this_quarter_forecasts')!.view;
+
+  beforeAll(async () => {
+    ql = await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: {
+        crm_forecast: {
+          name: 'crm_forecast',
+          fields: {
+            id: { type: 'text' },
+            owner_id: { type: 'text' },
+            period: { type: 'text' },
+            period_start: { type: 'date' },
+            quota: { type: 'number' },
+            closed_amount: { type: 'number' },
+          },
+        },
+      } as never,
+    });
+    api = ql.createContext({ isSystem: true, userId: 'usr_1', tenantId: 'org_1' } as never);
+
+    // The current quarter, as the 03:00 sweep opens it — one row per owner.
+    await api.object('crm_forecast').insert({
+      owner_id: 'rep_alice', period: 'quarter', period_start: currentQuarterStart,
+      quota: 1_500_000, closed_amount: 900_000,
+    });
+    await api.object('crm_forecast').insert({
+      owner_id: 'rep_bob', period: 'quarter', period_start: currentQuarterStart,
+      quota: 1_500_000, closed_amount: 400_000,
+    });
+    // A settled quarter — what the unscoped filter used to hand back as well.
+    await api.object('crm_forecast').insert({
+      owner_id: 'rep_alice', period: 'quarter', period_start: lastQuarterStart,
+      quota: 1_200_000, closed_amount: 1_100_000,
+    });
+    // The MONTH row that opens the current quarter: same `period_start`, and
+    // the reason `period` has to stay in the filter beside the macro.
+    await api.object('crm_forecast').insert({
+      owner_id: 'rep_alice', period: 'month', period_start: currentQuarterStart,
+      quota: 500_000, closed_amount: 300_000,
+    });
+  });
+
+  afterAll(async () => {
+    await ql?.close();
+  });
+
+  it('the fixture really does hold more than one period', async () => {
+    // Premise of every assertion below: on a single-period table they would all
+    // pass for the wrong reason.
+    const all = await api.object('crm_forecast').find({ where: {} });
+    expect(all.length).toBe(4);
+  });
+
+  it('selects the current quarter only — not zero rows, and not every quarter', async () => {
+    const rows: AnyRec[] = await api.object('crm_forecast').find({
+      where: whereFromViewFilter(view.filter),
+    });
+
+    // Not zero: the macro RESOLVED. An unresolved `{current_quarter_start}`
+    // compares as a literal string and selects nothing — the failure mode #515
+    // removed the filter to escape, and the one that looks identical to a
+    // legitimately empty quarter on a screenshot.
+    expect(rows.length, 'macro resolved and matched rows').toBeGreaterThan(0);
+
+    // Not every quarter: the label is honoured.
+    expect(rows.map((r) => r.period_start)).toEqual([currentQuarterStart, currentQuarterStart]);
+    expect(rows.map((r) => r.owner_id).sort()).toEqual(['rep_alice', 'rep_bob']);
+
+    // And not the month row that shares the quarter's first day.
+    expect(rows.every((r) => r.period === 'quarter')).toBe(true);
+  });
+
+  it('the same filter WITHOUT the macro half returns every quarter — the #730 defect', async () => {
+    // The subtraction, run rather than asserted from memory: this is exactly
+    // the filter `main` shipped, and it is what the "This Quarter" label sat
+    // over. Pinning it here means the guard above cannot pass vacuously.
+    const rows: AnyRec[] = await api.object('crm_forecast').find({
+      where: { period: 'quarter' },
+    });
+    expect(rows.length).toBe(3);
+    expect([...new Set(rows.map((r) => r.period_start))].sort())
+      .toEqual([lastQuarterStart, currentQuarterStart].sort());
+  });
+
+  it('the pre-#515 spelling is now rejected outright, not silently unresolved', async () => {
+    // `{this_quarter_start}` is not in the vocabulary. On 16.1.0 it reached the
+    // driver as text and matched nothing; from 17.0.0-rc.0 the resolver throws
+    // and names the fix, so the silent-empty mode that motivated the removal is
+    // no longer reachable at all.
+    await expect(
+      api.object('crm_forecast').find({ where: { period_start: '{this_quarter_start}' } }),
+    ).rejects.toThrow(/Unresolvable filter placeholder/);
+  });
+});

--- a/test/forecast-period-scope.test.ts
+++ b/test/forecast-period-scope.test.ts
@@ -353,9 +353,11 @@ describe('quota_attainment_by_rep over the real seeds plus one sweep (#614)', ()
     expect(filtersSeen.length).toBeGreaterThan(0);
     // An unresolved token would reach the driver as the literal string
     // "{current_quarter_start}", compare as text and match nothing — an empty
-    // table indistinguishable from "no data yet". This is exactly what the
-    // LIST path does with the same macro (see src/views/forecast.view.ts), so
-    // the analytics path is asserted, never assumed.
+    // table indistinguishable from "no data yet". That WAS the list path's
+    // behaviour on 16.1.0, which is why this assertion was written for the
+    // analytics path alone; since 17.0.0-rc.0 the ObjectQL read path resolves
+    // the same macro too (#3582), and `test/forecast-current-quarter-view.test.ts`
+    // pins that half. Both paths are asserted, neither assumed.
     expect(leaves.filter((v) => /^\{.+\}$/.test(v))).toEqual([]);
     expect(leaves).toContain(currentQuarterStart);
   });

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -607,20 +607,40 @@ describe('dashboard actions land on real routes', () => {
 
 describe('filter template tokens are resolvable', () => {
   /**
-   * Token support differs per data path, verified empirically against the
-   * running 16.1.0 console (2026-07-28):
+   * Token support differs per data path — and the difference MOVED under us at
+   * the 17.0 upgrade, so the shape of this rule changed with it (#730).
    *
-   * - LIST-VIEW data path (`/api/v1/data/...`): resolves ONLY the user tokens
-   *   (`{current_user_id}`). Date macros ship to the server as literal
-   *   strings — and because `'2026-…' < '{…'` is lexicographically TRUE, a
-   *   `< {180_days_ago}` filter matched freshly-reviewed articles (inverted
-   *   semantics, not just empty results). Use operator-only filters + sort.
+   * - LIST-VIEW data path (`/api/v1/data/...`): resolves user tokens AND date
+   *   macros. The date-macro half is new. Through 16.1.0 nothing on the server
+   *   substituted placeholders on the read path, so a macro shipped as a
+   *   literal string — and because `'2026-…' < '{…'` is lexicographically
+   *   TRUE, a `< {180_days_ago}` filter matched freshly-reviewed articles
+   *   (inverted semantics, not merely empty). That is why this rule used to
+   *   read "user tokens ONLY", and why views were written as operator-only
+   *   filters plus a sort.
+   *
+   *   `resolveFilterTokens()` was wired into the ObjectQL READ path in
+   *   17.0.0-rc.0 (objectql `feat(filters): evaluate {filter-token}
+   *   placeholders server-side`, #3582) — ahead of the middleware chain,
+   *   covering `find`/`findOne`/`count`/`aggregate`, which is the one gate
+   *   every server-side read passes through, saved-view filters included. The
+   *   lexicographic hazard above is gone in BOTH directions now: a known token
+   *   is substituted before the driver sees it, and an unknown one throws
+   *   `Unresolvable filter placeholder` naming the near-miss fix instead of
+   *   comparing as text.
+   *
+   *   Measured on the pinned 17.0.0-rc.2, not inferred from the changelog:
+   *   `test/forecast-current-quarter-view.test.ts` runs a shipped view filter
+   *   through a real engine and pins one quarter selected out of three, plus
+   *   the throw on the retired `{this_quarter_start}` spelling.
    *
    * - ANALYTICS path (dashboard widgets / dataset reports,
-   *   `/api/v1/analytics/...`): resolves the DATE_MACRO_TOKENS vocabulary
-   *   (the YTD revenue widget returns a non-zero sum, impossible with a
-   *   literal token), but NO user token — `{current_user}` and even
-   *   `{current_user_id}` match no owner (see crm.app.ts's My Work note).
+   *   `/api/v1/analytics/...`): resolves the DATE_MACRO_TOKENS vocabulary (the
+   *   YTD revenue widget returns a non-zero sum, impossible with a literal
+   *   token), but still NO user token — `{current_user}` and even
+   *   `{current_user_id}` match no owner (see crm.app.ts's My Work note). That
+   *   half is unchanged and tracked at #510, so the two rules below remain
+   *   asymmetric — just not in the direction they were written for.
    */
   const dashboards: AnyRec[] = (stack as any).dashboards ?? [];
   const reports: AnyRec[] = (stack as any).reports ?? [];
@@ -649,8 +669,8 @@ describe('filter template tokens are resolvable', () => {
     }
   };
 
-  it('list view and page filters only use user tokens', () => {
-    const allowed = (t: string) => USER_TOKENS.has(t);
+  it('list view and page filters only use user tokens or date macros', () => {
+    const allowed = (t: string) => USER_TOKENS.has(t) || isDateMacroToken(t);
     const bad: string[] = [];
     for (const v of views) {
       const lists = [v.list, ...Object.values(v.listViews ?? {})].filter(Boolean) as AnyRec[];
@@ -660,6 +680,31 @@ describe('filter template tokens are resolvable', () => {
       badTokensIn(`page "${p.name}"`, p.interfaceConfig?.filterBy, allowed, bad);
     }
     expect(bad, `unresolvable view/page filter tokens:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('the widened list-view rule still rejects what neither path resolves', () => {
+    // Widening a rule is how a rule dies. `{this_quarter_start}` is the exact
+    // spelling #515 removed from `this_quarter_forecasts`, and the engine now
+    // throws on it — so it must stay rejected HERE too, at author time, rather
+    // than being waved through by the new date-macro allowance. `{current_user}`
+    // covers the other near-miss (the resolvable spelling is `{current_user_id}`).
+    const allowed = (t: string) => USER_TOKENS.has(t) || isDateMacroToken(t);
+    const bad: string[] = [];
+    badTokensIn('probe', [
+      { value: '{this_quarter_start}' },
+      { value: '{current_user}' },
+      { value: '{not_a_token}' },
+    ], allowed, bad);
+    expect(bad).toHaveLength(3);
+
+    // …and still accepts both classes it is now supposed to accept.
+    const good: string[] = [];
+    badTokensIn('probe', [
+      { value: '{current_user_id}' },
+      { value: '{current_quarter_start}' },
+      { value: '{30_days_ago}' },
+    ], allowed, good);
+    expect(good).toEqual([]);
   });
 
   it('dashboard widget and report filters only use date macros', () => {


### PR DESCRIPTION
Fixes #730

## 方向与分诊预判相反 —— 因为前提已过期，且是实测推翻的

分诊预判是「标签侧修」：把 label 和四个语言包改成「季度预测」，理由是当前季度限定当初被**刻意**去掉，因为列表路径不解析日期宏（平台限制，不在本仓修）。

复核后这条理由不成立，所以按 issue 派单里写明的反向分支处理：**恢复限定，保留标签**。

去掉限定的那次提交是 628e413b（#515，2026-07-29），当时 `package.json` 里是 `@objectstack/runtime 16.1.0`。服务端过滤器占位符解析是在 **17.0.0-rc.0** 才接进 ObjectQL 读路径的（objectql CHANGELOG，`feat(filters): evaluate {filter-token} placeholders server-side`，#3582），本仓早已跑在 17.0.0-rc.2 上。也就是说：那条注释在写下时是对的，在被引用时已经不对了。

不是照 changelog 推断，是在 pinned 的 17.0.0-rc.2 上跑出来的：

```
ALL rows:                    3 rows (2026-07-01, 2025-01-01, 2025-04-01)
where { period:'quarter', period_start:'{current_quarter_start}' }
                          -> 1 row  (2026-07-01)          err: undefined
where { period_start:'{this_quarter_start}' }
                          -> throws: Unresolvable filter placeholder
                             "{this_quarter_start}". Resolvable placeholders are
                             the context tokens ({current_user_id}, {current_org_id})
                             and the date macros ({today}, {current_quarter_start}, …)
```

三条旁证互相印证：`@objectstack/lint` 的 `validate-filter-tokens` 把 `views` 明确列为 token 面并且只对**未知** token 报错；console 前端 bundle 自带 `current_quarter_start` 的解析实现；以及本仓 `my_forecast` 视图早就在同一个 `filter:` 数组位置上依赖 `{current_user_id}` 并且工作正常 —— 两类 token 走的是同一个 `resolveFilterTokens`，不存在「只解析用户 token 不解析日期宏」的中间态。

## 改了什么

**`src/views/forecast.view.ts`**

- `filter` 补回 `period_start = {current_quarter_start}`。两半都是必需的，和 `sales_dashboard/quota_attainment_by_rep` 钉的是同一对键：只有 `period` 会跨年返回所有季度（就是本 issue 的缺陷），只有 `period_start` 会把季度行和「开在同一天的月度行」混在一起（Q3 和 7 月都从 1 号开始）。
- `label` 从 `Quarterly · Latest First` 回到 `This Quarter`，tab 标签从 `Quarterly` 回到 `This Quarter`。
- `sort` 去掉 `period_start desc`：这个键当初只是为了把当前季度浮到无限定列表的顶部，现在列表只含一个季度，它可证明是空转。保留 `closed_amount desc`，以及解释「为什么不是 `attainment_pct`（公式字段，引擎查询后才在 JS 里算）」的原注释。
- 新增 `emptyState`。这是本 PR 唯一的用户可见副作用，必须讲清楚：按 #702，种子数据**故意**不发当前季度的行（那个窗口归 03:00 的 `forecast_snapshot` 扫描任务，两个生产者曾经留下过一条无主的幽灵行）。所以全新安装在扫描首次跑完之前，这个视图是空的 —— 和配额达成表在季度交界处的选择一致，「空着才是诚实的」。没有这段文案，用户分不清它和坏掉的视图。

**四个语言包** —— label **一个字都没改**。这是这次方向翻转后的一个结论：说谎的是 metadata label，四个语言包从头到尾是对的。它们只新增了 `emptyState` 的 title/message 两条。

## 测试

**`test/forecast-current-quarter-view.test.ts`（新增，10 条）**

- 结构守卫是通用的，不是钉死这一个视图：对全仓每个 list view，把 metadata label **加上四个语言包的 label** 一起取出来，凡是宣称了「当前周期」（this quarter / 本季度 / este trimestre / 今四半期，以及月/周/年的对应说法）的，filter 里就必须带上对应的 `{current_*_start}`。这样「标签承诺了 filter 没做的时间范围」这条谎话不能再回来。
- 运行时块把**实际发布的 filter** 喂给真引擎，钉的是三选一而不是二选一 —— 因为其中两种在截图上长得一样：0 行 = 宏没解析（#515 当初躲的那个失败模式），全部行 = filter 没限定（本 issue），一个季度 = 契约。同时钉住月度行不会被误收，以及 `{this_quarter_start}` 现在是抛异常而不是静默匹配空。

**`test/metadata-references.test.ts`** —— 这个文件里的 `list view and page filters only use user tokens` 规则编码的正是同一条过期的 16.1.0 实测，在本改动上**直接转红了**（不是我预判的，是全量跑出来的）。它的 docblock 里白纸黑字写着 "verified empirically against the running 16.1.0 console (2026-07-28)"。

规则放宽为「用户 token **或**日期宏」，docblock 改写成记录「变了什么、什么时候变的、凭什么」而不是删掉历史 —— 包括那个已经消失的字典序陷阱（`'2026-…' < '{…'` 为真，导致 `< {180_days_ago}` 当年匹配到的是刚复核过的文章，是语义反转而不只是空结果）。

放宽规则的风险是把规则放死，所以**同时加了一条反空转探针**：`{this_quarter_start}`、`{current_user}`、`{not_a_token}` 三个近似拼写必须仍然被拒（断言正好 3 条），`{current_user_id}`、`{current_quarter_start}`、`{30_days_ago}` 必须被接受。

分析层那一半**没动**：analytics 路径至今不解析用户 token（#510 仍开着），所以两条规则依然不对称 —— 只是不对称的方向和它们当初被写下来时相反了。`test/forecast-period-scope.test.ts` 里那句「LIST 路径对同一个宏就是这么干的」的注释同步改正。

## 反向验证（方向为事先预判，两个都跑了）

- 预判 **红**：把 `period_start` 那一行删掉（即恢复 `main` 的 filter）→ 3 条转红，且各自点名真实原因：结构守卫列出全部五种拼法（`metadata:"This Quarter", en:"This Quarter", zh-CN:"本季度", ja-JP:"今四半期", es-ES:"Este trimestre"`）说 filter 里没有 `{current_quarter_start}`；both-halves 断言收到 `[['period','equals','quarter']]`；运行时断言收到 3 个 `period_start` 而不是 2 个。
- 预判 **红**：把新探针的 `allowed` 改成恒真 → `expected [] to have a length of 3`。
- `metadata-references` 那一条不需要预判方向 —— 它是在全量跑里先红给我看的，我才去读它的 docblock。

## 越界的部分：没改，已立 issue

- **#743**（新提，`bug`/`metadata`）—— 通用守卫在引入的当次运行里就抓出了第二个同类缺陷：`crm_opportunity.closing_this_quarter` 四个语言包都叫「Closing This Quarter」，filter 里对 `close_date` **没有任何**条件，明年成交的单子也在里面。它属于另一个对象、另一个视图，而且需要的是区间而不是等值钉，所以按派单的文件面约束不在本 PR 修。本 PR 用一条 `KNOWN_DEBT` 例外挂住它，例外**会自己过期**：另有一条测试断言每个例外「仍然确实在违规」，#743 修好那天这里会转红提醒删掉例外。
- **#744**（新提，`finding`）—— 两处源码注释仍在断言「列表路径不解析日期宏」，其中 `src/dashboards/sales.dashboard.ts` 那处还带一句祈使的 "Do not generalise from one path to the other"。两处在本 PR 之前就已经是错的（不是本 PR 造成的回归），但本 PR 会让其中一处变成悬空引用。分别位于 `src/dashboards/**` 与 `src/data/**`（后者 #671 在飞），都在文件面之外，故只立 issue 不动手。

## 关于视图 API 名与文档

- **`this_quarter_forecasts` 这个名字没有改，这是刻意的判断**。方向翻转之后它本来也不该改了 —— 名字现在和行为完全一致。即便不翻转，改 API 名也是契约面变更，属于另一个 PR 的事。
- 文档**一行没动**，是查过之后的结论而不是跳过：`content/docs/sales/forecasting.mdx` 全文没有点名这个视图的标签（PR #735 因为本 issue 刻意回避了点名）。第 55 行「Until then, anything scoped to *this quarter* … is legitimately empty」本来就是一般性表述，现在正好把这个列表视图也覆盖进去了，仍然准确。#732 在飞的 AI 段落没有碰到。

## 验证

```
pnpm validate   ✓ Validation passed (1017ms)
pnpm typecheck  ✓ (tsc --noEmit, 无输出)
pnpm lint       13 warning(s), 14 suggestion(s)  —— 与 main 同量，均为既有项
pnpm hygiene    ✓ source hygiene clean
pnpm build      ✓ Build complete (1077ms)
pnpm test       Test Files 61 passed (61)
                Tests 1446 passed | 1 skipped (1447)
```

平台依赖未动，仍锁在 `@objectstack/* 17.0.0-rc.2`；没有任何日期宏的绕行实现 —— 用的就是平台自己的 token 词表。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_