### PR TITLE
chore(hygiene): 控制字节扫描面扩到 content/ 与 .changeset/，其余三关按关分树 (#818)

### DIFF
--- a/.changeset/hygiene-control-bytes-content-and-changesets.md
+++ b/.changeset/hygiene-control-bytes-content-and-changesets.md
@@ -1,0 +1,40 @@
+---
+---
+
+Extend the source hygiene gate's control-byte scan to `content/` and
+`.changeset/`, the two first-party text trees it could not see (#818).
+
+The scan added in #686 read `src`, `test`, `e2e` and `scripts` — the same
+directory list the three code-level checks use. That list is right for them and
+wrong for a byte-level check: `content/` holds every product documentation page
+in three locales, `.changeset/` holds a file that every PR is required to add,
+and both are pure text. #807 changed four files and this gate judged one of
+them.
+
+The gap matters because of how the defect hides. One raw control byte makes
+grep and ripgrep classify the entire file as binary: `grep -rn` answers
+`binary file matches` instead of line hits, and the `-l` / `-c` forms most
+sweeps use report nothing at all. `content/` is one of the most grep-ed trees
+in the repo and the read surface of several documentation guards, which read it
+with `readFileSync` — and `readFileSync` does not care about control bytes at
+all. So the first thing to break is not CI, it is the ability of a human or an
+agent to find anything in that file.
+
+Only the control-byte check moves. The other three keep their existing surface,
+which was measured rather than assumed: `console.log` is already `src/`-only
+and appears legitimately in the docs — the three marketplace
+`publishing-your-first-app` pages instruct the reader to run
+`node -e "console.log(...)"` — the marker check reads `.ts` files and these two
+trees contain none, and the 100KB cap's remedy — "split the file" — is a review
+argument about modules that does not transfer to documentation pages. Whether
+docs want a size ceiling is a separate question (#814), not a silent side
+effect of this change.
+
+Both trees were already clean, so the gate lands green; the byte scan's surface
+roughly triples (244 code files, plus 379 under the two text trees).
+`test/source-hygiene-scan-surface.test.ts` pins both
+halves of the split — that a control byte under `content/` or `.changeset/` is
+now reported with file, line, byte value and column, and that the other three
+checks did **not** widen with it.
+
+Tooling only — no CRM metadata changes, nothing ships to users.

--- a/scripts/check-source-hygiene.mjs
+++ b/scripts/check-source-hygiene.mjs
@@ -21,6 +21,10 @@
  * bodies that the runtime executes. Diagnostics there belong on `ctx.logger`,
  * which is why `console.log` is banned. `scripts/` is deliberately NOT scanned
  * for `console.log` — those files are CLIs whose entire job is stdout.
+ *
+ * The checks do not all read the same tree, and that is deliberate — see
+ * `SCANNED` and `TEXT_SCANNED` below. Three checks judge code; the byte-level
+ * one judges first-party text wherever it lives (#818).
  */
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
@@ -90,10 +94,11 @@ const CONTROL_BYTE = /[\u0000-\u0008\u000b\u000c\u000e-\u001f]/;
  * carried a raw NUL as a key separator for months for exactly this reason; the
  * separator was fine, its spelling was not.
  *
- * Scans every file under the scanned directories, not just `.ts` — the hazard
- * is about the bytes on disk, not the language. Those directories hold text
- * only; a binary fixture arriving there should fail loudly and be an explicit
- * decision, not something a silent skip-list absorbs.
+ * Scans every file under the widest surface this script reads — `SCANNED` plus
+ * `TEXT_SCANNED` — and not just `.ts`: the hazard is about the bytes on disk,
+ * not the language, so it follows first-party text rather than code. Those
+ * directories hold text only; a binary fixture arriving there should fail
+ * loudly and be an explicit decision, not something a silent skip-list absorbs.
  *
  * Read as `latin1` so each byte maps 1:1 to a code point. utf8 decoding folds
  * an invalid byte into U+FFFD, which sits outside the control range and would
@@ -131,11 +136,47 @@ function check(name, hits, remedy) {
   failures.push(name);
 }
 
-// The directories these checks are guarding. A typo here (or a directory that
-// gets renamed out from under us) must be loud, not silently vacuous — that is
-// the exact failure mode this script exists to fix.
+// The code directories these checks are guarding. A typo here (or a directory
+// that gets renamed out from under us) must be loud, not silently vacuous —
+// that is the exact failure mode this script exists to fix.
 const SCANNED = ['src', 'test', 'e2e', 'scripts'];
-const missing = SCANNED.filter((d) => {
+
+/**
+ * First-party text trees read by the control-byte check, and ONLY by it (#818).
+ *
+ * `content/` (the product docs, three locales) and `.changeset/` (a file every
+ * PR must add) are pure text and among the most grep-ed trees in the repo, yet
+ * they sat outside every check: #807 touched four files and this gate saw one
+ * of them. The hazard the byte scan guards is about the bytes on disk, so its
+ * surface is "first-party text", not "code".
+ *
+ * The other three checks stay on `SCANNED`. That split is measured, not
+ * assumed — as of this change, over `content/` + `.changeset/`:
+ *
+ *   - `console.log` is already `src/`-only, and docs legitimately print it:
+ *     `content/docs/marketplace/publishing-your-first-app*.mdx` instruct the
+ *     reader to run `node -e "console.log(...)"` (3 occurrences). Widening
+ *     that check here would be wrong, not merely noisy.
+ *   - `TODO`/`FIXME` filters to `.ts`, and these two trees hold none of it
+ *     (201 `.mdx` + 137 `.md` + 40 `.json`, zero `.ts`). Widening would guard
+ *     nothing while reading, to the next maintainer, as if prose were covered.
+ *   - the 100KB cap would newly constrain documentation pages. Nothing is over
+ *     it today (largest: 15KB, `content/docs/administration/
+ *     sharing-and-security.zh-Hant.mdx`), but its remedy — "split the file" —
+ *     is a review argument about modules that does not transfer to prose, and
+ *     whether docs want a size ceiling belongs to #814, not to a silent
+ *     side effect of this one.
+ *
+ * Both trees are text-only today (no file outside `.mdx` / `.md` / `.json`;
+ * doc screenshots live in `assets/screenshots/` and are referenced by URL). A
+ * binary arriving here should fail loudly and be an explicit decision — the
+ * same rule the code trees already live under.
+ */
+const TEXT_SCANNED = ['content', '.changeset'];
+
+/** Every directory this script reads, in either surface. */
+const ALL_SCANNED = [...SCANNED, ...TEXT_SCANNED];
+const missing = ALL_SCANNED.filter((d) => {
   try {
     return !statSync(join(ROOT, d)).isDirectory();
   } catch {
@@ -144,16 +185,20 @@ const missing = SCANNED.filter((d) => {
 });
 if (missing.length) {
   console.error(`✗ source hygiene: scanned director(y|ies) missing: ${missing.join(', ')}`);
-  console.error('  Update SCANNED in scripts/check-source-hygiene.mjs — a check that');
-  console.error('  scans nothing is worse than no check at all.');
+  console.error('  Update SCANNED / TEXT_SCANNED in scripts/check-source-hygiene.mjs —');
+  console.error('  a check that scans nothing is worse than no check at all.');
   process.exit(1);
 }
 
-const allFiles = SCANNED.flatMap(walk);
-const allTs = allFiles.filter(isTs);
+const codeFiles = SCANNED.flatMap(walk);
+const textFiles = TEXT_SCANNED.flatMap(walk);
+const allTs = codeFiles.filter(isTs);
 const srcTs = allTs.filter((f) => f.startsWith('src/'));
 
-console.log(`Source hygiene — ${allFiles.length} files under ${SCANNED.join(', ')}\n`);
+console.log(
+  `Source hygiene — ${codeFiles.length} files under ${SCANNED.join(', ')}; ` +
+    `the control-byte scan adds ${textFiles.length} under ${TEXT_SCANNED.join(', ')}\n`,
+);
 
 check(
   'no console.log in src/',
@@ -168,14 +213,14 @@ check(
 );
 
 check(
-  'no raw control bytes in source files',
-  scanControlBytes(allFiles),
+  'no raw control bytes in first-party files',
+  scanControlBytes([...codeFiles, ...textFiles]),
   'write the character as an escape sequence (\\u0000 for NUL) — byte-identical at runtime, and it keeps the file findable by grep',
 );
 
 check(
   `no source file over ${MAX_FILE_BYTES / 1024}KB`,
-  allFiles
+  codeFiles
     .filter((f) => statSync(join(ROOT, f)).size > MAX_FILE_BYTES)
     .map((f) => ({
       file: f,

--- a/scripts/check-source-hygiene.mjs
+++ b/scripts/check-source-hygiene.mjs
@@ -161,11 +161,11 @@ const SCANNED = ['src', 'test', 'e2e', 'scripts'];
  *     (201 `.mdx` + 137 `.md` + 40 `.json`, zero `.ts`). Widening would guard
  *     nothing while reading, to the next maintainer, as if prose were covered.
  *   - the 100KB cap would newly constrain documentation pages. Nothing is over
- *     it today (largest: 15KB, `content/docs/administration/
- *     sharing-and-security.zh-Hant.mdx`), but its remedy — "split the file" —
- *     is a review argument about modules that does not transfer to prose, and
- *     whether docs want a size ceiling belongs to #814, not to a silent
- *     side effect of this one.
+ *     it today — the largest is 15KB:
+ *     `content/docs/administration/sharing-and-security.zh-Hant.mdx` — but its
+ *     remedy, "split the file", is a review argument about modules that does
+ *     not transfer to prose, and whether docs want a size ceiling belongs to
+ *     #814, not to a silent side effect of this one.
  *
  * Both trees are text-only today (no file outside `.mdx` / `.md` / `.json`;
  * doc screenshots live in `assets/screenshots/` and are referenced by URL). A

--- a/test/source-hygiene-scan-surface.test.ts
+++ b/test/source-hygiene-scan-surface.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { REPO_ROOT } from './helpers/repo-root';
+
+/**
+ * `scripts/check-source-hygiene.mjs` scan-surface guard (#818).
+ *
+ * The gate runs four checks over two different trees, and the split is the part
+ * that silently rots: a check whose directory list no longer covers the files
+ * people write is not red, it is *vacuous* — exactly the failure the script was
+ * written to end. Before #818 the control-byte scan read `src/test/e2e/scripts`
+ * only, so `content/` (all product docs) and `.changeset/` (a file every PR
+ * adds) were invisible to it; #807 changed four files and the gate saw one.
+ *
+ * The three code-level checks deliberately did NOT move with it — `console.log`
+ * is legitimate prose in the marketplace docs, the marker check reads `.ts`
+ * (of which those trees have none), and the 100KB cap's remedy ("split the
+ * file") is a review argument about modules, not documentation pages (#814).
+ * Both halves are pinned below: widening the byte scan is asserted, and NOT
+ * widening the other three is asserted just as explicitly, so a later change to
+ * either is a deliberate edit to this file rather than an accident.
+ *
+ * Mechanics: the script derives its repo root from its own location
+ * (`new URL('..', import.meta.url)`), so copying it into `<sandbox>/scripts/`
+ * makes a throwaway directory its root. That runs the real, unmodified script
+ * against fixtures we control, without adding a test-only seam to production
+ * tooling and without ever writing a control byte into the real tree.
+ */
+
+/** Trees the three code-level checks judge. */
+const CODE_TREES = ['src', 'test', 'e2e', 'scripts'];
+
+/** Trees only the control-byte check judges. */
+const TEXT_TREES = ['content', '.changeset'];
+
+const GATE = 'scripts/check-source-hygiene.mjs';
+
+/**
+ * Assembled at runtime on purpose: this file is itself scanned by the gate's
+ * marker check, and spelling the marker literally would fail the very check it
+ * is here to exercise.
+ */
+const MARKER = ['TO', 'DO'].join('');
+
+/**
+ * The bytes under test, built from their code points instead of being spelled
+ * into this file. Every fixture byte is materialised at run time inside a
+ * temporary directory, so no file in this repository — least of all the one
+ * arguing about control bytes — ever holds one, and no editor or agent writing
+ * here has to round-trip a literal byte. Both are present because the gate
+ * guards the whole class, not just NUL.
+ */
+const NUL = String.fromCharCode(0x00);
+const SOH = String.fromCharCode(0x01);
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'hygiene-surface-'));
+  for (const dir of [...CODE_TREES, ...TEXT_TREES]) mkdirSync(join(root, dir), { recursive: true });
+  copyFileSync(join(REPO_ROOT, GATE), join(root, GATE));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function write(rel: string, contents: string): void {
+  const path = join(root, rel);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}
+
+/** Run the gate against the sandbox root; never throws. */
+function runGate(): { status: number; output: string } {
+  try {
+    const stdout = execFileSync(process.execPath, [join(root, GATE)], { encoding: 'utf8' });
+    return { status: 0, output: stdout };
+  } catch (error) {
+    const failure = error as { status?: number; stdout?: string; stderr?: string };
+    return {
+      status: failure.status ?? -1,
+      output: `${failure.stdout ?? ''}${failure.stderr ?? ''}`,
+    };
+  }
+}
+
+describe('source hygiene — scan surface', () => {
+  it('passes on a clean tree (the harness is not vacuously red)', () => {
+    write('content/docs/guide.mdx', '# Guide\n\nOrdinary prose.\n');
+    write('.changeset/entry.md', '---\n---\n\nOrdinary changeset.\n');
+
+    const { status, output } = runGate();
+    expect(status).toBe(0);
+    expect(output).toContain('source hygiene clean');
+    // The header names the byte-scan trees, so a reader of a red run can tell
+    // which surface produced the finding.
+    expect(output).toContain('content, .changeset');
+  });
+
+  it('reports a control byte under content/, naming the file, byte and column', () => {
+    write('content/docs/guide.mdx', `# Guide\n\nbefore${SOH}after\n`);
+
+    const { status, output } = runGate();
+    expect(status).toBe(1);
+    expect(output).toContain('content/docs/guide.mdx:3');
+    expect(output).toContain('control byte 0x01 at column 7');
+    expect(output).toContain('no raw control bytes');
+  });
+
+  it('reports a raw NUL under .changeset/', () => {
+    write('.changeset/entry.md', `---\n---\n\nkey${NUL} value\n`);
+
+    const { status, output } = runGate();
+    expect(status).toBe(1);
+    expect(output).toContain('.changeset/entry.md:4');
+    expect(output).toContain('control byte 0x00 at column 4');
+  });
+
+  it('still reports a control byte under the original code trees', () => {
+    write('src/probe.ts', `export const separator = "a${NUL}b";\n`);
+
+    const { status, output } = runGate();
+    expect(status).toBe(1);
+    expect(output).toContain('src/probe.ts:1');
+    expect(output).toContain('control byte 0x00');
+  });
+
+  it('does not extend the console.log, marker or size checks to the text trees', () => {
+    // All three would be violations if the code-level checks had been widened:
+    // a documented CLI one-liner that prints, a marker in a stray .ts file, and
+    // a page well past the 100KB cap.
+    write('content/docs/publishing.mdx', '# Publishing\n\n```bash\nnode -e "console.log(1)"\n```\n');
+    write('content/stray.ts', `export const x = 1; // ${MARKER}: not judged here\nconsole.log(x);\n`);
+    write('content/docs/huge.mdx', `${'x'.repeat(120 * 1024)}\n`);
+
+    const { status, output } = runGate();
+    expect(status).toBe(0);
+    expect(output).toContain('source hygiene clean');
+  });
+
+  it('keeps applying the size cap inside the code trees', () => {
+    write('src/huge.ts', `export const x = "${'y'.repeat(120 * 1024)}";\n`);
+
+    const { status, output } = runGate();
+    expect(status).toBe(1);
+    expect(output).toContain('src/huge.ts');
+    expect(output).toContain('over 100KB');
+  });
+
+  it('fails loudly when a scanned tree is absent, text trees included', () => {
+    for (const dir of TEXT_TREES) {
+      rmSync(join(root, dir), { recursive: true, force: true });
+
+      const { status, output } = runGate();
+      expect(status).toBe(1);
+      expect(output).toContain(`missing: ${dir}`);
+
+      mkdirSync(join(root, dir), { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #818

## 前提复核（基线 origin/main = 4c127919）

| issue 说法 | 复核结果 |
| --- | --- |
| `scripts/check-source-hygiene.mjs:137` 的 `SCANNED = ['src','test','e2e','scripts']` | 成立，逐字一致 |
| 控制字节那一关（同文件 `:170`）用的就是这个目录集 | 成立，`scanControlBytes(allFiles)`，而 `allFiles = SCANNED.flatMap(walk)` |
| `content/` 与 `.changeset/` 完全在扫描面外 | 成立 |
| 两棵树今天零命中 | 成立，落地前重扫一次：`grep -rnaP '[\x00-\x08\x0b\x0c\x0e-\x1f]' content/ .changeset/` 零命中 |
| 100KB 上限走 `allFiles`，扩面会连带约束文档页 | 成立——这正是本 PR 按关分树而不是一刀切的原因 |
| `TODO/FIXME` 只作用于 `allTs`，mdx 不受影响 | 成立，且**比 issue 说的更彻底**：两棵树里一个 `.ts` 都没有，扩它是空扩 |

注：仓库共享 checkout 当时停在另一分支的旧版脚本（只有三关），复核一律以 `origin/main` 为准。

## 改了什么

`scripts/check-source-hygiene.mjs` 一处结构调整：把「扫哪些目录」从一个列表拆成两个，**只有控制字节那一关吃更宽的那个**。

```
const SCANNED      = ['src', 'test', 'e2e', 'scripts'];   // 三关代码检查
const TEXT_SCANNED = ['content', '.changeset'];           // 仅控制字节这一关追加
const ALL_SCANNED  = [...SCANNED, ...TEXT_SCANNED];       // 目录缺失预检查覆盖两者
```

- `allFiles` 更名 `codeFiles`（语义不再是「全部」），三关代码检查的取面**逐字未变**。
- 控制字节关取 `[...codeFiles, ...textFiles]`。
- 目录缺失预检查扩到 `ALL_SCANNED`——新加的两棵树被改名或写错，同样要吵，不能静默变空。
- 表头行现在自报两个面：`244 files under src, test, e2e, scripts; the control-byte scan adds 379 under content, .changeset`，读红报告的人一眼知道命中来自哪个面。
- 该关的名字由 `no raw control bytes in source files` 改为 `... in first-party files`——命中会打印 `content/docs/*.mdx`，旧名字读起来对不上。

## 其余三关为什么不跟着扩：先实测，再定

| 关 | 实测（`content/` + `.changeset/`，共 378 个文件） | 处置 |
| --- | --- | --- |
| `console.log` | **会误伤**：三个 marketplace `publishing-your-first-app` 页正文让读者执行 `node -e "console.log(...)"`，共 3 处合法出现 | 不扩（它本来还额外限定 `src/` 前缀，扩了也够不着，但语义方向本身就是错的） |
| `TODO`/`FIXME` | **空扩**：该关过滤 `.ts`，两棵树里 201 个 mdx、137 个 md、40 个 json，`.ts` 为 0 | 不扩——扩了一条守不住任何东西的关，只会让下一个维护者以为散文也被守着 |
| 100KB 上限 | 今天不会红（最大 15KB：`content/docs/administration/sharing-and-security.zh-Hant.mdx`，余量 6.6 倍），但会**新增一条文档页的体积约束** | 不扩——它的补救话术是「拆文件，过大模块妨碍评审」，那是模块评审的道理，不能顺移到散文页；文档要不要体积上限是 #814 的题，不该由本 PR 顺手默认掉 |

另一条前置事实：两棵树今天**纯文本**，没有任何 `.mdx`/`.md`/`.json` 之外的文件；文档截图放在 `assets/screenshots/`，页面按 URL 引用。所以扩面不会把二进制拖进来；真有二进制落到这两棵树，按脚本自己的既定立场就该吵出来、由人明确决定，而不是被跳过名单悄悄吸收。

## 反向验证：方向先声明，再跑

**探针不入库**（临时文件，跑完即删；`git status` 已确认工作区只剩三个目标文件）。

**方向一：同一探针，旧脚本必须绿，新脚本必须红。** 这比「改完变红」更有说服力——它证明红的原因是扫描面，不是探针本身。

`origin/main` 版脚本（临时拷贝为 `scripts/probe-old-hygiene.mjs`），两个探针都在树上：

```
Source hygiene — 244 files under src, test, e2e, scripts
  ✓ no raw control bytes in source files
✓ source hygiene clean
old exit=0
```

同一棵树，本 PR 的脚本：

```
✗ no raw control bytes in first-party files — 2 violation(s)
      content/docs/probe-control-byte.mdx:2  control byte 0x01 at column 7
      .changeset/probe-control-byte.md:4  control byte 0x01 at column 21
✗ source hygiene failed
new exit=1
```

两棵树各自点名，且给出 file:line、字节值、列号。

**方向二：三关不跟着扩，必须仍然绿。** 探针换成「若一刀切就会红」的三件套——`content/docs/probe-oversized.mdx`（120KB）、`content/probe-marker.ts`（含标记词 + `console.log`）：

```
  ✓ no console.log in src/
  ✓ no TODO/FIXME markers
  ✓ no raw control bytes in first-party files
  ✓ no source file over 100KB
exit=0
```

**方向三：新测试自身的反向验证。** 把脚本还原成 `origin/main`、测试保持新版，预测 **4 红 / 3 绿**（红：content 字节、changeset 字节、表头点名新树、缺目录预检查；绿：src 字节、src 体积上限、三关不扩那条——它们的判据没被本 PR 动过，本就不该跟着变）。实测与预测逐条相符：

```
 × passes on a clean tree (the harness is not vacuously red)
 × reports a control byte under content/, naming the file, byte and column
 × reports a raw NUL under .changeset/
 × fails loudly when a scanned tree is absent, text trees included
AssertionError: expected +0 to be 1      ← 旧脚本 exit 0，新脚本要求 exit 1
 Tests  4 failed | 3 passed (7)
```

## 测试

脚本此前无配套测试。按仓库既有惯例（`test/labeler-config.test.ts`：给仓库工具配置钉一条「规则不得空转」的守卫）补一个最小自测 `test/source-hygiene-scan-surface.test.ts`，7 例：

脚本的 root 是从它自己的位置推出来的（`new URL('..', import.meta.url)`），所以把**真实脚本原样拷进临时目录的 `scripts/` 下**，那个临时目录就成了它的仓库根。好处有三：跑的是真脚本而不是复刻逻辑；不必为测试给生产工具开 env 口子；控制字节只在临时目录里被造出来，真实仓库树永远不写入一个裸字节。

钉住的是**分树这件事的两半**：控制字节在两棵新树上必须被点名（含字节值与列号）、在老树上仍然被点名；而 `console.log`/标记/100KB 三关**不得**跟着扩（同一例里同时放 120KB 的 mdx、带标记词的 `.ts`、带 `console.log` 的文档页，必须全绿），体积上限在 `src/` 里仍然生效；再加一条：两棵新树若缺失，预检查必须吵。以后谁要改这个分树，得先动这个文件，而不是顺手改掉。

测试文件里的标记词与控制字节都是运行期拼出来的（`['TO','DO'].join('')`、`String.fromCharCode(0x00)`），因为这个文件本身就在 gate 的扫描面内——字面写下去会红掉它正要测的那条关。

## 验证

四件套 + hygiene + lint 全绿（`flock /tmp/os-heavy-verify.lock`，`NODE_OPTIONS=--max-old-space-size=4096`，vitest `--maxWorkers=2`）：

```
pnpm validate  → ✓ Validation passed        exit=0（5 条既有 author-time warning）
pnpm typecheck → tsc --noEmit               exit=0
pnpm build     → ✓ Build complete           exit=0
pnpm test      → Test Files 65 passed (65)
                 Tests 1567 passed | 1 skipped (1568)
pnpm lint      → 13 warning(s), 14 suggestion(s)  exit=0（均为既有）
pnpm hygiene   → ✓ source hygiene clean     244 + 379 个文件
```

测试数由 64 files / 1560 passed 增至 65 / 1567，即本 PR 新增的 7 例。

## 撰写期自陈：#4890 的物化陷阱当场复现了一次

本单主题就是裸控制字节，而写测试时**第一版就踩了 #4890**：编辑工具把我意图中的转义在落盘时物化成了真字节，`test/source-hygiene-scan-surface.test.ts` 的三行 fixture 里真的躺进了 `0x01`/`0x00`（`od -c` 确认）。整份文件随后被改写为按码点构造（`String.fromCharCode`），并按 `grep -naP` 自扫确认零命中；提交前对三个改动文件各扫一遍，均零命中。

说明两点：一是这个陷阱不是历史掌故，写着写着就会中；二是**如果这条关没有本 PR 这次扩面，这类字节落在 `content/` 或 `.changeset/` 里今天仍然没有任何闸拦得住**——而按 #807 的改动面比例，那是每个文档 PR 的一半文件。

## 相关与越界

- #753（同一个 gate，CI step 名字漏列第四条检查）：本 PR 让它更陈旧了一点——step 名仍写「console.log / TODO / file size」，而第四条关现在还多扫两棵树。按越界纪律未在此 PR 改工作流，已在 #753 追评记下新事实。
- #814（同一个 gate 的 100KB 上限）：上表已说明为何本 PR 不把该上限带到文档页。
- 越界发现：`docs/`（内部维护文档）、`.github/`、`.claude/`、根目录若干 markdown 仍在控制字节扫描面之外，今日实测零命中。同类缺陷在上游正是落在 `.claude/` 的 `SKILL.md` 里（objectstack#4890）。已去重后另立 issue，未在本 PR 扩面——本单的裁定面是 `content/` 与 `.changeset/`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_