### PR TITLE
fix(views): window "Closing This Quarter" to deals that close this quarter (#743)

### DIFF
--- a/.changeset/quiet-donkeys-repeat.md
+++ b/.changeset/quiet-donkeys-repeat.md
@@ -1,0 +1,18 @@
+---
+"hotcrm": patch
+---
+
+Scope the Opportunity "Closing This Quarter" list to deals that actually close this quarter.
+
+The view was labelled "Closing This Quarter" in metadata and in all four locales while its
+filter carried no condition on `close_date` at all, so it returned every open commit and
+best-case deal whenever it was due to close — a deal slated for next March sat under the
+heading, and a rep who summed the Amount column got a number that was not this quarter's
+commit. The filter now windows `close_date` to the current quarter, using the platform's
+own date macros (`{current_quarter_start}` … `{current_quarter_end}`), which the ObjectQL
+read path substitutes server-side.
+
+Scoping the list makes an empty result reachable — near the end of a quarter, or in an org
+whose commit has slipped — so the view now carries an empty state explaining what it lists
+and where the later deals are, translated in all four locales. The labels are unchanged:
+they were right all along; the filter was the part that lied.

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -574,6 +574,16 @@ export const en: TranslationData = {
         deal_timeline: { label: 'Deal Timeline' },
         deal_gallery: { label: 'Deal Cards' },
         my_open_deals: { label: 'My Open Deals' },
+        // No `label` here on purpose: this view (like `stale_opportunities`)
+        // takes its English name from the metadata `label`, which is already
+        // English. Only the empty state needs a bundle entry — it has no
+        // metadata fallback path through the locale resolver.
+        closing_this_quarter: {
+          emptyState: {
+            title: 'No Deals Closing This Quarter',
+            message: 'This tab lists open commit and best-case deals with a close date inside the current quarter. Nothing matches right now — deals closing later are on the Open Deals tab.',
+          },
+        },
       },
       _sections: {
         basic: { label: 'Basic Information' },

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -589,7 +589,13 @@ export const esES: TranslationData = {
         deal_timeline: { label: 'Línea de Tiempo' },
         deal_gallery: { label: 'Galería de Negocios' },
         my_open_deals: { label: 'Mis Negocios Abiertos' },
-        closing_this_quarter: { label: 'Cierres de Este Trimestre' },
+        closing_this_quarter: {
+          label: 'Cierres de Este Trimestre',
+          emptyState: {
+            title: 'No hay negocios que cierren este trimestre',
+            message: 'Esta pestaña muestra los negocios abiertos en categoría Compromiso o Mejor Caso cuya fecha de cierre cae dentro del trimestre actual. Ahora mismo no hay ninguno; los negocios que cierran más adelante están en la pestaña Negocios Abiertos.',
+          },
+        },
         stale_opportunities: { label: '⚠️ Oportunidades Estancadas · Más Tiempo en Etapa Primero' },
       },
       _sections: {

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -578,7 +578,13 @@ export const jaJP: TranslationData = {
         deal_gallery: { label: '商談カード' },
         my_open_deals: { label: '私のオープン商談' },
         stale_opportunities: { label: '⚠️ 停滞商談 · ステージ滞在が長い順' },
-        closing_this_quarter: { label: '今四半期にクローズ予定' },
+        closing_this_quarter: {
+          label: '今四半期にクローズ予定',
+          emptyState: {
+            title: '今四半期にクローズ予定の商談はありません',
+            message: 'このタブには、完了予定日が今四半期内にあるコミット／ベストケースのオープン商談が表示されます。現在該当する商談はありません。それ以降にクローズする商談は「オープン商談」タブにあります。',
+          },
+        },
       },
       _sections: {
         // 詳細ページの `record:details` セクション名（opportunity_detail.page.ts）

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -959,7 +959,13 @@ export const zhCN: TranslationData = {
         deal_gallery: { label: '商机卡片' },
         my_open_deals: { label: '我的进行中商机' },
         stale_opportunities: { label: '⚠️ 停滞商机 · 按阶段停留时间排序' },
-        closing_this_quarter: { label: '本季度待成交商机' },
+        closing_this_quarter: {
+          label: '本季度待成交商机',
+          emptyState: {
+            title: '本季度暂无待成交商机',
+            message: '本标签页列出成交日期落在当前季度内、且处于承诺（Commit）或最佳可能（Best Case）的进行中商机。当前没有符合条件的记录——成交日期更晚的商机请见“进行中商机”标签页。',
+          },
+        },
       },
       _sections: {
         // Detail-page `record:details` section names (opportunity_detail.page.ts)

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -239,11 +239,52 @@ export const OpportunityViews = defineView({
       label: 'Closing This Quarter',
       data: { provider: 'object', object: 'crm_opportunity' },
       columns: ['name', 'crm_account', 'amount', 'forecast_category', 'probability', 'close_date', 'owner_id'],
+      // The `close_date` window is what makes the label true (#743). Without
+      // it this view returned EVERY open commit/best-case deal whenever it
+      // closed — a deal slated for next March sat under a heading that said
+      // "Closing This Quarter", and summing the Amount column gave a number
+      // that was not this quarter's commit.
+      //
+      // Both bounds are date macros resolved server-side: `resolveFilterTokens()`
+      // was wired into the ObjectQL read path in 17.0.0-rc.0 (objectql #3582,
+      // covering find/findOne/count/aggregate ahead of the middleware chain),
+      // so a saved-view filter value reaches the driver already substituted.
+      // Measured on the pinned 17.0.0-rc.2, not inferred — see the runtime
+      // block in `test/forecast-current-quarter-view.test.ts`.
+      //
+      // The upper bound is INCLUSIVE against `{current_quarter_end}` rather
+      // than half-open against `{next_quarter_start}`, and that choice is
+      // deliberate: a `*_end` token resolves to the period's last calendar DAY
+      // (2026-09-30), which on a `datetime` column would stop at midnight and
+      // silently drop that day's rows — the spec says to use the half-open
+      // form there. `close_date` is `Field.date()`, stored as `YYYY-MM-DD`
+      // TEXT on both sides of the comparison, so the inclusive bound is exact.
+      // That is the same field-type property `metadata-references.test.ts`
+      // relies on for why the CRM/Sales/Executive dashboards may window
+      // `close_date` at all (#460). Both forms were measured to return the
+      // identical row set here; the inclusive one reads as what it means.
       filter: [
         { field: 'forecast_category', operator: 'in', value: ['commit', 'best_case'] },
         { field: 'stage', operator: 'not_in', value: ['closed_won', 'closed_lost'] },
+        { field: 'close_date', operator: 'greater_than_or_equal', value: '{current_quarter_start}' },
+        { field: 'close_date', operator: 'less_than_or_equal', value: '{current_quarter_end}' },
       ],
       sort: [{ field: 'close_date', order: 'asc' }],
+      // Scoping the list makes "empty" a state a real user meets, so it needs
+      // copy. Unlike the forecast view's (#745, where the sweep owns the
+      // window and a fresh install is ALWAYS empty until it runs), the seeds
+      // here do produce rows for most of a quarter — six seeded deals qualify
+      // on forecast_category + stage, at `daysFromNow` offsets 11/14/24/30/38/45.
+      // But every one of those offsets is relative to the INSTALL day, so once
+      // fewer than 11 days remain in the quarter all six land in the next one
+      // and a freshly seeded demo opens this tab on nothing. A real org meets
+      // the same state whenever a quarter's commit slips out. Empty is
+      // legitimate here; unexplained, it reads as broken.
+      emptyState: {
+        title: 'No Deals Closing This Quarter',
+        message: 'This tab lists open commit and best-case deals with a close date inside the current quarter. Nothing matches right now — deals closing later are on the Open Deals tab.',
+        icon: 'calendar-check',
+      },
     },
   },
 

--- a/test/forecast-current-quarter-view.test.ts
+++ b/test/forecast-current-quarter-view.test.ts
@@ -36,8 +36,8 @@ import stack from '../objectstack.config';
  * middleware chain, covering `find` / `findOne` / `count` / `aggregate` — the
  * one gate every server-side read passes through, saved-view filters included.
  *
- * This file does not take that on faith. The RUNTIME block below runs the
- * shipped filter through a real engine on the pinned 17.0.0-rc.2 and pins a
+ * This file does not take that on faith. The RUNTIME blocks below run the
+ * shipped filters through a real engine on the pinned 17.0.0-rc.2 and pin a
  * THREE-way outcome, because two of the three look alike from a screenshot:
  *
  *   | rows back | meaning                                              |
@@ -49,6 +49,19 @@ import stack from '../objectstack.config';
  * The STRUCTURAL block is the one that stops the lie coming back: it re-derives
  * the claim from the labels themselves, in all four locales, so a view renamed
  * "This Month" without a matching filter fails on the day it is renamed.
+ *
+ * ### Two surfaces, two filter SHAPES (#730 and #743)
+ *
+ * The structural guard found a second instance on the run that introduced it,
+ * and the second one needed a different fix, which is why both runtime blocks
+ * are here rather than one being a copy of the other:
+ *
+ * - `crm_forecast.this_quarter_forecasts` pins a period by EQUALITY —
+ *   `period_start` stores the period's first day, so one `=` names one quarter.
+ * - `crm_opportunity.closing_this_quarter` needs a RANGE — `close_date` is an
+ *   arbitrary day inside the quarter. A range has a failure mode an equality
+ *   does not: lose one bound and the list widens back out while still looking
+ *   scoped, so that block subtracts each bound separately (#743).
  */
 
 type AnyRec = Record<string, any>;
@@ -98,16 +111,17 @@ const CURRENT_PERIOD_CLAIMS: Array<{ period: string; token: string; phrases: Reg
  * the line. An exemption that quietly outlives its defect is how a guard
  * becomes decoration.
  *
- * `crm_opportunity.closing_this_quarter` was found BY this guard on the run
- * that introduced it: labelled "Closing This Quarter" in all four locales with
- * no `close_date` condition of any kind, so it returns deals closing next year.
- * It is a different object and a different view from #730's, and it needs a
- * RANGE (`close_date` between quarter start and end) rather than the equality
- * pin that fits `crm_forecast.period_start` — so it is filed, not folded in.
+ * Currently EMPTY, and it earned that: the one entry it shipped with,
+ * `crm_opportunity.closing_this_quarter` (#743), was found BY this guard on the
+ * run that introduced it — labelled "Closing This Quarter" in all four locales
+ * with no `close_date` condition of any kind. #743 gave it the range the label
+ * promises, and the self-expiry assertion below is what said so: it went red on
+ * the fix and stayed red until this line was deleted, which is the whole point
+ * of asserting an exemption rather than suppressing one. Keep the map (and both
+ * assertions) — the next instance of this defect class needs somewhere to be
+ * recorded that cannot rot.
  */
-const KNOWN_DEBT: Record<string, string> = {
-  'crm_opportunity.closing_this_quarter': '#743',
-};
+const KNOWN_DEBT: Record<string, string> = {};
 
 /** Every list view in the stack, flattened with the object it reads. */
 const listViews: Array<{ object: string; name: string; view: AnyRec }> = views.flatMap((record) => {
@@ -240,24 +254,64 @@ const lastQuarterStart = isoDate(
 );
 
 /**
+ * Canonical `VIEW_FILTER_OPERATORS` spellings, lowered to the engine's
+ * comparison keys. The mapping is the same one `spec/data/filter.zod.ts`
+ * applies (`AST_OPERATOR_MAP`); it is spelled out here rather than imported so
+ * this test asserts against the vocabulary an author actually writes.
+ */
+const COMPARISON_OPERATORS: Record<string, string> = {
+  in: '$in',
+  not_in: '$nin',
+  greater_than_or_equal: '$gte',
+  less_than_or_equal: '$lte',
+  greater_than: '$gt',
+  less_than: '$lt',
+};
+
+/**
  * Translate a view `filter` (the authored `[{field, operator, value}]` shape)
  * into an engine `where`.
  *
- * Only the operators the shipped view uses are implemented, and an unknown one
+ * Only the operators the shipped views use are implemented, and an unknown one
  * THROWS rather than being dropped: a silently-dropped condition widens the
  * result set, which is the very failure this file exists to catch. It would
  * turn a red test green.
+ *
+ * Two rules on the SAME field merge into one comparison object — that is how
+ * `closing_this_quarter` expresses its half of a range (#743), and dropping
+ * either bound would widen the window rather than fail. A scalar equality
+ * colliding with a range on one field throws for the same reason: one of the
+ * two would have to be discarded.
  */
 const whereFromViewFilter = (filter: AnyRec[]): AnyRec => {
   const where: AnyRec = {};
+  const isComparison = (v: unknown) => typeof v === 'object' && v !== null && !Array.isArray(v);
   for (const rule of filter ?? []) {
-    if (rule.operator !== 'equals') {
+    const existing = where[rule.field];
+    if (rule.operator === 'equals') {
+      if (existing !== undefined) {
+        throw new Error(
+          `field "${rule.field}" already carries a condition; adding an equality would `
+          + 'discard one of them rather than narrow the result',
+        );
+      }
+      where[rule.field] = rule.value;
+      continue;
+    }
+    const key = COMPARISON_OPERATORS[rule.operator];
+    if (!key) {
       throw new Error(
         `view filter operator "${rule.operator}" is not implemented by this test's `
         + 'translator — implement it rather than letting the condition vanish',
       );
     }
-    where[rule.field] = rule.value;
+    if (existing !== undefined && !isComparison(existing)) {
+      throw new Error(
+        `field "${rule.field}" already carries a scalar equality; merging a `
+        + `"${rule.operator}" clause onto it would drop one of them`,
+      );
+    }
+    where[rule.field] = { ...(isComparison(existing) ? existing : {}), [key]: rule.value };
   }
   return where;
 };
@@ -358,5 +412,199 @@ describe('this_quarter_forecasts returns the current quarter, on the real engine
     await expect(
       api.object('crm_forecast').find({ where: { period_start: '{this_quarter_start}' } }),
     ).rejects.toThrow(/Unresolvable filter placeholder/);
+  });
+});
+
+// ─── Runtime: the same three-way pin, on the RANGE case (#743) ──────────────
+
+/**
+ * `crm_opportunity.closing_this_quarter` is the second surface the structural
+ * guard above caught, and it differs from `crm_forecast`'s in the shape the fix
+ * takes. `period_start` stores a period's first day, so ONE equality names one
+ * quarter. `close_date` is an arbitrary day inside the quarter, so the only
+ * honest filter is a RANGE — and a range fails in a way an equality cannot:
+ * lose one bound and the list silently widens back out, which looks exactly
+ * like the defect it replaced.
+ *
+ * Hence the same three-way pin as the #730 block (0 rows = macro unresolved,
+ * all rows = unscoped, one quarter = contract) plus a bound-by-bound
+ * subtraction, and boundary rows on the quarter's first and last day so the
+ * INCLUSIVE upper bound cannot quietly become exclusive.
+ */
+const quarterEndDate = isoDate(
+  new Date(Date.UTC(now.getUTCFullYear(), Math.floor(now.getUTCMonth() / 3) * 3 + 3, 0)),
+);
+const nextQuarterStart = isoDate(
+  new Date(Date.UTC(now.getUTCFullYear(), Math.floor(now.getUTCMonth() / 3) * 3 + 3, 1)),
+);
+const nextYearDay = `${now.getUTCFullYear() + 1}-03-15`;
+const lastYearDay = `${now.getUTCFullYear() - 1}-05-20`;
+
+describe('closing_this_quarter returns this quarter only, on the real engine (#743)', () => {
+  let ql: Awaited<ReturnType<typeof ObjectQL.create>>;
+  let api: AnyRec;
+  const view = listViews.find((v) => v.name === 'closing_this_quarter')!.view;
+
+  /** Every seeded deal, and whether the SHIPPED filter should return it. */
+  const fixtures: Array<{ name: string; close_date: string; forecast_category: string; stage: string; expected: boolean }> = [
+    // In-window, and qualifying on the two conditions that already shipped.
+    { name: 'opens-the-quarter', close_date: currentQuarterStart, forecast_category: 'commit', stage: 'negotiation', expected: true },
+    { name: 'closes-the-quarter', close_date: quarterEndDate, forecast_category: 'best_case', stage: 'proposal', expected: true },
+    { name: 'mid-quarter', close_date: isoDate(new Date(Date.UTC(now.getUTCFullYear(), Math.floor(now.getUTCMonth() / 3) * 3 + 1, 15))), forecast_category: 'commit', stage: 'proposal', expected: true },
+    // Out of window — the #743 defect, in both directions.
+    { name: 'first-day-of-next-quarter', close_date: nextQuarterStart, forecast_category: 'commit', stage: 'negotiation', expected: false },
+    { name: 'next-year', close_date: nextYearDay, forecast_category: 'commit', stage: 'proposal', expected: false },
+    { name: 'last-year', close_date: lastYearDay, forecast_category: 'best_case', stage: 'proposal', expected: false },
+    // In window, but excluded by the halves that were already correct. These
+    // keep the date range from being credited for the whole result set.
+    { name: 'in-window-but-pipeline', close_date: quarterEndDate, forecast_category: 'pipeline', stage: 'qualification', expected: false },
+    { name: 'in-window-but-won', close_date: currentQuarterStart, forecast_category: 'commit', stage: 'closed_won', expected: false },
+  ];
+  const expectedNames = fixtures.filter((f) => f.expected).map((f) => f.name).sort();
+
+  beforeAll(async () => {
+    ql = await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: {
+        crm_opportunity: {
+          name: 'crm_opportunity',
+          fields: {
+            id: { type: 'text' },
+            name: { type: 'text' },
+            stage: { type: 'text' },
+            forecast_category: { type: 'text' },
+            amount: { type: 'number' },
+            // `date`, NOT `datetime` — the property the inclusive upper bound
+            // rests on. See the comment on the view's filter.
+            close_date: { type: 'date' },
+          },
+        },
+      } as never,
+    });
+    api = ql.createContext({ isSystem: true, userId: 'usr_1', tenantId: 'org_1' } as never);
+    for (const f of fixtures) {
+      await api.object('crm_opportunity').insert({
+        name: f.name, close_date: f.close_date, forecast_category: f.forecast_category,
+        stage: f.stage, amount: 100_000,
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await ql?.close();
+  });
+
+  it('the shipped filter carries both bounds, in the canonical operator spelling', () => {
+    // Structural, and deliberately strict about the SPELLING: the schema folds
+    // `greater_or_equal`/`gte` to canonical on parse, so an alias would work at
+    // runtime and drift the source away from the one authoring vocabulary
+    // `VIEW_FILTER_OPERATORS` defines. #743's own issue body proposed the alias.
+    const pairs = (view.filter ?? []).map((r: AnyRec) => [r.field, r.operator, r.value]);
+    expect(pairs).toEqual([
+      ['forecast_category', 'in', ['commit', 'best_case']],
+      ['stage', 'not_in', ['closed_won', 'closed_lost']],
+      ['close_date', 'greater_than_or_equal', '{current_quarter_start}'],
+      ['close_date', 'less_than_or_equal', '{current_quarter_end}'],
+    ]);
+  });
+
+  it('the fixture really does hold deals outside the quarter', async () => {
+    // Premise of every assertion below: on an all-in-quarter table they would
+    // all pass without the range doing anything.
+    const all: AnyRec[] = await api.object('crm_opportunity').find({ where: {} });
+    expect(all.length).toBe(fixtures.length);
+    expect(all.some((r) => r.close_date === nextYearDay)).toBe(true);
+    expect(all.some((r) => r.close_date === lastYearDay)).toBe(true);
+  });
+
+  it('selects this quarter only — not zero rows, and not every open deal', async () => {
+    const rows: AnyRec[] = await api.object('crm_opportunity').find({
+      where: whereFromViewFilter(view.filter),
+    });
+
+    // Not zero: both macros RESOLVED. An unresolved `{current_quarter_start}`
+    // compares as a literal string, and on a range it is worse than the
+    // equality case — `>= '{current…'` and `<= '{current…'` cannot both hold,
+    // so the list is empty and looks like a quarter with no commit.
+    expect(rows.length, 'macros resolved and matched rows').toBeGreaterThan(0);
+
+    // Not every open deal: the label is honoured.
+    expect(rows.length).toBeLessThan(fixtures.length);
+    expect(rows.map((r) => r.name).sort()).toEqual(expectedNames);
+
+    // Every surviving row really is inside the window, by value.
+    for (const r of rows) {
+      expect(r.close_date >= currentQuarterStart, `${r.name} on or after quarter start`).toBe(true);
+      expect(r.close_date <= quarterEndDate, `${r.name} on or before quarter end`).toBe(true);
+    }
+  });
+
+  it('both quarter boundary days are INSIDE the window', async () => {
+    // The upper bound is `<= {current_quarter_end}`, i.e. the quarter's last
+    // calendar day. Were it silently exclusive (or were the token to resolve to
+    // the next period's first day) the deal closing ON the last day would drop
+    // out — a one-row loss at the exact moment of the quarter a manager is
+    // reading this list hardest.
+    const rows: AnyRec[] = await api.object('crm_opportunity').find({
+      where: whereFromViewFilter(view.filter),
+    });
+    const dates = rows.map((r) => r.close_date);
+    expect(dates).toContain(currentQuarterStart);
+    expect(dates).toContain(quarterEndDate);
+    // …and the very next day is not.
+    expect(dates).not.toContain(nextQuarterStart);
+  });
+
+  it('the same filter WITHOUT the range returns deals closing next year — the #743 defect', async () => {
+    // The subtraction, run rather than asserted from memory: this is exactly
+    // the filter `main` shipped under a "Closing This Quarter" heading. It adds
+    // rows rather than removing them, so this case cannot pass for the empty
+    // reason a subtraction case sometimes does.
+    const withoutRange = (view.filter ?? []).filter((r: AnyRec) => r.field !== 'close_date');
+    const rows: AnyRec[] = await api.object('crm_opportunity').find({
+      where: whereFromViewFilter(withoutRange),
+    });
+    expect(rows.map((r) => r.name).sort()).toEqual([
+      'closes-the-quarter', 'first-day-of-next-quarter', 'last-year',
+      'mid-quarter', 'next-year', 'opens-the-quarter',
+    ]);
+    expect(rows.map((r) => r.close_date)).toContain(nextYearDay);
+  });
+
+  it('dropping EITHER bound alone widens the window', async () => {
+    // A range has two ways to rot, and losing one bound is the quiet one: the
+    // list still looks scoped and still excludes half the offenders.
+    const only = (op: string) => (view.filter ?? []).filter(
+      (r: AnyRec) => r.field !== 'close_date' || r.operator === op,
+    );
+    const noUpper: AnyRec[] = await api.object('crm_opportunity').find({
+      where: whereFromViewFilter(only('greater_than_or_equal')),
+    });
+    expect(noUpper.map((r) => r.close_date)).toContain(nextYearDay);
+    expect(noUpper.map((r) => r.close_date)).not.toContain(lastYearDay);
+
+    const noLower: AnyRec[] = await api.object('crm_opportunity').find({
+      where: whereFromViewFilter(only('less_than_or_equal')),
+    });
+    expect(noLower.map((r) => r.close_date)).toContain(lastYearDay);
+    expect(noLower.map((r) => r.close_date)).not.toContain(nextYearDay);
+  });
+
+  it('the empty state is authored and translated in all four locales', () => {
+    // Unlike the forecast view's, the seeds here DO qualify for most of a
+    // quarter — six deals at `daysFromNow` offsets 11…45. But those offsets run
+    // from the install day, so a demo seeded with under 11 days left in the
+    // quarter opens this tab on nothing, and a real org meets the same state
+    // whenever the quarter's commit slips out. Untranslated, that reads as a
+    // broken view rather than an honest zero.
+    expect(view.emptyState?.title, 'authored empty-state title').toBeTruthy();
+    expect(view.emptyState?.message, 'authored empty-state message').toBeTruthy();
+    const missing: string[] = [];
+    for (const [locale, pack] of localePacks) {
+      const t = pack.objects?.crm_opportunity?._views?.closing_this_quarter?.emptyState;
+      if (!t?.title) missing.push(`${locale}: title`);
+      if (!t?.message) missing.push(`${locale}: message`);
+    }
+    expect(missing, `untranslated empty-state copy:\n  ${missing.join('\n  ')}`).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #743

## 前提复核：成立，且区间可表达

派单要求先证伪再实现。两半都复核了，都成立：

**缺陷本身在 `origin/main` 上确实存在**（`src/views/opportunity.view.ts:236`）：`closing_this_quarter` 的 filter 只有 `forecast_category in [commit, best_case]` 和 `stage not_in [closed_won, closed_lost]`，对 `close_date` 没有任何条件。四个语言包（metadata "Closing This Quarter" / zh-CN 本季度待成交商机 / es-ES Cierres de Este Trimestre / ja-JP 今四半期にクローズ予定）都在承诺这个时间范围。`test/forecast-current-quarter-view.test.ts:109` 的 KNOWN_DEBT 例外和它的自过期断言也都在原处。

**区间在 17.0.0-rc.2 上可以表达** —— 这是不能靠推断的那一半，所以是跑出来的。宏词表在 `@objectstack/spec/src/data/date-macros.zod.ts` 的 `DATE_MACRO_PERIOD_TOKENS` 里，`current_quarter_end` 和 `current_quarter_start` 并列存在；解析实现在 `@objectstack/core` 的 `resolvePeriodToken`，`*_end` 走 `next period start 减一天`。在 pinned 17.0.0-rc.2 上实测：

```
quarter window: 2026-07-01 .. 2026-09-30
all rows:                    5  ["2026-07-01","2026-09-30","2026-10-01","2027-03-15","2025-05-20"]
$gte {current_quarter_start} + $lte {current_quarter_end}
                          -> 2  ["first-day-of-quarter=2026-07-01","last-day-of-quarter=2026-09-30"]
$gte {current_quarter_start} + $lt  {next_quarter_start}
                          -> 2  （同一结果集）
$gte {current_quarter_start} 单边
                          -> 4  （2026-10-01 / 2027-03-15 都漏进来）
{this_quarter_start}      -> throws: Unresolvable filter placeholder
```

所以不需要 needs_decision，也没有把算出来的日期冻进 metadata。

## 改了什么

**`src/views/opportunity.view.ts`**

- filter 增加两条 `close_date` 边界。算子用**规范拼写** `greater_than_or_equal` / `less_than_or_equal`——不是 issue 正文里建议的 `greater_or_equal` / `less_or_equal`。后者在 `VIEW_FILTER_OPERATOR_ALIASES` 里，parse 时会被折叠成规范形式，所以运行起来一样，但源码就偏离了 `VIEW_FILTER_OPERATORS` 这唯一的 authoring 词表。测试里对拼写做了结构钉。
- 上界取**闭区间** `<= {current_quarter_end}`，而不是半开的 `< {next_quarter_start}`。这是刻意选的，理由写进了注释：`*_end` 是周期的最后一个**日历日**，spec 明确警告在 `datetime` 列上它会停在午夜——但 `close_date` 是 `Field.date()`，两侧都是 `YYYY-MM-DD` TEXT，闭区间是精确的。这正是 `metadata-references.test.ts` 里「dashboard 只能 window `date` 字段」那条规则（#460）依据的同一个字段类型性质。两种写法实测同一结果集，闭区间读起来就是它的字面意思。
- 新增 `emptyState`。这是本 PR 唯一的用户可见副作用，判断依据说清楚：和 #745 那个**不一样**。forecast 视图是全新安装必然为空（窗口归扫描任务）；这里种子**会**产出行——查了 `src/data/sales.seed.ts`，六条商机在 forecast_category + stage 上合格，close_date 分别是 `daysFromNow` 的 11/14/24/30/38/45。但这些偏移都是相对**安装日**的，所以当季度剩余不足 11 天时六条全部落到下个季度，刚种子化的演示打开这个 tab 就是空的；真实组织在本季度承诺滑出时同样会遇到。空是合法状态，不解释就像坏了。

**四个语言包** —— label **一个字没改**（它们本来就是对的，说谎的是 filter），只加 `emptyState` 的 title/message。`en.ts` 里 `closing_this_quarter` 原本就没有条目（和 `stale_opportunities` 一样，英文名走 metadata label），所以只补 emptyState、不补 label，并把这个取舍写在注释里。

## 测试

**`test/forecast-current-quarter-view.test.ts`**

- KNOWN_DEBT 例外行删除。map 本身保留（留空）并改写 docblock —— 下一个同类缺陷需要一个不会腐烂的记录位置。
- 新增第二个运行时块，按 #745 的三选一钉法钉**区间**这一形态：0 行 = 宏没解析、全部行 = 没限定、只有本季度 = 契约。区间比等值多一种腐烂方式，所以额外加了**逐边界减法**（只去掉上界 → 明年的单子漏进来；只去掉下界 → 去年的漏进来），以及季度**首日和末日**两条边界行，防止闭区间哪天悄悄变成开区间。
- fixture 里放了两条「在窗口内但被另外两个条件排除」的行（pipeline 类别、closed_won），这样日期区间不会被记在整个结果集的功劳上。
- `whereFromViewFilter` translator 原本对非 `equals` 直接抛异常（刻意如此：静默丢条件会把红测试变绿）。现在实现了比较算子，并且同字段两条规则合并成一个比较对象；标量等值和区间撞在同一字段上仍然抛异常，因为那必然要丢掉一条。

## 反向验证（方向事先预判，两个都跑了，都命中）

**预判红 —— 删掉两条 range 条件（即恢复 main 的 filter）→ 5 条转红**，且各自点名真实原因：

```
× every current-period label is backed by a filter that pins that period
    crm_opportunity.closing_this_quarter is labelled metadata:"Closing This Quarter",
    zh-CN:"本季度待成交商机", ja-JP:"今四半期にクローズ予定",
    es-ES:"Cierres de Este Trimestre" but its filter carries no
    {current_quarter_start} … (filter tokens: none)
× the shipped filter carries both bounds, in the canonical operator spelling
× selects this quarter only — expected [ 'closes-the-quarter', …(5) ] to deeply equal …(2)
× both quarter boundary days are INSIDE the window — expected […] to not include '2026-10-01'
× dropping EITHER bound alone widens the window — expected […] to not include '2025-05-20'
      Tests  5 failed | 12 passed (17)
```

**预判绿 —— 同一次运行里 `every KNOWN_DEBT exemption is still needed` 保持绿**，因为 map 已清空，没有例外可以过期。这条不是疏漏，是这个断言的语义。

**第二个反向验证（自过期断言本身）**：在**修好**的 filter 之上把 KNOWN_DEBT 条目加回去 → 正好这一条转红，措辞就是 issue 承诺的那句：

```
× every KNOWN_DEBT exemption is still needed
AssertionError: these views no longer breach the rule — delete their KNOWN_DEBT
entries so the guard covers them again:
  crm_opportunity.closing_this_quarter (#743)
      Tests  1 failed | 16 passed (17)
```

docblock 里「它在修好那天转红、直到删掉这行」这句话因此是实测的，不是转述的。

## 验证

```
pnpm validate   ✓ Validation passed (1008ms)
pnpm typecheck  ✓ (tsc --noEmit，无输出)
pnpm hygiene    ✓ source hygiene clean
pnpm build      ✓ Build complete (1075ms)
pnpm lint       13 warning(s), 14 suggestion(s)  —— 与 main 同量，无新增项
pnpm test       Test Files 62 passed (62)
                Tests 1473 passed | 1 skipped (1474)
```

平台依赖未动，仍锁在 `@objectstack/* 17.0.0-rc.2`；没有任何绕行实现或冻结日期，用的就是平台自己的宏词表。

## 越界的部分：没改

- **`src/views/opportunity.view.ts:219-221`（`stale_opportunities` 的注释）仍然写着「the list data path resolves no date macros」** —— 这是 #744 那一类过期注释的**第三处**，而且和本 PR 在同一个文件里、在我改的 filter 上方十几行，读起来是直接自相矛盾的。没有在这里顺手改，也没有另开 issue（那会和 #744 撞成孪生），而是把这处补充到了 **#744** 的评论里，让三处在同一次修正中保持一致口径。它不影响 `stale_opportunities` 的形态：那条注释还给了第二个独立且**仍然成立**的理由（`days_in_stage` 是公式字段，引擎查询后才算）。
- `content/docs/sales/opportunities.mdx:117` 用第三个名字（"Pipeline This Quarter"）称呼这个视图、并列出仓库里并不存在的视图名 —— issue 正文已记录，属于 #736/#739 同轮在飞的文档面，本 PR 一行未动。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_