### PR TITLE
fix(opportunity): 补齐 needs_analysis 的阶段路径与 Open Deals 行着色，并加派生式完整性守卫

### DIFF
--- a/.changeset/opportunity-needs-analysis-stage-coverage.md
+++ b/.changeset/opportunity-needs-analysis-stage-coverage.md
@@ -1,0 +1,41 @@
+---
+'hotcrm': patch
+---
+
+Show the Needs Analysis stage on the opportunity path and tint its rows in Open
+Deals, and guard stage coverage against the canonical picklist.
+
+`crm_opportunity.stage` has **seven** canonical values
+(`OPPORTUNITY_STAGE_OPTIONS` in `src/objects/_picklists.ts`), but two pieces of
+UI metadata enumerated only six, and both dropped the same one:
+`needs_analysis`. On the detail page's `record:path` a deal sitting in Needs
+Analysis lit up **no step at all**, so the strip read as though the deal had
+skipped straight from Qualification to Proposal; in the Open Deals list its rows
+got no stage tint while every neighbouring stage did. Needs Analysis is an
+ordinary mid-funnel stage — 40% default probability, `best_case` forecast
+category, reachable from Qualification by the object's own state machine and
+offered by `mass_update_stage` — so this was six-sevenths of a working feature
+presenting as corrupted data on the seventh.
+
+Both sites now carry the stage: the path gains a step between Qualification and
+Proposal (funnel order; the two terminal stages stay last), and `rowColor` gains
+teal `#14b8a6`, which sits between the cool qualification blue and the warm
+proposal amber. The colour is deliberately **not** the `#FFD700` the option
+carries in `_picklists.ts` — that map is a separate Tailwind palette, and gold is
+one hue step from proposal's `#f59e0b`, so reusing it would have left the two
+adjacent stages tinting rows indistinguishably and re-created the bug in a form
+harder to see.
+
+`test/metadata-references.test.ts` already checked these two surfaces in one
+direction — every value written there must be a real option. That subset check
+passes happily on a map that lists six of seven, which is why nothing caught
+this. Four assertions add the converse: every value of
+`OPPORTUNITY_STAGE_OPTIONS` must appear in every `record:path` bound to
+`crm_opportunity.stage` and in every stage-keyed `rowColor`, no two stages may
+share a row colour, and the object field must still be built from that same
+constant. The expectation is **derived** from the picklist rather than
+hand-copied, so an eighth stage cannot ship half-covered — a copied list would
+need the same edit as the metadata it guards, and would be forgotten in the same
+commit.
+
+Fixes #759.

--- a/src/pages/opportunity_detail.page.ts
+++ b/src/pages/opportunity_detail.page.ts
@@ -76,9 +76,17 @@ export const OpportunityDetailPage: Page = {
           label: 'Opportunity Stage Path',
           properties: {
             statusField: 'stage',
+            // Every canonical value of `stage` must appear here, in funnel
+            // order — the path is the only place a rep reads "where is this
+            // deal". `needs_analysis` was missing, so a deal sitting in that
+            // stage lit up NO step at all and the strip read as if the deal
+            // had skipped from Qualification to Proposal. The two terminal
+            // stages stay last (won before lost), matching lead_detail's
+            // converted/unqualified tail.
             stages: [
               { value: 'prospecting', label: 'Prospecting' },
               { value: 'qualification', label: 'Qualification' },
+              { value: 'needs_analysis', label: 'Needs Analysis' },
               { value: 'proposal', label: 'Proposal' },
               { value: 'negotiation', label: 'Negotiation' },
               { value: 'closed_won', label: 'Closed Won' },

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -43,6 +43,12 @@ export const OpportunityViews = defineView({
       colors: {
         prospecting: '#94a3b8',
         qualification: '#60a5fa',
+        // Teal sits between the cool qualification blue and the warm proposal
+        // amber, keeping the cool→warm funnel ramp readable. NOT the
+        // `#FFD700` this option carries in `_picklists.ts`: this map is a
+        // Tailwind palette, and gold is one hue step from proposal's
+        // `#f59e0b` — the two adjacent stages would tint rows the same.
+        needs_analysis: '#14b8a6',
         proposal: '#f59e0b',
         negotiation: '#a855f7',
         closed_won: '#16a34a',

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -972,7 +972,7 @@ describe('every canonical opportunity stage reaches the UI that enumerates stage
           ]),
       );
 
-  it('the canonical stage list is the seven-value set the object validates against', () => {
+  it('the canonical stage list is the set the object validates against', () => {
     // Guards the guard twice over: an empty or renamed constant would make
     // every assertion below pass by comparing against nothing, and a `stage`
     // field that stopped being built from this constant would leave the two

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest';
 import { isDateMacroToken } from '@objectstack/spec/data';
 import { AgentSchema } from '@objectstack/spec/ai';
 import stack from '../objectstack.config';
+import { OPPORTUNITY_STAGE_OPTIONS } from '../src/objects/_picklists';
 
 /**
  * Dangling-reference guards for UI metadata.
@@ -920,6 +921,121 @@ describe('row colors and kanban groups key off real option values', () => {
       }
     }
     expect(bad, `broken kanban groupings:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});
+
+/**
+ * Stage enumerations are COMPLETE, not merely valid.
+ *
+ * The two guards above answer "is every value written here a real option?" —
+ * a subset check. Nothing asked the converse, "is every real option written
+ * here?", and that is the half that broke (#759): `needs_analysis` is one of
+ * the seven canonical `OPPORTUNITY_STAGE_OPTIONS` and was absent from BOTH the
+ * detail page's stage path and the Open Deals `rowColor` map. Six of seven
+ * stages worked, so both surfaces looked fine on every deal that happened not
+ * to be in Needs Analysis — the deal that WAS lit up no step on the path and
+ * got no row tint, which reads to a user as corrupted data rather than as
+ * missing metadata.
+ *
+ * The expectation is derived from `OPPORTUNITY_STAGE_OPTIONS` itself — the
+ * single source `crm_opportunity.stage` and the `mass_update_stage` action are
+ * both built from — so an EIGHTH stage cannot ship half-covered. A hand-copied
+ * list here would need the same edit as the metadata it guards, and would
+ * therefore be forgotten in the same commit.
+ */
+describe('every canonical opportunity stage reaches the UI that enumerates stages', () => {
+  const canonical = OPPORTUNITY_STAGE_OPTIONS.map((o) => String(o.value));
+
+  /** Every `record:path` bound to `crm_opportunity.stage`, as [pageName, values]. */
+  const stagePaths = (): [string, string[]][] =>
+    pages
+      .filter((page) => page.object === 'crm_opportunity')
+      .flatMap((page) =>
+        [...walk(page.regions), ...walk(page.slots)]
+          .filter((c) => c.type === 'record:path' && c.properties?.statusField === 'stage')
+          .map((c): [string, string[]] => [
+            `${page.name} / ${c.id}`,
+            (c.properties?.stages ?? []).map((s: AnyRec) => String(s.value)),
+          ]),
+      );
+
+  /** Every list `rowColor` keyed on `crm_opportunity.stage`, as [viewName, colors]. */
+  const stageRowColors = (): [string, AnyRec][] =>
+    views
+      .filter((v) => (v.list?.data?.object ?? v.object) === 'crm_opportunity')
+      .flatMap((v) =>
+        ([v.list, ...Object.values(v.listViews ?? {})].filter(Boolean) as AnyRec[])
+          .filter((list) => list.rowColor?.field === 'stage')
+          .map((list): [string, AnyRec] => [
+            `view "${list.name ?? 'default'}"`,
+            list.rowColor?.colors ?? {},
+          ]),
+      );
+
+  it('the canonical stage list is the seven-value set the object validates against', () => {
+    // Guards the guard twice over: an empty or renamed constant would make
+    // every assertion below pass by comparing against nothing, and a `stage`
+    // field that stopped being built from this constant would leave the two
+    // sites below chasing a list the runtime no longer enforces.
+    expect(canonical.length, 'OPPORTUNITY_STAGE_OPTIONS is empty').toBeGreaterThan(0);
+    const objDef = objects.find((o) => o.name === 'crm_opportunity');
+    const fieldValues = (objDef?.fields?.stage?.options ?? []).map((o: AnyRec) => String(o.value));
+    expect([...fieldValues].sort(), 'crm_opportunity.stage no longer mirrors OPPORTUNITY_STAGE_OPTIONS')
+      .toEqual([...canonical].sort());
+  });
+
+  it('every stage has a step on the opportunity stage path', () => {
+    const sites = stagePaths();
+    // A renamed component type or statusField would silently empty this list
+    // and turn the assertion below into a no-op — exactly how the navigation
+    // guard in this file spent its life passing.
+    expect(sites.length, 'no record:path bound to crm_opportunity.stage was found').toBeGreaterThan(0);
+
+    const bad: string[] = [];
+    for (const [site, values] of sites) {
+      for (const stage of canonical) {
+        if (!values.includes(stage)) bad.push(`${site}: no path step for stage "${stage}"`);
+      }
+      for (const value of values) {
+        if (!canonical.includes(value)) bad.push(`${site}: path step "${value}" is not a canonical stage`);
+      }
+    }
+    expect(bad, `incomplete stage paths:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every stage has a row colour in the opportunity list views that tint by stage', () => {
+    const sites = stageRowColors();
+    expect(sites.length, 'no rowColor keyed on crm_opportunity.stage was found').toBeGreaterThan(0);
+
+    const bad: string[] = [];
+    for (const [site, colors] of sites) {
+      const keys = Object.keys(colors);
+      for (const stage of canonical) {
+        if (!keys.includes(stage)) bad.push(`${site}: no rowColor entry for stage "${stage}"`);
+      }
+      for (const key of keys) {
+        if (!canonical.includes(key)) bad.push(`${site}: rowColor key "${key}" is not a canonical stage`);
+      }
+    }
+    expect(bad, `incomplete stage row colours:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('stage colours stay distinguishable from one another', () => {
+    // The point of the map is that a rep can tell two stages apart at a
+    // glance; two stages sharing a hex make the tint say nothing. (#759 was
+    // nearly fixed by copying `needs_analysis`'s `#FFD700` out of
+    // _picklists.ts, one hue step from proposal's `#f59e0b`.)
+    const bad: string[] = [];
+    for (const [site, colors] of stageRowColors()) {
+      const seen = new Map<string, string>();
+      for (const key of Object.keys(colors)) {
+        const hex = String(colors[key]).toLowerCase();
+        const owner = seen.get(hex);
+        if (owner) bad.push(`${site}: "${key}" and "${owner}" are both ${hex}`);
+        else seen.set(hex, key);
+      }
+    }
+    expect(bad, `stages sharing a row colour:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Fixes #759

## 前提复核（对 `origin/main` = c55aaf5a）

issue 的两处指认都成立，唯一的更正是路径那处的键名是 `stages` 而不是 `steps`，以及 picklist 的实际路径是 `src/objects/_picklists.ts`（issue 正文写对了，派单摘要写成了 `src/data/`）：

- `src/objects/_picklists.ts:111-119` `OPPORTUNITY_STAGE_OPTIONS` 有 **7** 个规范取值。
- `src/pages/opportunity_detail.page.ts` 的 `record:path` 只列了 6 个，缺 `needs_analysis`。
- `src/views/opportunity.view.ts` `open_opportunities` 的 `rowColor.colors` 只列了 6 个，同样缺 `needs_analysis`。

**并且按要求排查了"是否还有别的逐项枚举 stage 的地方也漏了"** —— 结论是没有，这两处就是全部：

| 站点 | 是否逐项枚举 | 7 个是否齐全 |
| --- | --- | --- |
| `opportunity.object.ts:110` `stage` 字段 options | 是（`[...OPPORTUNITY_STAGE_OPTIONS]`，派生） | 齐 |
| `opportunity.object.ts:421-428` 状态机 transitions | 是（手写） | 齐（含两个终态空数组） |
| `opportunity.hook.ts` `STAGE_PROBABILITY` / `STAGE_FORECAST` | 是（手写） | 齐 |
| 4 份 locale pack 的 `stage.options` | 是（手写） | 齐（en / zh-CN / es-ES / ja-JP） |
| `mass_update_stage` 的 `stage` 参数 | 是（`plainOptions(...)`，派生） | 齐 |
| `pipeline_kanban` | 否（`groupByField: 'stage'`，列由 picklist 生成） | 不适用 |
| dashboards / reports / datasets | 否（只有 `closed_won` / `$nin: [closed_won, closed_lost]` 这类过滤，不逐项列举） | 不适用 |
| `quote-generation.flow.ts` | 否（三值条件表达式，已含 `needs_analysis`） | 不适用 |

所以无需另开 issue，越界文件面为空。

## 修法

**阶段路径** —— 在 Qualification 与 Proposal 之间插一步。终态的处理沿用现有约定：`closed_won` / `closed_lost` 仍排在最后（先赢后输），与 `lead_detail` 的 converted/unqualified 收尾一致，不做 variant 之类的特殊标注。

**行着色** —— 取 teal `#14b8a6`。这里**没有**照搬 issue 建议的、`_picklists.ts` 里该项自带的 `#FFD700`：`rowColor` 用的是另一套 Tailwind 调色板（slate-400 / blue-400 / amber-500 / purple-500 / green-600 / red-600），而金色与相邻的 proposal `#f59e0b` 只差一个色相档，两个相邻阶段的行会染成看不出差别的同一种颜色 —— 那等于用一种更难发现的形式把 bug 重新做一遍。teal 落在 qualification 冷蓝与 proposal 暖琥珀之间，正好接上这条冷→暖的漏斗渐变。

## 守卫

`test/metadata-references.test.ts` 原本已经检查这两处，但只查**一个方向**：写下来的每个值必须是真实 option（子集）。一张只列了 7 个里的 6 个的表，在子集检查下完全合法 —— 这就是它没被发现的原因。新增 4 条断言补上反方向，且期望值**派生自** `OPPORTUNITY_STAGE_OPTIONS` 而非手抄：手抄的清单需要和它守卫的元数据在同一个 commit 里一起改，也就会在同一个 commit 里一起被忘掉。

- 每个规范阶段都必须在**每个**绑定 `crm_opportunity.stage` 的 `record:path` 上有一步；
- 每个规范阶段都必须在**每个**以 stage 为键的 `rowColor` 里有一项；
- 任意两个阶段不得共用同一个色值；
- `crm_opportunity.stage` 字段本身必须仍然由该常量构建（否则前两条就是在对着一份运行时已经不认的清单较劲）。

两条完整性断言各自先 `expect(sites.length).toBeGreaterThan(0)` —— 组件类型或 `statusField` 一旦改名，站点集合会静默变空、断言退化成空转，这个文件的注释里记着导航守卫就是这么"一直通过"了很久的。

## 反向验证（方向是先预测再跑的）

预测：**红，并且报出被删阶段的名字**。断言遍历的是 `canonical`（删 UI 条目不会让它变短），而 `sites.length` 守卫挡住了"集合变空所以通过"那条退路 —— 所以这里不存在 #5046 那种"删掉一条反而少一个 finding"的计数反转，也不存在 #5009 那种前后都红的倒挂。四项实测与预测一致：

删掉路径那一步：

```
FAIL … > every stage has a step on the opportunity stage path
AssertionError: incomplete stage paths:
  opportunity_detail_page / opp_stage_path: no path step for stage "needs_analysis"
```

删掉 rowColor 那一项：

```
FAIL … > every stage has a row colour in the opportunity list views that tint by stage
AssertionError: incomplete stage row colours:
  view "open_opportunities": no rowColor entry for stage "needs_analysis"
```

把 `needs_analysis` 的颜色改成 proposal 的 `#f59e0b`（即"照搬 `#FFD700` 会走到的那一步"的放大版）：

```
FAIL … > stage colours stay distinguishable from one another
AssertionError: stages sharing a row colour:
  view "open_opportunities": "proposal" and "needs_analysis" are both #f59e0b
```

把 `statusField` 改名（验证守卫本身不空转）：

```
AssertionError: no record:path bound to crm_opportunity.stage was found: expected 0 to be greater than 0
```

## 验证

```
pnpm typecheck                     → 通过（tsc --noEmit 无输出）
pnpm vitest run --maxWorkers=2      → Test Files 62 passed (62) / Tests 1479 passed | 1 skipped (1480)
pnpm validate                       → exit 0（余下 warning 均为既有项：审批流 approver 组、campaign_member 字段组）
pnpm build                          → exit 0，dist/objectstack.json 1913.4 KB
pnpm hygiene                        → ✓ no raw control bytes in source files
```

平台依旧钉在 `17.0.0-rc.2`，无版本变动、无平台绕行。文件面严格限于 issue 授权范围：`stale_opportunities` 的注释块（#744）与 `closing_this_quarter` 的过滤（#746）均未触碰，`content/docs/**` 未触碰（#758/#756 在飞）。用户可见，已附 changeset。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_