### PR TITLE
docs(comments): 订正四处仍断言「列表路径不解析日期宏」的注释（含 stale_articles）

### DIFF
--- a/.changeset/stale-date-macro-comments.md
+++ b/.changeset/stale-date-macro-comments.md
@@ -1,0 +1,45 @@
+---
+---
+
+No user-visible change: four source comments are corrected, nothing else. The
+diff's non-comment content is empty, proved two ways (every changed diff line is
+a `//` line; the comment-stripped emit of each file is byte-identical before and
+after).
+
+Four comments still asserted that "the list data path resolves no date macros".
+That was measured on @objectstack 16.1.0 and expired at 17.0.0-rc.0, when
+`resolveFilterTokens()` was wired into the ObjectQL **read** path (objectql
+#3582) ahead of the middleware chain, covering `find` / `findOne` / `count` /
+`aggregate` — saved-view filters included. `test/forecast-current-quarter-view.test.ts`
+already pins both filter shapes against a real engine on the pinned
+17.0.0-rc.2 (the `period_start` equality from #730, the `close_date` range from
+#743), so the corrected comments cite that measurement instead of re-asserting
+from prose:
+
+- `src/dashboards/sales.dashboard.ts` — kept the analytics-path verification,
+  replaced the asymmetry claim, and deleted the instruction it ended on ("Do not
+  generalise from one path to the other"), which told the next author to
+  preserve a distinction that no longer exists. Its dangling cross-reference to
+  a since-rewritten comment in `src/views/forecast.view.ts` now points at what
+  that view actually says.
+- `src/data/revenue.seed.ts` — the claim that calendar-true `period_start`
+  values make a `{this_quarter_start}` filter "match the seeded row" was wrong
+  three ways: `{this_quarter_start}` was never in the token vocabulary (it is
+  `{current_quarter_start}`, and the misspelling now throws `Unresolvable filter
+  placeholder`), the filter was removed in #515 and only returned in #730, and
+  per #702 these seeds deliberately ship no current-quarter row for it to match.
+  Replaced with what those values are actually for; the `period_label` dialect
+  point (#490) is untouched.
+- `src/views/opportunity.view.ts` (`stale_opportunities`) — the comment gave two
+  independent reasons for not expressing the 14-day cut. The date-macro half has
+  expired; the other half has **not** (`days_in_stage` is a formula field
+  evaluated after the query, so the data engine can neither filter nor sort on
+  it) and is kept. The rewrite states explicitly that correcting the comment
+  decides nothing about the filter — expressing the cut as
+  `stage_entry_date <= {14_days_ago}` is a behaviour change, filed separately.
+  The file had been self-contradictory since #743 added working date-macro
+  bounds fifteen lines below.
+- `src/views/knowledge_article.view.ts` (`stale_articles`) — the cross-referenced
+  "same trap", resting on the same expired premise, corrected in the same pass.
+
+Fixes #744.

--- a/src/dashboards/sales.dashboard.ts
+++ b/src/dashboards/sales.dashboard.ts
@@ -304,10 +304,25 @@ export const SalesDashboard: Dashboard = {
       // rather than assumed: `queryDataset` runs both the dataset filter and the
       // widget's `runtimeFilter` through `resolveFilterTokens`, which
       // understands `{(current|last|next)_(week|month|quarter|year)_(start|end)}`
-      // and throws `FILTER_TOKEN_UNKNOWN` on anything else. This is NOT true of
-      // the list-view path — see the comment on `this_quarter_forecasts` in
-      // `src/views/forecast.view.ts`, where the same macro would ship to the
-      // driver as a literal string. Do not generalise from one path to the other.
+      // and throws `FILTER_TOKEN_UNKNOWN` on anything else.
+      //
+      // The LIST path resolves the same macros, and has since 17.0.0-rc.0:
+      // `resolveFilterTokens()` was wired into the ObjectQL READ path (objectql
+      // `feat(filters): evaluate {filter-token} placeholders server-side`,
+      // #3582) ahead of the middleware chain, covering `find` / `findOne` /
+      // `count` / `aggregate` — the one gate every server-side read passes
+      // through, saved-view filters included. So this widget's filter and a
+      // saved view's filter now read the same way, and the sibling
+      // `this_quarter_forecasts` in `src/views/forecast.view.ts` pins this same
+      // quarter with this same macro. Measured, not inferred:
+      // `test/forecast-current-quarter-view.test.ts` runs both filter shapes —
+      // the `period_start` equality (#730) and the `close_date` range (#743) —
+      // through a real engine on the pinned 17.0.0-rc.2 and pins a three-way
+      // outcome (current quarter only: not zero rows, not every quarter).
+      //
+      // What stood here before described the two paths as asymmetric and told
+      // the next author not to generalise between them. That was true on
+      // @objectstack 16.1.0 and expired at rc.0 (#744).
       //
       // Cost of pinning to the CURRENT quarter rather than the latest one: for
       // the few hours between a quarter boundary and the 03:00 sweep that opens

--- a/src/data/revenue.seed.ts
+++ b/src/data/revenue.seed.ts
@@ -273,9 +273,26 @@ export const quoteLineItems = defineSeed(QuoteLineItem, {
 // forecast.hook.ts derives them ('Q3 2026' / 'Aug 2026') — hooks don't run
 // over seeds, and the hook only fills a BLANK period_label, so seeded rows
 // must speak the same dialect as runtime snapshots or list views end up
-// mixing 'This Quarter' with 'Q3 2026' (#490). Calendar-true period_start
-// values also make the `this_quarter_forecasts` view's
-// `{this_quarter_start}` filter actually match the seeded row.
+// mixing 'This Quarter' with 'Q3 2026' (#490). Calendar-true `period_start`
+// values carry the same obligation on the QUERY side: `period_start` is one
+// half of the (owner, period, period_start) key the snapshot sweep upserts on,
+// the object indexes, and every period-scoped surface pins by equality — a
+// value that is not the period's real first day names a row no such filter can
+// ever select, and no rollup can line up against its neighbours.
+//
+// What these rows must NOT do is answer a CURRENT-quarter filter: per #702 that
+// window belongs to `forecast_snapshot` alone, so the seeds below ship settled
+// quarters plus the current month, and `this_quarter_forecasts` /
+// `quota_attainment_by_rep` correctly return none of them.
+//
+// (The sentence that stood here said the opposite — that these values make the
+// `this_quarter_forecasts` view's `{this_quarter_start}` filter "match the
+// seeded row". Corrected in #744, and it was wrong three ways:
+// `{this_quarter_start}` is not in the token vocabulary — the spelling is
+// `{current_quarter_start}`, and since 17.0.0-rc.0 the misspelling throws
+// `Unresolvable filter placeholder` instead of silently matching nothing; the
+// filter itself was removed from the view in #515 and only came back in #730;
+// and matching is the outcome #702 rules out.)
 //
 // Computed in plain TS (UTC, mirroring the hook's helpers): this module is
 // evaluated when the app bundle loads, the same moment the cel`...` seeds

--- a/src/views/knowledge_article.view.ts
+++ b/src/views/knowledge_article.view.ts
@@ -73,11 +73,32 @@ export const KnowledgeArticleViews = defineView({
     stale_articles: {
       name: 'stale_articles',
       type: 'grid',
-      // Operator-only filter + oldest-review-first sort. The list data path
-      // does NOT resolve date macros: `last_reviewed_at < '{180_days_ago}'`
-      // compared the literal string, and since '2026-…' < '{…' is
-      // lexicographically true it matched EVERY published article — including
-      // ones reviewed minutes ago (verified against the running console).
+      // Operator-only filter + oldest-review-first sort, and the reason
+      // recorded here has expired (#744).
+      //
+      // It read: the list data path does NOT resolve date macros, so
+      // `last_reviewed_at < '{180_days_ago}'` compared the literal string, and
+      // since '2026-…' < '{…' is lexicographically true it matched EVERY
+      // published article — including ones reviewed minutes ago (verified
+      // against the running console). That was measured on @objectstack 16.1.0
+      // and stopped being true at 17.0.0-rc.0, when `resolveFilterTokens()` was
+      // wired into the ObjectQL read path (objectql #3582) ahead of the
+      // middleware chain — `find`/`findOne`/`count`/`aggregate`, saved-view
+      // filters included. `{180_days_ago}` matches the parameterised token
+      // grammar `DATE_MACRO_PARAM_RE`, so on the pinned 17.0.0-rc.2 it reaches
+      // the driver as a resolved instant and the lexicographic inversion above
+      // is unreachable on this path. `test/forecast-current-quarter-view.test.ts`
+      // pins that seam against a real engine for the view filters that use it.
+      //
+      // So the window is expressible now, and this view still does not express
+      // it — which matters more here than it does for `stale_opportunities`,
+      // because the four locale labels DO promise one ('Stale (>180d)' and its
+      // translations) while the metadata label promises only an ordering. That
+      // gap is #769: adding the bound is a behaviour change with two things to
+      // measure first (`last_reviewed_at` is `Field.datetime`, so a bare
+      // calendar-day comparand carries the #3777 upper-bound convention, and
+      // never-reviewed articles have no value at all), so it is filed rather
+      // than done here. Nothing below was touched.
       label: 'Review Queue · Oldest First',
       data: { provider: 'object', object: 'crm_knowledge_article' },
       columns: ['article_number', 'title', 'category', 'owner_id', 'last_reviewed_at'],

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -219,16 +219,44 @@ export const OpportunityViews = defineView({
     stale_opportunities: {
       name: 'stale_opportunities',
       type: 'grid',
-      // Honest label: the view cannot express the 14-day cut its automation
-      // twin uses, for two independent reasons. `days_in_stage` is a FORMULA
-      // (#489) — evaluated after the query, so the data engine can neither
-      // filter nor sort on it — and the list data path resolves no date
-      // macros, so `stage_entry_date < {14_days_ago}` would ship the literal
-      // token and invert the comparison (same trap as `stale_articles`).
-      // So: operator-only filter, ordered by the stored `stage_entry_date`
-      // ascending — longest-parked on top, which is the queue a manager works.
-      // The `days_in_stage` column puts the `opportunity_stagnation` threshold
-      // (STALE_THRESHOLD_DAYS = 14) in plain sight on every row.
+      // Honest label: this view does not apply the 14-day cut its automation
+      // twin (`opportunity_stagnation`, STALE_THRESHOLD_DAYS = 14) uses, and
+      // does not claim to. Two independent reasons were recorded for that; one
+      // still holds and one has expired, so they are separated here.
+      //
+      // STILL TRUE — `days_in_stage` is a FORMULA (#489), evaluated in JS after
+      // the query, so the data engine can neither filter nor sort on it. Any
+      // filter phrased in terms of `days_in_stage` remains impossible.
+      //
+      // EXPIRED (#744) — the second reason said the list data path resolves no
+      // date macros, so `stage_entry_date < {14_days_ago}` would ship the token
+      // as a literal and invert the comparison lexicographically ('2026-…' sorts
+      // below '{', so every row matched). That was measured on @objectstack
+      // 16.1.0 and stopped being true at 17.0.0-rc.0, when `resolveFilterTokens()`
+      // was wired into the ObjectQL read path (objectql #3582). `{14_days_ago}`
+      // is a first-class vocabulary member — it matches the parameterised
+      // grammar `DATE_MACRO_PARAM_RE`, `{N_(minutes|hours|days|weeks|months|
+      // years)_(ago|from_now)}` — and on the pinned 17.0.0-rc.2 it reaches the
+      // driver already substituted for an ISO date. It is the same seam
+      // `closing_this_quarter` uses a few views below, pinned against a real
+      // engine in `test/forecast-current-quarter-view.test.ts`.
+      //
+      // Correcting that half of the comment does not decide anything about the
+      // filter, and is deliberately not a licence to change it: expressing the
+      // cut as `stage_entry_date <= {14_days_ago}` would drop `days_in_stage`
+      // from the question entirely and change which rows this view returns —
+      // hiding today's 13-day-old deals from a manager's queue. That is a
+      // BEHAVIOUR change with its own issue (#770), where the open question is
+      // whether this queue should be a cut or a ranking at all — this label
+      // promises a ranking and honours it. `stale_articles` in
+      // `src/views/knowledge_article.view.ts` carried the same expired premise
+      // and was corrected in the same pass; its label does promise a window, so
+      // it has a defect this view does not (#769). Nothing below was touched.
+      //
+      // As shipped: operator-only filter, ordered by the stored
+      // `stage_entry_date` ascending — longest-parked on top, which is the
+      // queue a manager works. The `days_in_stage` column puts the
+      // `opportunity_stagnation` threshold in plain sight on every row.
       label: '⚠️ Stale Opportunities · Longest in Stage First',
       data: { provider: 'object', object: 'crm_opportunity' },
       columns: ['name', 'crm_account', 'stage', 'amount', 'stage_entry_date', 'days_in_stage', 'close_date', 'owner_id'],

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -238,8 +238,9 @@ export const OpportunityViews = defineView({
       // grammar `DATE_MACRO_PARAM_RE`, `{N_(minutes|hours|days|weeks|months|
       // years)_(ago|from_now)}` — and on the pinned 17.0.0-rc.2 it reaches the
       // driver already substituted for an ISO date. It is the same seam
-      // `closing_this_quarter` uses a few views below, pinned against a real
-      // engine in `test/forecast-current-quarter-view.test.ts`.
+      // `closing_this_quarter` — the very next view in this file — relies on,
+      // pinned against a real engine in
+      // `test/forecast-current-quarter-view.test.ts`.
       //
       // Correcting that half of the comment does not decide anything about the
       // filter, and is deliberately not a licence to change it: expressing the


### PR DESCRIPTION
Fixes #744

纯注释改写，零行为变更。四处注释仍在断言「the list data path resolves no date macros」——这在 @objectstack 16.1.0 上成立，自 17.0.0-rc.0 起不成立（`resolveFilterTokens()` 接进 ObjectQL **读**路径，objectql #3582，位于 middleware chain 之前，覆盖 `find` / `findOne` / `count` / `aggregate`，saved-view filter 包含在内）。

订正后的注释一律以**实测**为依据，而不是换一段 prose 再断言一次：`test/forecast-current-quarter-view.test.ts` 已经在 pinned 17.0.0-rc.2 上把两种 filter 形态跑过真引擎并钉住三态结果（#730 的 `period_start` 等值、#743 的 `close_date` 区间）。

## 四处改了什么

| 文件 | 改动 |
| --- | --- |
| `src/dashboards/sales.dashboard.ts` | 保留 analytics 路径那段实证；删掉祈使句 “Do not generalise from one path to the other”；修掉指向 `src/views/forecast.view.ts` 的悬空交叉引用（那处注释早已被 #730 重写成相反的结论） |
| `src/data/revenue.seed.ts` | 「calendar-true period_start 让 `{this_quarter_start}` filter 真的匹配到种子行」这句三重错误（该拼法从来不在词表里、filter 在 #515 被移除、#702 明确排除匹配），换成这些值**实际**的用途；#490 的 period_label 方言那半原样保留 |
| `src/views/opportunity.view.ts`（`stale_opportunities`） | 两条理由分开写，见下 |
| `src/views/knowledge_article.view.ts`（`stale_articles`） | 交叉引用里点名的「same trap」，同一个过期前提，同一轮一起修 |

## `stale_opportunities` 的关键分寸

这段注释给了**两个**独立理由，只有一个过期：

- **仍然成立**：`days_in_stage` 是公式字段（#489），查询后才在 JS 里算，所以引擎既不能 filter 也不能 sort。任何以 `days_in_stage` 措辞的过滤仍然不可能 —— 这半原样保留。
- **已过期**：日期宏那半。`{14_days_ago}` 是合法词表成员（匹配 `DATE_MACRO_PARAM_RE` 的参数化文法），在 rc.2 上会被解析成 ISO 日期下发，字典序反转的陷阱在这条路径上消失了。

注释里**明确写死**：订正注释不等于该改 filter。把切分表达成 `stage_entry_date` 与 `{14_days_ago}` 的比较会改变返回的行（今天可见的 13 天行会被藏起来），那是行为变更，已单独立 #770 记录待决策。这个文件自 #746 起就自相矛盾（紧邻的下一条视图 `closing_this_quarter` 正在用同一条 seam），现在一致了。

## 实测记录（pinned 17.0.0-rc.2，`InMemoryDriver` + `ObjectQL.find`，未提交的一次性探针）

```
date 列, 行分别在 1/13/30/200 天前:
  { d: { $lte: '{14_days_ago}' } }   =>  [ 'stale-200d', 'stale-30d' ]
  { d: { $lt:  '{14_days_ago}' } }   =>  [ 'stale-200d', 'stale-30d' ]
  { d: { $lt:  '{180_days_ago}' } }  =>  [ 'stale-200d' ]
  { d: { $lt:  '{14_day_agos}' } }   =>  throws Unresolvable filter placeholder
datetime 列, 行分别在 0/179/181/400 天前复核:
  { r: { $lt:  '{180_days_ago}' } }  =>  [ 'reviewed-181d', 'reviewed-400d' ]
```

若旧断言仍成立，第一条会返回全部 4 行（字面量比较 + 字典序反转），而不是只返回逾期的两行。

## 零行为变更的机械证明（两种独立形式，均对 origin/main）

1. **注释前缀排除法**：`src/` 下 126 行增删，去掉行首缩进后逐行过滤掉以 `//` 开头的行，残集为 **0 行**。
2. **剥注释后逐字节比对**：四个文件的 origin/main 版与本分支版分别经 esbuild（`minifyWhitespace`，不动标识符/语法）剥掉注释后，输出**逐字节相同** —— 8989 / 9103 / 2752 / 6084 bytes，四个 `IDENTICAL`。

## 验证

- `pnpm typecheck` — 通过
- `pnpm validate` — `✓ Validation passed (1266ms)`（告警是 main 上既有的）
- `pnpm hygiene` — 4/4 通过，含 `✓ no raw control bytes in source files`
- `npx vitest run --maxWorkers=2` — **62 files / 1479 passed, 1 skipped**，无变化（按上面的证明，本 PR 不可能改变任何测试结果）
- 控制字符自扫：`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 对四个改动文件命中 0 处

平台版本未动，保持 pinned 17.0.0-rc.2。changeset 为空 frontmatter（纯注释，不发布任何东西）。

## 顺带记录的越界发现（已单独立 issue，本 PR 未改）

- **#769**（具体缺陷）：`stale_articles` 的四个语言包 label 都写着 “180 天以上”，而 filter 只有 `status = published` —— 列表返回每一篇已发布文章。与 #730 同类，且谎言同样只活在翻译那一半；现有结构化守卫的 claim 词表只认「当前日历周期」，抓不到参数化天数窗口。
- **#770**（`finding`，#744 追评点名要求单独立）：`stale_opportunities` 的 14 天切分现在可表达了，但要不要改是行为决策，需回答「队列语义是切分还是排序」「阈值 single source of truth」「空态文案」三个问题后再动。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa