### PR TITLE
docs(comments): 订正 task.view.ts 两处立在 17.0 前过期前提上的注释（#744 缺陷类第五个文件）

### DIFF
--- a/.changeset/task-view-stale-comments.md
+++ b/.changeset/task-view-stale-comments.md
@@ -1,0 +1,43 @@
+---
+---
+
+No user-visible change: two source comments in `src/views/task.view.ts` are
+corrected, nothing else. The diff's non-comment content is empty, proved two
+ways (every changed diff line is a `//` line; the comment-stripped emit of the
+file is byte-identical before and after).
+
+Same defect class as #744 / PR #773 — the fifth file, missed by that pass. Both
+comments rested on the pre-17.0 premise that the list data path interpolates no
+templates, and they contradicted each other about it fifteen lines apart:
+`todays_tasks` said `{current_user_id}` does not interpolate, `overdue_tasks`
+said only `{current_user_id}` does. `resolveFilterTokens()` was wired into the
+ObjectQL read path at 17.0.0-rc.0 (objectql #3582) ahead of the middleware
+chain, covering `find` / `findOne` / `count` / `aggregate` — saved-view filters
+included — so both readings are stale.
+
+Corrections are anchored to measurements on the pinned 17.0.0-rc.2, not to
+replacement prose:
+
+- `todays_tasks` — the retired reason is replaced by what a real engine does.
+  `{current_user_id}` resolves (#784's two-probe split: `{current_org_id}`
+  returned 0 rows, so the filter is not dropped; `{current_user_id}` returned
+  every seeded task, so it is not a literal compare). `{TODAY()}` was never in
+  the vocabulary — the canonical spelling is `{today}` — and, measured here, it
+  is not rejected either: the placeholder grammar admits only word characters,
+  so `classifyFilterToken('{TODAY()}')` returns null and the string reaches the
+  driver verbatim. Over a four-row fixture, `due_date < '{today}'` selected the
+  two past-due rows, `{TODAY}` threw `UnknownFilterTokenError`, and `{TODAY()}`
+  matched all four including one due next week. The comment's separate claim
+  that the sort "puts urgent at top" is corrected too: the shipped sort is
+  `due_date`-major and `priority_rank` only breaks ties within a due date.
+- `overdue_tasks` — the two reasons are split. The `is_overdue` half still
+  holds (`task.hook.ts:68` stamps it in `beforeSave`, and nothing re-stamps it),
+  and is kept; the date-macro half is retired, along with the follow-up it
+  implied that an hourly re-stamping flow is the only route to a truly-overdue
+  gauge.
+
+Both rewrites state explicitly that correcting a comment decides nothing about
+the filter: giving either view a `{today}` bound, an owner condition, or a
+different label is a behaviour change on #770's line for the task views.
+
+Fixes #782.

--- a/src/views/task.view.ts
+++ b/src/views/task.view.ts
@@ -138,8 +138,54 @@ export const TaskViews = defineView({
       label: '📅 My Priority Tasks',
       data: { provider: 'object', object: 'crm_task' },
       columns: ['subject', 'priority', 'status', 'due_date', 'related_to_type', 'owner_id'],
-      // Operator-only filter (the view runtime does not interpolate
-      // `{TODAY()}` / `{current_user_id}` templates). Sort puts urgent at top.
+      // Operator-only filter — priority and status, no tokens — and the reason
+      // recorded here for that has expired (#782). Two claims stood here; both
+      // are wrong on the pinned 17.0.0-rc.2, in different ways.
+      //
+      // `{current_user_id}` DOES interpolate. `resolveFilterTokens()` was wired
+      // into the ObjectQL READ path at 17.0.0-rc.0 (objectql #3582) ahead of
+      // the middleware chain, covering `find` / `findOne` / `count` /
+      // `aggregate` — saved-view filters included. `my_open_tasks`, the view
+      // directly above, ships that exact token. Measured in #784 with two probes
+      // that separate the three possible outcomes: `owner_id =
+      // {current_org_id}` returned 0 rows (the filter is not being dropped)
+      // while `owner_id = {current_user_id}` returned every seeded task (not a
+      // literal-string compare either — the literal matches no owner at all).
+      //
+      // `{TODAY()}` is not a spelling of anything and never was. The vocabulary
+      // is `{today}` / `{yesterday}` / `{tomorrow}` / `{now}`, the period
+      // tokens, and the parameterised `{N_days_ago}` family. Nor is `{TODAY()}`
+      // REJECTED, which is the part worth writing down: the placeholder grammar
+      // is `/^\$?\{([a-zA-Z0-9_]+)\}$/`, parentheses fall outside it, so
+      // `classifyFilterToken('{TODAY()}')` returns null — it is never treated
+      // as a token, ships to the driver verbatim, and compares as text.
+      // Measured on rc.2 over a four-row `crm_task` fixture (due 30d ago / 1d
+      // ago / today / in 7d):
+      //
+      //     due_date <  '{today}'     ->  2 rows (the two past-due)
+      //     due_date <= '{today}'     ->  3 rows
+      //     due_date <  '{TODAY}'     ->  throws UnknownFilterTokenError
+      //                                   (code FILTER_TOKEN_UNKNOWN)
+      //     due_date <  '{TODAY()}'   ->  ALL 4 rows, including next week's
+      //
+      // That last line is the #744 lexicographic inversion ('2026-…' sorts
+      // below '{'), still live for spellings the grammar cannot see. Nothing in
+      // this repo can ship one: the author-time guard in
+      // `test/metadata-references.test.ts` scans the broader `/\{([^{}]+)\}/`
+      // and rejects any token neither path resolves.
+      //
+      // Correcting the comment is not a licence to change the filter. Whether
+      // this view should carry a date bound at all — and whether a label
+      // reading "My Priority Tasks" over a filter with no owner condition is
+      // the right name — are BEHAVIOUR decisions on #770's line for the task
+      // views, not this one's.
+      //
+      // The sort below is due_date-MAJOR, not priority-major: `priority_rank
+      // desc` only breaks ties inside a single due date, so a high task due
+      // tomorrow outranks an urgent one due next week. Measured on rc.2 with
+      // the shipped sort over four rows — soon/urgent, soon/high, later/urgent,
+      // later/high, in that order. What stood here said the sort "puts urgent
+      // at top", which is what the OTHER key order would do.
       filter: [
         { field: 'status', operator: 'in', value: ['not_started', 'in_progress'] },
         { field: 'priority', operator: 'in', value: ['high', 'urgent'] },
@@ -151,13 +197,40 @@ export const TaskViews = defineView({
     overdue_tasks: {
       name: 'overdue_tasks',
       type: 'grid',
-      // Honest label: the view layer cannot resolve `due_date < {TODAY()}`
-      // (only `{current_user_id}` interpolates) and `is_overdue` is a
-      // write-time snapshot that goes stale, so we cannot reliably filter to
-      // *strictly* past-due rows here. Instead this is the open-task backlog
-      // ordered most-overdue-first (oldest due date on top), which is the
-      // actionable queue a manager wants. A truly-overdue gauge belongs to an
-      // hourly flow that stamps `is_overdue` (follow-up).
+      // Honest label. Two independent reasons were recorded for it; one still
+      // holds and one has expired (#782), so they are separated here.
+      //
+      // STILL TRUE — `is_overdue` is a WRITE-TIME snapshot. `task.hook.ts:68`
+      // stamps it in `beforeSave` off that moment's clock (`effDue < todayStr`
+      // and not completed) and nothing re-stamps it afterwards, so a task that
+      // was on time when it was last saved still reads `is_overdue = false` the
+      // day after its due date passes. A filter on that column would hand back
+      // the wrong rows, and it would go wrong silently.
+      //
+      // EXPIRED — the other reason said the view layer cannot resolve
+      // `due_date < {TODAY()}`, and that only `{current_user_id}` interpolates.
+      // Both halves are wrong on the pinned 17.0.0-rc.2, and the file said the
+      // opposite of itself: the note on `todays_tasks` above asserted that
+      // `{current_user_id}` does NOT interpolate. It does. That comment carries
+      // the measurements — including why `{TODAY()}` is not a spelling of
+      // anything, and is not rejected either. The canonical `{today}` resolves
+      // on the read path, so a strictly past-due filter IS expressible now:
+      // `due_date < '{today}'` selected exactly the past-due rows out of four
+      // on rc.2.
+      //
+      // So the honest statement is narrower than the one that stood here: this
+      // view CAN be given a strictly past-due cut through `{today}`, and is not
+      // given one. Adding it is a BEHAVIOUR change, not a comment correction —
+      // it would drop today's due-today work out of the queue and turn an
+      // "Open Tasks" backlog into a strict overdue list, which is the
+      // cut-versus-ranking question already open on #770 for the task views.
+      // That also retires the follow-up this comment used to end on: an hourly
+      // flow re-stamping `is_overdue` was proposed as the ONLY route to a
+      // truly-overdue gauge, because the filter route was believed closed.
+      // There are two routes now, and choosing between them belongs to #770.
+      //
+      // As shipped: the open-task backlog ordered most-overdue-first (oldest
+      // due date on top), which is the actionable queue a manager works.
       label: '⏰ Open Tasks · Most Overdue First',
       data: { provider: 'object', object: 'crm_task' },
       columns: ['subject', 'priority', 'status', 'due_date', 'owner_id'],


### PR DESCRIPTION
Fixes #782

纯注释订正，零行为变更。`task.view.ts` 是 #744 / PR #773 那一轮漏掉的第五个文件，两处注释都立在「列表数据路径不插值模板」的 17.0 前提上，而且**彼此矛盾**：`todays_tasks` 说 `{current_user_id}` 不插值，十几行外的 `overdue_tasks` 说「只有 `{current_user_id}` 插值」。

按 #773 的模式：过期的半句退役、仍成立的半句保留，订正依据一律用**实测**锚定而不是以 prose 换 prose。

## 实测（pinned 17.0.0-rc.2，`InMemoryDriver` + `ObjectQL.find`，一次性探针，未入库）

四行 `crm_task` 夹具，`due_date` 分别在 30 天前 / 1 天前 / 今天 / 7 天后；`owner_id` 两行属登录用户、两行不属：

```
classifyFilterToken (spec/data)：
  {today}            => {"kind":"date-macro","token":"today"}
  {TODAY}            => {"kind":"unknown","token":"TODAY"}
  {TODAY()}          => null
  {current_user_id}  => {"kind":"context","token":"current_user_id"}

ObjectQL 读路径：
  due_date <  '{today}'            =>  2 行（恰好两行逾期）
  due_date <= '{today}'            =>  3 行
  due_date <  '{yesterday}'        =>  1 行
  due_date <  '{TODAY}'            =>  THROWS UnknownFilterTokenError / FILTER_TOKEN_UNKNOWN
  due_date <  '{TODAY()}'          =>  4 行（含下周才到期的那行）
  owner_id =  '{current_user_id}'  =>  2 行（只有该用户的）
  owner_id =  '{current_org_id}'   =>  0 行（对照：过滤没有被丢弃）
```

**issue 正文的第三条断言被这次实测证伪了一半，订正后写进注释的是实测结果。** issue 说 `{TODAY()}` 会被 `classifyFilterToken` 判为 `unknown` 并**抛** `UnknownFilterTokenError`。实际不抛：占位符文法是 `/^\$?\{([a-zA-Z0-9_]+)\}$/`，圆括号不在字符类里，所以 `{TODAY()}` 根本**不被识别为令牌**（classify 返回 `null`），原样下发给 driver 按字面串比较——上表里它匹配了全部 4 行，正是 #744 记录的那个字典序倒置（`'2026-…'` 排在 `'{'` 之前）。抛错的是**不带括号**的 `{TODAY}`。「不解析」这个结论仍然过期（canonical 的 `{today}` 真解析），但机制与 issue 写的不同，注释按实测写。

`{current_user_id}` 解析这一条与 #784 的浏览器双探针一致（`{current_org_id}` 0 行 + `{current_user_id}` 全命中），本地引擎层再钉了一遍。

## 两处注释各改了什么

**`todays_tasks`** —— 整段理由退役，换成上面的实测；另外该注释里「Sort puts urgent at top」这句也是错的，一并订正：shipped 的 `sort` 是 `due_date` 为**主键**、`priority_rank desc` 只在同一到期日内破平，实测四行的顺序是 soon/urgent → soon/high → later/urgent → later/high，即明天到期的 high 排在下周到期的 urgent 之上。「urgent 置顶」是**另一种**键序才会有的效果。

**`overdue_tasks`** —— 两条理由分拆（#773 对 `stale_opportunities` 的做法）：

- **仍然成立**：`is_overdue` 是写入时快照。`src/objects/task.hook.ts:68` 在 `beforeSave` 里按当时的时钟盖戳，此后无人重盖，所以上次保存时还没逾期的任务，过了到期日仍读作 `is_overdue = false`。按这一列过滤仍然会静默地拿到错的行。
- **已过期**：日期宏那半，以及「只有 `{current_user_id}` 插值」那句（就是与上一处矛盾的来源）。`{today}` 在读路径上真解析，严格逾期的过滤**现在可以表达**。

## 注释里写死：订正注释 ≠ 改 filter

两处都明确写了这一点。`overdue_tasks` 加 `{today}` 下界会把今天到期的活从队列里挪走、把 backlog 变成严格逾期列表；`todays_tasks` 该不该加日期条件、`📅 My Priority Tasks` 的「My」与没有 owner 条件对不上该怎么办——都是**行为决策**，属 #770 那条线，本 PR 一行没动。同时退役了旧注释结尾那条 follow-up（「truly-overdue 只能靠每小时重盖 `is_overdue` 的 flow」）：当时那么写是因为以为 filter 路线关着，现在有两条路线，选哪条同样归 #770。

## 零行为变更的机械证明（两种独立形式，均对 origin/main）

1. **注释前缀排除法**：`src/` 下 91 行增删（+82 / -9），去掉行首缩进后逐行过滤掉以 `//` 开头的行，残集为 **0 行**。

```
diff lines under src/: 91 (+82 / -9)
residue after dropping de-indented '//' lines: 0
PROOF 1 PASS: every changed line under src/ is a comment line.
```

2. **剥注释后逐字节比对**：`task.view.ts` 的 origin/main 版与本分支版分别经 esbuild（`minifyWhitespace`，不动标识符/语法）剥掉注释后输出逐字节相同。

```
IDENTICAL  src/views/task.view.ts  (4294 bytes before / 4294 bytes after,
           sha256 7116fe48f7a08807 vs 7116fe48f7a08807)
PROOF 2 PASS: comment-stripped emit is byte-identical.
```

## 验证

- `pnpm hygiene` — 4/4 通过，含 `✓ no raw control bytes in source files`
- `pnpm typecheck` — `tsc --noEmit` 退出码 0
- `pnpm validate` — `✓ Validation passed (1400ms)`（5 条告警是 main 上既有的：approval 组解析 ×4、campaign_member 字段组）
- `npx vitest run --maxWorkers=2` — **Test Files 63 passed / Tests 1513 passed | 1 skipped**
- 控制字符自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 对改动文件命中 0 处

**测试结果按上面两个证明不可能变化，这里不硬造反向验证**：被证伪的对象是旧注释的断言本身，不是任何测试。真正的反向证据是上表——旧注释若成立，`due_date <  '{today}'` 应当返回 0 行（未解析的字面量匹配不到）或 4 行（字典序倒置），实际返回恰好 2 行逾期行。

平台版本未动，锁 17.0.0-rc.2。changeset 为空 frontmatter（纯注释，不发布任何东西）。未动 `content/docs/releases/`，未动其它文件。

## 顺带记录的越界发现（未折入本 PR）

- **平台侧观察**：`UnknownFilterTokenError` 的覆盖面止于 `[a-zA-Z0-9_]+` 的占位符文法。任何含非 word 字符的类占位符串——`{TODAY()}`、`{current-user-id}`、`{30 days ago}`——都绕过这个诊断、原样下发按字面串比较，正好落回该诊断本要消灭的那个失败模式（本 PR 实测：匹配全部 4 行）。hotcrm 自己的作者期守卫用的是更宽的 `/\{([^{}]+)\}/`，所以本仓库今天碰不到，属 observation-class。已单独立 issue（见下）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_