### PR TITLE
fix(hooks): agree in number when one opportunity blocks an account delete (#721)

### DIFF
--- a/.changeset/account-delete-guard-singular-agreement.md
+++ b/.changeset/account-delete-guard-singular-agreement.md
@@ -1,0 +1,31 @@
+---
+'hotcrm': patch
+---
+
+Make the customer-account delete guard agree with itself when exactly one
+opportunity blocks. The refusal switched its noun on the count but left the verb
+and the closing pronoun plural, so a single open deal produced:
+
+```
+DELETE /api/v1/data/crm_account/<id>
+→ 400 "Cannot delete customer account: 1 open opportunity still reference it.
+        Close or reassign them first."
+```
+
+Both halves were wrong for one record — "still reference" for a singular subject,
+and "them" pointing at a single opportunity the reader then has to go and find.
+The plural case was already correct and reads the same as before. Now:
+
+```
+1 blocker  → "Cannot delete customer account: 1 open opportunity still
+              references it. Close or reassign it first."
+2 blockers → "Cannot delete customer account: 2 open opportunities still
+              reference it. Close or reassign them first."
+```
+
+Wording only — the guard refuses exactly the same deletes, counts the same open
+opportunities, and names the same account. The two sentences are now written out
+per branch in `src/objects/account.hook.ts` rather than stitched from a noun
+suffix, because agreement here runs across three words at once, and both are
+measured end-to-end against a real kernel in
+`test/cascade-guard-messages.test.ts`. Refs #721.

--- a/src/objects/account.hook.ts
+++ b/src/objects/account.hook.ts
@@ -133,8 +133,17 @@ const accountHook: Hook = {
         },
       });
       if (openOpps > 0) {
+        // Whole sentence per branch, not a stitched-together noun (#721). The
+        // count switched the NOUN only (`opportunit{y,ies}`) while the verb and
+        // the closing pronoun stayed plural, so the singular case read
+        // "1 open opportunity still reference it. Close or reassign them
+        // first." Agreement runs across three words here — noun, verb and
+        // pronoun — and the two readable sentences are cheaper to keep correct
+        // (and to grep for) than three interlocking conditionals.
         throw new Error(
-          `Cannot delete customer account: ${openOpps} open opportunit${openOpps === 1 ? 'y' : 'ies'} still reference it. Close or reassign them first.`,
+          openOpps === 1
+            ? 'Cannot delete customer account: 1 open opportunity still references it. Close or reassign it first.'
+            : `Cannot delete customer account: ${openOpps} open opportunities still reference it. Close or reassign them first.`,
         );
       }
     }

--- a/test/cascade-guard-messages.test.ts
+++ b/test/cascade-guard-messages.test.ts
@@ -319,3 +319,71 @@ describe('sibling guards reached the same way', () => {
     expect(message).not.toContain('may be edited');
   });
 });
+
+// ───────────────────── the account guard's own sentence, measured (#721) ──
+
+/**
+ * `account_protection`'s open-opportunity refusal, taken from a real `DELETE`.
+ *
+ * Not a cascade case — nothing cascades INTO `crm_account`, so this guard only
+ * ever answers a caller who addressed the account, and "Cannot delete customer
+ * account" was already accurate (#721 says so explicitly). What was wrong was
+ * agreement: the count switched the noun (`opportunit{y,ies}`) and left the
+ * verb and the closing pronoun plural, so one open deal produced
+ *
+ *     Cannot delete customer account: 1 open opportunity still reference it.
+ *     Close or reassign them first.
+ *
+ * It lives in this file because this is where the app boots a real kernel: the
+ * unit pins in `hooks-runtime-sales.test.ts` call the handler directly, which
+ * proves the string the handler builds, not the string a user is shown. Both
+ * branches are measured here end-to-end, because only one of them was broken
+ * and the fix must not trade one wrong sentence for the other.
+ */
+describe('deleting a customer account with open opportunities', () => {
+  /** A customer account carrying `openDeals` open opportunities. */
+  const accountWithOpenDeals = async (openDeals: number) => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Busy Corp ${n}`, type: 'customer', industry: 'technology',
+    });
+    for (let i = 0; i < openDeals; i++) {
+      await insert('crm_opportunity', {
+        name: `Busy Deal ${n}-${i}`, crm_account: account.id,
+        stage: 'negotiation', amount: 1000, close_date: '2026-12-01',
+      });
+    }
+    return account;
+  };
+
+  it('agrees with a single blocker: "1 open opportunity still references it … reassign it"', async () => {
+    const account = await accountWithOpenDeals(1);
+    const message = await deleteAndCatch('crm_account', account.id);
+
+    expect(message, 'the delete must still be refused').toBeTruthy();
+    expect(message).toContain(
+      'Cannot delete customer account: 1 open opportunity still references it. Close or reassign it first.',
+    );
+    // The reported symptom, both halves of it.
+    expect(message).not.toContain('opportunity still reference it');
+    expect(message).not.toContain('reassign them');
+  });
+
+  it('agrees with several blockers: "2 open opportunities still reference it … reassign them"', async () => {
+    const account = await accountWithOpenDeals(2);
+    const message = await deleteAndCatch('crm_account', account.id);
+
+    expect(message, 'the delete must still be refused').toBeTruthy();
+    expect(message).toContain(
+      'Cannot delete customer account: 2 open opportunities still reference it. Close or reassign them first.',
+    );
+    expect(message).not.toContain('opportunities still references');
+    expect(message).not.toContain('reassign it first');
+  });
+
+  it('refuses, and leaves the account in place (semantics unchanged)', async () => {
+    const account = await accountWithOpenDeals(1);
+    await deleteAndCatch('crm_account', account.id);
+    expect(await rowsOf('crm_account', account.id)).toHaveLength(1);
+  });
+});

--- a/test/hooks-runtime-sales.test.ts
+++ b/test/hooks-runtime-sales.test.ts
@@ -468,22 +468,56 @@ describe('account_protection', () => {
     expect(input.last_activity_date).toBeUndefined();
   });
 
-  it('refuses to delete a customer account with open opportunities', async () => {
+  /**
+   * The refusal is asserted as the WHOLE sentence, per branch (#721).
+   *
+   * The count switches noun, verb and closing pronoun together, and the
+   * singular branch used to get only the noun — "1 open opportunity still
+   * reference it. Close or reassign them first." The pin that was here,
+   * `/1 open opportunity still reference/`, could not see that: it is
+   * unanchored, so it matches the correct "still references" just as happily
+   * as the broken "still reference". A message pin that passes on both
+   * spellings of the thing it is pinning is not pinning anything — hence the
+   * full strings below, one per branch, ending at the final period.
+   */
+  const refuseDelete = (openStages: string[]) => {
     const h = makeHarness({
       crm_opportunity: [
-        { id: 'o1', crm_account: 'acc1', stage: 'proposal' },
-        { id: 'o2', crm_account: 'acc1', stage: 'closed_won' },   // closed — ignored
-        { id: 'o3', crm_account: 'other', stage: 'proposal' },    // other account
+        ...openStages.map((stage, i) => ({ id: `o${i + 1}`, crm_account: 'acc1', stage })),
+        { id: 'closed', crm_account: 'acc1', stage: 'closed_won' },  // closed — ignored
+        { id: 'elsewhere', crm_account: 'other', stage: 'proposal' }, // other account
       ],
     });
-    await expect(
-      hook.handler(makeCtx({
-        event: 'beforeDelete',
-        previous: { id: 'acc1', type: 'customer' },
-        user: USER,
-        api: h.api,
-      })),
-    ).rejects.toThrow(/1 open opportunity still reference/);
+    return hook.handler(makeCtx({
+      event: 'beforeDelete',
+      previous: { id: 'acc1', type: 'customer' },
+      user: USER,
+      api: h.api,
+    }));
+  };
+
+  it('refuses to delete a customer account with ONE open opportunity (singular agreement)', async () => {
+    await expect(refuseDelete(['proposal'])).rejects.toThrow(
+      'Cannot delete customer account: 1 open opportunity still references it. Close or reassign it first.',
+    );
+  });
+
+  it('refuses to delete a customer account with SEVERAL open opportunities (plural agreement)', async () => {
+    await expect(refuseDelete(['proposal', 'negotiation'])).rejects.toThrow(
+      'Cannot delete customer account: 2 open opportunities still reference it. Close or reassign them first.',
+    );
+  });
+
+  it('never mixes the two branches — no plural verb on 1, no singular verb on 2', async () => {
+    // The defect was a stitched sentence, so guard the halves that were wrong
+    // rather than only the halves that were right.
+    const one = await refuseDelete(['proposal']).catch((e: Error) => e.message);
+    expect(one).not.toMatch(/opportunity still reference /);   // plural verb on a singular noun
+    expect(one).not.toMatch(/reassign them/);                  // plural pronoun on one record
+
+    const two = await refuseDelete(['proposal', 'negotiation']).catch((e: Error) => e.message);
+    expect(two).not.toMatch(/opportunities still references/); // singular verb on a plural noun
+    expect(two).not.toMatch(/reassign it first/);              // singular pronoun on two records
   });
 
   it('allows deleting a customer account whose opportunities are all closed', async () => {


### PR DESCRIPTION
Fixes #721

## 问题

`src/objects/account.hook.ts` 的客户账户删除守卫按数量切换了**名词**（`opportunit{y,ies}`），但动词和末句代词写死成复数。单数场景（17.0.0-rc.2 真实内核实测）：

```
DELETE /api/v1/data/crm_account/(id)
→ 400 "Cannot delete customer account: 1 open opportunity still reference it.
        Close or reassign them first."
```

两处都错：单数主语配了复数动词 `reference`，末句 `them` 指向的其实只有一条记录，读者还得自己去数。复数分支本来就是对的。

## 改法

一致性在这里横跨三个词（名词、动词、代词），拼接式条件很难保持正确，也难 grep。所以按分支整句给出，复数分支输出与改前逐字节一致：

```
1 条  → "Cannot delete customer account: 1 open opportunity still references it. Close or reassign it first."
2 条  → "Cannot delete customer account: 2 open opportunities still reference it. Close or reassign them first."
```

**只改文案**：触发条件、`$nin: ['closed_won', 'closed_lost']` 的计数谓词、`type !== 'customer'` 的适用范围、以及 #693/#719 收口的"守卫要指名拒绝方"措辞，全部未动。issue 里也已确认这条守卫的 "Cannot delete customer account" 主语本身是准确的——没有任何对象级联进 `crm_account`，它只在被直接寻址时触发。

## 原有的钉子钉不住这个缺陷

`test/hooks-runtime-sales.test.ts` 里唯一的钉是 `rejects.toThrow(/1 open opportunity still reference/)`。这个正则**没有右边界**，所以修好后的 `still references` 同样匹配——它对坏文案和好文案一视同仁，等于没钉。（PM 派单时预期钉在 #719 落的 `test/cascade-guard-messages.test.ts` 里，实际那个文件从未覆盖这条守卫。）

现在：

- `test/hooks-runtime-sales.test.ts`：单数、复数各一条**整句**断言（到句末句点为止），外加一条"不许串味"的反向断言——单数不得出现复数动词或 `reassign them`，复数不得出现单数动词或 `reassign it first`。
- `test/cascade-guard-messages.test.ts`：新增真实内核（`ObjectKernel` + `ObjectQL` + 应用自身元数据）下的端到端实测，1 条和 2 条开放商机各走一次真实 `DELETE`，断言用户真正看到的那句话；并保留一条"仍然拒绝、账户仍在"的语义未变断言。单元钉证明 handler 拼出了什么，这一层才证明用户被展示了什么。

## 反向验证（方向先声明，再执行）

预期方向：把旧文案改回去，**只有单数**断言转红，复数断言保持绿——因为复数分支本来就是对的。实测完全吻合：

```
❯ test/hooks-runtime-sales.test.ts (77 tests | 2 failed)
   × refuses to delete a customer account with ONE open opportunity (singular agreement)
   × never mixes the two branches — no plural verb on 1, no singular verb on 2
❯ test/cascade-guard-messages.test.ts (12 tests | 1 failed)
   × agrees with a single blocker: "1 open opportunity still references it … reassign it"
 Tests  3 failed | 86 passed (89)
```

复数分支的两条断言（单元 + engine 级）在旧文案下也是绿的，符合预期。

## 验证

`pnpm validate` / `pnpm typecheck` / `pnpm lint` / `pnpm hygiene` / `pnpm build` 全绿；`vitest run --maxWorkers=2` 全量 **63 files, 1545 passed | 1 skipped**。

控制字符自扫：`grep -naP` 按 C0 控制字符区间（NUL 至 US，排除制表与换行）扫描全部改动文件，零命中；`pnpm hygiene` 的 "no raw control bytes in source files" 亦通过。

已附 patch 级 changeset（用户可见文案修复）。
