### PR TITLE
fix(knowledge): 归档文章重新上架时保留首次发布日期

### DIFF
--- a/.changeset/republish-keeps-original-publish-date.md
+++ b/.changeset/republish-keeps-original-publish-date.md
@@ -1,0 +1,51 @@
+---
+'hotcrm': patch
+---
+
+Re-publishing an archived knowledge article no longer moves its original publish
+date, so a 2024 article put back on the shelf this year stops jumping to the top
+of the article list as if it were newly written.
+
+`knowledge_article_publish_timestamps` decided "is this the first publish?" by
+looking at the status the write arrived from — `previous.status === 'published'`
+— which recognises only the published → published edit as a re-publish. The
+documented article lifecycle is `draft → in_review → published → archived`, so
+the ordinary re-shelving move `archived → published` arrives with
+`previous.status === 'archived'`, fell into the first-publish branch, and
+overwrote `published_at` with the current time. The `all_articles` view sorts
+`published_at desc` and `published_articles` reads the same field, so the
+re-shelved article surfaced everywhere as the newest thing in the knowledge base.
+Archiving and re-shelving is routine content operations, not an exotic path.
+
+The criterion is now the existence of the date rather than the previous status: a
+write that leaves the article `published` stamps `published_at` only when the
+record does not already carry one. The date is read as
+`input.published_at ?? previous?.published_at` — the value the record would end
+up with if the handler stamped nothing — because both halves of a write can
+legitimately carry it. `previous` is the full stored row (the engine's
+`sys_fetch_previous_update` builtin fetches it unprojected), and `input` carries
+the date whenever the write supplies one — on an insert that supplied value is
+what gets stored, so an import or migration publishing records with their
+historical dates was having that history rewritten by the same branch.
+
+`last_reviewed_at` is unchanged and still refreshes on every write that leaves
+the article published, including a re-publish — re-shelving an article is itself
+a review, and the admin "stale article" reports depend on that stamp.
+
+The behaviour was already asserted, and already named correctly: the existing
+test carried `'republishing must not move the original publish date'`. It fed
+`previous: { status: 'published' }` — the one arrow the old implementation
+handled — so it stayed green while the invariant it names was broken on the
+other one. The suite now pins every arrow that ends on `published`, including
+the archived article that never shipped (no original date to keep, so publishing
+it really is a first publish).
+
+This is the single-record path only; the bulk (`multi: true`) path, where the
+engine hands hooks no `previous` at all, is tracked separately in #779. Two
+adjacent engine behaviours found while measuring this are filed as #788 and
+deliberately not papered over here: `readonly: true` is not enforced on the
+insert path, and on the update path the read-only strip removes the
+caller-supplied key along with anything a hook wrote there. Both behave
+identically before and after this change.
+
+Fixes #780.

--- a/src/objects/knowledge_article.hook.ts
+++ b/src/objects/knowledge_article.hook.ts
@@ -5,28 +5,74 @@ import type { Hook, HookContext } from '@objectstack/spec/data';
 /**
  * Knowledge article lifecycle hook.
  *
- * On status transition to `published`, stamps `published_at` and
- * `last_reviewed_at`. On any subsequent edit while published, refreshes
- * `last_reviewed_at` so admin "stale article" reports work.
+ * On the FIRST publish, stamps `published_at` and `last_reviewed_at`. On every
+ * later write that leaves the article published — an ordinary edit, or a
+ * re-publish after archiving — refreshes `last_reviewed_at` only, so admin
+ * "stale article" reports keep working while the original publish date stays
+ * put.
+ *
+ * "First publish" is decided by whether the record ALREADY CARRIES a
+ * `published_at`, not by which status the write arrives from (#780). The old
+ * test was `previous.status === 'published'`, which recognises only the
+ * published → published edit as a re-publish. But the documented lifecycle is
+ * `draft → in_review → published → archived`, so the ordinary re-shelving move
+ * `archived → published` arrives with `previous.status === 'archived'`, fell
+ * into the first-publish branch, and moved a 2024 publish date to today. The
+ * `all_articles` view sorts `published_at desc`, so the re-shelved article
+ * jumped to the top of the list as if it had just been written.
+ *
+ * The date is read as `input.published_at ?? previous?.published_at` — the
+ * value this record would end up with if the handler stamped nothing, which is
+ * exactly the question "does it already have one". This is precedence between
+ * the two halves of one write, not a tolerated alias for one key, and both
+ * halves are load-bearing:
+ *
+ *   - `previous` is the FULL stored row: the engine's `sys_fetch_previous_update`
+ *     builtin fetches it with an unprojected `findOne`, so a re-publish sees the
+ *     original date there.
+ *   - `input` carries the date whenever the write supplies one, and on an INSERT
+ *     that value is what gets stored: measured on 17.0.0-rc.2, the engine's
+ *     read-only strip runs on the update path only, and hooks run before it in
+ *     any case. So an import or migration publishing records with their
+ *     historical dates reaches this handler with `published_at` set and no
+ *     `previous`, and stamping over it rewrites imported history.
+ *
+ * Two adjacent engine behaviours this handler deliberately does NOT try to
+ * paper over, both measured and filed as #788: `readonly: true` is not enforced
+ * on the insert path at all, and on the update path the strip deletes the
+ * caller-supplied key together with whatever a hook wrote there — so an update
+ * that echoes `published_at` back can land a published article with none. That
+ * outcome is identical before and after this change; a lenient consumer here
+ * would only hide it.
+ *
+ * Deliberately unchanged: this is the single-record path. On the bulk path
+ * (`multi: true`) there is no `input.id`, so `sys_fetch_previous_update` fetches
+ * nothing and `previous` is always absent — tracked separately as #779, and the
+ * existence criterion above is the one that degrades most gracefully there
+ * (a bulk write supplying its own `published_at` now keeps it).
  */
 const knowledgeArticlePublish: Hook = {
   name: 'knowledge_article_publish_timestamps',
   object: 'crm_knowledge_article',
   events: ['beforeInsert', 'beforeUpdate'],
   priority: 300,
-  description: 'Stamp published_at / last_reviewed_at on status transitions.',
+  description: 'Stamp published_at on the first publish; refresh last_reviewed_at while published.',
   handler: async (ctx: HookContext) => {
     const { input } = ctx;
     const previous = ctx.previous;
     const nextStatus = (typeof input.status === 'string' && input.status) || previous?.status;
-    const wasPublished = previous?.status === 'published';
-    const nowIso = new Date().toISOString();
+    if (nextStatus !== 'published') return;
 
-    if (nextStatus === 'published' && !wasPublished) {
+    const nowIso = new Date().toISOString();
+    // Publishing, re-publishing and editing while published are all reviews.
+    input.last_reviewed_at = nowIso;
+    // The emptiness test is spelled out here rather than factored into a
+    // module-scope helper: hook handlers lower to a metadata-only body, and a
+    // free identifier would push this one into the legacy runtime bundle
+    // instead — `test/action-sandbox.test.ts` fails the build on it.
+    const existing = input.published_at ?? previous?.published_at;
+    if (existing === undefined || existing === null || existing === '') {
       input.published_at = nowIso;
-      input.last_reviewed_at = nowIso;
-    } else if (nextStatus === 'published' && wasPublished) {
-      input.last_reviewed_at = nowIso;
     }
   },
 };

--- a/test/hooks-runtime-service.test.ts
+++ b/test/hooks-runtime-service.test.ts
@@ -415,12 +415,38 @@ describe('forecast_derive_period', () => {
 
 // ──────────────────────────────────────────────────── knowledge article ──
 
+/**
+ * The article lifecycle is `draft → in_review → published → archived`, and
+ * every arrow that ENDS on `published` is covered below, because the criterion
+ * the hook applies is not "which status did we come from" but "does this record
+ * already carry a `published_at`" (#780).
+ *
+ * The distinction is what the old implementation got wrong. It asked
+ * `previous.status === 'published'`, which recognises only the
+ * published → published edit as a re-publish; `archived → published` — the
+ * ordinary re-shelving move — therefore fell into the FIRST-publish branch and
+ * moved the original date to today. `all_articles` sorts `published_at desc`,
+ * so a 2024 article re-shelved this year jumped to the top of the list as if
+ * newly written. One test covering only published → published is exactly how
+ * the assertion below ("must not move the original publish date") stayed green
+ * while the invariant it names was broken on the other arrow.
+ */
 describe('knowledge_article_publish_timestamps', () => {
   const hook = hookNamed(knowledgeHooks, 'knowledge_article_publish_timestamps');
+  const ORIGINAL_PUBLISH = '2024-03-01T00:00:00.000Z';
 
-  it('stamps both timestamps on the transition into published', async () => {
+  it('stamps both timestamps on the draft → published first publish', async () => {
     const input: Rec = { status: 'published' };
     await hook.handler(makeCtx({ event: 'beforeUpdate', input, previous: { status: 'draft' } }));
+    expect(input.published_at).toBeTruthy();
+    expect(input.last_reviewed_at).toBe(input.published_at);
+  });
+
+  it('stamps both timestamps on the in_review → published first publish', async () => {
+    // The reviewed route to the same first publish — no `published_at` exists
+    // yet on either, so both must stamp one.
+    const input: Rec = { status: 'published' };
+    await hook.handler(makeCtx({ event: 'beforeUpdate', input, previous: { status: 'in_review' } }));
     expect(input.published_at).toBeTruthy();
     expect(input.last_reviewed_at).toBe(input.published_at);
   });
@@ -428,9 +454,50 @@ describe('knowledge_article_publish_timestamps', () => {
   it('refreshes only last_reviewed_at when editing an already-published article', async () => {
     const input: Rec = { title: 'Revised' };
     await hook.handler(makeCtx({
-      event: 'beforeUpdate', input, previous: { status: 'published', published_at: '2020-01-01T00:00:00.000Z' },
+      event: 'beforeUpdate', input, previous: { status: 'published', published_at: ORIGINAL_PUBLISH },
     }));
     expect(input.published_at, 'republishing must not move the original publish date').toBeUndefined();
+    expect(input.last_reviewed_at).toBeTruthy();
+  });
+
+  it('keeps the original published_at when an ARCHIVED article is re-published', async () => {
+    // The arrow the old status test could not see (#780): `previous.status` is
+    // 'archived', so it read as a first publish and re-stamped a date the
+    // article had held since 2024.
+    const input: Rec = { status: 'published' };
+    await hook.handler(makeCtx({
+      event: 'beforeUpdate', input, previous: { status: 'archived', published_at: ORIGINAL_PUBLISH },
+    }));
+    expect(input.published_at, 'republishing must not move the original publish date').toBeUndefined();
+    expect(input.last_reviewed_at, 're-shelving an article is itself a review').toBeTruthy();
+  });
+
+  it('stamps published_at when an article archived before it ever shipped is published', async () => {
+    // Existence of the date, not the previous status, is the criterion: a draft
+    // archived without ever being published has no original date to keep, so
+    // this IS its first publish. (This arrow behaves the same under the old
+    // status test — it pins the criterion, it does not discriminate between
+    // the two implementations.)
+    const input: Rec = { status: 'published' };
+    await hook.handler(makeCtx({ event: 'beforeUpdate', input, previous: { status: 'archived' } }));
+    expect(input.published_at).toBeTruthy();
+    expect(input.last_reviewed_at).toBe(input.published_at);
+  });
+
+  it('honours a published_at carried by the write itself', async () => {
+    // The other slot the date can arrive in, and it is not hypothetical:
+    // measured end-to-end on a real engine, an insert carrying `published_at`
+    // stores exactly what it supplied (the read-only strip runs on the update
+    // path only, and hooks run ahead of it regardless). So an import or
+    // migration publishing records with their historical dates — the shape the
+    // `src/data/service.seed.ts` records use — reaches this handler with
+    // `published_at` on `input` and no `previous`. Stamping over it rewrites
+    // imported history exactly as the archived case rewrites a re-shelved
+    // article's.
+    const input: Rec = { status: 'published', published_at: ORIGINAL_PUBLISH };
+    await hook.handler(makeCtx({ event: 'beforeInsert', input }));
+    expect(input.published_at, 'an explicitly supplied publish date is history, not a default')
+      .toBe(ORIGINAL_PUBLISH);
     expect(input.last_reviewed_at).toBeTruthy();
   });
 


### PR DESCRIPTION
Fixes #780

## 问题

`knowledge_article_publish_timestamps` 判断「是不是首次发布」用的是**上一状态**:

```
const wasPublished = previous?.status === 'published';
if (nextStatus === 'published' && !wasPublished) { input.published_at = nowIso; … }
```

这只认得 published → published 这一条边。而文章生命周期是 `draft → in_review → published → archived`,重新上架这个日常动作走的是 `archived → published`,`previous.status` 是 `archived`,于是掉进首发分支,**`published_at` 被覆写成当下**。`all_articles` 按 `published_at desc` 排序,`published_articles` 也读这个字段,所以一篇 2024 年发布、中途归档、今年重新上架的文章会跳到列表最前面,像刚写的一样。

仓库其实早就把相反的意图写进了断言名 —— `'republishing must not move the original publish date'` —— 但那条用例只喂 `previous: { status: 'published' }`,恰好是实现唯一处理对的那条边,所以它一直是绿的,而它命名的不变量在另一条边上是破的。

## 修法

判据从「上一状态是什么」换成「**这条记录是不是已经有 `published_at` 了**」。日期读作 `input.published_at ?? previous?.published_at` —— 即「如果 handler 什么都不戳,这条记录最终会带的那个值」,正好就是「它是不是已经有一个」这个问题。这不是给一个 key 容忍两种拼写的 fallback,而是同一次写的两个半边之间的优先级,两边都实测有用:

- `previous` 是**完整的**存量行(引擎的 `sys_fetch_previous_update` 内建用不带投影的 `findOne` 取的),重新上架时原始日期在这里;
- `input` 在写方自带日期时携带它,而且 insert 路径上**自带的值就是最终落库的值**(实测:只读剥离只跑在 update 路径,且 hook 无论如何都在它之前)。所以带着历史日期导入/迁移的写,原本会被同一个分支改写成导入当天。

`last_reviewed_at` 按裁定不动:凡是让文章停留在 published 的写都刷新它 —— 重新上架本身就是一次复核,管理员的「过期文章」报表依赖这个戳。

## 反向验证(先声明方向,再跑)

声明的方向:两条**有判别力**的新用例在修复前必须红,其余保持绿;`archived → 从未发布过` 那条**没有**判别力(新旧实现都会打戳),它钉的是判据本身,如实标注在用例注释里,不冒充证据。

修复前(仅新增用例,hook 未改):

```
 ❯ test/hooks-runtime-service.test.ts (90 tests | 2 failed | 83 skipped)
     × keeps the original published_at when an ARCHIVED article is re-published
     × honours a published_at carried by the write itself

AssertionError: republishing must not move the original publish date:
  expected '2026-08-05T19:40:37.625Z' to be undefined
AssertionError: an explicitly supplied publish date is history, not a default:
  expected '2026-08-05T19:40:37.637Z' to be '2024-03-01T00:00:00.000Z'

 Tests  2 failed | 5 passed | 83 skipped (90)
```

红的正是预测的那两条,方向与数量都对上。修复后 `Tests 90 passed (90)`。

### 另外在真引擎上端到端量了一次

hook harness 之外,用真 `ObjectQL` + `InMemoryDriver` + 真 schema 跑了一遍(`sys_fetch_previous_update` 需要自己复刻 —— 真内建是 kernel 服务的 private `registerAuditHooks()` 装的,裸引擎拿不到,第一次没复刻时探针假红了一轮):

```
                                  修复前            修复后
archived -> re-published          戳被移到今天       保持原始日期
insert 带 published_at(非系统)    被覆写成今天       保留 2024-03-01
```

探针脚本按越界规则未入库。

## 用例覆盖

现在每一条**指向 `published`** 的边都钉住了:draft→published 与 in_review→published 首发打戳、published→published 编辑不动戳、archived→published 不动戳,三条路径的 `last_reviewed_at` 都刷新;外加两条边界 —— 从未发布就归档的文章重新发布**要**打戳(它确实是首发),以及写方自带日期不被覆写。

## 边界

- 批量路径(`multi: true` 上 `previous` 恒空)是 #779 的地盘,没顺手动。
- 实测过程中量到两条相邻的引擎行为,已单独立 #788,**本 PR 不做消费端兜底**:`readonly: true` 在 insert 路径上完全不生效;update 路径的只读剥离会把调用方回传的 key 连同 hook 写进去的值一起删掉(于是回传 `published_at` 的 update 能落出「已发布但 published_at 为 null」的行)。这两条在本改动前后**行为完全一致**,在 hook 里加容忍只会把它们藏起来。
- 顺带给 #617(seed doctrine 那单)留了一条 rc.2 上 `SEED_WRITE_OPTIONS` 的读码证据。

## 验证

```
pnpm typecheck   ✓ (exit 0)
pnpm hygiene     ✓ source hygiene clean
pnpm validate    ✓ Validation passed (1357ms)
pnpm test        ✓ Test Files 63 passed | Tests 1517 passed | 1 skipped (1518)
```

改动文件控制字符自扫零命中。changeset 一份(patch)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_