### PR TITLE
fix(actions): give mass_update_stage the engine facade's (data, options) update

### DIFF
--- a/.changeset/mass-update-stage-facade-signature.md
+++ b/.changeset/mass-update-stage-facade-signature.md
@@ -1,0 +1,35 @@
+---
+'hotcrm': patch
+---
+
+Fix the "Update Stage" action on an Opportunity: choosing a new stage now
+actually moves the deal. Until this release the dialog accepted a stage, the
+request left the browser, and the server refused it with
+`update('crm_opportunity') does not recognise option 'stage'` — the deal stayed
+where it was and a red toast was all the rep got.
+
+The cause was the same one that hit the hook-side derived writes (#616): the
+action body called `ctx.api.object('crm_opportunity').update(id, { stage })`,
+but `ctx.api` is the engine repo facade, whose update takes
+`(document, options)` — the second positional argument is the OPTIONS bag, so
+the id landed in the `data` slot and the stage arrived as an unrecognised
+option. The body now writes `update({ id, stage }, { where: { id } })`, the
+spelling the rest of this app already uses and the only one live on both
+surfaces the runtime can hand a body (`updateById(id, data)` exists on
+`ObjectRepository` but not on the facade built when there is no scoped context).
+
+`test/action-sandbox.test.ts` used to pin this defect as a known break — it
+asserted the action was *rejected* by the engine. That pin is now inverted into
+a contract: the shipped body is executed under the real QuickJS sandbox against
+a real ObjectQL kernel on the in-memory driver, and the assertion is that the
+STORED record's stage moved, read back from the driver rather than taken from
+the body's return value. Reverting the call to the old spelling turns four tests
+red, one of them reproducing the production error string verbatim.
+
+This is only the single-record half of #508. A multi-row selection still cannot
+reach any action in the console — the client rejects it before a request is
+sent, a top-level `selectedIds` is not delivered to the body, and
+`params.selectedIds` is refused as undeclared — so the "Update Stage" bulk
+button stays off the Opportunity list view until that ships upstream
+(objectstack-ai/objectstack#5568). The body's selection loop is covered by tests
+so nothing else stands in the way when it does. Refs #508.

--- a/src/actions/opportunity.actions.ts
+++ b/src/actions/opportunity.actions.ts
@@ -64,23 +64,32 @@ export const CloneOpportunityAction: Action = {
 /**
  * Mass Update Opportunity Stage.
  *
- * KNOWN-BROKEN in console 16.1.0 — kept DEFINED, no longer wired, tracked in
- * issue #508. No invocation path currently executes it: modal submits resolve
- * `target` as an object name (400), the selection-bar bulk button is a
- * client-side no-op (zero network requests), and the header toolbar path
- * rejects multi-row selections, so `input.selectedIds` never arrives.
- * Script-typed (modal is provably dead) with a recordId fallback so a
- * single-row invocation works the moment the toolbar delivers it.
+ * SINGLE-RECORD ONLY today, and that half now works. #508 split into two on
+ * the 17.0.0-rc.2 retest:
  *
- * The list view no longer lists it in `bulkActions` (#588): that button was
- * the one path that failed *silently* — success toast, nothing written — so it
- * read as data loss rather than as a tracked gap. This definition stays put so
- * the restore is a one-line edit in `src/views/opportunity.view.ts`; do it in
- * the PR that closes #508, and fix the `ctx.api...update(id, {...})` call
- * pinned in `test/action-sandbox.test.ts` at the same time.
+ *   - the SINGLE-row toolbar path reaches this body — the param dialog renders
+ *     and the console POSTs `{ recordId, params: { stage } }`. What it then hit
+ *     was this body's own bug: it called `update(id, { stage })`, but `ctx.api`
+ *     is the engine repo facade, whose update takes `(data, options)`. The id
+ *     landed in the `data` slot and every invocation 400'd with
+ *     `update('crm_opportunity') does not recognise option 'stage'`. Fixed
+ *     below, and executed end-to-end in `test/action-sandbox.test.ts`.
+ *   - the MULTI-row path is still dead upstream (objectstack-ai/objectstack
+ *     #5568): the console rejects a multi-row selection client-side (zero
+ *     network requests), a top-level `selectedIds` is not delivered to the
+ *     body, and `params.selectedIds` is refused by the action-param validator
+ *     as undeclared. So `input.selectedIds` cannot arrive by any route yet —
+ *     the branch below is kept because it is what the fix lands into.
  *
- * Until upstream ships bulk-selection delivery, stage moves happen via the
- * pipeline kanban drag-and-drop, inline grid editing, or the record form.
+ * The list view therefore still does NOT list it in `bulkActions` (#588): that
+ * button was the one path that failed *silently* — success toast, nothing
+ * written — so it read as data loss rather than as a tracked gap. Restoring it
+ * is a one-line edit in `src/views/opportunity.view.ts`; do it in the PR that
+ * closes #508, once objectstack#5568 ships multi-row delivery and the selection
+ * bar is verified to POST `selectedIds`.
+ *
+ * Until then, multi-record stage moves happen via the pipeline kanban
+ * drag-and-drop, inline grid editing, or the record form.
  */
 export const MassUpdateStageAction: Action = {
   name: 'mass_update_stage',
@@ -100,7 +109,14 @@ export const MassUpdateStageAction: Action = {
       if (!ids.length) throw new Error('mass_update_stage: no opportunity selected');
       let updated = 0;
       for (const id of ids) {
-        await ctx.api.object('crm_opportunity').update(id, { stage: newStage });
+        // \`update(data, options)\` — \`ctx.api\` is the engine repo facade, whose
+        // update takes a DOCUMENT, not an id. \`updateById(id, data)\` exists on
+        // ObjectRepository but NOT on the facade the runtime builds when it has
+        // no scoped context, so this spelling is the only one live on both.
+        await ctx.api.object('crm_opportunity').update(
+          { id: id, stage: newStage },
+          { where: { id: id } },
+        );
         updated++;
       }
       return { stage: newStage, updated };

--- a/test/action-sandbox.test.ts
+++ b/test/action-sandbox.test.ts
@@ -16,6 +16,7 @@ import {
   runActionBody,
   runHookBody,
   type Rec,
+  type SandboxEngine,
 } from './helpers/action-sandbox';
 
 /**
@@ -252,9 +253,6 @@ describe('every script action body executes under QuickJS', () => {
     ),
   };
 
-  /** Asserted separately below, because it does not currently reach the engine. */
-  const BROKEN = 'crm_opportunity:mass_update_stage';
-
   it('covers every action the runtime will sandbox', () => {
     // Keyed the way the runtime keys its own registry, so fifteen distinct
     // activity bodies are fifteen distinct cases rather than three.
@@ -269,7 +267,7 @@ describe('every script action body executes under QuickJS', () => {
     expect(stale, `INVOCATIONS names actions that no longer exist:\n  ${stale.join('\n  ')}`).toEqual([]);
   });
 
-  it.each(SCRIPT_ACTIONS.map(keyOf).filter((k) => k !== BROKEN))('%s', async (key) => {
+  it.each(SCRIPT_ACTIONS.map(keyOf))('%s', async (key) => {
     const { opts, seed } = (INVOCATIONS[key] ?? INVOCATIONS[key.split(':')[1]!])!;
     const engine = makeSandboxEngine(seed ?? {});
     const { result } = await runActionBody(action(key), { ...opts, engine });
@@ -277,26 +275,124 @@ describe('every script action body executes under QuickJS', () => {
   });
 
   /**
-   * The defect this executor was built to be able to find, recorded rather than
-   * fixed: `mass_update_stage` calls `update(id, { stage })`, but `ctx.api` is
-   * the engine repo facade, whose update takes `(data, options)` — so the id
-   * lands in the `data` slot and the engine refuses the write (the same
-   * rejection pinned against the real kernel at the top of this file). Every
-   * invocation of this action fails, and nothing before this file could say so:
-   * the metadata is valid, the body parses, and the action has no live
-   * invocation path to fail on (#508, `src/actions/opportunity.actions.ts`).
+   * `mass_update_stage` — the defect this executor was built to be able to
+   * find, now fixed and pinned the other way round (#508, CRM half).
    *
-   * Fixing the body is a change to a shipped action and belongs to whoever
-   * revives it — at which point this assertion is the thing that tells them the
-   * behaviour moved.
+   * The body used to call `update(id, { stage })`, but `ctx.api` is the engine
+   * repo facade, whose update takes `(data, options)` — so the id landed in the
+   * `data` slot and the engine refused the write. Live, that was an HTTP 400 on
+   * every single-row dispatch: `update('crm_opportunity') does not recognise
+   * option 'stage'`. The rejection ITSELF is still pinned, action-independently,
+   * at the top of this file (`rejects update(id, doc)`), against both the real
+   * kernel and the stub — so nothing here has to re-prove that the wrong
+   * spelling is wrong. What these three assert is the shipped body: the call it
+   * makes, and the row that moves because of it.
+   *
+   * Reverting the body to `update(id, { … })` turns all three red, plus the
+   * `it.each` case above, which now covers this action like any other.
+   *
+   * The MULTI-record leg still has no live invocation path — the console cannot
+   * deliver a selection to an action at all (objectstack-ai/objectstack#5568),
+   * which is why #508 stays open and `bulkActions` stays un-wired. The loop is
+   * covered anyway, because the moment that delivery lands the only thing
+   * standing between it and a mass stage move is this body.
    */
-  it(`${BROKEN} is rejected by the engine — it passes an id where the facade wants a document`, async () => {
-    const { opts, seed } = INVOCATIONS[BROKEN.split(':')[1]!]!;
-    const engine = makeSandboxEngine(seed ?? {});
-    await expect(runActionBody(action(BROKEN), { ...opts, engine })).rejects.toThrow(
-      /Update requires an ID or options\.multi=true/,
-    );
-    expect(engine.rows('crm_opportunity')[0]!.stage, 'the stage move silently landed').toBe('prospecting');
+  describe('mass_update_stage writes the stage it was given (#508, CRM half)', () => {
+    const MASS_UPDATE = 'crm_opportunity:mass_update_stage';
+
+    /**
+     * A real ObjectQL, handed to the body runner in the `engine` slot.
+     *
+     * `runActionBody` passes `engine.engine` through as the runner factory's
+     * `ql`, and `buildSandboxApi` wraps whatever it gets in the very same
+     * `buildEngineRepoFacade` production builds: an ObjectQL instance exposes
+     * no `.object()`, and this harness supplies no `executionContext`, so both
+     * of the earlier branches are skipped. What the body meets here is
+     * therefore the production facade over the production kernel — only the
+     * `SandboxEngine` recorder side is missing, which this leg does not use.
+     */
+    const asBodyEngine = (kernel: unknown): SandboxEngine =>
+      ({ engine: kernel } as unknown as SandboxEngine);
+
+    const makeKernel = () =>
+      ObjectQL.create({
+        datasources: { default: new InMemoryDriver({ persistence: false }) },
+        objects: {
+          crm_opportunity: {
+            name: 'crm_opportunity',
+            fields: { id: { type: 'text' }, name: { type: 'text' }, stage: { type: 'text' } },
+          },
+        } as never,
+      });
+
+    let ql: Awaited<ReturnType<typeof makeKernel>>;
+
+    beforeAll(async () => {
+      ql = await makeKernel();
+    });
+    afterAll(async () => {
+      await ql?.close();
+    });
+
+    it('calls the facade with (data, options) — and the stub row moves', async () => {
+      const engine = makeSandboxEngine({ crm_opportunity: [{ id: 'opp_1', stage: 'qualification' }] });
+      const { result } = await runActionBody(action(MASS_UPDATE), {
+        objectName: 'crm_opportunity',
+        record: { id: 'opp_1' },
+        input: { stage: 'needs_analysis' },
+        engine,
+      });
+      const [call] = engine.callsFor('crm_opportunity', 'update');
+      // The document in the `data` slot, the predicate in `options` — the id is
+      // never a positional argument.
+      expect(call!.args[0]).toEqual({ id: 'opp_1', stage: 'needs_analysis' });
+      expect(call!.args[1]).toEqual({ where: { id: 'opp_1' } });
+      expect(engine.rows('crm_opportunity')[0]!.stage).toBe('needs_analysis');
+      expect(result).toEqual({ stage: 'needs_analysis', updated: 1 });
+    });
+
+    it('moves the STORED stage on a real kernel — the single-row path end to end', async () => {
+      // The exact live 400 from the rc.2 acceptance run: a `qualification` deal
+      // dispatched single-row to `needs_analysis`, which never applied.
+      const api = ql.createContext({ isSystem: true });
+      const row = await api.object('crm_opportunity').insert({
+        name: 'Acme Expansion',
+        stage: 'qualification',
+      });
+
+      const { result } = await runActionBody(action(MASS_UPDATE), {
+        objectName: 'crm_opportunity',
+        record: { id: row.id },
+        input: { stage: 'needs_analysis' },
+        engine: asBodyEngine(ql),
+      });
+
+      expect(result).toEqual({ stage: 'needs_analysis', updated: 1 });
+      // Read back from the driver, not from the body's return value: the return
+      // value was always honest about what the body INTENDED.
+      const stored = await api.object('crm_opportunity').findOne({ where: { id: row.id } });
+      expect(stored?.stage, 'the stage move never reached the store').toBe('needs_analysis');
+    });
+
+    it('walks every id of a selection, once the console can deliver one', async () => {
+      const api = ql.createContext({ isSystem: true });
+      const a = await api.object('crm_opportunity').insert({ name: 'Deal A', stage: 'prospecting' });
+      const b = await api.object('crm_opportunity').insert({ name: 'Deal B', stage: 'proposal' });
+
+      const { result } = await runActionBody(action(MASS_UPDATE), {
+        objectName: 'crm_opportunity',
+        // No `record`: a selection-scoped dispatch carries no single recordId,
+        // which is exactly why the body prefers `input.selectedIds`.
+        input: { stage: 'negotiation', selectedIds: [a.id, b.id] },
+        engine: asBodyEngine(ql),
+      });
+
+      expect(result).toEqual({ stage: 'negotiation', updated: 2 });
+      for (const id of [a.id, b.id]) {
+        const stored = await api.object('crm_opportunity').findOne({ where: { id } });
+        expect(stored?.stage).toBe('negotiation');
+      }
+    });
   });
 
   it('clone_opportunity copies the required fields onto a fresh prospecting deal', async () => {


### PR DESCRIPTION
Refs #508

**本 PR 只交付 #508 的 CRM 半,不关单。** 关单条件维持 rc.2 三条复核给出的两半齐:平台交付多选投递(已镜像 objectstack-ai/objectstack#5568,阻塞中)+ 本仓签名修复(本 PR)+ `bulkActions` 还原后选择栏验收通过。因此正文用 `Refs` 而非 `Fixes`,并且**未触碰** `src/views/opportunity.view.ts` 的 `bulkActions` —— 那一行还原等 #5568 交付后另行安排。

## Description

`mass_update_stage` 的 action body 原先调用 `ctx.api.object('crm_opportunity').update(id, { stage })`。而 `ctx.api` 是引擎的 repo facade,其 `update` 签名是 `(document, options)` —— 第二个位置参数是 options 包。于是 id 落进 `data` 槽、`stage` 变成一个未识别的 option,单行派发每次都被服务端拒:

```
400 VALIDATION_ERROR
update('crm_opportunity') does not recognise option 'stage'. The engine executes
none of it, so the call would succeed with the option silently ignored (#4371).
Legal keys for update: bypassTenantAudit, context, multi, onFieldsDropped,
preserveAudit, returning, tenantId, tenantIds, timezone, transaction, upsert, where.
```

rc.2 上参数弹窗已修、单行 `recordId` 派发已能通到 body(见 #508 的三条 2026-08-05 复核),所以这个签名就是单行路径的唯一拦路石。改为 `update({ id, stage }, { where: { id } })` 后,选一个新 stage 真的会把商机移过去。

这个拼法不是随便挑的:它与本仓既有的两处正确写法一致(`global.actions.ts` 的 SLA 首响标记、`contact.actions.ts` 的 `mark_primary`),并且是运行时可能交给 body 的两种 api 上**唯一都存在**的拼法 —— `updateById(id, data)` 只存在于 `ObjectRepository`,`buildEngineRepoFacade`(运行时在没有 scoped context 时构造的那个)没有这个方法。与 #616 修掉的九处 hook 侧派生写是同一类缺陷,只是这次在 action 侧。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Refs #508 —— CRM 半,不关单。
平台半镜像:objectstack-ai/objectstack#5568(多选投递,阻塞中)。
同类缺陷先例:#616(hook 侧九处派生写的同一签名问题)。

## Changes Made

- `src/actions/opportunity.actions.ts`:body 内的 update 调用改用 facade 的 `(data, options)` 形状;顺带把该 action 的文档注释订正到 rc.2 现状(原注释还停在 console 16.1.0「三条路径全断」的口径,并挂账说要「随关闭本单的 PR 一并修复」——现在签名这一项已兑现,多选那一项挂到 #5568)。
- `test/action-sandbox.test.ts`:把原先「钉住缺陷」的断言翻成「钉住契约」(见下)。
- `.changeset/mass-update-stage-facade-signature.md`。

## Testing

- [x] Unit tests pass (`pnpm test` —— 62 files / 1482 passed, 1 skipped)
- [x] Linting passes (`pnpm lint`、`pnpm hygiene`、`pnpm validate` 全绿)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing completed(真实 dev server + REST 实测,见下)
- [x] New tests added

### 测试怎么翻的

原来 `test/action-sandbox.test.ts` 把这个缺陷**钉成「已知坏」**:`crm_opportunity:mass_update_stage` 被排除在「每个 script body 都要能跑」的 `it.each` 之外,单独断言它会被引擎拒绝。现在:

1. 该 action 回到 `it.each`,和其它 body 一视同仁;
2. 新增三条断言 —— 桩引擎上检查**送达引擎的实参形状**(`args[0]` 是文档、`args[1]` 是 `{ where }`),真实 ObjectQL 内核上检查**存储层读回来的 stage 真的变了**,以及多行 selection 循环会逐条写;
3. 「错拼法会被拒」这件事本身仍然钉着 —— 文件顶部那两条与 action 无关的契约测试(真实内核 + 桩各一次)原样保留。

关键点是新断言**不是只测新写法能跑**:有人把 body 改回 `update(id, {...})`,上面这四条会全红。

### 反向验证(先声明方向再跑:普通「红」向,非反转)

预期:改回旧写法后,`it.each` 那一例 + 三条新断言共 **4 条转红**,而文件顶部两条与 action 无关的契约测试**保持绿**。实测一致:

```
✓ the sandbox engine stub obeys the kernel's update contract > rejects update(id, doc) …
✓ the sandbox engine stub obeys the kernel's update contract > applies update(data, { where }) …
× every script action body executes under QuickJS > crm_opportunity:mass_update_stage
  → action 'mass_update_stage' threw: Error: Update requires an ID or options.multi=true
× … > calls the facade with (data, options) — and the stub row moves
× … > moves the STORED stage on a real kernel — the single-row path end to end
  → action 'mass_update_stage' threw: Error: update('crm_opportunity') does not
    recognise option 'stage'. … (#4371)
× … > walks every id of a selection, once the console can deliver one

Tests  4 failed | 75 passed (79)
```

真实内核那两条复现的报错字符串,与验收实录里服务端 400 的原文逐字相同 —— 这是 engine 级测试确实忠实于生产路径的证据。修复后同一文件 79 passed。

### 真实 dev server 实测(同一套干净环境的前后对照)

同一台 dev server 配置、同一条商机、同一次 stage 迁移(`qualification` → `needs_analysis`),各自从空库重新 seed:

**改前(body 是旧写法)**

```
POST /api/v1/actions/crm_opportunity/mass_update_stage
     {"recordId":"el788thkkJoPiqs-","params":{"stage":"needs_analysis"}}
→ 400 {"code":"VALIDATION_ERROR","message":"update('crm_opportunity') does not
       recognise option 'stage'. … (#4371)"}
读回:stage 仍是 qualification
```

**改后(本 PR)**

```
POST /api/v1/actions/crm_opportunity/mass_update_stage
     {"recordId":"aNvQ_nMHHe2Nnm1M","params":{"stage":"needs_analysis"}}
→ 200 {"success":true,"data":{"stage":"needs_analysis","updated":1}}
读回:stage = needs_analysis  ✅
```

两次都先用 `GET /api/v1/meta/actions` 核对服务端**实际注册**的 body 是哪一版再发请求。

### 关于身份/共享闸门

#508 正文(16.1 时代)提过一层担心:sandbox body 的 UPDATE 会被 sharing 中间件以 `FORBIDDEN: insufficient privileges to update` 挡下。**rc.2 上实测没有发生** —— 上面那次 200 是真写进去了,服务端日志同时给出原因:

```
[action-audit] REST action 'crm_opportunity/mass_update_stage' — body executes
TRUSTED (system-elevated context, RLS/FLS-bypassing) for user '…'
```

即 action body 走的是系统提权上下文,不经 RLS/FLS。所以这一层不再是拦路石,也就没有引入任何 runAs 之类的绕过。

## Additional Notes

多行 selection 那条腿仍然没有任何可达路径(console 客户端就拦下多行、顶层 `selectedIds` 不投递、`params.selectedIds` 被参数校验器按未声明拒绝),因此 `bulkActions` 保持摘除、`test/metadata-references.test.ts` 里那条「不许把死的 bulk 按钮接回去」的守卫原样不动。body 里的 selection 循环已有测试覆盖,#5568 交付后本仓这边不需要再改 body。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_