### PR TITLE
docs(sharing): correct the campaign_leadership_* argument to public_read (#724)

### DIFF
--- a/.changeset/campaign-sharing-public-read-argument.md
+++ b/.changeset/campaign-sharing-public-read-argument.md
@@ -1,0 +1,47 @@
+---
+---
+
+No user-visible change: one source comment — the file header of
+`src/sharing/campaign.sharing.ts` — is corrected, nothing else. The diff's
+non-comment content is empty, proved two ways (every changed diff line is a
+comment line; the comment-stripped emit of the file is byte-identical before and
+after).
+
+Same defect class as #744 / PR #773, but the stale premise here never had a
+valid era: the header argued from an OWD the object has never declared. It said
+`crm_campaign` "is a private-OWD object and the only set with org-wide campaign
+access is `marketing_user` — so a marketing manager or director could not open a
+campaign a specialist owned", while `src/objects/campaign.object.ts` declares
+`sharingModel: 'public_read'`. Neither line ever changed: `git log -L 18,18` on
+the object and `git log -L 7,9` on the sharing file each return exactly one
+commit, the file's own creation (#570). `src/profiles/marketing-user.profile.ts`
+records the same OWD correctly, so the repo held two contradictory accounts of
+one object.
+
+The argument was a READ argument, and under `public_read` no part of it stands:
+the OWD baseline already opens reads, so both leadership rungs could open any
+campaign with or without these rules. What the rules actually buy is the **edit**
+the baseline withholds — `@objectstack/plugin-sharing` 17.0.0-rc.2 states it in
+`buildWriteFilter`'s own comment, that the editable set applies to both `private`
+and `read` models because "public_read is read-open but write-owned". The header
+is rewritten onto that, and the ADR-0090 D3 flat-positions paragraph is kept
+verbatim because it still holds.
+
+The rewritten header's behavioural claims are measured on the pinned
+17.0.0-rc.2, over this app's own metadata, rather than reasoned from the engine's
+prose. For a user holding the `marketing_user` permission set plus position
+`marketing_manager` and owning no campaign: reads return every campaign at every
+point in the run; before the rules materialise, `buildWriteFilter` is
+`{ owner_id: specialist }` and updating a specialist-owned campaign is FORBIDDEN;
+after, the filter gains `{ id: { $in: [live campaign] } }` and the same update
+succeeds, while the completed campaign stays FORBIDDEN. That also settles the
+redundancy question the wrong premise invited: the `marketing_user` set's
+`marketing_campaign_updates` RLS policy (`id != null`) widens the RLS layer only,
+and the sharing layer's write-owned baseline refuses the update regardless — so
+deleting these two rules would cost the two rungs their only edit path while
+changing nothing they can read.
+
+The rules themselves are untouched: same names, same object, same criteria, same
+`accessLevel`, same recipients.
+
+Fixes #724.

--- a/src/sharing/campaign.sharing.ts
+++ b/src/sharing/campaign.sharing.ts
@@ -4,12 +4,36 @@ import { P } from '@objectstack/spec';
 /**
  * Campaign leadership sharing.
  *
- * `crm_campaign` is a private-OWD object and the only set with org-wide campaign
- * access is `marketing_user` — so a marketing manager or director could not open
- * a campaign a specialist owned. ADR-0090 D3 positions are FLAT (no hierarchy
- * to roll visibility up), so each rung that needs the access carries its own
- * grant. Scoped to live campaigns: finished ones stay with their owner and the
- * analytics surfaces that report on them.
+ * `crm_campaign` is `public_read` (`src/objects/campaign.object.ts`), so the OWD
+ * baseline already hands READ to everyone holding object-level read on it: a
+ * marketing manager or director opens any campaign with or without this file.
+ * What `public_read` does NOT hand out is WRITE. `@objectstack/plugin-sharing`
+ * 17.0.0-rc.2 states the boundary in `buildWriteFilter`'s own comment — the
+ * editable set "applies to BOTH `private` and `read` (public_read) models —
+ * public_read is read-open but write-owned; only a fully `public` object is
+ * write-open" — i.e. owner-match OR records shared at a write access level.
+ *
+ * These two rules are that second branch, and `accessLevel: 'edit'` is the part
+ * doing the work: they let a marketing manager / director EDIT a live campaign a
+ * specialist owns, rather than having to take ownership of it. Nor does the
+ * `marketing_user` permission set make them redundant — its
+ * `marketing_campaign_updates` RLS policy (`id != null`) widens the RLS layer
+ * only, and the sharing layer's write-owned baseline still refuses the update.
+ *
+ * MEASURED on 17.0.0-rc.2 against this app's own metadata (#724), for a user
+ * holding the `marketing_user` set plus position `marketing_manager` and owning
+ * no campaign: reads return EVERY campaign at all times; before these rules
+ * materialise, `buildWriteFilter` is `{ owner_id: specialist }` and updating a
+ * specialist-owned campaign is FORBIDDEN; after, the filter gains
+ * `{ id: { $in: [live campaign] } }` and the same update succeeds, while the
+ * completed campaign stays FORBIDDEN. So deleting these rules costs the two
+ * rungs their only edit path and changes nothing about what they can READ —
+ * which is exactly what makes the loss easy to miss.
+ *
+ * ADR-0090 D3 positions are FLAT (no hierarchy to roll visibility up), so each
+ * rung that needs the access carries its own grant. Scoped to live campaigns:
+ * finished ones stay with their owner and the analytics surfaces that report on
+ * them.
  */
 export const CampaignLeadershipSharingRules = [
   {


### PR DESCRIPTION
Fixes #724

纯注释修正，零行为变更。`src/sharing/campaign.sharing.ts` 的文件头论证建立在一个 `crm_campaign` 从未声明过的 OWD 上：它称该对象为 private-OWD，并据此推出"marketing manager / director 打不开 specialist 拥有的 campaign"。而 `src/objects/campaign.object.ts:18` 声明的是 `sharingModel: 'public_read'`。

## 前提复核（对 `origin/main` `983f465d`）

issue 记录的形态仍然成立，两行都没有漂移过：

```
$ git log --oneline -L 18,18:src/objects/campaign.object.ts   → 仅建档一笔
$ git log --oneline -L 7,9:src/sharing/campaign.sharing.ts    → 仅 #570 建档一笔
```

也就是说这句注释从写下那天起就是错的，不是后来漂移。`src/profiles/marketing-user.profile.ts:30` 对同一对象 OWD 的记载是**对的**（"`crm_campaign` is `public_read`"），仓内两处互相打架。

## 改写的依据

原注释给的是一条**读**权限论证，在 `public_read` 下整条不成立：OWD baseline 已经把读放开，两个岗位本来就打得开任何一条 campaign。规则真正补的是 baseline 扣住的 **edit** —— `@objectstack/plugin-sharing` 17.0.0-rc.2 在 `buildWriteFilter` 的自带注释里就写明了这条边界：可写集合 "applies to BOTH `private` and `read` (public_read) models — public_read is read-open but write-owned; only a fully `public` object is write-open"。

新注释就架在这句上。ADR-0090 D3「岗位扁平」那段**逐字保留**（仍然成立），规则本体一行未动：name / object / criteria / accessLevel / sharedWith 全部相同。

## 新注释里的行为断言是量出来的，不是推出来的

按 #773 的纪律，注释里凡是新的行为断言，先用一次性探针在 pinned 17.0.0-rc.2 真引擎上量过（探针不入库）。栈与 `test/parent-derived-reach.test.ts` 相同：ObjectQL + `plugin-security` + `plugin-sharing`，跑本仓自己的 `objectstack.config.ts`。被测主体持 `marketing_user` 权限集 + `marketing_manager` 岗位，不拥有任何 campaign：

```
=== crm_campaign sharingModel (as declared in objectstack.config) ===
  public_read

=== principals ===
  mgr  permissions= [ 'marketing_user' ] positions= [ 'marketing_manager', 'everyone' ] admin= false
  spec permissions= [ 'marketing_user' ] positions= [ 'marketing_user', 'everyone' ] admin= false

=== BEFORE the campaign_leadership rules are materialised ===
  share rows            : []
  mgr  reads            : [ 'done', 'live' ]
  buildReadFilter (mgr) : null
  buildWriteFilter(mgr) : {"owner_id":"sys_user-1785966156435-3"}
  mgr  update live      : DENIED: FORBIDDEN: insufficient privileges to update crm_campaign ...
  mgr  update done      : DENIED: FORBIDDEN: insufficient privileges to update crm_campaign ...
  spec update live (own): OK

=== AFTER evaluateRule(campaign_leadership_*) ===
  share rows            : [ 'live→mgr:edit:rule', ... ]
  mgr  reads            : [ 'done', 'live' ]
  buildWriteFilter(mgr) : {"$or":[{"owner_id":"sys_user-..."},{"id":{"$in":["crm_campaign-...-1"]}}]}
  mgr  update live      : OK
  mgr  update done      : DENIED: FORBIDDEN: insufficient privileges to update crm_campaign ...
```

三件事被直接证实：`buildReadFilter` 对 `public_read` 返回 `null`（读全开，规则化前后 `mgr reads` 恒为全部）；写在规则化前收敛到 owner-match，规则化后才多出 `$in` 那一支；criteria 的活动期界限是真的（completed 那条始终 FORBIDDEN）。

顺带把 issue 担心的「被当成冗余删掉」这条堵死：`marketing_user` 权限集的 `marketing_campaign_updates` RLS 策略（`id != null`）只放宽 RLS 那一层，sharing 层 write-owned 的 baseline 照样拒——上面 BEFORE 段的 DENIED 就是持该权限集的用户量出来的。删掉这两条规则，两个岗位失去唯一的编辑通道，而读权限一点变化都没有，正是这一点让损失极难察觉。

## 机械证明：确为纯注释

**证明一 —— diff 增删行去缩进后，非注释残集为 0**

```
$ git diff -U0 HEAD~1 HEAD -- src/sharing/campaign.sharing.ts \
    | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | sed -E 's/^[+-][[:space:]]*//' > a.txt
$ wc -l < a.txt                                  # 36
$ grep -vcE '^(/\*\*|\*/|\*|//)' a.txt           # 0
```

**证明二 —— esbuild 剥注释后逐字节相同**

```
$ npx esbuild --minify-whitespace --legal-comments=none b_head.ts > b_head.min.js
$ npx esbuild --minify-whitespace --legal-comments=none b_work.ts > b_work.min.js
$ cmp b_head.min.js b_work.min.js && echo identical
identical
$ sha256sum b_head.min.js b_work.min.js
2bf8b6dc42a5fa3047edcf2eb75c3ce97235bb8b331ed5a4c0ce9816b9feca36  b_head.min.js
2bf8b6dc42a5fa3047edcf2eb75c3ce97235bb8b331ed5a4c0ce9816b9feca36  b_work.min.js
$ wc -c b_head.ts b_work.ts b_head.min.js b_work.min.js
1379 b_head.ts   2957 b_work.ts   649 b_head.min.js   649 b_work.min.js
```

源文件 1379 → 2957 字节，剥注释后的产物 649 → 649 字节、哈希相同。（两份都放在同一目录下编译：直接对仓内文件跑 esbuild 会因 tsconfig 解析多出一个 `"use strict";` 前缀，那是解析上下文差异，不是内容差异。）

## 验证

```
pnpm hygiene   ✓ source hygiene clean（含 no raw control bytes in source files）
pnpm typecheck ✓ exit=0
pnpm validate  ✓ Validation passed (1424ms)
pnpm lint      ✓ 13 warning(s), 14 suggestion(s)（与 main 同）
vitest run --maxWorkers=2  ✓ Test Files 64 passed (64) / Tests 1548 passed | 1 skipped (1549)
```

测试全绿，但按证明二这**不可能**是别的结果：编译产物逐字节相同，任何测试都无从观察到差异。这里贴出来是为了排除"改动波及了别处"，不是把它当作注释正确性的证据——注释的正确性由上面那段 rc.2 实测背书。控制字符自扫（`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`）在改动的两个文件上零命中。

按 PM 裁定，**不**加「注释断言的 OWD 与对象 `sharingModel` 对账」的守卫（issue 自身也标注该项"不必然"）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_