### PR TITLE
fix(i18n): 五处 zh-CN help 串按 B1 跟 label 收口 (#846)

### DIFF
--- a/.changeset/help-strings-follow-labels.md
+++ b/.changeset/help-strings-follow-labels.md
@@ -1,0 +1,45 @@
+---
+'hotcrm': patch
+---
+
+Five simplified-Chinese help bubbles now use the words the locale pack's own
+labels use. A help string explains a label, so where the two disagreed the help
+followed the label.
+
+`src/translations/zh-CN.ts` was internally inconsistent in three places, and each
+one sent the reader looking for a word the product never puts on screen:
+
+| field | help said | pack's label says |
+| --- | --- | --- |
+| `crm_account.name_normalized` | 线索**转换**的匹配键 | `convert_lead` 转化线索 / `is_converted` 已转化 |
+| `crm_lead.company_normalized` | 线索**转换**的匹配键 | 同上 |
+| `crm_opportunity.win_reason` | 将商机关闭为"**赢单**"时必填 | `stage.closed_won` 成交 |
+| `crm_opportunity.loss_reason` | 将商机关闭为"**丢单**"时必填 | `stage.closed_lost` 失败 |
+| `crm_opportunity.crm_campaign` | 带来此商机的**市场活动** | 营销活动 (on the same line) |
+
+The two reason fields are the sharpest case: the help quotes a stage **by name**,
+and neither quoted word is in the stage picklist. A rep reading "将商机关闭为
+赢单时必填" then opens the stage dropdown and finds 成交. The campaign one is the
+starkest: 「市场活动」 was a zero-label word — this help string was its only
+occurrence left anywhere in the repository once the documentation moved to
+「营销活动」.
+
+**Only the words used as references moved; the pack's own outcome vocabulary did
+not.** 赢单/丢单 are what this pack calls a win and a loss — `win_reason` 赢单原因,
+`loss_reason` 丢单原因, `loss_details` 赢/丢单详情, 赢单数, 丢单数, 赢单概率 — so
+those labels are untouched, exactly as the Chinese documentation kept them. What
+changed is only the word each help string quotes as a **stage value**, which is a
+different fact from what the field is called.
+
+The other three locales were checked field by field and were already consistent,
+so nothing outside zh-CN changed. `ja-JP` in particular already writes what this
+change makes zh-CN write — `win_reason` is labelled 受注理由 while its help quotes
+the stage as 「成立」, the exact `closed_won` option label. `en` and `es-ES` build
+the campaign help from the label's own head word (`Campaign` / `Marketing
+campaign that generated this opportunity`), and their lead-conversion help shares
+a lexeme with the convert action (`conversion` / `Convert Lead`).
+
+Display text only: no field, option value, label, view or behaviour changed, and
+no documentation page rendered any of these five strings.
+
+Fixes #846.

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -107,7 +107,7 @@ export const zhCN: TranslationData = {
         },
         renewal_owner: { label: '续约负责人 (CSM)' },
         next_renewal_date: { label: '下次续约日期' },
-        name_normalized: { label: '客户名称（规范化）', help: '线索转换的匹配键：客户名称转小写、去除首尾空格、内部连续空白合并为一个空格。由 account_protection 钩子维护——请勿直接编辑。' },
+        name_normalized: { label: '客户名称（规范化）', help: '线索转化的匹配键：客户名称转小写、去除首尾空格、内部连续空白合并为一个空格。由 account_protection 钩子维护——请勿直接编辑。' },
         display_title: { label: '显示名称' },
       },
       _views: {
@@ -397,7 +397,7 @@ export const zhCN: TranslationData = {
           options: { suspected: '疑似重复', confirmed: '已确认重复' },
         },
         display_title: { label: '显示名称' },
-        company_normalized: { label: '公司名称（规范化）', help: '线索转换的匹配键：公司名称转小写、去除首尾空格、内部连续空白合并为一个空格。由 lead_duplicate_check 钩子维护——请勿直接编辑。' },
+        company_normalized: { label: '公司名称（规范化）', help: '线索转化的匹配键：公司名称转小写、去除首尾空格、内部连续空白合并为一个空格。由 lead_duplicate_check 钩子维护——请勿直接编辑。' },
         next_followup_date: { label: '下次跟进日期' },
         last_contacted_date: { label: '最近联系时间' },
       },
@@ -922,7 +922,7 @@ export const zhCN: TranslationData = {
           label: '竞争对手',
           options: { competitor_a: '竞争对手 A', competitor_b: '竞争对手 B', competitor_c: '竞争对手 C' },
         },
-        crm_campaign: { label: '营销活动', help: '带来此商机的市场活动' },
+        crm_campaign: { label: '营销活动', help: '带来此商机的营销活动' },
         days_in_stage: { label: '当前阶段天数' },
         stage_entry_date: { label: '进入当前阶段日期', help: '本商机进入当前阶段的日期。' },
         is_private: { label: '私密' },
@@ -932,7 +932,7 @@ export const zhCN: TranslationData = {
         },
         approved_date: { label: '批准时间' },
         win_reason: {
-          help: '赢单原因。将商机关闭为"赢单"时必填。',
+          help: '赢单原因。将商机关闭为"成交"时必填。',
           label: '赢单原因',
           options: {
             better_product: '产品更优', better_price: '价格更优', relationship: '客户关系',
@@ -941,7 +941,7 @@ export const zhCN: TranslationData = {
           },
         },
         loss_reason: {
-          help: '丢单原因。将商机关闭为"丢单"时必填。',
+          help: '丢单原因。将商机关闭为"失败"时必填。',
           label: '丢单原因',
           options: {
             price: '价格过高', competitor: '输给竞争对手', no_budget: '无预算',


### PR DESCRIPTION
Fixes #846

按 PM 的 **B1 裁定（help 跟 label）** 收口 `src/translations/zh-CN.ts` 里五处 help 串。只改 help 里被当作**引用**的词，label 一个字未动。

## 一、前提复核（基线 3912845b → 实施在 9d2c787a）

issue 行号取自 3912845b，逐条在最新 main 上重定位重核。**五处全部仍然成立，行号也未漂移**（中间的 #833/#854 只动了 `content/`）：

| # | 位置 | issue 说的 | 最新 main 实测 | 前提 |
| --- | --- | --- | --- | --- |
| 1 | `zh-CN.ts:110` `crm_account.fields.name_normalized.help` | 「线索**转换**的匹配键」 | 一字不差，行号未动 | ✅ 成立 |
| 2 | `zh-CN.ts:400` `crm_lead.fields.company_normalized.help` | 「线索**转换**的匹配键」 | 一字不差，行号未动 | ✅ 成立 |
| 3 | `zh-CN.ts:935` `crm_opportunity.fields.win_reason.help` | 「关闭为"**赢单**"时必填」 | 一字不差，行号未动 | ✅ 成立 |
| 4 | `zh-CN.ts:944` `crm_opportunity.fields.loss_reason.help` | 「关闭为"**丢单**"时必填」 | 一字不差，行号未动 | ✅ 成立 |
| 5 | `zh-CN.ts:925` `crm_opportunity.fields.crm_campaign.help` | 「带来此商机的**市场活动**」 | 一字不差，行号未动 | ✅ 成立 |

被引用侧也实测过，确认 help 点的确实是包里不存在的词：

- `stage.closed_won` = 「成交」、`stage.closed_lost` = 「失败」（`:889`、`:1002` 两处阶段列表都是），选择列表里**没有**「赢单」「丢单」。
- convert 动词面：`convert_lead.label` 「转化线索」（`:441`）、`is_converted` 「已转化」（`:359`）、`success.converted`（`:1241`）、`confirm.convert_lead`（`:1243`）等 14 处全是「转化」；「线索转换」只有 `:110` / `:400` 这两处。
- 「市场活动」在**全仓 `src/` 只有 `:925` 这一处**（`grep -rn 市场活动 src/` → 1 命中），追评说的「零-label 词」属实。

## 二、五处改动

```diff
-110  name_normalized:   help: '线索转换的匹配键：客户名称转小写…'
+110  name_normalized:   help: '线索转化的匹配键：客户名称转小写…'
-400  company_normalized:help: '线索转换的匹配键：公司名称转小写…'
+400  company_normalized:help: '线索转化的匹配键：公司名称转小写…'
-925  crm_campaign: { label: '营销活动', help: '带来此商机的市场活动' },
+925  crm_campaign: { label: '营销活动', help: '带来此商机的营销活动' },
-935  win_reason.help:  '赢单原因。将商机关闭为"赢单"时必填。'
+935  win_reason.help:  '赢单原因。将商机关闭为"成交"时必填。'
-944  loss_reason.help: '丢单原因。将商机关闭为"丢单"时必填。'
+944  loss_reason.help: '丢单原因。将商机关闭为"失败"时必填。'
```

改动共 5 行，`git diff --stat` = `1 file changed, 5 insertions(+), 5 deletions(-)`。

**label 一个字未动**，按 #842 的裁定（赢单/丢单 是包自己的成败词汇）：

- `win_reason.label` 「赢单原因」 — 原样
- `loss_reason.label` 「丢单原因」 — 原样
- `loss_details` 「赢/丢单详情」+ help「赢单或丢单原因的补充说明。」 — 原样（该 help 里的「赢单/丢单」指**原因**不指阶段值，不在本单口径内）

一处**刻意不改**并在此说明：`:288` `crm_forecast.closed_amount` = `{ label: '已成交金额', help: '本周期内已赢单的金额。' }`。label 用「成交」、help 用「赢单」，形式上像第六处，但 help 这里说的是「已赢下的金额」这一**结果**，不是用引号点名一个阶段值，属于 #842 确认的成败词汇正常用法（同 `won_deals` 「赢单数」、`win_rate_by_owner`）。按本单「只改被当作阶段值引用的词」的口径，不动。

## 三、四包复核（独立复测，未照抄追评）

逐字段读了四个包的对应条目：

**甲组 · convert 动词面**

| 包 | help 中心词 | 包里对应的 label | 一致？ |
| --- | --- | --- | --- |
| `en:115/422` | Match key for lead **conversion** | `convert_lead` **Convert** Lead / `is_converted` **Converted** | ✅ 同词根 |
| `zh-CN:110/400` | 线索**转换** | 转化线索 / 已转化 | ❌ **本单修** |
| `es-ES:67/353` | la **conversión** de prospectos | **Convertir** Prospecto / **Convertido** | ✅ 同词根 |
| `ja-JP:107/385` | **リード変換**の照合キー | `convert_lead.label` **リード変換** | ✅ 逐字相同 |

**乙组 · help 引号里的阶段值**

| 包 | win 侧 help | `closed_won` label | loss 侧 help | `closed_lost` label | 一致？ |
| --- | --- | --- | --- | --- | --- |
| `en:552/561` | close … as **Won** | **Closed Won** | as **Lost** | **Closed Lost** | ✅ 中心词即 label |
| `zh-CN:935/944` | 关闭为"**赢单**" | **成交** | 关闭为"**丢单**" | **失败** | ❌ **本单修** |
| `es-ES:562/572` | como **Ganada** | Cerrada **Ganada** | como **Perdida** | Cerrada **Perdida** | ✅ 中心词即 label |
| `ja-JP:553/563` | 商談を「**成立**」でクローズ | **成立** | 「**不成立**」でクローズ | **不成立** | ✅ 引号内逐字即 label |

`ja-JP` 尤其值得记一笔：它的 `win_reason.label` 是「受注理由」（用自己的成败词汇），而 help 引号里逐字引用阶段 label「成立」——**这正是 B1 要 zh-CN 变成的样子**，四包里已经有一个现成范本。

**丙组 · campaign**：复测与追评一致 —— `en:538` `Campaign` / `Marketing campaign that generated this opportunity`、`es-ES:545` `Campaña` / `Campaña de marketing…`、`ja-JP:540` `キャンペーン` / `…マーケティングキャンペーン`，三个都是「修饰词 + label 中心词」，只有 zh-CN 换了中心词。

**结论：另外三个包在这五个条目上无同类孤例，故本 PR 未动 `en.ts` / `es-ES.ts` / `ja-JP.ts`。**

> 复测中确实发现 ja-JP 另有一处**不同类**的问题（包内 label vs label 的 convert 词汇分派：`grep -c` 实测 14 处「変換」对 4 处「取引開始」，同一次转化两条措辞不同的成功提示）。它不是 help-vs-label，B1 给不出答案，选哪个词是需要维护者点头的译名决定，故按去重纪律**另立观察单 #858，本 PR 一处未改**。

## 四、文档消费面 sweep

对五条 help 的旧原文逐条 grep `content/`（含简繁两侧写法）：

| 旧原文 | `content/` 命中 | 处置 |
| --- | --- | --- |
| `线索转换的匹配键` / `匹配键`（该义项） | 0 | 无需处理 |
| `关闭为"赢单"` / `关闭为"丢单"` / `关闭为` | 0 | 无需处理 |
| `市场活动` / `市場活動` | 0 | 无需处理 |
| `带来此商机` | 0 | 无需处理 |
| `name_normalized` / `company_normalized` | 0 | 文档从不渲染这两条 help |

**预期成立：五条 help 在 `content/` 零残留**，#825 / #842 / #830(PR #849) 已把文档侧清完。`content/docs/ai-copilot/**` **零命中**，故与 #847 无文件面冲突。

唯一一条相邻命中，**不属于本单且已被既有单覆盖**：`content/docs/administration/automation.zh-Hans.mdx:57`（及 zh-Hant 孪生 `:57`）的表格行「线索转换流程 / 線索轉換流程」。这是 flow `lead_conversion` 的**文档侧译名**（flow 自身 label 是英文 `Lead Conversion Process`，四个包都没有它的 label），不是这五条 help 的渲染。#844 正文已逐条点名了它（那里记的行号是 `:73`，基线 a501812e；#833/#854 改过该页后现为 `:57`，同一行），并注明「纯文档侧的译名，跟不跟包可另判」。**留给 #844，本 PR 未改。**

## 五、测试同步

grep `test/` 找是否有用例钉了这五条 help 原文：**没有任何一处**（`匹配键` / `必填。` / `带来此商机` / `转化` / `成交` / `失败` 在 `test/` 全部零命中）。因此**本 PR 未改任何测试文件**，`test/metadata-references.test.ts` 的 100KB hygiene 上限未被触及。

两处相邻命中，核实后确认**不是钉子、且不因本 PR 失效**：

- `test/sharing-coverage.test.ts:535` — 注释「This row read 「市场活动」 until #830」，讲的是 OWD 文档表格那一行的历史，不是本 help 串；其陈述在本 PR 后依然准确（它说 zh-Hans 应为「营销活动」，正是包 label），不需改。
- `test/automation-docs-coverage.test.ts:198` — `ROW_LABEL.lead_conversion` 钉的是上面第四节那条 flow 文档译名，属 #844 范围。

按 PM 边界，**不新增守卫**（包内一致性缺闸是 #802 / #846 已记录的能力缺口，#858 是它的第三个实例）。

## 六、验证输出（共享锁 + `NODE_OPTIONS=--max-old-space-size=4096`）

| 步骤 | 退出码 | 关键输出 |
| --- | --- | --- |
| `pnpm validate` | **0** | `✓ Validation passed (1294ms)`；`17 Objects 344 Fields` |
| `pnpm typecheck` | **0** | `tsc --noEmit` 无输出 |
| `pnpm build` | **0** | `✓ Build complete (1666ms)`；`Artifact: dist/objectstack.json (1921.3 KB)` |
| `pnpm test --maxWorkers=2` | **0** | `Test Files 66 passed (66)` / `Tests 1587 passed \| 1 skipped (1588)` |
| `pnpm lint` | **0** | `13 warning(s), 14 suggestion(s)` — 全部为既有告警（approval 空审批人、line-item lookup 建议） |
| `pnpm hygiene` | **0** | `✓ no raw control bytes in first-party files` / `✓ no source file over 100KB` / `✓ source hygiene clean` |

`validate` / `build` 的 5 条 `⚠` 与 `lint` 的 13 条告警在基线上即存在（approval 审批人可能解析为空、`crm_campaign_member` basic 分组、line-item 关系建议），与本改动无关。test 输出里的 `✗ source hygiene failed: …` stderr 是 source-hygiene 元测试构造失败样本时的预期打印，套件本身 66/66 通过。

CI（`24d0551c`）9 项检查全绿：`Build and Test (22.x)` / `Quality Checks` / `Check Changeset` / `link-check` / `Playwright` / `CodeQL` / `Analyze Code (javascript)` / `Label Pull Request` / `Vercel Preview Comments`。其中 `link-check` 绿确认 changeset 未踩 #797 的站内相对路径坑。

**控制字节自扫**：`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' src/translations/zh-CN.ts .changeset/help-strings-follow-labels.md` → 零命中。

### 落地核验（比"回滚看红"更能定性的一步）

这是纯文案改动，且仓里**没有任何一道闸门读 help 与 label 的一致性**（这正是 #802 / #846 记录的缺闸），所以"把改动还原、看诊断转红"在本单不产生任何信号——如实说明，不编造。改为核验一件真正可判定的事：**改后的串确实进入了发布产物，且它引用的词确实能在选择列表里找到。**

对 `dist/objectstack.json` 做结构化走查：

```
.translations.0.zh-CN.objects.crm_account.fields.name_normalized.help    = "线索转化的匹配键：客户名称转小写…"
.translations.0.zh-CN.objects.crm_lead.fields.company_normalized.help    = "线索转化的匹配键：公司名称转小写…"
.translations.0.zh-CN.objects.crm_opportunity.fields.crm_campaign.help   = "带来此商机的营销活动"
.translations.0.zh-CN.objects.crm_opportunity.fields.win_reason.help     = "赢单原因。将商机关闭为\"成交\"时必填。"
.translations.0.zh-CN.objects.crm_opportunity.fields.loss_reason.help    = "丢单原因。将商机关闭为\"失败\"时必填。"

stage.options.closed_won  = "成交"   ← win_reason.help 引号内逐字命中
stage.options.closed_lost = "失败"   ← loss_reason.help 引号内逐字命中
win_reason.label = "赢单原因"  loss_reason.label = "丢单原因"  loss_details.label = "赢/丢单详情"  ← 三个 label 未动
convert_lead.label = "转化线索"  is_converted.label = "已转化"  ← 甲组 help 现与之同词
```

产物里旧拼法零残留（`线索转换` 0 处、`市场活动` 0 处，`关闭为` 的 2 处均为新词）。即：用户读完 help 去阶段下拉里找「成交」/「失败」，**现在找得到**——这是本单要修的那件事的直接证据。

## 七、changeset

`.changeset/help-strings-follow-labels.md`（`'hotcrm': patch`）。按 #797 的教训，站内路径一律反引号，未使用任何 markdown 链接。
