### PR TITLE
fix(opportunity): 用声明通道 `params._selectedIds` 接回多选批量改阶段 (#508)

### DIFF
--- a/.changeset/opportunity-bulk-stage-selectedids.md
+++ b/.changeset/opportunity-bulk-stage-selectedids.md
@@ -1,0 +1,57 @@
+---
+'hotcrm': patch
+---
+
+Restore the opportunity list's bulk "Update Stage" button, and move a whole
+selection in one dispatch.
+
+Selecting several deals and moving them to a new stage has not worked in this
+app since the button was pulled from the list in #588. It was pulled for a good
+reason — it reported success and wrote nothing — and the failure was then
+attributed to the platform: no REST shape appeared to deliver a multi-row
+selection to an action, and the console refused a multi-row selection in the
+browser without issuing a request. Both readings were wrong in the same small
+way. The declared channel is `params._selectedIds`, a built-in action param with
+a **leading underscore**, and every probe had spelled it without one. A
+top-level `selectedIds` is never merged into the params bag; a
+`params.selectedIds` is correctly refused by the strict params gate as
+undeclared. The
+platform verified the declared channel end to end and closed its mirror issue as
+works-as-declared (objectstack-ai/objectstack#5568).
+
+The console's own "This action runs on a single record" toast was the clearest
+evidence of the real cause: it fires exactly when `_selectedIds` was **not**
+injected, and nothing injects it for a list that declares no bulk action. So all
+three symptoms trace to one missing declaration in this repo.
+
+`src/views/opportunity.view.ts` now declares the action as an aggregate bulk
+def — `{ name: 'mass_update_stage', operation: 'custom', execution: 'aggregate' }`
+— which dispatches it **once** for the whole selection rather than once per row,
+and `src/actions/opportunity.actions.ts` reads `input._selectedIds`. The
+single-record path (`ctx.recordId`) is unchanged; the write signature it depends
+on was fixed separately in #777. `execution: 'aggregate'` is not decoration: an
+`operation: 'custom'` def without it has no dispatcher, and the spec refuses that
+shape at parse time.
+
+The body no longer counts iterations, either. An id matching no row resolves to
+`null` instead of throwing, so the previous loop would have counted a stale or
+deleted id as updated and toasted success for a write that never happened —
+re-introducing #588's silent failure through a different door. It now counts only
+rows the engine returned and rejects a run it cannot cover in full, which is what
+the aggregate contract requires: there is no per-row retry, so a partial result
+must be an error. Rows already moved keep their new stage, and re-running the
+action over the selection is the retry (setting a stage is idempotent).
+
+Verified against a real dev server: the same request that answers
+`400 mass_update_stage: no opportunity selected` before the change answers `200
+{"stage":"proposal","updated":2}` after it, with both rows re-read from the store
+at the new stage.
+
+The guard in `test/metadata-references.test.ts` that forbade this wiring is
+inverted rather than deleted — its premise expired, but the risk it named is real
+— and moved to `test/bulk-action-dispatch.test.ts`, since the old file sits one
+edit from the repo's 100KB source-hygiene ceiling. The new pins cover the
+declaration, the underscore, and a hole nothing else saw: an aggregate def naming
+an action that does not exist parses cleanly and dispatches nothing.
+
+Fixes #508.

--- a/src/actions/opportunity.actions.ts
+++ b/src/actions/opportunity.actions.ts
@@ -64,32 +64,39 @@ export const CloneOpportunityAction: Action = {
 /**
  * Mass Update Opportunity Stage.
  *
- * SINGLE-RECORD ONLY today, and that half now works. #508 split into two on
- * the 17.0.0-rc.2 retest:
+ * Both invocation halves work as of #508 (17.0.0-rc.2):
  *
- *   - the SINGLE-row toolbar path reaches this body — the param dialog renders
- *     and the console POSTs `{ recordId, params: { stage } }`. What it then hit
- *     was this body's own bug: it called `update(id, { stage })`, but `ctx.api`
- *     is the engine repo facade, whose update takes `(data, options)`. The id
- *     landed in the `data` slot and every invocation 400'd with
- *     `update('crm_opportunity') does not recognise option 'stage'`. Fixed
- *     below, and executed end-to-end in `test/action-sandbox.test.ts`.
- *   - the MULTI-row path is still dead upstream (objectstack-ai/objectstack
- *     #5568): the console rejects a multi-row selection client-side (zero
- *     network requests), a top-level `selectedIds` is not delivered to the
- *     body, and `params.selectedIds` is refused by the action-param validator
- *     as undeclared. So `input.selectedIds` cannot arrive by any route yet —
- *     the branch below is kept because it is what the fix lands into.
+ *   - SINGLE record (row selection / toolbar with one row): the console POSTs
+ *     `{ recordId, params: { stage } }` and the body reads `ctx.recordId`. The
+ *     write itself was fixed in #777 — this body used to call
+ *     `update(id, { stage })`, but `ctx.api` is the engine repo facade whose
+ *     update takes `(data, options)`, so the id landed in the `data` slot and
+ *     every invocation 400'd with `update('crm_opportunity') does not
+ *     recognise option 'stage'`.
+ *   - MULTI record: the selection arrives in the BUILT-IN `_selectedIds`
+ *     param — leading underscore — injected by the grid renderer for the
+ *     view's `bulkActionDefs` entry with `execution: 'aggregate'`, which
+ *     dispatches this action ONCE for the whole selection (no `recordId`).
  *
- * The list view therefore still does NOT list it in `bulkActions` (#588): that
- * button was the one path that failed *silently* — success toast, nothing
- * written — so it read as data loss rather than as a tracked gap. Restoring it
- * is a one-line edit in `src/views/opportunity.view.ts`; do it in the PR that
- * closes #508, once objectstack#5568 ships multi-row delivery and the selection
- * bar is verified to POST `selectedIds`.
+ * That underscore is the whole story of why #508 read as "bulk is impossible".
+ * A script body's `input` IS the action's params bag
+ * (`@objectstack/runtime` `sandbox/body-runner.ts:338`), and `_selectedIds` is
+ * one of the params gate's builtin keys
+ * (`@objectstack/spec` `ui/action-params.zod.ts:70`, alongside `recordId` /
+ * `objectName`). The three rc.2 failure reports all probed UNDECLARED shapes —
+ * a top-level `selectedIds` (never merged into the bag), and a
+ * `params.selectedIds` without the underscore (correctly refused by the strict
+ * params gate, ADR-0104) — while the console's own "select exactly one row"
+ * toast fires precisely when `_selectedIds` was NOT injected, which is what
+ * happens to a view carrying no bulk declaration at all (#588 had removed it).
+ * Platform verified the declared channel end to end and closed
+ * objectstack-ai/objectstack#5568 as works-as-declared.
  *
- * Until then, multi-record stage moves happen via the pipeline kanban
- * drag-and-drop, inline grid editing, or the record form.
+ * Do NOT declare `_selectedIds` in `params` below: builtin keys are injected by
+ * the renderer, and the gate admits them without a declaration (declaring one
+ * is not a supported authoring move). Do NOT re-add a no-underscore
+ * `input.selectedIds` read either — nothing can deliver that key, so it would
+ * be a limb that only ever reads `undefined`.
  */
 export const MassUpdateStageAction: Action = {
   name: 'mass_update_stage',
@@ -102,22 +109,44 @@ export const MassUpdateStageAction: Action = {
     source: `
       const newStage = input.stage ?? null;
       if (!newStage) throw new Error('mass_update_stage requires a stage');
-      // Selection first, single record as the fallback (see the note above —
-      // the console does not deliver multi-row selections to actions yet).
-      const selected = Array.isArray(input.selectedIds) ? input.selectedIds : [];
+      // Selection first, single record as the fallback. An aggregate dispatch
+      // carries the whole selection in \`_selectedIds\` and NO recordId; a
+      // single-record dispatch carries recordId and no selection. The two are
+      // never both present, so the order only decides which shape wins if the
+      // platform ever sends both.
+      const selected = Array.isArray(input._selectedIds) ? input._selectedIds : [];
       const ids = selected.length ? selected : (ctx.recordId ? [ctx.recordId] : []);
       if (!ids.length) throw new Error('mass_update_stage: no opportunity selected');
+      const missed = [];
       let updated = 0;
       for (const id of ids) {
         // \`update(data, options)\` — \`ctx.api\` is the engine repo facade, whose
         // update takes a DOCUMENT, not an id. \`updateById(id, data)\` exists on
         // ObjectRepository but NOT on the facade the runtime builds when it has
         // no scoped context, so this spelling is the only one live on both.
-        await ctx.api.object('crm_opportunity').update(
+        const row = await ctx.api.object('crm_opportunity').update(
           { id: id, stage: newStage },
           { where: { id: id } },
         );
-        updated++;
+        // An id that matched no row resolves to null — the engine does NOT
+        // throw for it. Counting the attempt instead of the returned row is how
+        // a stale or invisible id turns into a success toast for a write that
+        // never happened, which is the exact silent-success failure #588 pulled
+        // this button for. Count only what came back.
+        if (row) { updated++; } else { missed.push(id); }
+      }
+      // Aggregate dispatch is all-or-nothing (objectui#3139): a handler that
+      // cannot cover the whole selection must reject rather than report partial
+      // work, because the bar offers no per-row retry — the retry IS re-running
+      // the action over the selection, which is safe here since setting a stage
+      // is idempotent. Rows already moved in this run keep the new stage; the
+      // error names the ones that did not so the rep can see the difference.
+      if (missed.length) {
+        throw new Error(
+          'mass_update_stage: ' + missed.length + ' of ' + ids.length
+          + ' selected opportunities could not be updated (' + missed.join(', ')
+          + '). Re-run the action on the selection to retry.'
+        );
       }
       return { stage: newStage, updated };
     `,

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -78,28 +78,42 @@ export const OpportunityViews = defineView({
     // own `locations: ['list_item']`. Built-in `exportOptions` covers CSV
     // export.
     //
-    // There is deliberately NO `bulkActions` here.
+    // `mass_update_stage` is wired as an AGGREGATE bulk def, not as a bare
+    // `bulkActions: ['mass_update_stage']` string (#508). The two forms are
+    // different dispatch contracts, and only this one moves a whole selection:
     //
-    // `mass_update_stage` used to be listed, and the selection-bar button that
-    // produced is a pure client-side no-op in this console: selecting rows and
-    // clicking it fires ZERO network requests and then raises a generic
-    // "Action completed successfully" toast (#508, path 2). A rep therefore
-    // watches a stage move report success and never happen — which reads as
-    // silent data loss, not as a tracked platform gap. Not shipping the
-    // control is the honest state until the platform can deliver the
-    // selection.
+    //   - bare string  → per-record fan-out: the action is dispatched ONCE PER
+    //     selected row with `recordId` set. N requests, N stage moves.
+    //   - aggregate def → ONE dispatch for the whole selection, carrying every
+    //     id in the builtin `params._selectedIds` and no `recordId`. One
+    //     request, N stage moves, one audit entry.
     //
-    // The action DEFINITION stays in `src/actions/opportunity.actions.ts`
-    // (with its KNOWN-BROKEN note), so restoring the button is one line:
+    // Aggregate is the right shape here because the body already loops over the
+    // selection itself, and because the run is all-or-nothing: a partial result
+    // rejects instead of leaving the bar reporting per-row success it cannot
+    // honour (see the body in `src/actions/opportunity.actions.ts`).
     //
-    //     bulkActions: ['mass_update_stage'],
+    // `execution: 'aggregate'` is REQUIRED on an `operation: 'custom'` def and
+    // is not boilerplate: a custom def without it has no dispatcher, so the
+    // button ticks green once per row and does nothing at all. The spec refuses
+    // that shape at parse time (#4457) — which is also what makes this
+    // declaration safe to trust rather than merely present.
     //
-    // Re-add it in the same PR that closes #508 — i.e. once the selection bar
-    // is verified to POST /api/v1/actions/crm_opportunity/mass_update_stage
-    // with `selectedIds`, and the action body has been fixed to match the
-    // engine facade (pinned in `test/action-sandbox.test.ts`). Until then reps
-    // move stages via the pipeline kanban drag-and-drop, inline grid editing,
-    // or the record form.
+    // History: this list carried the bare-string form until #588 removed it as
+    // a silent no-op, and the removal was read as "the platform cannot deliver
+    // a selection" for two release candidates. It could: the channel is
+    // `params._selectedIds`, the underscore is load-bearing, and nothing was
+    // injecting it precisely BECAUSE this declaration was gone
+    // (objectstack-ai/objectstack#5568, closed works-as-declared).
+    //
+    // The def deliberately carries only the three keys that choose the dispatch
+    // contract. Label, icon, params (the New Stage picker) and `visible` are
+    // promoted from the action itself by the renderer, so the dialog and the
+    // toolbar button cannot drift apart — and the label stays i18n-resolved,
+    // which an inline `label:` here would not be.
+    bulkActionDefs: [
+      { name: 'mass_update_stage', operation: 'custom', execution: 'aggregate' },
+    ],
   },
 
   listViews: {

--- a/test/action-sandbox.test.ts
+++ b/test/action-sandbox.test.ts
@@ -291,11 +291,14 @@ describe('every script action body executes under QuickJS', () => {
    * Reverting the body to `update(id, { … })` turns all three red, plus the
    * `it.each` case above, which now covers this action like any other.
    *
-   * The MULTI-record leg still has no live invocation path — the console cannot
-   * deliver a selection to an action at all (objectstack-ai/objectstack#5568),
-   * which is why #508 stays open and `bulkActions` stays un-wired. The loop is
-   * covered anyway, because the moment that delivery lands the only thing
-   * standing between it and a mass stage move is this body.
+   * The MULTI-record leg is live as of #508: the opportunity list declares
+   * `bulkActionDefs: [{ name: 'mass_update_stage', operation: 'custom',
+   * execution: 'aggregate' }]`, and the renderer delivers the whole selection
+   * in the builtin `params._selectedIds` — which a script body reads as
+   * `input._selectedIds`, because `input` IS the params bag. The underscore is
+   * the entire reason this looked undeliverable for two release candidates
+   * (objectstack-ai/objectstack#5568, closed works-as-declared). The two legs
+   * below execute that shape against a real kernel.
    */
   describe('mass_update_stage writes the stage it was given (#508, CRM half)', () => {
     const MASS_UPDATE = 'crm_opportunity:mass_update_stage';
@@ -374,24 +377,57 @@ describe('every script action body executes under QuickJS', () => {
       expect(stored?.stage, 'the stage move never reached the store').toBe('needs_analysis');
     });
 
-    it('walks every id of a selection, once the console can deliver one', async () => {
+    it('moves every STORED row of an aggregate selection — the multi-row path end to end', async () => {
       const api = ql.createContext({ isSystem: true });
       const a = await api.object('crm_opportunity').insert({ name: 'Deal A', stage: 'prospecting' });
       const b = await api.object('crm_opportunity').insert({ name: 'Deal B', stage: 'proposal' });
 
       const { result } = await runActionBody(action(MASS_UPDATE), {
         objectName: 'crm_opportunity',
-        // No `record`: a selection-scoped dispatch carries no single recordId,
-        // which is exactly why the body prefers `input.selectedIds`.
-        input: { stage: 'negotiation', selectedIds: [a.id, b.id] },
+        // No `record`: an aggregate dispatch carries NO recordId — the whole
+        // selection arrives under the builtin `_selectedIds` instead. This is
+        // the shape the grid renderer POSTs, underscore included.
+        input: { stage: 'negotiation', _selectedIds: [a.id, b.id] },
         engine: asBodyEngine(ql),
       });
 
       expect(result).toEqual({ stage: 'negotiation', updated: 2 });
+      // Read back from the driver: `updated: 2` is the body's own count, and
+      // the point of this leg is that two rows really moved in the store.
       for (const id of [a.id, b.id]) {
         const stored = await api.object('crm_opportunity').findOne({ where: { id } });
         expect(stored?.stage).toBe('negotiation');
       }
+    });
+
+    it('rejects an aggregate run it cannot cover, instead of counting the miss', async () => {
+      // All-or-nothing (objectui#3139): the selection bar offers no per-row
+      // retry, so a handler that covers only part of the selection must reject
+      // rather than return a success the bar will toast.
+      //
+      // The trap this pins is specific and silent: an id matching no row does
+      // NOT make the engine throw — `update` RESOLVES WITH NULL. A body that
+      // counted iterations instead of returned rows would answer `updated: 2`
+      // for one write, which is exactly the "success toast, nothing written"
+      // failure #588 pulled this button off the list for.
+      const api = ql.createContext({ isSystem: true });
+      const live = await api.object('crm_opportunity').insert({ name: 'Deal C', stage: 'prospecting' });
+      const stale = 'opp_deleted_between_select_and_submit';
+
+      await expect(
+        runActionBody(action(MASS_UPDATE), {
+          objectName: 'crm_opportunity',
+          input: { stage: 'negotiation', _selectedIds: [live.id, stale] },
+          engine: asBodyEngine(ql),
+        }),
+      ).rejects.toThrow(/1 of 2 selected opportunities could not be updated/);
+
+      // And the honest half of "all-or-nothing without a transaction": the row
+      // that WAS written keeps its new stage. The body says so in its error and
+      // in its comment; re-running the action is the retry, which is safe
+      // because setting a stage is idempotent.
+      const stored = await api.object('crm_opportunity').findOne({ where: { id: live.id } });
+      expect(stored?.stage).toBe('negotiation');
     });
   });
 

--- a/test/bulk-action-dispatch.test.ts
+++ b/test/bulk-action-dispatch.test.ts
@@ -82,30 +82,31 @@ describe('bulk dispatch is declared the way the renderer reads it', () => {
     ).toEqual([]);
   });
 
-  it('every custom bulk def names a real action and declares the aggregate dispatcher', () => {
-    // The name-resolution half is coverage nothing else has: the guard in
-    // `metadata-references.test.ts` ("every rowAction / bulkAction names a
-    // defined action") reads `bulkActions` STRINGS only, and the spec schema
-    // cannot resolve a name against this app's actions. An aggregate def naming
-    // an action that does not exist gets no `actionDef` attached by the
-    // renderer, so the button dispatches nothing — the silent no-op again,
-    // through a third door.
+  it('every custom bulk def names a real action', () => {
+    // Coverage nothing else has. The guard in `metadata-references.test.ts`
+    // ("every rowAction / bulkAction names a defined action") reads
+    // `bulkActions` STRINGS only, and the spec schema cannot resolve a name
+    // against THIS app's actions — `SnakeCaseIdentifierSchema` checks the
+    // spelling, not the referent. An aggregate def naming an action that does
+    // not exist gets no `actionDef` attached by the renderer, so the button
+    // dispatches nothing: the silent no-op again, through a third door.
     //
-    // The `execution` half is an app-local echo of a rule `pnpm validate`
-    // enforces through the spec (#4457). Kept deliberately: it fails in the
-    // unit run an author is already watching, and names the intent rather than
-    // the schema path.
+    // What this test deliberately does NOT re-assert is `execution:
+    // 'aggregate'` on a custom def. That was in the first draft and it was a
+    // phantom: `defineView` parses through the spec at MODULE IMPORT time, so a
+    // custom def without `execution` throws a ZodError carrying the whole
+    // #4457 explanation before this file can collect a single test. The
+    // assertion could never fail, because metadata in that state cannot be
+    // imported at all — verified by making the edit and watching the suite fail
+    // to load rather than fail an expectation. The schema owns that verdict and
+    // states it better; re-stating it here would only look like coverage.
     const bad: string[] = [];
     for (const v of views) {
       for (const list of listsOf(v)) {
         for (const def of (list.bulkActionDefs ?? []) as AnyRec[]) {
           if (def?.operation !== 'custom') continue;
-          const where = `view "${list.name ?? 'default'}" bulk "${def.name}"`;
-          if (def.execution !== 'aggregate') {
-            bad.push(`${where}: operation 'custom' without execution 'aggregate' — no dispatcher`);
-          }
           if (!actionNames.has(def.name)) {
-            bad.push(`${where}: names no defined action`);
+            bad.push(`view "${list.name ?? 'default'}" bulk "${def.name}": names no defined action`);
           }
         }
       }

--- a/test/bulk-action-dispatch.test.ts
+++ b/test/bulk-action-dispatch.test.ts
@@ -1,0 +1,154 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import stack from '../objectstack.config';
+
+/**
+ * The bulk-dispatch contract: how a list view delivers a multi-row selection
+ * to an action, and how that action reads it (#508).
+ *
+ * Split out of `metadata-references.test.ts`, which owns dangling-reference
+ * guards and is one edit from the 100KB hygiene ceiling. The guard that used to
+ * live there said the OPPOSITE of what this file says, and the inversion is the
+ * point:
+ *
+ * Until #508 closed, that file forbade any view from naming `mass_update_stage`
+ * in `bulkActions`, on the finding that the selection-bar button was a
+ * client-side no-op — zero network requests, generic success toast. The premise
+ * was disproven end to end by the platform (objectstack-ai/objectstack#5568,
+ * closed works-as-declared): the console delivers a selection perfectly well,
+ * through `bulkActionDefs` + `execution: 'aggregate'`, which makes the grid
+ * renderer inject every selected id into the builtin `params._selectedIds`. The
+ * button looked dead because the DECLARATION was missing (#588 had removed it),
+ * and the no-op the old guard described is what a bare-string `bulkActions`
+ * entry produces when the action behind it has no per-record dispatcher.
+ *
+ * So the guard is inverted, not deleted: the risk it protected against is real
+ * and unchanged — a bulk button that reports success and writes nothing — but
+ * its direction was wrong. What must not regress now is the declaration itself.
+ *
+ * These are METADATA pins: they assert the shape the renderer needs. The
+ * execution half — that the shape actually moves rows — is
+ * `test/action-sandbox.test.ts`, which runs the shipped body against a real
+ * ObjectQL kernel with `_selectedIds` in the params bag.
+ */
+
+type AnyRec = Record<string, any>;
+
+const views: AnyRec[] = (stack as any).views ?? [];
+const actions: AnyRec[] = (stack as any).actions ?? [];
+const actionNames = new Set(actions.map((a) => a.name));
+
+const listsOf = (v: AnyRec): AnyRec[] =>
+  [v.list, ...Object.values(v.listViews ?? {})].filter(Boolean) as AnyRec[];
+
+describe('bulk dispatch is declared the way the renderer reads it', () => {
+  it('the opportunity list dispatches mass_update_stage once for the whole selection', () => {
+    const oppView = views.find((v) => (v.list?.data?.object ?? v.object) === 'crm_opportunity');
+    expect(oppView, 'no crm_opportunity view').toBeTruthy();
+
+    const defs = (oppView!.list?.bulkActionDefs ?? []) as AnyRec[];
+    const massUpdate = defs.find((d) => d?.name === 'mass_update_stage');
+    expect(
+      massUpdate,
+      'the opportunity list no longer declares a mass_update_stage bulk def — without it the '
+      + 'renderer injects no `_selectedIds`, the toolbar button degrades to a single-record '
+      + 'action, and a multi-row selection is refused client-side (#508)',
+    ).toBeTruthy();
+    // The two keys that CHOOSE the dispatch contract. `custom` says "dispatch
+    // the action this def names"; `aggregate` says "once, for the whole
+    // selection". Dropping the second is refused at parse time (#4457) — the
+    // shape it leaves behind ticks green per row and does nothing.
+    expect(massUpdate!.operation).toBe('custom');
+    expect(massUpdate!.execution).toBe('aggregate');
+
+    // …and NOT the bare-string form anywhere. That is the per-record fan-out —
+    // a different contract (N dispatches, each carrying `recordId`), which this
+    // body is not written for: it would re-enter the selection loop once per
+    // row, and the all-or-nothing rejection would report per row rather than
+    // per selection.
+    const fanout: string[] = [];
+    for (const v of views) {
+      for (const list of listsOf(v)) {
+        for (const name of list.bulkActions ?? []) {
+          if (name === 'mass_update_stage') fanout.push(`view "${list.name ?? 'default'}"`);
+        }
+      }
+    }
+    expect(
+      fanout,
+      'mass_update_stage is wired as a per-record fan-out here, but its body is written for the '
+      + `aggregate contract:\n  ${fanout.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('every custom bulk def names a real action and declares the aggregate dispatcher', () => {
+    // The name-resolution half is coverage nothing else has: the guard in
+    // `metadata-references.test.ts` ("every rowAction / bulkAction names a
+    // defined action") reads `bulkActions` STRINGS only, and the spec schema
+    // cannot resolve a name against this app's actions. An aggregate def naming
+    // an action that does not exist gets no `actionDef` attached by the
+    // renderer, so the button dispatches nothing — the silent no-op again,
+    // through a third door.
+    //
+    // The `execution` half is an app-local echo of a rule `pnpm validate`
+    // enforces through the spec (#4457). Kept deliberately: it fails in the
+    // unit run an author is already watching, and names the intent rather than
+    // the schema path.
+    const bad: string[] = [];
+    for (const v of views) {
+      for (const list of listsOf(v)) {
+        for (const def of (list.bulkActionDefs ?? []) as AnyRec[]) {
+          if (def?.operation !== 'custom') continue;
+          const where = `view "${list.name ?? 'default'}" bulk "${def.name}"`;
+          if (def.execution !== 'aggregate') {
+            bad.push(`${where}: operation 'custom' without execution 'aggregate' — no dispatcher`);
+          }
+          if (!actionNames.has(def.name)) {
+            bad.push(`${where}: names no defined action`);
+          }
+        }
+      }
+    }
+    expect(bad, `custom bulk defs that cannot dispatch:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  /**
+   * The handler half of the same contract.
+   *
+   * The declaration only DELIVERS the selection; something has to read it, and
+   * the key is `_selectedIds` with a leading underscore — a builtin of the
+   * action-params gate, alongside `recordId` / `objectName`. #508 spent two
+   * release candidates believing multi-select delivery did not exist because
+   * every probe spelled the key without that underscore: a top-level
+   * `selectedIds` (never merged into the params bag) and a `params.selectedIds`
+   * (correctly refused by the strict gate as undeclared).
+   */
+  it('mass_update_stage reads the selection from the builtin `_selectedIds`', () => {
+    const massUpdate = actions.find((a) => a.name === 'mass_update_stage');
+    expect(massUpdate, 'mass_update_stage is not defined').toBeTruthy();
+    const source = String(massUpdate!.body?.source ?? '');
+
+    expect(
+      source.includes('input._selectedIds'),
+      'the body no longer reads `input._selectedIds` — the aggregate dispatch delivers the '
+      + 'selection under exactly that builtin key and nothing else carries it',
+    ).toBe(true);
+
+    // The no-underscore spelling is not a synonym and not a fallback: nothing
+    // can deliver it, so a limb reading it only ever sees `undefined`. Matched
+    // with a boundary so `input._selectedIds` itself does not trip it.
+    expect(
+      /(?<![\w$])input\.selectedIds\b/.test(source),
+      'the body reads `input.selectedIds` (no underscore) — an undeliverable key: the params '
+      + 'gate refuses it as undeclared, and the renderer injects only `_selectedIds`',
+    ).toBe(false);
+
+    // `_selectedIds` is injected by the renderer and admitted by the gate as a
+    // builtin. Declaring it as a param is not a supported authoring move, and
+    // an author who tries is usually about to re-invent the channel.
+    const declared = (massUpdate!.params ?? []).map((p: AnyRec) => p?.name);
+    expect(declared, 'builtin keys must not be declared as action params')
+      .not.toContain('_selectedIds');
+  });
+});

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -922,51 +922,17 @@ describe('list-level action references resolve', () => {
   });
 
   /**
-   * No view may wire an action whose bulk invocation path is known dead (#588).
+   * Bulk dispatch (`bulkActionDefs` / `bulkActions`) is pinned in
+   * `test/bulk-action-dispatch.test.ts`.
    *
-   * `bulkActions` renders a selection-bar button. For `mass_update_stage` that
-   * button fires ZERO network requests and then toasts "Action completed
-   * successfully" (#508, path 2, verified live against the dev console) — the
-   * worst possible failure mode, because a rep sees a stage move confirmed and
-   * silently not applied. Neither `os validate` nor the dangling-reference
-   * guard above can see this: the action IS defined, so the reference resolves
-   * and the metadata is shape-valid. Only this list knows the button is dead.
-   *
-   * Retire an entry here in the SAME PR that proves its path works — for
-   * `mass_update_stage` that means #508: the selection bar POSTing
-   * /api/v1/actions/crm_opportunity/mass_update_stage with `selectedIds`, and
-   * the body fixed to match the engine facade (see `action-sandbox.test.ts`).
+   * A guard forbidding `mass_update_stage` on any list used to live here: the
+   * selection-bar button was found to be a client-side no-op (#588), so the
+   * wiring was treated as the defect. #508 disproved that premise — the console
+   * delivers a selection through `bulkActionDefs` + `execution: 'aggregate'`
+   * (objectstack-ai/objectstack#5568), and the button was inert because the
+   * DECLARATION had been removed. The guard is inverted rather than deleted,
+   * and moved: this file is one edit from the 100KB hygiene ceiling.
    */
-  const BULK_INVOCATION_DEAD: Record<string, string> = {
-    mass_update_stage: '#508 — selection-bar button is a client-side no-op in console 16.1.0',
-  };
-
-  it('no view wires an action whose bulk path is known dead', () => {
-    const wired: string[] = [];
-    for (const v of views) {
-      const lists = [v.list, ...Object.values(v.listViews ?? {})].filter(Boolean) as AnyRec[];
-      for (const list of lists) {
-        for (const name of list.bulkActions ?? []) {
-          const why = typeof name === 'string' ? BULK_INVOCATION_DEAD[name] : undefined;
-          if (why) wired.push(`view "${list.name ?? 'default'}": "${name}" — ${why}`);
-        }
-      }
-    }
-    expect(wired, `dead bulk buttons back on a list view:\n  ${wired.join('\n  ')}`).toEqual([]);
-  });
-
-  /**
-   * …and the counterpart: un-wiring must not become deletion.
-   *
-   * The definition is what makes the #508 restore a one-line edit, and what
-   * keeps the KNOWN-BROKEN note, the translations and the sandbox pin alive. A
-   * future cleanup pass that "removes the unused action" would throw all of
-   * that away and quietly close the paper trail.
-   */
-  it('keeps the definition of every un-wired action so the restore stays one line', () => {
-    const missing = Object.keys(BULK_INVOCATION_DEAD).filter((n) => !actionNames.has(n));
-    expect(missing, `un-wired but also deleted:\n  ${missing.join('\n  ')}`).toEqual([]);
-  });
 });
 
 describe('row colors and kanban groups key off real option values', () => {


### PR DESCRIPTION
Fixes #508

## Description

把商机列表的批量「Update Stage」接回来，并让一次派发真正搬动整个选择集。

#508 的两半现在齐了：**#777** 修好了 body 的 update 签名（写路径），**本 PR** 接上投递通道（读路径）。

依据是 objectstack-ai/objectstack#5568 的关单结论（works as declared，平台组真机端到端验证）：rc.2 声明的多选投递通道**一直存在**，是 `params._selectedIds` —— **带前导下划线**的内建键（`ACTION_PARAM_BUILTIN_KEYS`，`@objectstack/spec` `ui/action-params.zod.ts:70`），由列表视图的 `bulkActionDefs` + `execution: 'aggregate'` 驱动；script body 里的 `input` 就是 params 袋本身（`@objectstack/runtime` `sandbox/body-runner.ts:338`），所以 handler 的读法是 `input._selectedIds`。

三轮复核的失败证据测的全是**未声明形状**，且三条同一个 app 侧原因：

| 复核证据 | rc.2 实际含义 |
|:---|:---|
| 顶层 `selectedIds` → 400「no opportunity selected」 | 顶层键不并进 params 袋，body 自己的守卫命中——**正确行为** |
| `params.selectedIds`（无下划线）→ 400「Unknown action param」 | ADR-0104 严格参数门按声明拒绝——**参数门正常工作** |
| console 多选 → 红 toast + 零请求 | objectui 的多选守卫在 `_selectedIds` 存在时显式绕过；toast 弹出恰恰证明**它没被注入**，而没被注入是因为 #588 摘掉了视图的 bulk 声明行 |

即：按钮之所以像死的，是因为**声明没了**，不是因为通道没有。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #508
Related to #777（签名半，已合并）、objectstack-ai/objectstack#5568（平台半，works as declared 关单）、#588（当初摘除按钮的处置）

## Changes Made

- **`src/views/opportunity.view.ts`**：恢复 bulk 声明，用 **aggregate def** 而非裸字符串：
  `bulkActionDefs: [{ name: 'mass_update_stage', operation: 'custom', execution: 'aggregate' }]`
  两种形状是两套派发契约：裸字符串 `bulkActions: ['mass_update_stage']` 是 per-record fan-out（N 次请求、每次带 `recordId`）；aggregate def 是**一次**派发带上全部 id、不带 `recordId`。本 body 自己就在循环整个选择集，选 aggregate。⚠️ `execution: 'aggregate'` 不是样板：`operation: 'custom'` 不带它在 **parse 阶段即被拒**（#4457），那种形状历史上就是「N 个绿勾、零工作」。
- **`src/actions/opportunity.actions.ts`**：handler 改读 `input._selectedIds`（带下划线）；未把它声明进 `params[]`（内建键，声明不了也不需要）；单行 `recordId` 路径保留不变。**另外把 all-or-nothing 从注释升级成了强制**（见下）。
- **`test/metadata-references.test.ts` → `test/bulk-action-dispatch.test.ts`**：「不许把死 bulk 按钮接回去」的守卫前提已被证伪，**翻转**而非删除——它防的风险（批量按钮报成功却不写）真实且未变，错的只是方向。现在钉住声明形状本身。
- **`test/action-sandbox.test.ts`**：选择集测试对齐 `_selectedIds`，engine 级真跑 shipped body、从 driver 读回多行 stage；另加一条 all-or-nothing 用例。
- changeset。

### 顺带修掉一个会重演 #588 的坑

原 body 是 `updated++` **盲计数**。实测确认：**id 匹配不到行时 `update` 不抛错，而是 resolve 成 `null`**。所以一个失效/已删除的 id 会被算成「已更新」，接回按钮后就是「成功 toast + 没写进去」——正是 #588 当初摘掉这个按钮的那个失败形态，只是换了扇门。

现在只计入引擎真正返回的行，覆盖不全整个选择集就**整体拒绝**——这也正是 aggregate 契约的要求（选择栏没有逐行重试，所以部分结果必须是错误）。已写入的行保留新 stage，重试方式是重跑整个 action（设置 stage 是幂等的），错误信息里点名没能覆盖的 id。

## Testing

- [x] Unit tests pass — `pnpm test`：**64 files / 1536 passed, 1 skipped**
- [x] Linting passes — `pnpm lint` 干净（13 warning / 14 suggestion 全为既有 flow/campaign_member 提示，与本改动无关）
- [x] Build succeeds — `pnpm build` + `pnpm validate` exit 0，`pnpm hygiene` clean
- [x] Manual testing completed（真实 dev server，见下）
- [x] New tests added

### 真机验收（dev server + REST，改前/改后对照）

两次都是**独立端口 + 各自 `rm -rf .objectstack/data` 重新 seed**，每轮发请求前先 `GET /api/v1/meta/actions` **核对服务端实际注册的是哪一版 body**，拆除按精确 PID（防 #777 报告里那个「旧 server 占端口」的假绿陷阱）。目标 stage 选 `proposal`——它对每个 pre-proposal 阶段都是合法跃迁，不会被 `opportunity_stage_progression` 状态机干扰证据。

**改后**（本分支，:4138，注册 body 已核对为 `_selectedIds` 版）：

```
A 顶层 selectedIds        → 400 mass_update_stage: no opportunity selected
B params.selectedIds      → 400 Unknown action param "selectedIds" — not declared on this action
D params._selectedIds     → 200 {"success":true,"data":{"stage":"proposal","updated":2}}
```

A / B 与 #508 的复核实录**逐字一致**（未声明形状，本就该被拒）。D 的两行 re-GET：

```
9MzPkMEjjE1kF6tJ  qualification → proposal   Vertex Analytics Expansion
O-1QpbEodwWvd8hp  prospecting   → proposal   Lattice Student Success Platform
```

**改前对照**（`git checkout origin/main -- ` 那两个源文件后重新 build，:4139，注册 body 已核对为无下划线版）——**同一个请求形状**：

```
D params._selectedIds     → 400 mass_update_stage: no opportunity selected
两行 stage 复查：prospecting / needs_analysis，未变
```

**all-or-nothing 真机实测**（一个真 id + 一个失效 id）：

```
→ 400 mass_update_stage: 1 of 2 selected opportunities could not be updated
       (opp_deleted_between_select_and_submit). Re-run the action on the selection to retry.
真 id 复查：stage = proposal（已写入的行保留，与注释/changeset 的说法一致）
```

服务端 `[action-audit]` 全程 2 条：A 条到达 handler 后被 body 守卫抛出，D 条 1 条；B 条在参数门就被拒、未到 handler。即 **D 是一次派发写两行**，与 #5568 的计数口径一致。

### 反向验证（方向先声明后执行）

| # | 反向改动 | 预声明方向 | 实测 |
|:--|:---|:---|:---|
| R1 | 删掉视图的 `bulkActionDefs` | 红 | ✅ 红（"no longer declares a mass_update_stage bulk def"） |
| R2 | 换成裸字符串 `bulkActions` | 红 | ✅ 红；又单独把 fan-out 那一枝隔离验了一次（def 保留 + 并列加裸字符串），避免它被前一条断言遮住 |
| R3 | 去掉 `execution: 'aggregate'` | 单测红 + validate 红 | ⚠️ **方向与预设不同，见下** |
| R4 | body 改回无下划线 `input.selectedIds` | 红 | ✅ 3 条红；且 engine 级复现的报错串与验收实录的 400 原文逐字相同 |
| R5 | 把覆盖检查改回盲 `updated++` | 红 | ✅ 红——**resolve 成功而不是 reject**，正是它该抓的那个假成功 |

**R3 是一次诚实的方向修正，值得单独说**：`pnpm validate` 如预期变红（#4457 原文消息）；但单测那边不是「断言失败」，而是**整个 suite collect 不起来**——`defineView` 在**模块导入时**就 parse，ZodError 直接抛在 `import` 上。也就是说我第一版写的那条「custom 必须带 aggregate」的断言**永远不可能失败**：metadata 处于那个状态时根本导入不了。那是个 phantom check，已删除（commit e981a3cd 记录了这个判断），只保留 schema **做不到**的那一半——「aggregate def 必须指向真实存在的 action」。这一半单独验证过是**可达**的：塞一个 `no_such_action` 的 def 进去，测试如期变红。这也堵上了一个此前没人覆盖的洞：这种 def parse 完全通过，渲染器却挂不上 `actionDef`，按钮什么都不派发。

## Additional Notes

**为什么新钉子换了文件**：派发单点名在 `test/metadata-references.test.ts` 里翻转守卫，但该文件在 `origin/main` 上是 **101,583 字节**，距 `pnpm hygiene` 的 100KB（102,400）上限只剩 **817 字节**，装不下三条带解释的钉子（加完 106KB，hygiene 红）。按 hygiene 自己给的处方（"split the file"）拆到 `test/bulk-action-dispatch.test.ts`，原处留指路注释，原文件回落到 99,872 字节。该文件的体积压力另立 #814 登记。

**边界**：未升降任何 `@objectstack/*`（通道在 rc.2 上本就存在）、未动平台代码、未动 `content/docs/releases/`、未动其它视图/action。界外发现另立 **#813**（`lead.actions.ts` 与 `docs/developers/code_examples.md` 仍读/仍教无下划线的 `input.selectedIds`）、**#814**（上述体积）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_