### PR TITLE
docs+fix(actions): 教声明形状的多选通道，删掉 lead 侧读无下划线键的死枝 (#813)

### DIFF
--- a/.changeset/selectedids-teaching-and-lead-dead-limb.md
+++ b/.changeset/selectedids-teaching-and-lead-dead-limb.md
@@ -1,0 +1,64 @@
+---
+'hotcrm': patch
+---
+
+Teach the selection key the platform can actually deliver, and drop the one
+remaining limb in the app that read the key it cannot.
+
+`docs/developers/code_examples.md` is the copy-paste surface for the next author
+of an action — human or AI — and its "Add An Action" example was a bulk
+enrolment body reading `input.selectedIds`. No underscore, and therefore
+undeliverable: a top-level `selectedIds` is never merged into the params bag, so
+the body reads `undefined` and the author's own "nothing selected" guard fires;
+a `params.selectedIds` is refused by the strict params gate (ADR-0104) with
+`400 Unknown action param "selectedIds" — not declared on this action`. Both
+refusals are correct, and together they read as proof that the platform has no
+multi-select channel. It has one — `_selectedIds`, a built-in action param with
+a leading underscore — and this example is where the wrong conclusion kept
+getting re-derived. It cost #508 two release candidates and a bulk button that
+shipped removed.
+
+The example now reads `input._selectedIds`, and — because a handler is only half
+the contract — it also shows the view-side declaration that injects the key:
+`bulkActionDefs: [{ name, operation: 'custom', execution: 'aggregate' }]`. A new
+section sets the two dispatch contracts side by side, since they are not two
+spellings of one thing: a bare-string `bulkActions: ['x']` entry is a per-record
+fan-out (N rows, N requests, each carrying that row's `recordId` and no
+selection array), while an aggregate def is ONE dispatch carrying every id in
+`params._selectedIds` and no `recordId`. The underscore trap is written up as an
+explicit callout with both 400s quoted, and the section points at the live
+reference implementation landed for #508 — `mass_update_stage` in
+`src/actions/opportunity.actions.ts` plus its def in
+`src/views/opportunity.view.ts`.
+
+Two further corrections the example needed to be runnable at all: it was
+`type: 'modal'` carrying a `body`, and a modal action has no server dispatch —
+the renderer just opens its `target` and the runtime refuses it over REST, so
+that body could never have executed. It is now `type: 'script'`, and the
+now-redundant `target` is gone.
+
+`create_campaign` in `src/actions/lead.actions.ts` carried the same
+no-underscore read as a selection-first branch with a `ctx.recordId` fallback
+behind it. That branch never executed: the lead list wires the action as the
+bare-string form, and the per-record fan-out delivers a `recordId` and no
+selection array on every dispatch. Its comment nevertheless promised, in the
+present tense, that the bulk path would "light up" once the runtime started
+passing `selectedIds` — it would not have, under that spelling, on either
+contract. The dead limb is removed and the body now reads `ctx.recordId` alone,
+which is exactly what its wiring delivers. **No behaviour change**: multi-lead
+enrolment worked before and works now, one lead per dispatch. Whether it should
+instead move to the aggregate contract is a product decision (one audit entry
+and one dedupe read per run instead of per lead, plus all-or-nothing failure
+semantics) and is deliberately left open.
+
+New pins: `test/docs-drift.test.ts` guards the teaching surface — the example
+must show `input._selectedIds`, must not show the no-underscore spelling, must
+show both view-side declarations, and must keep the trap callout. Text-matched
+deliberately, because a fenced code block is prose to `os validate`, `pnpm lint`
+and every metadata assertion in this repo. `test/bulk-action-dispatch.test.ts`
+pins the lead half as one contract: the body reads `ctx.recordId` and no
+undeliverable key, AND the lead list keeps the bare-string wiring that makes
+that read correct — flip either half alone and the button breaks silently, so
+either half alone turns it red. `test/action-sandbox.test.ts` gains the positive
+behaviour nail that was missing: a dispatch carrying only a `recordId` writes
+exactly one `crm_campaign_member` row for that lead.

--- a/docs/developers/code_examples.md
+++ b/docs/developers/code_examples.md
@@ -100,8 +100,11 @@ export const AddLeadsToCampaignAction: Action = {
   label: 'Add to Campaign',
   objectName: 'crm_lead',
   icon: 'send',
-  type: 'modal',
-  target: 'add_leads_to_campaign',
+  // `script` — the body runs on the server. A `type: 'modal'` action has no
+  // server dispatch at all (the renderer just opens its `target`), so a `body`
+  // on one never executes: the runtime refuses it over REST with
+  // `400 … a client-side action with no server dispatch`.
+  type: 'script',
   locations: ['list_toolbar'],
   params: [
     {
@@ -110,13 +113,21 @@ export const AddLeadsToCampaignAction: Action = {
       type: 'lookup',
       required: true,
     },
+    // NOTE: `_selectedIds` is NOT declared here. See "Bulk actions" below.
   ],
   body: {
     language: 'js',
     capabilities: ['api.write'],
     timeoutMs: 10000,
     source: `
-      const ids = Array.isArray(input.selectedIds) ? input.selectedIds : [];
+      // \`input\` IS the action's params bag. An aggregate bulk dispatch puts
+      // the whole selection under the built-in \`_selectedIds\` (leading
+      // underscore) and sends no recordId; a single-record dispatch sends a
+      // recordId and no selection.
+      const selected = Array.isArray(input._selectedIds) ? input._selectedIds : [];
+      const ids = selected.length ? selected : (ctx.recordId ? [ctx.recordId] : []);
+      if (!ids.length) throw new Error('No lead selected');
+
       const campaignId = input.campaign;
       if (!campaignId) throw new Error('Campaign is required');
 
@@ -137,6 +148,67 @@ export const AddLeadsToCampaignAction: Action = {
 ```
 
 Export actions from `src/actions/index.ts` so `objectstack.config.ts` can register them.
+
+### Bulk actions: how a multi-row selection reaches the body
+
+An action does not decide on its own whether it runs once per selected row or
+once for the whole selection. **The list view does**, and the two declarations
+are different dispatch contracts — not two spellings of one thing. Declare the
+one whose shape your body is written for.
+
+| View declaration | Dispatches | Each call carries | Body reads |
+|:---|:---|:---|:---|
+| `bulkActions: ['add_leads_to_campaign']` (bare string) | once **per selected row** — N rows, N requests | that row's `recordId`, **no** selection array | `ctx.recordId` |
+| `bulkActionDefs: [{ name: 'add_leads_to_campaign', operation: 'custom', execution: 'aggregate' }]` | **once** for the whole selection | every selected id in `params._selectedIds`, **no** `recordId` | `input._selectedIds` |
+
+The body above handles both, which is why it reads `_selectedIds` first and
+falls back to `ctx.recordId`. Wire it up in the view:
+
+```typescript
+// src/views/example.view.ts — inside the `list` block
+bulkActionDefs: [
+  { name: 'add_leads_to_campaign', operation: 'custom', execution: 'aggregate' },
+],
+```
+
+`execution: 'aggregate'` is required on an `operation: 'custom'` def and is not
+boilerplate. A custom def without it has no dispatcher: the button ticks green
+once per row and does nothing. The spec rejects that shape at parse time rather
+than letting it ship.
+
+Two more rules the shipped code depends on:
+
+- **Do not declare `_selectedIds` in `params[]`.** It is a *built-in* key
+  (`ACTION_PARAM_BUILTIN_KEYS` in `@objectstack/spec`, alongside `recordId` and
+  `objectName`), injected by the grid renderer and admitted by the params gate
+  without a declaration. Declaring it is not a supported authoring move.
+- **An aggregate run is all-or-nothing.** The selection bar has no per-row
+  retry, so a body that cannot cover the whole selection must throw rather than
+  return a partial count the bar will toast as success.
+
+> ⚠️ **The underscore is load-bearing. `selectedIds` without it is not a
+> synonym — nothing can ever deliver it.**
+>
+> - as a **top-level** request key → never merged into the params bag, so the
+>   body reads `undefined` and your own "nothing selected" guard fires;
+> - under **`params.`** → refused by the strict params gate (ADR-0104) with
+>   `400 Unknown action param "selectedIds" — not declared on this action`.
+>
+> Both refusals are correct, and together they look exactly like "the platform
+> has no multi-select channel". It does; the key is `_selectedIds`. This cost
+> two release candidates in this repo (#508): three rounds of review probed the
+> no-underscore spelling, read the two 400s as proof of a missing capability,
+> and shipped the bulk button removed. See objectstack-ai/objectstack#5568.
+
+The live reference implementation is `mass_update_stage` —
+`src/actions/opportunity.actions.ts` (the body) plus the `bulkActionDefs` entry
+in `src/views/opportunity.view.ts` (the declaration), pinned end to end in
+`test/bulk-action-dispatch.test.ts` and `test/action-sandbox.test.ts`. Read
+those two files together: a body reading `_selectedIds` with no aggregate def in
+the view is just as dead as the misspelling, because nothing injects the key.
+
+`create_campaign` in `src/actions/lead.actions.ts` is the other contract — bare
+string, per-record fan-out — and reads `ctx.recordId` only.
 
 ## Add A Flow
 

--- a/src/actions/lead.actions.ts
+++ b/src/actions/lead.actions.ts
@@ -80,18 +80,52 @@ export const ScheduleFollowUpAction: Action = {
  * Add selected leads to a Campaign.
  *
  * Script-typed action: collects a campaign id (param dialog) then writes one
- * `crm_campaign_member` record per selected lead via the metadata body,
- * skipping leads already on the campaign. Selected ids are surfaced through
- * `input.selectedIds` (populated by the list toolbar) and the chosen
- * campaign through `input.crm_campaign`.
+ * `crm_campaign_member` record for the dispatched lead, skipping leads already
+ * on the campaign. The chosen campaign arrives as `input.crm_campaign`; the
+ * lead arrives as `ctx.recordId`.
+ *
+ * PER-RECORD dispatch, deliberately. `src/views/lead.view.ts` wires this as the
+ * BARE-STRING form — `bulkActions: ['create_campaign']` — and that string is a
+ * dispatch contract, not a spelling of the other one:
+ *
+ *   - bare string    → the renderer promotes the action to a def carrying its
+ *     own label / icon / params / `visible` and dispatches it ONCE PER selected
+ *     row, each call carrying that row's `recordId` and NO selection array. A
+ *     10-lead selection is 10 dispatches through this body, one lead each.
+ *   - `bulkActionDefs` + `execution: 'aggregate'` → ONE dispatch for the whole
+ *     selection, every id in the builtin `params._selectedIds` and no
+ *     `recordId` (see `mass_update_stage` in `opportunity.actions.ts`, #508).
+ *
+ * So multi-select enrollment already works here — it just arrives one lead at a
+ * time. This body reads `ctx.recordId` and nothing else, which is exactly what
+ * the fan-out delivers.
+ *
+ * There is NO `input.selectedIds` read (no underscore), and re-adding one would
+ * be dead code, not a fallback: nothing can deliver that key on either contract
+ * (#813). A top-level `selectedIds` is never merged into the params bag, and a
+ * `params.selectedIds` is refused by the strict params gate (ADR-0104) with
+ * `Unknown action param "selectedIds" — not declared on this action`. The only
+ * selection channel is the underscore-prefixed builtin, and only the aggregate
+ * contract injects it (`@objectstack/spec` `ui/action-params.zod.ts`,
+ * `ACTION_PARAM_BUILTIN_KEYS`; verified end to end in
+ * objectstack-ai/objectstack#5568).
+ *
+ * Switching this action to the aggregate contract would be a PRODUCT change —
+ * one audit entry and one dedupe read per run instead of per lead, and
+ * all-or-nothing failure semantics — so it needs `lead.view.ts` changed with it
+ * and is deliberately not done here (#813).
  */
 export const CreateCampaignAction: Action = {
   name: 'create_campaign',
   label: 'Add to Campaign',
   objectName: 'crm_lead',
   icon: 'send',
-  // script, not modal — modal submits never execute the body in 16.1.0 (the
-  // console resolves `target` as an object name; see ScheduleFollowUpAction).
+  // script, not modal — a `type: 'modal'` action has NO server dispatch at all:
+  // the renderer just opens its `target`, and the runtime refuses it over REST
+  // (`headlessActionTypeError`, 400 "a client-side action with no server
+  // dispatch"), so its `body` never runs. To collect input and then run
+  // server-side, the shape is `type: 'script'` + `params` — the runner collects
+  // the same dialog. See ScheduleFollowUpAction.
   type: 'script',
   body: {
     language: 'js',
@@ -99,17 +133,16 @@ export const CreateCampaignAction: Action = {
       // Value key = the param's field name ('crm_campaign') since the param
       // omits an explicit 'name'. Insert uses the REAL lookup field names on
       // crm_campaign_member (crm_campaign / crm_lead) — not the generic
-      // campaign_id / lead_id from the doc example, which don't exist here and
-      // left crm_campaign null → 'Campaign required' validation failure.
+      // campaign_id / lead_id an earlier revision of the doc example taught,
+      // which don't exist here and left crm_campaign null → 'Campaign required'
+      // validation failure.
       const campaignId = input.crm_campaign ?? null;
       if (!campaignId) throw new Error('create_campaign requires a campaign id');
-      // Selection first, single record as the fallback: console 16.1.0 does
-      // not deliver multi-row selections to actions (the toolbar path rejects
-      // them), so the working invocation today is one lead at a time via the
-      // row menu / a single-row selection. When the runtime starts passing
-      // selectedIds, the bulk path lights up with no further change here.
-      const selected = Array.isArray(input.selectedIds) ? input.selectedIds : [];
-      const ids = selected.length ? selected : (ctx.recordId ? [ctx.recordId] : []);
+      // One lead per dispatch — the bare-string \`bulkActions\` wiring fans this
+      // body out once per selected row (see the note above). \`ids\` stays a
+      // list so the dedupe + skip loop below reads the same on both contracts,
+      // should this action ever move to an aggregate def.
+      const ids = ctx.recordId ? [ctx.recordId] : [];
       if (!ids.length) throw new Error('create_campaign: no lead selected');
       // Skip leads already on this campaign — the modal copy promises
       // duplicates are skipped, and re-running the action on the same
@@ -137,9 +170,13 @@ export const CreateCampaignAction: Action = {
     capabilities: ['api.read', 'api.write'],
     timeoutMs: 10000,
   },
-  // list_item gives every row a working record-scoped entry point; the
-  // toolbar button works for a single-row selection (multi-row selections are
-  // rejected client-side in 16.1.0).
+  // list_item gives every row a working record-scoped entry point. The
+  // list_toolbar button is single-record by construction: with no `_selectedIds`
+  // in the bag the dispatcher resolves a recordId from the grid selection, and a
+  // multi-row selection there is ambiguous, so it is refused client-side with
+  // "This action runs on a single record — select exactly one row."
+  // Multi-lead enrollment is the SELECTION-BAR button instead, which the view's
+  // `bulkActions: ['create_campaign']` produces and which fans out per row.
   locations: ['list_toolbar', 'list_item'],
   params: [
     // Field-backed param: `field` + `objectOverride` make the console resolve

--- a/test/action-sandbox.test.ts
+++ b/test/action-sandbox.test.ts
@@ -458,6 +458,40 @@ describe('every script action body executes under QuickJS', () => {
     expect(engine.rows('crm_contact')[0]!.is_primary).toBe(true);
   });
 
+  /**
+   * The behaviour pin for #813's lead half — deliberately a NON-regression
+   * nail, not a change detector.
+   *
+   * The dead `input.selectedIds` limb removed there was unreachable, so this
+   * body's observable behaviour is identical before and after: the old code
+   * evaluated an empty selection and fell through to the same `ctx.recordId`
+   * path. Restoring the limb therefore leaves this test GREEN, and that is the
+   * point being pinned: behaviour unchanged. What the limb's removal could have
+   * broken is the fan-out path itself, and nothing else asserted that a
+   * dispatch carrying only a recordId actually WRITES a membership row: the
+   * `it.each` smoke case above only checks the body returns something, and the
+   * dedupe case below asserts a row is NOT written. The change-detecting half
+   * lives in `test/bulk-action-dispatch.test.ts`, which goes red if the
+   * no-underscore read (or an aggregate wiring the body cannot serve) returns.
+   */
+  it('create_campaign enrols the dispatched lead from ctx.recordId alone', async () => {
+    // The per-record fan-out shape exactly: `bulkActions: ['create_campaign']`
+    // dispatches once per selected row with that row's recordId and NO
+    // selection array, so the params bag holds the campaign param only.
+    const engine = makeSandboxEngine();
+    const { result } = await runActionBody(action('create_campaign'), {
+      objectName: 'crm_lead',
+      record: { id: 'lead_7' },
+      input: { crm_campaign: 'cmp_1' },
+      engine,
+    });
+
+    expect(result).toMatchObject({ campaignId: 'cmp_1', count: 1, skipped: 0 });
+    const members = engine.rows('crm_campaign_member');
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({ crm_campaign: 'cmp_1', crm_lead: 'lead_7', status: 'sent' });
+  });
+
   it('create_campaign skips a lead already enrolled on the campaign', async () => {
     const engine = makeSandboxEngine({
       crm_campaign_member: [{ id: 'cm_1', crm_campaign: 'cmp_1', crm_lead: 'lead_1' }],

--- a/test/bulk-action-dispatch.test.ts
+++ b/test/bulk-action-dispatch.test.ts
@@ -153,3 +153,82 @@ describe('bulk dispatch is declared the way the renderer reads it', () => {
       .not.toContain('_selectedIds');
   });
 });
+
+/**
+ * The OTHER contract, pinned on the app's only bare-string wiring (#813).
+ *
+ * `create_campaign` is wired as `bulkActions: ['create_campaign']` on the lead
+ * list — the per-record fan-out. The renderer promotes the action to a def
+ * carrying its own label / icon / params / `visible` and dispatches it ONCE PER
+ * selected row, each call carrying that row's `recordId` and no selection
+ * array. So the body's whole input is `ctx.recordId`, and multi-lead enrolment
+ * already works: it just arrives one lead at a time.
+ *
+ * Until #813 that body also carried `const selected = Array.isArray(
+ * input.selectedIds) ? input.selectedIds : [];` with a `ctx.recordId` fallback
+ * behind it. The limb never executed — nothing delivers a no-underscore
+ * `selectedIds` on EITHER contract — and its comment promised, in the present
+ * tense, that "when the runtime starts passing selectedIds the bulk path lights
+ * up". It would not have. The limb is gone; these pin why it must not come back
+ * AND the wiring the surviving body depends on.
+ *
+ * The two halves are one test on purpose: `ctx.recordId` is correct *because*
+ * the view uses the bare string. Move the lead list to an aggregate def and the
+ * body stops receiving a recordId at all — every dispatch would answer "no lead
+ * selected". Whichever half changes, this goes red rather than the button.
+ */
+describe('create_campaign is the per-record fan-out, body and wiring agreeing (#813)', () => {
+  const leadLists = () => {
+    const leadView = views.find((v) => (v.list?.data?.object ?? v.object) === 'crm_lead');
+    expect(leadView, 'no crm_lead view').toBeTruthy();
+    return listsOf(leadView!);
+  };
+
+  it('the lead list wires it as a bare string, not an aggregate def', () => {
+    const lists = leadLists();
+    const wiredBare = lists.some((l) => (l.bulkActions ?? []).includes('create_campaign'));
+    expect(
+      wiredBare,
+      'the lead list no longer names create_campaign in `bulkActions`. That bare string IS the '
+        + "per-record contract the body is written for — it reads `ctx.recordId` and nothing else. "
+        + 'Dropping it removes multi-lead enrolment from the selection bar; replacing it with an '
+        + 'aggregate def sends the whole selection in `_selectedIds` and NO recordId, so every '
+        + 'dispatch would throw "no lead selected" (#813).',
+    ).toBe(true);
+
+    const aggregateDefs = lists.flatMap((l) =>
+      ((l.bulkActionDefs ?? []) as AnyRec[]).filter((d) => d?.name === 'create_campaign'),
+    );
+    expect(
+      aggregateDefs,
+      'create_campaign is declared as a bulk DEF on the lead list while its body still reads '
+        + '`ctx.recordId`. Moving it to `execution: \'aggregate\'` is a product decision (one '
+        + 'audit entry and one dedupe read per run instead of per lead, plus all-or-nothing '
+        + 'failure semantics) and requires the body to read `input._selectedIds` in the same '
+        + 'change — see `mass_update_stage` for the finished shape.',
+    ).toEqual([]);
+  });
+
+  it('the body reads ctx.recordId and no undeliverable selection key', () => {
+    const createCampaign = actions.find((a) => a.name === 'create_campaign');
+    expect(createCampaign, 'create_campaign is not defined').toBeTruthy();
+    const source = String(createCampaign!.body?.source ?? '');
+
+    expect(
+      source.includes('ctx.recordId'),
+      'the create_campaign body no longer reads `ctx.recordId` — the per-record fan-out delivers '
+        + 'the lead under exactly that key and carries no selection array',
+    ).toBe(true);
+
+    // Boundary-matched so an `input._selectedIds` read (which would be correct
+    // only alongside an aggregate def, guarded above) does not trip this.
+    expect(
+      /(?<![\w$])input\.selectedIds\b/.test(source),
+      'the create_campaign body reads `input.selectedIds` (no underscore) again. It is not a '
+        + 'fallback and not a forward-compatible limb: on the fan-out contract nothing delivers '
+        + 'any selection array, and on the aggregate contract the key is `_selectedIds`. Top-level '
+        + 'it is never merged into the params bag; under `params.` the strict gate answers 400 '
+        + '`Unknown action param "selectedIds"` (#813).',
+    ).toBe(false);
+  });
+});

--- a/test/docs-drift.test.ts
+++ b/test/docs-drift.test.ts
@@ -590,3 +590,84 @@ describe('translated docs pages keep the English page callouts', () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * The developer example must teach the DELIVERABLE selection key (#813).
+ *
+ * `docs/developers/code_examples.md` is the copy-paste surface for the next
+ * author of an action — human or AI — and its "Add An Action" example was a
+ * bulk enrolment body reading `input.selectedIds`. That key cannot arrive by
+ * any route: a top-level `selectedIds` is never merged into the params bag, and
+ * a `params.selectedIds` is refused by the strict params gate (ADR-0104) as
+ * undeclared. The only multi-select channel is the built-in `_selectedIds`,
+ * with a LEADING UNDERSCORE (`ACTION_PARAM_BUILTIN_KEYS` in `@objectstack/spec`
+ * `ui/action-params.zod.ts`), injected by an `execution: 'aggregate'` bulk def.
+ *
+ * This is not a style pin. #508 spent two release candidates concluding the
+ * platform had no multi-select channel, because every probe spelled the key the
+ * way this example spells it, and both refusals looked like proof. The example
+ * is where that conclusion gets re-manufactured, so it is where the guard goes.
+ *
+ * Pinned as text, deliberately: the example is prose to `os validate`, `pnpm
+ * lint` and every metadata assertion in this repo — nothing else in the gate
+ * chain reads a fenced code block at all.
+ */
+describe('the action example teaches a selection key the platform can deliver (#813)', () => {
+  const EXAMPLES = 'docs/developers/code_examples.md';
+  const text = () => readFileSync(join(REPO_ROOT, EXAMPLES), 'utf8');
+
+  it('reads the built-in `input._selectedIds`, never the undeliverable spelling', () => {
+    const src = text();
+    expect(
+      src.includes('input._selectedIds'),
+      `${EXAMPLES} no longer shows \`input._selectedIds\` — that built-in key is the only route a `
+        + 'multi-row selection has to an action body, so an example that omits it teaches the gap '
+        + 'that cost #508 two release candidates',
+    ).toBe(true);
+
+    // Boundary-matched so `input._selectedIds` itself does not trip it — the
+    // same guard `test/bulk-action-dispatch.test.ts` applies to the shipped
+    // opportunity body, applied here to the teaching copy of it.
+    const noUnderscore = [...src.matchAll(/(?<![\w$])input\.selectedIds\b/g)];
+    expect(
+      noUnderscore.length,
+      `${EXAMPLES} still teaches \`input.selectedIds\` (no underscore) in ${noUnderscore.length} `
+        + 'place(s). Nothing can deliver that key: top-level it is never merged into the params '
+        + 'bag, and under `params.` the strict gate answers 400 `Unknown action param '
+        + '"selectedIds"`. Both refusals read as "the platform has no bulk channel" — which is '
+        + 'exactly the wrong lesson (#813).',
+    ).toBe(0);
+  });
+
+  it('shows the view-side declaration that injects the key, and names the underscore trap', () => {
+    const src = text();
+    // Half a contract teaches a dead body. A handler reading `_selectedIds`
+    // with no aggregate def in the view is injected nothing and is just as
+    // inert as the misspelling — which is precisely how #508's button looked
+    // dead while the channel worked (#588 had removed the declaration).
+    for (const required of ['bulkActionDefs', "execution: 'aggregate'", 'bulkActions']) {
+      expect(
+        src.includes(required),
+        `${EXAMPLES} does not show \`${required}\`. The action body is only half the bulk `
+          + 'contract: the LIST VIEW chooses whether the action is dispatched once per row '
+          + '(bare-string `bulkActions`) or once for the whole selection (an aggregate '
+          + '`bulkActionDefs` entry, which is what injects `_selectedIds`).',
+      ).toBe(true);
+    }
+
+    // The trap itself, in a `> …` callout — the shape this repo's docs use for
+    // "someone already fell into this". Prose that merely uses the right key
+    // teaches the spelling; the callout is what stops the next reader
+    // re-deriving "there is no bulk channel" from two correct 400s.
+    const callout = src
+      .split('\n')
+      .filter((l) => /^>/.test(l))
+      .join('\n');
+    expect(
+      callout.includes('Unknown action param'),
+      `${EXAMPLES} has no callout naming the \`Unknown action param "selectedIds"\` refusal. That `
+        + '400 and the silent top-level drop are the two pieces of evidence #508 misread as '
+        + 'proof the capability did not exist; the example is where that misreading is prevented.',
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #813

## Description

#813 的两个落点是同一条事实的两半：**教学面**（docs 示例）与**代码面**（`lead.actions.ts` 的休眠死枝）。教学面是更值得修的一半——#508 之所以耗掉两个 RC，正是因为三轮复核都在试这个示例教的那个拼法。

前提逐条复核过（基线含刚合并的 #815）：

| 前提 | 复核结果 |
|:---|:---|
| `docs/developers/code_examples.md:119` 仍教 `input.selectedIds` | ✅ 仍在 |
| `src/actions/lead.actions.ts:111` 死枝仍在 | ✅ 仍在 |
| `create_campaign` 接线仍是裸字符串 fan-out | ✅ `src/views/lead.view.ts:178` `bulkActions: ['create_campaign']` |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## 平台侧依据（读源码复核，不是转述 #815）

两套派发契约的差别在 objectui + spec 的源码里是明写的，本 PR 的每句教学都对着它写：

- **裸字符串 `bulkActions: ['x']`** — `resolveBulkActions.ts` 的 `toBulkActionDef()` 把 action 提升成 `{ operation: 'custom', actionDef: action, batchSize }`（**无** `execution`），于是 `useBulkExecutor` 的 `isAggregate` 为 false，走 `perRow` → `ObjectGrid.runBulkActionRecord` → `executeAction({ params: { ...params, _rowRecord: row } })`。`serverActionHandler` 剥掉 `_rowRecord`、由它解析出 `recordId`，POST `{ recordId, params }`。**每行一次请求，各带 `recordId`，不带任何选择集数组。**
- **aggregate def** — `runBulkActionAggregate` → `executeAction({ params: { ...params, _selectedIds: ids } })`；`resolveServerActionRecordId` 见到 `_selectedIds` 是数组即判定为 aggregate dispatch，**不**从选择集解析 recordId。**一次请求，带全部 id，不带 `recordId`。**
- **`_selectedIds` 是内建键** — `@objectstack/spec` `ui/action-params.zod.ts`：`ACTION_PARAM_BUILTIN_KEYS = ['recordId', 'objectName', '_selectedIds']`，未声明也放行；未在此列的键一律 `Unknown action param "&lt;key&gt;" — not declared on this action`。
- **`input` 就是 params 袋** — `@objectstack/runtime` `dist/index.js:1292`：`input: unwrapProxyToPlain(actionCtx?.params ?? {})`。

## Changes Made

### docs 半 — `docs/developers/code_examples.md`

- 示例 body 改读 `input._selectedIds`（内建键，前导下划线），`ctx.recordId` 兜底；**未**把 `_selectedIds` 声明进 `params[]`（内建键，声明不了也不需要，示例里留了一行 NOTE 说明）。
- 新增 **"Bulk actions: how a multi-row selection reaches the body"** 一节：一张表把两套契约的「派发几次 / 每次带什么 / body 读什么」并排列出，外加视图侧 `bulkActionDefs` 的代码块。理由写进正文——**handler 只是契约的一半**：body 读 `_selectedIds` 而视图没有 aggregate def，跟拼错一样死，这正是 #508 里按钮看着像死的那个形态（#588 摘掉了声明）。
- `execution: 'aggregate'` 不是样板：custom def 缺它没有 dispatcher，按钮逐行打绿勾、零工作，spec 在 parse 阶段就拒。
- ⚠️ **陷阱 callout**：无下划线的 `selectedIds` 不是同义词——顶层不并进 params 袋（body 读到 `undefined`，作者自己的守卫先响），`params.` 下被严格参数门 400 拒掉。两条 400 都正确，合起来正好像「没有多选通道」。callout 里点名 #508 与 objectstack-ai/objectstack#5568。
- 范例指向 #815 落地的 `mass_update_stage`（body + 视图声明 + 两个测试文件），并点明 `create_campaign` 是另一套契约。

**另外两处不修就跑不起来的**：示例原本是 `type: 'modal'` 却带 `body`——modal 动作根本没有服务端派发（渲染器只开 `target`，runtime 以 `headlessActionTypeError` 400 拒绝 `a client-side action with no server dispatch`），那个 body 永远不会执行。改为 `type: 'script'`，多余的 `target` 一并去掉（`resolveActionHandlerKeys`：有 `body` 时 primary key 就是 `name`）。示例的职责是给下一个作者一份能跑的模板，留着 `type: 'modal'` 等于「修好了拼法，示例照样不工作」。

### lead 半 — `src/actions/lead.actions.ts`（**行为不变**）

死枝删除，`const ids = ctx.recordId ? [ctx.recordId] : [];`。原注释以现在时承诺「runtime 开始传 selectedIds 时 bulk 路径就会亮起来」——按那个拼法，两套契约上都不会；时态与事实一并订正。`ids` 保留成数组，去重/skip 循环与返回形状（`count` / `skipped` / `ids`）逐字未变。

⛔ **未**改 `create_campaign` 走 aggregate——那是产品选择（每次运行一条审计、一次去重读，而不是每 lead 一次；外加 all-or-nothing 失败语义），且必须与 `lead.view.ts` 同批改，不在本单。

顺带订正了同一 action 里两句因本 PR 而失真的注释：modal 的机制说明（旧说法是 16.1.0 的 target 解析，实际是 runtime 的 400），以及「doc example 教的 campaign_id / lead_id」（改成「an earlier revision of the doc example」，因为本 PR 之后示例不再那样写）。

## Testing

- [x] `pnpm validate` exit 0（warning 全为既有 approval / campaign_member 提示）
- [x] `pnpm typecheck` exit 0
- [x] `pnpm lint` exit 0 — 13 warning / 14 suggestion，与 #815 报告的既有集合一致
- [x] `pnpm hygiene` clean — 含 `no raw control bytes in source files`；另做过自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 覆盖全部改动文件，零命中
- [x] `pnpm build` exit 0（`dist/objectstack.json` 1921.3 KB）
- [x] `pnpm test`（`vitest run --maxWorkers=2`）：**64 files / 1553 passed, 1 skipped**
- [x] New tests added

### 新增钉子

- **`test/docs-drift.test.ts`** — 教学面守卫：示例必须出现 `input._selectedIds`、不得出现无下划线拼法（带边界，`input._selectedIds` 自己不误伤）、必须同时展示 `bulkActionDefs` / `execution: 'aggregate'` / `bulkActions`、必须保留点名 `Unknown action param` 的 `>` callout。**刻意按文本匹配**：围栏代码块对 `os validate`、`pnpm lint` 和本仓每一条 metadata 断言都只是散文，没有别的门看得见它。
- **`test/bulk-action-dispatch.test.ts`** — 把 lead 半钉成**一个**契约而不是两条独立断言：body 读 `ctx.recordId` 且不读不可投递的键，**且** lead 列表保持裸字符串接线（正是它让那个读法正确）。单独改任一半都会静默弄坏按钮，所以单独改任一半都变红。放这个文件是按规则的消费半径选的——它就是 #815 建来专管 bulk 派发契约的那个文件。
- **`test/action-sandbox.test.ts`** — 补上此前缺的**正向**行为钉：只带 `recordId` 的一次派发确实写入一行 `crm_campaign_member`（既有的 `it.each` 只断言 body 有返回值，既有的去重用例断言的是**不**写）。

### 反向验证（方向先声明后执行，5 条全部如预期）

| # | 反向改动 | 预声明方向 | 实测 |
|:--|:---|:---|:---|
| R1 | 把死枝放回 `lead.actions.ts` | `bulk-action-dispatch` 红；`action-sandbox` 保持**绿** | ✅ 正是如此 — dispatch 红 1 条，sandbox 85 条全绿 |
| R2 | 示例改回 `input.selectedIds` | docs-drift 红 | ✅ 红（`no longer shows input._selectedIds`） |
| R2b | **保留**正确拼法、另加一处无下划线读法 | docs-drift 红（计数断言） | ✅ 红，报 `2 place(s)`；边界 lookbehind 确认不误伤 `_selectedIds` |
| R3 | lead 列表换成 aggregate def | dispatch 红 | ✅ 红 |
| R3b | **保留**裸字符串、并列加 aggregate def | dispatch 红（第二条断言） | ✅ 红 — 单独隔离验过，避免被前一条断言遮住 |
| R4 | 删掉 docs 的 callout | docs-drift 红 | ✅ 红 — 确认 callout 断言不是 phantom check |

**R1 的方向值得单说，它不是「红」而是「一红一绿，且绿是证据」**：把死枝放回去，`bulk-action-dispatch` 的文本钉如期变红，而 `action-sandbox` 里 `create_campaign` 的三条 engine 级用例**全部保持绿**。这恰恰是本单的论点本身——那条枝不可达，删掉它对运行时行为零影响。所以 `action-sandbox` 新增的那条正向钉**按设计就不是变更检测器**，它是非回归钉；测试的 doc 注释里把这一点写明了，没有伪装成红。

R2 与 R2b 分开跑，是因为两条断言在同一个 `it` 里，第一条失败会遮住第二条；R3 / R3b 同理（沿用 #815 复核里那条经验）。

## 边界

未升降任何 `@objectstack/*`；未动平台代码；未动 `content/docs/releases/`；未动 `opportunity.view.ts` / `opportunity.actions.ts`（#815 刚收口）；`src/views/lead.view.ts` 仅在反向验证时临时改过并已还原，最终 diff 里没有它。

界外发现另立 **#821**（示例的 `type: 'lookup'` 参数既无 `reference` 也无 `field`+`objectOverride`，渲染成粘贴 ID 文本框——与本单是不同的事实：本单讲选择集怎么到达 body，那条讲参数控件怎么解析出 picker）。已按 #4949 先搜后立，未打 label、未 assign。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_