### PR TITLE
fix(i18n): stop the Review Queue tab claiming a 180-day window its filter never applied (#769)

### DIFF
--- a/.changeset/stale-articles-review-queue-label.md
+++ b/.changeset/stale-articles-review-queue-label.md
@@ -1,0 +1,29 @@
+---
+"hotcrm": patch
+---
+
+Knowledge base: the Review Queue tab no longer claims a 180-day window it never applied.
+
+In English, Chinese, Spanish and Japanese the knowledge-article review tab was named
+"Stale (>180d)" (过期 (>180 天) / Obsoletos (>180d) / 古い (>180日)), but its filter
+selected only `status = published`. The tab therefore returned **every** published
+article — including one reviewed minutes ago, merely sorted to the bottom — under a
+heading that promised a six-month cut. Anyone who read the tab as a worklist was
+reading a list of the whole knowledge base.
+
+The four names now match the view's own metadata label, "Review Queue · Oldest First",
+which is what the view actually does: every published article, least-recently-reviewed
+first. Which rows the tab returns is unchanged.
+
+The 180-day window was measured before being ruled out rather than assumed impossible.
+The date macro does resolve on the read path now, and lands on the start of the calendar
+day 180 days back — but a comparison against it does not match articles that have never
+been reviewed at all, and those are exactly the rows a review queue most needs to show.
+Saying "older than 180 days **or** never reviewed" needs a disjunction, and a view filter
+is a flat list of conditions combined with AND, so the honest window cannot currently be
+written. Whether this queue should become a cut is now a separate, open product question.
+
+The house-rule guard that catches this defect class (a view name promising a time scope
+its filter does not express) previously recognised only current-calendar-period phrases
+like "This Quarter", so it could not see "> 180d". It now also reads parameterised day
+windows in all four locales.

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -263,7 +263,7 @@ export const en: TranslationData = {
         all_articles: { label: 'All Articles' },
         published_articles: { label: 'Published' },
         my_drafts: { label: 'My Drafts' },
-        stale_articles: { label: 'Stale (>180d)' },
+        stale_articles: { label: 'Review Queue · Oldest First' },
       },
       _sections: {
         basic: { label: 'Article Information' },

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -282,7 +282,7 @@ export const esES: TranslationData = {
         all_articles: { label: 'Todos los artículos' },
         published_articles: { label: 'Publicados' },
         my_drafts: { label: 'Mis borradores' },
-        stale_articles: { label: 'Obsoletos (>180d)' },
+        stale_articles: { label: 'Cola de revisión · Más antiguos primero' },
       },
       _sections: {
         basic: { label: 'Información del Artículo' },

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -290,7 +290,7 @@ export const jaJP: TranslationData = {
         all_articles: { label: 'すべての記事' },
         published_articles: { label: '公開済み' },
         my_drafts: { label: '自分の下書き' },
-        stale_articles: { label: '古い (>180日)' },
+        stale_articles: { label: 'レビューキュー · 古い順' },
       },
       _sections: {
         basic: { label: '記事情報' },

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -256,7 +256,7 @@ export const zhCN: TranslationData = {
         all_articles: { label: '全部文章' },
         published_articles: { label: '已发布' },
         my_drafts: { label: '我的草稿' },
-        stale_articles: { label: '过期 (>180 天)' },
+        stale_articles: { label: '复核队列 · 最久未复核在前' },
       },
       _sections: {
         basic: { label: '文章信息' },

--- a/src/views/knowledge_article.view.ts
+++ b/src/views/knowledge_article.view.ts
@@ -5,9 +5,13 @@ import { defineView } from '@objectstack/spec/ui';
 /**
  * Knowledge Article Views
  *
- *   • grid     — agent-facing article queue (status / category / audience)
+ *   • grid      — agent-facing article queue (status / category / audience)
  *   • published — public articles only
- *   • stale     — published > 180 days without review
+ *   • stale     — every published article, least-recently-reviewed first
+ *
+ * The third one is a RANKING, not a cut: `stale_articles` is the metadata
+ * item's name, not a claim about which rows come back. See its own note below
+ * for why it stays a ranking (#769).
  */
 export const KnowledgeArticleViews = defineView({
   list: {
@@ -73,32 +77,57 @@ export const KnowledgeArticleViews = defineView({
     stale_articles: {
       name: 'stale_articles',
       type: 'grid',
-      // Operator-only filter + oldest-review-first sort, and the reason
-      // recorded here has expired (#744).
+      // Operator-only filter + least-recently-reviewed-first sort. This view
+      // is a RANKING and the label says so; it deliberately applies no
+      // 180-day cut. Both halves of that sentence were settled by measurement
+      // (#769), so the reasoning is recorded here rather than re-derived.
       //
-      // It read: the list data path does NOT resolve date macros, so
-      // `last_reviewed_at < '{180_days_ago}'` compared the literal string, and
-      // since '2026-…' < '{…' is lexicographically true it matched EVERY
-      // published article — including ones reviewed minutes ago (verified
-      // against the running console). That was measured on @objectstack 16.1.0
-      // and stopped being true at 17.0.0-rc.0, when `resolveFilterTokens()` was
-      // wired into the ObjectQL read path (objectql #3582) ahead of the
-      // middleware chain — `find`/`findOne`/`count`/`aggregate`, saved-view
-      // filters included. `{180_days_ago}` matches the parameterised token
-      // grammar `DATE_MACRO_PARAM_RE`, so on the pinned 17.0.0-rc.2 it reaches
-      // the driver as a resolved instant and the lexicographic inversion above
-      // is unreachable on this path. `test/forecast-current-quarter-view.test.ts`
-      // pins that seam against a real engine for the view filters that use it.
+      // 1. The old note's premise expired (#744, #773). It read: the list data
+      //    path does NOT resolve date macros, so `last_reviewed_at <
+      //    '{180_days_ago}'` compared the literal string, and since '2026-…' <
+      //    '{…' is lexicographically true it matched EVERY published article.
+      //    True on @objectstack 16.1.0; false from 17.0.0-rc.0, when
+      //    `resolveFilterTokens()` was wired into the ObjectQL read path
+      //    (objectql #3582) ahead of the middleware chain —
+      //    `find`/`findOne`/`count`/`aggregate`, saved-view filters included.
+      //    Measured on the pinned 17.0.0-rc.2: `{180_days_ago}` resolves to
+      //    the START of the calendar day 180 days ago (00:00:00.000Z), so as
+      //    an EXCLUSIVE upper bound under `less_than` it excludes that whole
+      //    day — the #3777 day-boundary convention, and the right sense for a
+      //    label reading "> 180d".
       //
-      // So the window is expressible now, and this view still does not express
-      // it — which matters more here than it does for `stale_opportunities`,
-      // because the four locale labels DO promise one ('Stale (>180d)' and its
-      // translations) while the metadata label promises only an ordering. That
-      // gap is #769: adding the bound is a behaviour change with two things to
-      // measure first (`last_reviewed_at` is `Field.datetime`, so a bare
-      // calendar-day comparand carries the #3777 upper-bound convention, and
-      // never-reviewed articles have no value at all), so it is filed rather
-      // than done here. Nothing below was touched.
+      // 2. Expressible is not the same as expressible WITHOUT LOSS. A review
+      //    queue's most overdue population is the never-reviewed one, and
+      //    `last_reviewed_at` is nullable: a published article can carry no
+      //    review timestamp at all. Measured on the same engine, `$lt` does
+      //    not match null or absent values, so a bare window silently deletes
+      //    exactly those rows. The honest condition is "earlier than
+      //    {180_days_ago} OR empty" — and a view `filter` cannot say that. It
+      //    is a FLAT, strict array of `{field, operator, value}` rules
+      //    (`ViewFilterRuleSchema`) combined with AND; there is no `or`, no
+      //    nesting, no logic key. Spelled as the two rules the grammar does
+      //    allow, the window and the emptiness test AND together and the view
+      //    returns ZERO rows. (The engine itself has `$or` and answers the
+      //    question correctly — this is a view-authoring limit, not an engine
+      //    limit.)
+      //
+      // So the label is what changed in #769, not the filter: the four locale
+      // packs had translated this view as 'Stale (>180d)' / '过期 (>180 天)' /
+      // 'Obsoletos (>180d)' / '古い (>180日)', promising a window the filter
+      // never expressed — the #730 defect class, living (as it did there) only
+      // in the translated half. They now render the metadata label faithfully,
+      // and every user-visible name for this view again promises exactly the
+      // ordering it delivers. No `emptyState` is authored because the change
+      // introduces no new empty state: "no published articles" is the same
+      // zero this tab has always had, unlike `closing_this_quarter` (#746),
+      // where scoping made "empty" newly reachable.
+      //
+      // `test/forecast-current-quarter-view.test.ts` owns the house rule and
+      // pins all of the above against a real engine, including the day-window
+      // claim vocabulary that would fail this view the day a label reclaims a
+      // window. Whether the queue SHOULD become a 180-day cut is a product
+      // question that needs the null population handled first — filed
+      // separately, not decided by a translator.
       label: 'Review Queue · Oldest First',
       data: { provider: 'object', object: 'crm_knowledge_article' },
       columns: ['article_number', 'title', 'category', 'owner_id', 'last_reviewed_at'],

--- a/src/views/knowledge_article.view.ts
+++ b/src/views/knowledge_article.view.ts
@@ -98,10 +98,18 @@ export const KnowledgeArticleViews = defineView({
       //
       // 2. Expressible is not the same as expressible WITHOUT LOSS. A review
       //    queue's most overdue population is the never-reviewed one, and
-      //    `last_reviewed_at` is nullable: a published article can carry no
-      //    review timestamp at all. Measured on the same engine, `$lt` does
-      //    not match null or absent values, so a bare window silently deletes
-      //    exactly those rows. The honest condition is "earlier than
+      //    `last_reviewed_at` is nullable in exactly the case that matters.
+      //    On the SINGLE-record path `knowledge_article_publish_timestamps`
+      //    keeps it stamped — the engine's `sys_fetch_previous_update` builtin
+      //    hands the hook a `previous`, so publishing and every later edit
+      //    re-stamp. On the BULK path (`multi: true`) there is no
+      //    `input.id`, that builtin cannot fetch anything, the hook sees no
+      //    status at all and stamps nothing — so a bulk load or mass edit,
+      //    which is how an org imports an existing knowledge base, leaves
+      //    published articles with no review timestamp (measured; filed
+      //    separately). `$lt` matches neither null nor an absent key, so a
+      //    bare window deletes precisely those rows — the imported ones, the
+      //    least reviewed of all. The honest condition is "earlier than
       //    {180_days_ago} OR empty" — and a view `filter` cannot say that. It
       //    is a FLAT, strict array of `{field, operator, value}` rules
       //    (`ViewFilterRuleSchema`) combined with AND; there is no `or`, no

--- a/test/forecast-current-quarter-view.test.ts
+++ b/test/forecast-current-quarter-view.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ObjectQL } from '@objectstack/objectql';
 import { InMemoryDriver } from '@objectstack/driver-memory';
+import { ViewFilterRuleSchema } from '@objectstack/spec/ui';
 import stack from '../objectstack.config';
 
 /**
@@ -62,6 +63,16 @@ import stack from '../objectstack.config';
  *   arbitrary day inside the quarter. A range has a failure mode an equality
  *   does not: lose one bound and the list widens back out while still looking
  *   scoped, so that block subtracts each bound separately (#743).
+ *
+ * ### A third claim shape, and the one case the rule resolves the OTHER way
+ *
+ * The file's name predates its scope: it is the house rule's home, and the
+ * rule is not about forecasts. #769 added the third claim family — a
+ * PARAMETERISED DAY WINDOW ("> 180d"), which the calendar-period vocabulary
+ * could not see — and, unlike #730 and #743, it was fixed by correcting the
+ * NAME rather than the filter. The last runtime block records why, on
+ * measurement rather than on preference: the honest condition needs a
+ * disjunction, and a view `filter` has no way to write one.
  */
 
 type AnyRec = Record<string, any>;
@@ -103,6 +114,52 @@ const CURRENT_PERIOD_CLAIMS: Array<{ period: string; token: string; phrases: Reg
     phrases: [/this year/i, /current year/i, /本年度/, /este año/i, /今年度/],
   },
 ];
+
+/**
+ * Phrases that claim a PARAMETERISED DAY WINDOW — "nothing here has been
+ * touched for N days" — and, derived from the N the label itself names, the
+ * `{N_days_ago}` token a filter must carry to honour the claim.
+ *
+ * A second family rather than more rows in the list above, because the claim
+ * is PARAMETERISED: the scope is not one of four fixed calendar words, it is
+ * whatever number the label prints, and the token that would honour it is
+ * computed from that number. `CURRENT_PERIOD_CLAIMS` cannot express that
+ * without one entry per N.
+ *
+ * It exists because the vocabulary above could not see #769. Four locale packs
+ * named `crm_knowledge_article.stale_articles` 'Stale (>180d)', '过期 (>180
+ * 天)', 'Obsoletos (>180d)' and '古い (>180日)' over a filter reading only
+ * `status = published`, so the tab returned EVERY published article — one
+ * reviewed minutes ago included, merely sorted last. The metadata label
+ * ('Review Queue · Oldest First') was honest throughout: exactly as in #730,
+ * the lie lived only in the translated half, and "this/current quarter" does
+ * not match "> 180 days".
+ *
+ * Each pattern captures the day count in group 1, and every one of them
+ * requires an explicit DAY unit (`d` / `days` / `días` / `天` / `日`), so
+ * "Top 10", "Q4" and an SLA heading reading "> 4h" claim no window.
+ */
+const DAY_WINDOW_PATTERNS: RegExp[] = [
+  /[>＞]\s*(\d+)\s*d\b/i,             // Stale (>180d) · Obsoletos (>180d)
+  /[>＞]\s*(\d+)\s*days?\b/i,         // Stale (>180 days)
+  /[>＞]\s*(\d+)\s*天/,               // 过期 (>180 天)
+  /[>＞]\s*(\d+)\s*日/,               // 古い (>180日)
+  /older than\s*(\d+)\s*days?\b/i,
+  /over\s*(\d+)\s*days?\b/i,
+  /más de\s*(\d+)\s*días?\b/i,
+  /(\d+)\s*天(?:以上|未|没)/,          // 180 天未复核
+  /(\d+)\s*日(?:以上|超)/,             // 180日以上
+];
+
+/** The day counts a single label claims, deduped. `[]` when it claims none. */
+const dayWindowClaims = (label: string): number[] => {
+  const found = new Set<number>();
+  for (const pattern of DAY_WINDOW_PATTERNS) {
+    const m = label.match(pattern);
+    if (m) found.add(Number(m[1]));
+  }
+  return [...found].sort((a, b) => a - b);
+};
 
 /**
  * KNOWN DEBT — surfaces in breach of the rule above, with the issue that owns
@@ -153,6 +210,54 @@ const filterTokens = (view: AnyRec): string[] =>
     .map((rule: AnyRec) => rule?.value)
     .filter((v: unknown): v is string => typeof v === 'string' && /^\{.+\}$/.test(v));
 
+/**
+ * Every breach ONE view is in, given every name it can be read under and the
+ * `{token}`s its filter carries.
+ *
+ * A pure function of (labels, tokens) rather than of a view, so the guard can
+ * be run against a HYPOTHETICAL label set — which is what proves it is not
+ * decoration. Both claim families are fixed by removing their only instances,
+ * so on the day each fix lands the derivation over the shipped stack returns
+ * `[]` and would pass for a shipped-empty reason. Feeding it the labels the fix
+ * DELETED is the positive control (see the #769 block below).
+ */
+const breachesOf = (id: string, labels: Array<[string, string]>, tokens: string[]): string[] => {
+  const out: string[] = [];
+  const named = (claiming: Array<[string, string]>) =>
+    claiming.map(([where, label]) => `${where}:"${label}"`).join(', ');
+
+  // Family 1 — a named CURRENT calendar period (#730, #743).
+  for (const claim of CURRENT_PERIOD_CLAIMS) {
+    const claiming = labels.filter(([, label]) => claim.phrases.some((p) => p.test(label)));
+    if (claiming.length === 0) continue;
+    if (tokens.includes(claim.token)) continue;
+    out.push(
+      `${id} is labelled ${named(claiming)} `
+      + `but its filter carries no ${claim.token} — it returns every ${claim.period}, `
+      + `not the current one (filter tokens: ${tokens.join(', ') || 'none'})`,
+    );
+  }
+
+  // Family 2 — a parameterised day window (#769).
+  const byDays = new Map<number, Array<[string, string]>>();
+  for (const [where, label] of labels) {
+    for (const days of dayWindowClaims(label)) {
+      byDays.set(days, [...(byDays.get(days) ?? []), [where, label]]);
+    }
+  }
+  for (const [days, claiming] of [...byDays.entries()].sort((a, b) => a[0] - b[0])) {
+    const token = `{${days}_days_ago}`;
+    if (tokens.includes(token)) continue;
+    out.push(
+      `${id} is labelled ${named(claiming)} `
+      + `but its filter carries no ${token} — it returns rows of every age, not the `
+      + `ones untouched for ${days} days (filter tokens: ${tokens.join(', ') || 'none'})`,
+    );
+  }
+
+  return out;
+};
+
 describe('no view label promises a time scope its filter does not express (#730)', () => {
   it('the locale bundles this guard reads are actually loaded', () => {
     // Without this, a bundle rename would silently reduce the guard to the
@@ -170,25 +275,9 @@ describe('no view label promises a time scope its filter does not express (#730)
     expect(claims.map((c) => `${c.object}.${c.name}`)).toContain('crm_forecast.this_quarter_forecasts');
   });
 
-  /** Every (view, claimed period) pair whose filter does not pin that period. */
-  const breaches = (): string[] => {
-    const out: string[] = [];
-    for (const { object, name, view } of listViews) {
-      const labels = namesOf(object, name, view);
-      const tokens = filterTokens(view);
-      for (const claim of CURRENT_PERIOD_CLAIMS) {
-        const claiming = labels.filter(([, label]) => claim.phrases.some((p) => p.test(label)));
-        if (claiming.length === 0) continue;
-        if (tokens.includes(claim.token)) continue;
-        out.push(
-          `${object}.${name} is labelled ${claiming.map(([l, v]) => `${l}:"${v}"`).join(', ')} `
-          + `but its filter carries no ${claim.token} — it returns every ${claim.period}, `
-          + `not the current one (filter tokens: ${tokens.join(', ') || 'none'})`,
-        );
-      }
-    }
-    return out;
-  };
+  /** Every (view, claim) pair, in either family, that the filter does not honour. */
+  const breaches = (): string[] => listViews.flatMap(({ object, name, view }) =>
+    breachesOf(`${object}.${name}`, namesOf(object, name, view), filterTokens(view)));
 
   it('every current-period label is backed by a filter that pins that period', () => {
     const bad = breaches().filter((line) => !Object.keys(KNOWN_DEBT).some((k) => line.startsWith(`${k} `)));
@@ -208,6 +297,72 @@ describe('no view label promises a time scope its filter does not express (#730)
       'these views no longer breach the rule — delete their KNOWN_DEBT entries so the '
         + `guard covers them again:\n  ${stale.join('\n  ')}`,
     ).toEqual([]);
+  });
+
+  // ── The day-window family, and the probe that keeps it from being decoration ──
+
+  /**
+   * The four locale labels #769 deleted, verbatim. They are the only instances
+   * the day-window family has ever had, and the fix removed them — so without
+   * this control the family would ship green over an empty set and nobody
+   * would find out it never matched anything.
+   */
+  const RETIRED_180D_LABELS: Array<[string, string]> = [
+    ['en', 'Stale (>180d)'],
+    ['zh-CN', '过期 (>180 天)'],
+    ['es-ES', 'Obsoletos (>180d)'],
+    ['ja-JP', '古い (>180日)'],
+  ];
+
+  it('the day-window vocabulary reads a window out of every label #769 deleted', () => {
+    for (const [locale, label] of RETIRED_180D_LABELS) {
+      expect(dayWindowClaims(label), `${locale}: ${label}`).toEqual([180]);
+    }
+  });
+
+  it('re-installing those labels over the shipped filter is reported as a breach', () => {
+    // The subtraction, run rather than asserted from memory — and run against
+    // the filter `stale_articles` ACTUALLY ships, not a mock of it. Restore the
+    // deleted names and the guard must name the missing token; that is the
+    // whole claim this family makes.
+    const stale = listViews.find((v) => v.name === 'stale_articles')!;
+    const lines = breachesOf(
+      'crm_knowledge_article.stale_articles',
+      [['metadata', stale.view.label], ...RETIRED_180D_LABELS],
+      filterTokens(stale.view),
+    );
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('{180_days_ago}');
+    expect(lines[0]).toContain('en:"Stale (>180d)"');
+    expect(lines[0]).toContain('ja-JP:"古い (>180日)"');
+    // The metadata label was the honest half in #769 and must not be blamed.
+    expect(lines[0]).not.toContain('metadata:');
+  });
+
+  it('no name this stack actually ships claims a day window', () => {
+    const claiming = listViews.flatMap(({ object, name, view }) =>
+      namesOf(object, name, view)
+        .filter(([, label]) => dayWindowClaims(label).length > 0)
+        .map(([where, label]) => `${object}.${name} ${where}:"${label}"`));
+    expect(
+      claiming,
+      'a name claims an N-day window. Either carry {N_days_ago} in the filter, or '
+        + `drop the window from the name:\n  ${claiming.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('the vocabulary does not fire on names that merely contain a number', () => {
+    // False positives would be worse than the gap: they push authors to delete
+    // honest labels. A count, a quarter name and an hour-scoped SLA all name
+    // no day window.
+    for (const label of [
+      'Top 10 Articles', 'Q4 Pipeline', 'SLA > 4h', 'Tier 1 Accounts',
+      '2026 Renewals', '第 3 四半期', 'Review Queue · Oldest First',
+      '复核队列 · 最久未复核在前', 'Cola de revisión · Más antiguos primero',
+      'レビューキュー · 古い順',
+    ]) {
+      expect(dayWindowClaims(label), label).toEqual([]);
+    }
   });
 
   it('the quarter view pins BOTH halves of the period key', () => {
@@ -606,5 +761,216 @@ describe('closing_this_quarter returns this quarter only, on the real engine (#7
       if (!t?.message) missing.push(`${locale}: message`);
     }
     expect(missing, `untranslated empty-state copy:\n  ${missing.join('\n  ')}`).toEqual([]);
+  });
+});
+
+// ─── Runtime: why the third case is fixed at the NAME, not the filter (#769) ─
+
+/**
+ * `crm_knowledge_article.stale_articles` is the day-window family's origin, and
+ * the one surface under this rule where the honest fix was to correct the NAME.
+ * The two before it were not a precedent for that: `this_quarter_forecasts` and
+ * `closing_this_quarter` carried the time claim in their METADATA label — the
+ * authored contract itself promised a quarter — so the filter had to deliver
+ * one. Here the metadata label says 'Review Queue · Oldest First' and promises
+ * only an ordering, which the `last_reviewed_at asc` sort delivers exactly; the
+ * "> 180d" window existed nowhere but the four locale packs.
+ *
+ * That alone would not settle it — a promise four translators independently
+ * wrote is worth taking seriously as product intent. What settles it is that
+ * the honest window is NOT EXPRESSIBLE in a view filter, measured here rather
+ * than argued:
+ *
+ *   1. The macro resolves, and to the START of the calendar day 180 days ago,
+ *      so `less_than` excludes that whole day (#3777's day-boundary convention
+ *      on a `datetime` comparand) — the right sense for "> 180d".
+ *   2. `$lt` does not match null or absent values, so the window DELETES
+ *      never-reviewed articles — the rows a review queue most needs.
+ *   3. The honest condition is therefore a DISJUNCTION, "older than the window
+ *      OR never reviewed", and a view `filter` is a flat, strict array of
+ *      `{field, operator, value}` rules combined with AND. Written the only way
+ *      the grammar allows, it returns ZERO rows.
+ *   4. The engine itself answers the question correctly with `$or`. The limit
+ *      is the view-authoring grammar, not the data layer — which is why this is
+ *      recorded as a measurement with an issue behind it, not as a workaround.
+ *
+ * If a future spec gives view filters a disjunction, delete this block's fourth
+ * assertion, add the window, and give the tab an `emptyState` (the #746 rule:
+ * scoping makes "empty" newly reachable).
+ */
+describe('stale_articles: the 180-day window, measured on the real engine (#769)', () => {
+  let ql: Awaited<ReturnType<typeof ObjectQL.create>>;
+  let api: AnyRec;
+  const view = listViews.find((v) => v.name === 'stale_articles')!.view;
+
+  // Fixtures are pinned at module load; the boundary probes sit on the UTC day
+  // 180 days back, computed the same way the resolver does.
+  const DAY_MS = 86_400_000;
+  const nowMs = Date.now();
+  const daysAgo = (d: number) => new Date(nowMs - d * DAY_MS).toISOString();
+  const day180 = new Date(nowMs - 180 * DAY_MS);
+  const day180StartMs = Date.UTC(day180.getUTCFullYear(), day180.getUTCMonth(), day180.getUTCDate());
+  const day180Start = new Date(day180StartMs).toISOString();
+
+  /** name → what the row's `last_reviewed_at` holds. */
+  const fixtures: Array<{ title: string; status: string; last_reviewed_at?: string | null }> = [
+    { title: 'reviewed-today', status: 'published', last_reviewed_at: daysAgo(0) },
+    { title: 'reviewed-179d', status: 'published', last_reviewed_at: daysAgo(179) },
+    { title: 'boundary-day-opens', status: 'published', last_reviewed_at: day180Start },
+    { title: 'boundary-day-closes', status: 'published', last_reviewed_at: new Date(day180StartMs + DAY_MS - 60_000).toISOString() },
+    { title: 'reviewed-181d', status: 'published', last_reviewed_at: daysAgo(181) },
+    { title: 'reviewed-400d', status: 'published', last_reviewed_at: daysAgo(400) },
+    { title: 'never-reviewed-null', status: 'published', last_reviewed_at: null },
+    { title: 'never-reviewed-absent', status: 'published' },
+    // Ancient, but not published — keeps the status half of the filter honest.
+    { title: 'draft-ancient', status: 'draft', last_reviewed_at: daysAgo(900) },
+  ];
+
+  /** The window rule as it WOULD be authored, in canonical operator spelling. */
+  const WINDOW_RULE = { field: 'last_reviewed_at', operator: 'less_than', value: '{180_days_ago}' };
+
+  const titles = (rows: AnyRec[]) => rows.map((r) => r.title).sort();
+
+  beforeAll(async () => {
+    ql = await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: {
+        crm_knowledge_article: {
+          name: 'crm_knowledge_article',
+          fields: {
+            id: { type: 'text' },
+            title: { type: 'text' },
+            status: { type: 'text' },
+            // `datetime`, NOT `date` — the property assertion 1 rests on.
+            last_reviewed_at: { type: 'datetime' },
+          },
+        },
+      } as never,
+    });
+    api = ql.createContext({ isSystem: true, userId: 'usr_1', tenantId: 'org_1' } as never);
+    for (const f of fixtures) await api.object('crm_knowledge_article').insert(f);
+  });
+
+  afterAll(async () => {
+    await ql?.close();
+  });
+
+  it('the shipped filter is the status test alone, and the label promises only an order', () => {
+    expect((view.filter ?? []).map((r: AnyRec) => [r.field, r.operator, r.value])).toEqual([
+      ['status', 'equals', 'published'],
+    ]);
+    expect(view.sort).toEqual([{ field: 'last_reviewed_at', order: 'asc' }]);
+    expect(dayWindowClaims(view.label)).toEqual([]);
+  });
+
+  it('the fixture holds rows on both sides of the window AND rows with no value', async () => {
+    // Premise of everything below: on an all-stale or all-stamped table these
+    // assertions would pass without the window or the null case doing anything.
+    const all: AnyRec[] = await api.object('crm_knowledge_article').find({ where: {} });
+    expect(all.length).toBe(fixtures.length);
+    expect(all.filter((r) => r.last_reviewed_at == null).length).toBe(2);
+  });
+
+  it('{180_days_ago} resolves, and lands on the START of the day 180 days back', async () => {
+    // Not zero rows (the macro shipped unresolved) and not every row (the
+    // #769 defect): the same three-way pin the blocks above make, on a
+    // parameterised token. The second assertion is the day-boundary one — the
+    // macro is compared against the equivalent literal rather than described.
+    const macro: AnyRec[] = await api.object('crm_knowledge_article').find({
+      where: { last_reviewed_at: { $lt: '{180_days_ago}' } },
+    });
+    expect(macro.length).toBeGreaterThan(0);
+    expect(macro.length).toBeLessThan(fixtures.length);
+    expect(titles(macro)).toEqual(['draft-ancient', 'reviewed-181d', 'reviewed-400d']);
+
+    const literal: AnyRec[] = await api.object('crm_knowledge_article').find({
+      where: { last_reviewed_at: { $lt: day180Start } },
+    });
+    expect(titles(literal)).toEqual(titles(macro));
+  });
+
+  it('as an exclusive upper bound it excludes the whole 180-days-ago day', async () => {
+    // The three-state boundary: 179d is fresh, every hour of the 180th day is
+    // fresh, 181d is stale. `last_reviewed_at` is `Field.datetime`, so a row
+    // reviewed at 23:59 on the boundary day would fall INTO a window that used
+    // `less_than_or_equal` against a day-start comparand — a whole day of
+    // articles flipping side on the operator alone.
+    const stale = titles(await api.object('crm_knowledge_article').find({
+      where: { status: 'published', last_reviewed_at: { $lt: '{180_days_ago}' } },
+    }));
+    expect(stale).not.toContain('reviewed-179d');
+    expect(stale).not.toContain('boundary-day-opens');
+    expect(stale).not.toContain('boundary-day-closes');
+    expect(stale).toContain('reviewed-181d');
+  });
+
+  it('the window DELETES never-reviewed articles, which today’s filter returns', async () => {
+    // The measurement that decided #769. Both spellings of "no value" — an
+    // explicit null and an absent key — fall out of a `$lt`, and a review queue
+    // that hides never-reviewed articles hides its most overdue population.
+    const shipped: AnyRec[] = await api.object('crm_knowledge_article').find({
+      where: whereFromViewFilter(view.filter),
+    });
+    expect(titles(shipped)).toContain('never-reviewed-null');
+    expect(titles(shipped)).toContain('never-reviewed-absent');
+
+    const windowed: AnyRec[] = await api.object('crm_knowledge_article').find({
+      where: whereFromViewFilter([...(view.filter ?? []), WINDOW_RULE]),
+    });
+    expect(titles(windowed)).toEqual(['reviewed-181d', 'reviewed-400d']);
+    expect(titles(windowed)).not.toContain('never-reviewed-null');
+    expect(titles(windowed)).not.toContain('never-reviewed-absent');
+  });
+
+  it('the disjunction is not an authorable filter rule — `or` is not a key', async () => {
+    // A rule is `{field, operator, value}` and the object is STRICT, so there
+    // is no `or`, no nesting and no logic key to hang a second branch on. This
+    // asserts the KEY is not an authoring surface (unrecognized_keys), which is
+    // the fact in question — the operator vocabulary itself is fine.
+    const canonical = ViewFilterRuleSchema.safeParse(WINDOW_RULE);
+    expect(canonical.success, 'the window rule itself is authorable').toBe(true);
+
+    const disjunction = ViewFilterRuleSchema.safeParse({
+      ...WINDOW_RULE,
+      or: [{ field: 'last_reviewed_at', operator: 'is_empty' }],
+    });
+    expect(disjunction.success).toBe(false);
+    expect(disjunction.error!.issues.map((i) => i.code)).toContain('unrecognized_keys');
+  });
+
+  it('and spelled the only way the grammar allows, it returns nothing at all', async () => {
+    // Two rules on one field AND together. `last_reviewed_at` cannot be both
+    // older than the window and empty, so the tab would go blank — the failure
+    // that looks exactly like "nothing needs review".
+    const anded: AnyRec[] = await api.object('crm_knowledge_article').find({
+      where: { last_reviewed_at: { $lt: '{180_days_ago}', $null: true } },
+    });
+    expect(anded).toEqual([]);
+  });
+
+  it('the ENGINE answers the question correctly — the limit is the view grammar', async () => {
+    // Stated positively so the constraint above cannot be misread as "the data
+    // layer cannot do this". It can; a view just has no way to ask.
+    const rows: AnyRec[] = await api.object('crm_knowledge_article').find({
+      where: {
+        status: 'published',
+        $or: [
+          { last_reviewed_at: { $lt: '{180_days_ago}' } },
+          { last_reviewed_at: { $null: true } },
+        ],
+      },
+    });
+    expect(titles(rows)).toEqual([
+      'never-reviewed-absent', 'never-reviewed-null', 'reviewed-181d', 'reviewed-400d',
+    ]);
+  });
+
+  it('a token outside the macro grammar is rejected, not silently unresolved', async () => {
+    // The parameterised family is a GRAMMAR, not a fixed list: {180_days_ago}
+    // and {181_days_ago} both resolve. A misspelling throws and names the fix,
+    // so the 16.1.0 silent-empty mode is unreachable on this path too.
+    await expect(
+      api.object('crm_knowledge_article').find({ where: { last_reviewed_at: { $lt: '{180_days_agoo}' } } }),
+    ).rejects.toThrow(/Unresolvable filter placeholder/);
   });
 });


### PR DESCRIPTION
Fixes #769

四个语言包把 `crm_knowledge_article.stale_articles` 译成 `Stale (>180d)` / `过期 (>180 天)` / `Obsoletos (>180d)` / `古い (>180日)`,而 filter 只有 `status = published` —— 这个页签实际返回**每一篇**已发布文章(包括几分钟前刚复核过的,只是排在最后)。与 #730 同缺陷类,谎言同样只活在翻译那一半:canonical metadata label 是 `Review Queue · Oldest First`,自始至终只承诺排序,而 `last_reviewed_at asc` 确实兑现了这个排序。

## 裁定:走退路(翻译回归 canonical),依据是实测而非偏好

派单预授权了两个分支,并给了明确的切换判据:「若 filter 层无法无损表达『早于 {180_days_ago} 或为空』,这就是切换退路的判据,不许把空值行悄悄藏掉。」**这个判据实测成立**,所以本 PR 改的是名字,不是 filter。

四条实测(全部在 pinned 17.0.0-rc.2 + `InMemoryDriver` + 真 `ObjectQL.find` 上跑,`last_reviewed_at` 声明为 `datetime`):

**1. 宏解析,且日界落在 180 天前那一天的开始**

```
where {"last_reviewed_at":{"$lt":"{180_days_ago}"}}
  -> [reviewed-181d, reviewed-400d, draft-ancient]   (n=3)
```

用字面量二分定位边界(fixtures 分别在 179d / 180d 的 00:00、11:59、23:59 / 181d / 400d 复核):

```
$lt 2026-02-07T00:00:00.000Z (=179d 前 00:00) -> [boundary-180d-00:00, boundary-180d-11:59, boundary-180d-23:59, reviewed-181d, reviewed-400d, draft-ancient]
$lt 2026-02-06T00:00:00.000Z (=180d 前 00:00) -> [reviewed-181d, reviewed-400d, draft-ancient]     ← 与宏结果逐行相同
$lt 2026-02-05T00:00:00.000Z (=181d 前 00:00) -> [reviewed-400d, draft-ancient]
```

即 `{180_days_ago}` 解析为「180 天前那个日历日的 00:00:00.000Z」。配 `less_than`(排他上界)整天被排除 —— 正是 #3777 的日界惯例,也正是 `> 180d` 该有的语义。三态(窗口内 / 窗口外 / 边界日)已钉进测试。

**2. 空值在比较运算下不命中,而空值行由 BULK 写入路径产生(这一条我先测错了一次,如实记录)**

引擎侧的事实无争议:

```
where {"last_reviewed_at":{"$null":true}}          -> [never-reviewed-NULL, never-reviewed-ABSENT]  (n=2)
where {"status":"published","last_reviewed_at":{"$lt":"{180_days_ago}"}}
                                                    -> [reviewed-181d, reviewed-400d]               (n=2)
```

显式 `null` 与键缺失两种写法都掉出窗口。有争议的是「已发布文章能不能真的没有复核时间戳」。**第一次实测用的是裸 `ObjectQL.create()`,它并不注册引擎内建的 `sys_fetch_previous_update`**(那个由 kernel 服务的 `registerAuditHooks()` 装上),于是 `ctx.previous` 恒为 undefined,我据此得出「一条普通 update 就能写回 null」—— **这个结论是错的,已作废**。补上该内建的忠实复刻(priority 5 / beforeUpdate / object `*`)后重测:

```
=== single-row update (category only) ===
  [prev-fetch] input.id="crm_knowledge_article-…-1" previous=undefined
  [knowledge-hook sees] previous.status="published" input={"id":"…","category":"api"}
  => last_reviewed_at refreshed: true

=== MULTI update (category only, every published row) ===
  [prev-fetch] input.id=undefined previous=undefined
  [knowledge-hook sees] previous.status=undefined input={"category":"troubleshooting"}
  => B.category=troubleshooting  last_reviewed_at refreshed: false

=== MULTI update writing last_reviewed_at: null ===
  [prev-fetch] input.id=undefined previous=undefined
  [knowledge-hook sees] previous.status=undefined input={"last_reviewed_at":null}
  => A: last_reviewed_at=null
  => B: last_reviewed_at=null

=== the window over that table ===
  windowed -> [(none)]
  shipped   -> [A, B]
```

单行路径上 hook 正常补戳,null 写不进去;**`multi: true` 路径上没有 `input.id`,内建取不到 previous,hook 看不到 status、什么也不戳** —— 于是批量写把 null 直接落到已发布行上,批量编辑也不会把文章标记为已复核。

修正后的结论比原先更硬,不是更软:空值行不是「畸形操作产生的理论行」,而是**批量导入/批量编辑产生的行** —— 而批量导入正是一家公司把既有知识库搬进 CRM 的常规方式。最后两行是最锋利的陈述:加窗之后,这批**从来没有人复核过**的导入文章恰好一条都不显示。(该 bulk 路径缺陷已另立 issue,不在本 PR 修。)

**3. 诚实的条件是析取,而 view filter 语法写不出析取**

`ViewFilterRuleSchema` 是 `{field, operator, value}` 的**扁平严格数组**,规则之间 AND;没有 `or`,没有嵌套,没有 logic key。用语法允许的唯一写法拼出来,两条规则在同一字段上 AND,结果是**零行**:

```
where {"last_reviewed_at":{"$lt":"{180_days_ago}","$null":true}}   -> []  (n=0)
```

一个空白页签和「没有文章需要复核」在界面上完全一样 —— 这正是不能悄悄采用的形态。

**4. 引擎本身能答对,所以这是 view 授权语法的限制,不是数据层的限制**

```
where {"status":"published","$or":[{"last_reviewed_at":{"$lt":"{180_days_ago}"}},{"last_reviewed_at":{"$null":true}}]}
  -> [reviewed-181d, reviewed-400d, never-reviewed-NULL, never-reviewed-ABSENT]  (n=4)
```

这一条特意写成正面陈述并钉进测试,免得后来人把上面第 3 条误读成「引擎做不到」。

### 另一条独立理由:漂移发生在下游

#730 / #743 两个先例里,时间口径写在 **metadata label 本身**(`This Quarter`、`Closing This Quarter`)—— 契约自己作了承诺,所以必须由 filter 兑现。本条不同:canonical label 不含任何窗口承诺,`> 180d` 只存在于四个语言包。按 contract-first,漂移在翻译这半边,就在这半边修;让下游译文去反向重塑上游行为是反的。

不补 `emptyState`:本 PR 不引入新的空态(「没有已发布文章」是这个页签一直就有的零),#746 补空态的理由(加窗使「空」成为新可达状态)在这里不成立。

## 改了什么

| 文件 | 改动 |
| --- | --- |
| `src/translations/{en,zh-CN,es-ES,ja-JP}.ts` | `stale_articles` label 回归 canonical 的忠实翻译 |
| `src/views/knowledge_article.view.ts` | #773 刚重写的注释块同步改真实(原文写着 adding the bound「is filed rather than done here (#769)」,修完即过期);文件头 `stale — published > 180 days without review` 同样是假声明,一并订正 |
| `test/forecast-current-quarter-view.test.ts` | 守卫词表扩到参数化天数窗口 + 反真空正控 + #769 运行时实测块 |
| `.changeset/…` | 一份 |

行为不变:页签返回的行与顺序与 main 完全一致。

## 反向验证(两个方向,均先声明预期再跑)

**方向一 —— 预期 RED。** 把删掉的四个 `>180d` label 原样装回(filter 保持不加窗),新家族必须变红,且只红两条:`every current-period label is backed by a filter that pins that period` 与 `no name this stack actually ships claims a day window`;四条字面量/自带标签的探针必须保持绿,因为它们不读 stack。实跑:

```
FAIL … > every current-period label is backed by a filter that pins that period
+   "crm_knowledge_article.stale_articles is labelled en:\"Stale (>180d)\", zh-CN:\"过期 (>180 天)\", ja-JP:\"古い (>180日)\", es-ES:\"Obsoletos (>180d)\" but its filter carries no {180_days_ago} — it returns rows of every age, not the ones untouched for 180 days (filter tokens: none)"

FAIL … > no name this stack actually ships claims a day window
+   "crm_knowledge_article.stale_articles en:\"Stale (>180d)\"",  (…四条)

Tests  2 failed | 28 passed (30)
```

预期与实测一致。

**方向二 —— 预期 GREEN,证明词表扩展是承重的。** 同样装回四个 label,但把测试文件换回 `origin/main` 版本(即 #769 之前的守卫)。若旧词表本就能抓,这次扩展就是装饰:

```
Test Files  1 passed (1)
      Tests  17 passed (17)
```

旧守卫在这四个 label 上 **17/17 全绿** —— 只认「当前日历周期」短语的词表看不见 `> 180d`,这也是为什么 #769 只能靠人眼发现。扩展是承重的。

正控在文件里长期保留:`re-installing those labels over the shipped filter is reported as a breach` 把删掉的四个 label 喂给 `stale_articles` **实际发布的** filter,断言守卫必须报一条 breach —— 两个家族都是靠删除其唯一实例来修的,没有这条正控,词表会在实例清零后长期空转而无人察觉。

## 验证

```
node scripts/check-source-hygiene.mjs   ✓ source hygiene clean
npx tsc --noEmit                        (无输出)
npx objectstack validate                ✓ Validation passed (1390ms)
npx objectstack build                   ✓ Build complete (1810ms)
npx vitest run --maxWorkers=2           Test Files 62 passed (62)
                                        Tests 1492 passed | 1 skipped (1493)
```

改动文件控制字符自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 零命中。

## 越界发现(已另立 issue,未折入本 PR)

见下方评论。
