### PR TITLE
fix(i18n): 补齐 en 的列表视图标签，并为「视图标签跨语言一致性」加守卫 (#783, #767)

### DIFF
--- a/.changeset/view-label-locale-parity.md
+++ b/.changeset/view-label-locale-parity.md
@@ -1,0 +1,32 @@
+---
+'hotcrm': patch
+---
+
+Complete the English view labels, and guard the class that nothing was watching:
+every saved list view now has a label entry in all four locales, checked against
+the views the stack actually ships.
+
+Nine saved views had no `_views` label entry in the `en` bundle — `crm_task`'s
+"My Priority Tasks" and "Open Tasks · Most Overdue First", `crm_lead`'s "Hot
+Leads", `crm_account`'s "Upcoming Renewals" and "At-Risk Accounts",
+`crm_case`'s "My Open Cases" and "SLA at Risk", and `crm_opportunity`'s "Stale
+Opportunities" and "Closing This Quarter" — while zh-CN, ja-JP and es-ES all
+carried the full set. Every entry added here is the view's own metadata label
+verbatim, so no name a user reads changes.
+
+Nothing on the English screens was wrong, and that is exactly why it went
+unnoticed for so long: a missing key falls back to the label in the view
+metadata, which in the source locale is already correct English, so a gap and a
+correct entry render identically. It matters because the English bundle is the
+shape every other bundle is authored from — a view with no slot there is a view
+the next translator has nowhere to put — and because English silently tracked
+any rename of the metadata label while the other three locales kept translating
+the old name, with nothing red.
+
+The guard is the durable half. `objectstack lint` never covered this surface —
+the `lint` script passes `--skip-i18n`, and even without the flag app-authored
+view labels are not in the set it checks — so three new assertions derive the
+canonical view set from the compiled stack and require that every view has a
+label in every locale, that no locale carries an entry for a view the stack no
+longer ships, and that the English entry stays byte-identical to the metadata
+label it stands in for, which turns a silent rename into a failing test.

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -122,6 +122,8 @@ export const en: TranslationData = {
         account_map: { label: 'Accounts by Location', description: 'Geospatial distribution of accounts' },
         enterprise_accounts: { label: 'Enterprise Accounts', description: 'Accounts with the highest annual revenue' },
         my_accounts: { label: 'My Accounts', description: 'Accounts owned by the current user' },
+        renewals_due: { label: '🔄 Upcoming Renewals' },
+        at_risk_accounts: { label: '⚠️ At-Risk Accounts' },
       },
       _sections: {
         basic: { label: 'Basic Information' },
@@ -432,6 +434,7 @@ export const en: TranslationData = {
         gallery_view: { label: 'Lead Cards' },
         my_leads: { label: 'My Leads' },
         high_priority: { label: 'High Priority' },
+        hot_leads: { label: '🔥 Hot Leads' },
         suspected_duplicates: {
           label: 'Suspected Duplicates',
           emptyState: {
@@ -574,11 +577,9 @@ export const en: TranslationData = {
         deal_timeline: { label: 'Deal Timeline' },
         deal_gallery: { label: 'Deal Cards' },
         my_open_deals: { label: 'My Open Deals' },
-        // No `label` here on purpose: this view (like `stale_opportunities`)
-        // takes its English name from the metadata `label`, which is already
-        // English. Only the empty state needs a bundle entry — it has no
-        // metadata fallback path through the locale resolver.
+        stale_opportunities: { label: '⚠️ Stale Opportunities · Longest in Stage First' },
         closing_this_quarter: {
+          label: 'Closing This Quarter',
           emptyState: {
             title: 'No Deals Closing This Quarter',
             message: 'This tab lists open commit and best-case deals with a close date inside the current quarter. Nothing matches right now — deals closing later are on the Open Deals tab.',
@@ -681,6 +682,8 @@ export const en: TranslationData = {
         sla_calendar: { label: 'SLA Calendar' },
         case_timeline: { label: 'Case Timeline' },
         escalated_cases: { label: 'Escalated Cases' },
+        my_open_cases: { label: 'My Open Cases' },
+        sla_at_risk: { label: '⏰ SLA at Risk' },
       },
       _sections: {
         basic: { label: 'Case Information' },
@@ -950,6 +953,8 @@ export const en: TranslationData = {
         task_gantt: { label: 'Execution Plan' },
         task_timeline: { label: 'Worklog Timeline' },
         my_open_tasks: { label: 'My Open Tasks' },
+        todays_tasks: { label: '📅 My Priority Tasks' },
+        overdue_tasks: { label: '⏰ Open Tasks · Most Overdue First' },
       },
       _sections: {
         basic: { label: 'Task Information' },

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -1956,8 +1956,8 @@ describe('every locale is complete on every authored surface', () => {
     });
 
   it('sees a non-trivial set of canonical views and a _views table in every locale', () => {
-    // Guards the guard. Both assertions below iterate derived collections, and
-    // both would pass by checking nothing if `stack.views` came back empty, if
+    // Guards the guard. The three assertions below iterate derived collections,
+    // and all would pass by checking nothing if `stack.views` came back empty, if
     // the container walk stopped yielding, or if a bundle's `_views` tables
     // failed to flatten — the exact way the navigation guard in this file spent
     // its life green.

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -1901,6 +1901,154 @@ describe('every locale is complete on every authored surface', () => {
     expect(bad, `empty states with no translated copy:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 
+  /**
+   * ── View LABELS, the surface with no gate at all (#783, #767) ────────────
+   *
+   * The empty-state guard above covers the string a view shows when it has NO
+   * rows. Its label — the tab caption a user reads on every visit — had no
+   * guard of any kind, and two separate reviews found gaps by comparing the
+   * four bundles column by column with human eyes.
+   *
+   * Nothing mechanical could have found them:
+   *
+   *  - `pnpm lint` hard-codes `--skip-i18n`. Dropping the flag does not report
+   *    these either — the run emits one line, `platform built-ins: 2298 i18n
+   *    issue(s) hidden`, because app-authored `_views` completeness is not in
+   *    the set the linter checks at all. So this is NOT the #494 family (real
+   *    warnings suppressed by a flag); it is a surface nobody was checking.
+   *  - Every gap was in `en`, and in the source locale a missing key is
+   *    invisible: the resolver falls back to the metadata `label`, which is
+   *    already correct English. #679 wrote this down for select options, page
+   *    copy and empty states — "a missing key and a correct one render
+   *    identically" — and ruled it a defect anyway, because every other bundle
+   *    is authored by mirroring this one's shape: a view with no slot in `en`
+   *    is a view the next translator has nowhere to put.
+   *
+   * The requirement is therefore the same one the select-field guard states,
+   * applied to view labels: every canonical view, every locale, no exemptions.
+   * No ledger is introduced here — the nine rows this guard was born red on
+   * (`crm_task.todays_tasks` / `overdue_tasks` from #783, `crm_lead.hot_leads`
+   * / `crm_account.renewals_due` / `at_risk_accounts` from #767, and the four
+   * `crm_case` / `crm_opportunity` rows the derivation turned up beside them)
+   * were closed in the same PR. An empty ledger is an invitation to add a row.
+   */
+
+  /**
+   * Every canonical list view in the stack, as `{ object, name }`.
+   *
+   * Derived from the compiled stack rather than from a hand-kept list, which
+   * is the whole point: a view added tomorrow is held to the bar on the PR
+   * that adds it, without anyone remembering to extend a fixture. Same
+   * container walk as the empty-state guard above — a view record carries one
+   * default `list` plus a `listViews` map, and both are user-visible tabs.
+   */
+  const canonicalViews = (): Array<{ object: string; name: string; label?: string }> =>
+    views.flatMap((record) => {
+      const containers: [string, AnyRec][] = [
+        ...(record.list ? [['list', record.list] as [string, AnyRec]] : []),
+        ...Object.entries<AnyRec>(record.listViews ?? {}),
+      ];
+      return containers.map(([key, view]) => ({
+        object: view?.data?.object ?? record.list?.data?.object ?? record.object,
+        name: view?.name ?? key,
+        label: view?.label,
+      }));
+    });
+
+  it('sees a non-trivial set of canonical views and a _views table in every locale', () => {
+    // Guards the guard. Both assertions below iterate derived collections, and
+    // both would pass by checking nothing if `stack.views` came back empty, if
+    // the container walk stopped yielding, or if a bundle's `_views` tables
+    // failed to flatten — the exact way the navigation guard in this file spent
+    // its life green.
+    const derived = canonicalViews();
+    expect(derived.length, 'no canonical list views discovered').toBeGreaterThanOrEqual(50);
+    expect(
+      new Set(derived.map((v) => v.object)).size,
+      'canonical views collapsed onto too few objects — derivation is broken',
+    ).toBeGreaterThanOrEqual(10);
+    expect(
+      derived.filter((v) => typeof v.object === 'string' && typeof v.name === 'string').length,
+      'some canonical view resolved no object or no name',
+    ).toBe(derived.length);
+
+    for (const [locale, pack] of packs()) {
+      const tables = Object.values<AnyRec>(pack.objects ?? {}).filter((o) => o?._views);
+      expect(tables.length, `${locale}: no _views table parsed out of the bundle`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every canonical view label is translated in every locale', () => {
+    const bad: string[] = [];
+    for (const [locale, pack] of packs()) {
+      for (const { object, name } of canonicalViews()) {
+        if (!pack.objects?.[object]?._views?.[name]?.label) {
+          bad.push(`${locale}: ${object}._views.${name}.label`);
+        }
+      }
+    }
+    expect(
+      bad,
+      `canonical views with no translated label:\n  ${bad.join('\n  ')}\n` +
+        'Add the entry to src/translations/<locale>.ts. In en the gap is ' +
+        'invisible — the resolver falls back to the metadata label — which is ' +
+        'why it needs a test rather than a reviewer.',
+    ).toEqual([]);
+  });
+
+  it('no locale carries a _views entry for a view the stack does not ship', () => {
+    // The other direction of the same parity. A renamed or deleted view leaves
+    // four orphan entries behind, and an orphan is worse than a gap: it reads
+    // as coverage while translating nothing, and the next person to add a view
+    // by that name inherits a stale label.
+    const shipped = new Set(canonicalViews().map(({ object, name }) => `${object}.${name}`));
+    const bad: string[] = [];
+    for (const [locale, pack] of packs()) {
+      for (const [object, entry] of Object.entries<AnyRec>(pack.objects ?? {})) {
+        for (const name of Object.keys(entry?._views ?? {})) {
+          if (!shipped.has(`${object}.${name}`)) bad.push(`${locale}: ${object}._views.${name}`);
+        }
+      }
+    }
+    expect(bad, `_views entries naming no shipped view:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('the en view label is the canonical label verbatim, so a rename cannot pass silently', () => {
+    // What the parity assertion above CANNOT catch, and #767's actual concern:
+    // the key exists in all four bundles and the metadata label is then edited.
+    // Before this pin, `en` tracked the rename for free (its entry is a copy of
+    // the same English string, and where it was missing the resolver fell back),
+    // while zh-CN / ja-JP / es-ES kept translating the OLD name — four bundles
+    // describing two different views, with nothing red.
+    //
+    // Holding `en` byte-identical to the metadata label is what converts that
+    // into a build failure: rename `⏰ Open Tasks · Most Overdue First` and this
+    // goes red, which puts the author in the translations file with all four
+    // locales in front of them. Be honest about the limit — it proves the
+    // ENGLISH pair agrees, and nothing here can verify that a human then
+    // re-translated the other three. It makes the rename loud; it does not make
+    // it correct.
+    //
+    // This is not a new rule so much as the one the bundle already followed:
+    // all 61 `en` view labels that existed when this landed were already
+    // byte-identical to their metadata label, because #679 extracted them
+    // programmatically from `objectstack.config` rather than transcribing them.
+    // If English ever genuinely wants to read differently from the metadata,
+    // the fix is contract-first — correct the `label` in `*.view.ts`, the one
+    // place every locale is derived from — not to let two English strings drift.
+    const en = packFor('en');
+    expect(en, 'no en pack in stack.translations').toBeTruthy();
+    const bad: string[] = [];
+    for (const { object, name, label } of canonicalViews()) {
+      if (typeof label !== 'string') continue;
+      const translated = en?.objects?.[object]?._views?.[name]?.label;
+      if (typeof translated === 'string' && translated !== label) {
+        bad.push(`${object}.${name}: metadata "${label}" vs en "${translated}"`);
+      }
+    }
+    expect(bad, `en view labels that drifted from the metadata label:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
   it('every action parameter label is translated', () => {
     // A param label is the field caption inside an action's modal — untranslated,
     // it is a bare English word on an otherwise localized form.


### PR DESCRIPTION
Fixes #783
Fixes #767

## 先说复核结论：#783 的 premise 只成立一半

| 单 | 声称 | 在 `origin/main` (fb48ab59) 的复核结果 |
| --- | --- | --- |
| #783 | `en.ts` 的 `crm_task._views` 缺 `todays_tasks` / `overdue_tasks` | ✅ 成立 |
| #783 | `ja-JP.ts` 同样缺这两项 | ❌ **不成立** |
| #767 | `en.ts` 缺 `renewals_due` / `at_risk_accounts` / `hot_leads` | ✅ 三项全部成立 |

`ja-JP.ts:943-944` 早已有这两条（`📅 私の優先タスク` / `⏰ オープンタスク · 期限超過が長い順`），是 #679 补齐四语言包时一起落地的。#783 引用的基线 `7667c9b4` 上就已经是这样——`git show 7667c9b4:src/translations/ja-JP.ts` 的 `_views` 块从 937 行开到 946 行，八项齐全。issue 正文写的 `ja-JP.ts:937-942` 只读到 `my_open_tasks` 那一行就收尾了，漏看了后两行。**因此本 PR 不动 `ja-JP.ts`**，只有 #783 的 en 那一半是真的。

#767 的三项全部仍在，且 #774（对齐 hot 阈值到 rating ≥ 4）没有碰任何语言包，所以 `hot_leads` 的四语言现状与 #767 记录时一致。canonical label 是 `🔥 Hot Leads`，不含任何阈值措辞，照抄即可——没有 4.5 星的旧口径可以复活。

## 缺口的实际范围：9 条，不是 5 条

守卫的派生（不是人工清单）在 `origin/main` 上跑出 9 条，全部在 `en`：

```
en: crm_lead._views.hot_leads.label            (#767)
en: crm_account._views.renewals_due.label      (#767)
en: crm_account._views.at_risk_accounts.label  (#767)
en: crm_task._views.todays_tasks.label         (#783)
en: crm_task._views.overdue_tasks.label        (#783)
en: crm_opportunity._views.stale_opportunities.label
en: crm_opportunity._views.closing_this_quarter.label
en: crm_case._views.my_open_cases.label
en: crm_case._views.sla_at_risk.label
```

**后四条一并在本 PR 修掉，而不是另开 issue。** 这是一个需要说明的越界，理由是：它们与两单是同一文件、同一缺陷、同一成因，而本单要交付的守卫无论如何都需要对它们有个处置。剩下的唯一选择是引入豁免清单——而本文件里 `select fields are translated in every locale` 那段注释已经把这条路判为 regression（#679 退役 `PENDING_SELECT_LABELS` 时写的原话：「空清单就是在邀请别人加一行」）。带 4 行豁免的守卫等于出厂即破。

新增的 9 条全部是各视图 `*.view.ts` 里 `label` 的**逐字节照抄**——不是翻译，没有编辑余地，用户读到的任何名字都没有变。`stale_opportunities` 的 `·` 是 U+00B7、`⚠️` 是 U+26A0 U+FE0F，与 metadata 一致（第三条断言会替你核对）。

顺带删掉了 `closing_this_quarter` 上「No label here on purpose」那段注释。它是 #746 写的，而 #679 早已对其它每个 locale 面做了相反的裁定；它给出的理由（en 不需要条目，因为 resolver 会回落到 metadata label）恰恰就是让这 9 条长期无人发现的那种隐身性。

## 守卫（本单的核心交付）

两单都指出「没有任何 gate 看得见」，复核属实：`pnpm lint` 硬编码 `--skip-i18n`；把 flag 去掉重跑也**不**报这些——只会输出一行 `platform built-ins: 2298 i18n issue(s) hidden`，因为 app 自有的 `_views` 完整性根本不在被检查的集合里。所以这不属于 #494 那一类「被 flag 藏起来的告警」，而是压根没人检查的面。

`test/metadata-references.test.ts` 的 `every locale is complete on every authored surface` 块里加三条断言，视图集**从编译后的 stack 派生**（与 emptyState 守卫同一套 container 遍历），不是硬编码清单，所以明天新增的视图在引入它的那个 PR 上就被卡住：

1. 每个 canonical 视图在每个语言包都有 `label`（70 视图 × 4 语言包）；
2. 没有任何语言包为「stack 已不再 ship 的视图」保留 `_views` 条目——孤儿条目比缺口更坏，它看起来像覆盖，其实什么都没翻译；
3. `en` 的条目与它所代表的 metadata label **逐字节相同**。

第三条是 key 一致性做不到、而 #767 真正担心的那件事：当四个包的 key 都在时，改掉 metadata label，过去 `en` 会白白跟着变（它的条目本就是同一串英文的副本），而 zh-CN / ja-JP / es-ES 继续翻译旧名字，没有任何东西会红。诚实地说清这条断言的边界：它只证明**英文**这一对是一致的，无法验证另外三门语言随后被重新翻译过——它让改名变响，不能让改名变对。这不算新规矩：本次改动前 `en` 已有的 61 条视图标签本来就 61/61 逐字节相同，因为 #679 是从 `objectstack.config` 里程序化提取而非手抄的。

反真空断言守着派生本身：至少 50 个 canonical 视图、覆盖至少 10 个对象、每条都解析出 object 与 name，且每个语言包至少解析出一个 `_views` 表。

## 反向验证（四个方向，都是先声明后跑）

| 操作 | 预测 | 实测 |
| --- | --- | --- |
| 删掉刚补的 `en.crm_task.overdue_tasks` | 一致性断言红并点名 | ✅ `en: crm_task._views.overdue_tasks.label`；逐字节断言保持绿（无可比对象）——正是两条断言应有的分工 |
| 把该 label 改成看似合理的 `⏰ Overdue Tasks` | 逐字节断言红、一致性断言绿 | ✅ 红并同时报出两串；一致性绿——这正是 key 一致性看不见的那一类 |
| 加一条 stack 中不存在的 `renamed_last_release` 条目 | 孤儿断言红 | ✅ `en: crm_task._views.renamed_last_release` |
| 保留守卫、把 `en.ts` 退回 `origin/main` | 报出全部 9 条且全在 `en` | ✅ 9 条，含 #783 的 2 条与 #767 的 3 条；**ja-JP 零命中**——即上面 premise 复核的机器证据 |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `pnpm validate` — Validation passed
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 13 warning(s), 14 suggestion(s)（与改动前一致，无新增）
- [x] `pnpm hygiene` — source hygiene clean（含 no raw control bytes）
- [x] `pnpm build` — Build complete
- [x] `pnpm test` — 63 files / 1517 passed / 1 skipped
- [x] 控制字符自扫（`grep -naP` 覆盖 gate 的盲区）零命中
- [x] 新增测试 3 条 + 反真空 1 条

## Checklist

- [x] 已添加 changeset（`.changeset/view-label-locale-parity.md`，patch）
- [x] 未改动 canonical 视图 label 本身
- [x] 未改动 zh-CN / es-ES / ja-JP 的既有条目
- [x] 未升级 `@objectstack/*`（锁 17.0.0-rc.2）
- [x] 未改动 `content/docs/releases/`
- [x] 未改动 lint 的 `--skip-i18n` 配置

## 留给 reviewer 的两个判断点

1. **越界修了 4 条**（`crm_case` ×2、`crm_opportunity` ×2）。理由见上；若认为应当拆走，删掉这 4 条 en 条目后守卫会立刻变红，所以拆分必然要配一个豁免清单。
2. **第三条断言（en 逐字节 pin）超出了派单里「键集一致性」的字面要求。** 它当前是绿的，成本是一个 `it()` 块；若认为把 en 钉死在 metadata 上过度，删掉它不影响前两条。我的建议是留下：#767 列的第一条风险（改名后静默分叉）只有它能变成一次 CI 失败，而真要出现「英文该与 metadata 不同」的情形，contract-first 的解法是去改 `*.view.ts` 里那个唯一的生产者，而不是容忍两串英文各走各的。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_