### PR TITLE
docs(agents): 把唯一的 ObjectQL 范例改成本仓真实的读路径 (#855)

### DIFF
--- a/.changeset/agents-md-objectql-example.md
+++ b/.changeset/agents-md-objectql-example.md
@@ -28,7 +28,8 @@ first-party call sites use it. All sixty use the object form, so the example now
 
 The `where`-only rule is stated *scoped to `ctx.api`* on purpose: a flow node's `config`
 is a separate, schema-unvalidated bag (`config: z.record(z.string(), z.unknown())`), and
-all 24 `*.flow.ts` query/update nodes spell their predicate `filter:`. An unscoped rule
-would have invited the next agent to "fix" those into `where:`.
+`*.flow.ts` query/update nodes spell their predicate `filter:` — 44 occurrences across 17
+of the 21 flow files, with `where:` in none of them. An unscoped rule would have invited
+the next agent to "fix" those into `where:`.
 
 Documentation only — no runtime, metadata, or dependency change.

--- a/.changeset/agents-md-objectql-example.md
+++ b/.changeset/agents-md-objectql-example.md
@@ -1,0 +1,29 @@
+---
+'hotcrm': patch
+---
+
+Make `AGENTS.md`'s only ObjectQL example match the repo's real read path.
+
+The example under §"Tech Stack & Protocol" item 2 read
+`broker.find('opportunity', { filters: [['amount', '>', 50000]] })`, and every part of
+it was wrong for this codebase:
+
+- **`broker`** has zero occurrences in `src/`. The data surface an agent actually gets
+  is `ctx.api`: 43 call sites in `*.hook.ts` (cast once as `HookApi`, then
+  `api.object('crm_x')`) and 17 in action script bodies (`ctx.api.object('crm_x')`).
+- **`filters`** is not a key of the in-process query object at all. It is the
+  *deprecated plural alias* of the `filter` HTTP query-param, whose value is a JSON
+  string. Used in process it fails silently, which is the failure mode this repo has
+  already paid for once — `.changeset/hook-query-where-not-filter.md` records seventeen
+  hook calls whose predicate vanished: `findOne` returned the object's first row and
+  `count` counted the whole object, with no error and no `null`. `HookQuery` in
+  `src/objects/_hook-api.ts` now omits the alias precisely so the compiler rejects it.
+- **`'opportunity'`** violated the `crm_` prefix rule stated four lines above it in the
+  same file. The object is `crm_opportunity`.
+
+The predicate *value* changed shape too: `[['amount', '>', 50000]]` is a legal filter
+AST at the platform level, but it is not assignable to `HookQuery['where']`, and zero
+first-party call sites use it. All sixty use the object form, so the example now does:
+`where: { amount: { $gt: 50000 } }`.
+
+Documentation only — no runtime, metadata, or dependency change.

--- a/.changeset/agents-md-objectql-example.md
+++ b/.changeset/agents-md-objectql-example.md
@@ -26,4 +26,9 @@ AST at the platform level, but it is not assignable to `HookQuery['where']`, and
 first-party call sites use it. All sixty use the object form, so the example now does:
 `where: { amount: { $gt: 50000 } }`.
 
+The `where`-only rule is stated *scoped to `ctx.api`* on purpose: a flow node's `config`
+is a separate, schema-unvalidated bag (`config: z.record(z.string(), z.unknown())`), and
+all 24 `*.flow.ts` query/update nodes spell their predicate `filter:`. An unscoped rule
+would have invited the next agent to "fix" those into `where:`.
+
 Documentation only — no runtime, metadata, or dependency change.

--- a/.changeset/agents-md-objectql-example.md
+++ b/.changeset/agents-md-objectql-example.md
@@ -18,18 +18,22 @@ it was wrong for this codebase:
   hook calls whose predicate vanished: `findOne` returned the object's first row and
   `count` counted the whole object, with no error and no `null`. `HookQuery` in
   `src/objects/_hook-api.ts` now omits the alias precisely so the compiler rejects it.
-- **`'opportunity'`** violated the `crm_` prefix rule stated four lines above it in the
+- **`'opportunity'`** violated the `crm_` prefix rule stated five lines above it in the
   same file. The object is `crm_opportunity`.
 
 The predicate *value* changed shape too: `[['amount', '>', 50000]]` is a legal filter
-AST at the platform level, but it is not assignable to `HookQuery['where']`, and zero
-first-party call sites use it. All sixty use the object form, so the example now does:
-`where: { amount: { $gt: 50000 } }`.
+AST at the platform level, but it is not assignable to `HookQuery['where']`, and no
+`ctx.api` call site uses it — every predicate on that surface is written as an object.
+So the example now does: `where: { amount: { $gt: 50000 } }`.
 
-The `where`-only rule is stated *scoped to `ctx.api`* on purpose: a flow node's `config`
-is a separate, schema-unvalidated bag (`config: z.record(z.string(), z.unknown())`), and
-`*.flow.ts` query/update nodes spell their predicate `filter:` — 44 occurrences across 17
-of the 21 flow files, with `where:` in none of them. An unscoped rule would have invited
-the next agent to "fix" those into `where:`.
+The rule is stated *scoped to `ctx.api`* on purpose, because two other surfaces spell
+their predicate differently and an unscoped rule would have invited the next agent to
+"fix" them:
+
+- A flow node's `config` is a schema-unvalidated bag (`config: z.record(z.string(),
+  z.unknown())`) and `*.flow.ts` query/update nodes use `filter:` — 44 occurrences across
+  17 of the 21 flow files, `where:` in none.
+- A page component config uses `filter:` in the AST-array form, the one spelling of that
+  form in `src/` (`src/pages/lead_detail.page.ts:217`).
 
 Documentation only — no runtime, metadata, or dependency change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,14 +67,16 @@ hotcrm/
       cast once — `const api = ctx.api as HookApi | undefined`, from `src/objects/_hook-api.ts`
       — and then called as `api.object(...)`; action script bodies call `ctx.api.object(...)`
       directly.
-    - The predicate key is **`where`**, and only `where`. `filter` (canonical) and `filters`
-      (deprecated alias) are *HTTP query-param* spellings carrying a JSON **string**, not keys
-      of the in-process query object — passing either in process fails **silently**: `findOne`
-      spreads the query into the AST without aliasing and returns the object's **first row**,
-      `count` reads `query.where` only and counts the **whole object**. Neither throws. This
-      repo has already paid for it once — see `.changeset/hook-query-where-not-filter.md`.
-      `HookQuery` in `src/objects/_hook-api.ts` deliberately omits the alias so the mistake is
-      a compile error.
+    - On `ctx.api`, the predicate key is **`where`**, and only `where`. `filter` (canonical)
+      and `filters` (deprecated alias) are *HTTP query-param* spellings carrying a JSON
+      **string**, not keys of the in-process query object — passing either in process fails
+      **silently**: `findOne` spreads the query into the AST without aliasing and returns the
+      object's **first row**, `count` reads `query.where` only and counts the **whole object**.
+      Neither throws. This repo has already paid for that once — see
+      `.changeset/hook-query-where-not-filter.md`. `HookQuery` in `src/objects/_hook-api.ts`
+      deliberately omits the alias so the mistake is a compile error.
+      A flow node's `config` is a **different surface**: `*.flow.ts` query/update nodes take
+      `filter:` (all 24 flows do). Do not "fix" one spelling into the other.
 
 3.  **AI-Native**:
     - Every feature should consider AI augmentation (Co-Pilot, Agents).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,8 @@ hotcrm/
       `.changeset/hook-query-where-not-filter.md`. `HookQuery` in `src/objects/_hook-api.ts`
       deliberately omits the alias so the mistake is a compile error.
       A flow node's `config` is a **different surface**: `*.flow.ts` query/update nodes take
-      `filter:` (all 24 flows do). Do not "fix" one spelling into the other.
+      `filter:` (44 occurrences across 17 of the 21 flow files; `where:` appears in none of
+      them). Do not "fix" one spelling into the other.
 
 3.  **AI-Native**:
     - Every feature should consider AI augmentation (Co-Pilot, Agents).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,11 @@ hotcrm/
       Neither throws. This repo has already paid for that once — see
       `.changeset/hook-query-where-not-filter.md`. `HookQuery` in `src/objects/_hook-api.ts`
       deliberately omits the alias so the mistake is a compile error.
-      A flow node's `config` is a **different surface**: `*.flow.ts` query/update nodes take
-      `filter:` (44 occurrences across 17 of the 21 flow files; `where:` appears in none of
-      them). Do not "fix" one spelling into the other.
+      Other surfaces are **not** governed by this rule and have their own spelling: a
+      `*.flow.ts` node `config` takes `filter:` (44 occurrences across 17 of the 21 flow
+      files; `where:` in none), and a page component config takes `filter:` in the
+      AST-array form (`src/pages/lead_detail.page.ts:217`). Do not "fix" one surface's
+      spelling into another's.
 
 3.  **AI-Native**:
     - Every feature should consider AI augmentation (Co-Pilot, Agents).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,22 @@ hotcrm/
     - **All HotCRM business object names MUST use the `crm_` prefix and the prefix MUST be written explicitly in source** (e.g., `crm_account`, `crm_opportunity`, `crm_knowledge_article`). **No automatic prefix injection by the runtime.** Open architectural decision: AI-authored metadata is fragile around "context-aware" naming, so we trade verbosity for grep-ability. Cross-references via `reference_to` / `lookup` / `masterDetail` MUST use the prefixed name. Cube `sql:` fields, view `data.object`, hook `object:`, action `objectName:`, navigation `objectName:`, dashboard `object:`, translation `objects.{key}`, REST URLs, and DB table names ALL use the same prefixed name. The name in source = the name at runtime = the name in DB = the name in URL = the name in docs. No translation layer.
 
 2.  **ObjectQL (No-SQL)**:
-    - Data access MUST use **ObjectQL**.
+    - Data access MUST use **ObjectQL**, reached through the `ctx.api` surface. There is
+      **no `broker`** in this repo — the identifier has zero occurrences in `src/`.
     - **NEVER** write raw SQL.
-    - Format: `broker.find('opportunity', { filters: [['amount', '>', 50000]] })`.
+    - Format: `ctx.api.object('crm_opportunity').find({ where: { amount: { $gt: 50000 } } })`.
+      Object names carry the `crm_` prefix, same as rule 1. In a `*.hook.ts` the surface is
+      cast once — `const api = ctx.api as HookApi | undefined`, from `src/objects/_hook-api.ts`
+      — and then called as `api.object(...)`; action script bodies call `ctx.api.object(...)`
+      directly.
+    - The predicate key is **`where`**, and only `where`. `filter` (canonical) and `filters`
+      (deprecated alias) are *HTTP query-param* spellings carrying a JSON **string**, not keys
+      of the in-process query object — passing either in process fails **silently**: `findOne`
+      spreads the query into the AST without aliasing and returns the object's **first row**,
+      `count` reads `query.where` only and counts the **whole object**. Neither throws. This
+      repo has already paid for it once — see `.changeset/hook-query-where-not-filter.md`.
+      `HookQuery` in `src/objects/_hook-api.ts` deliberately omits the alias so the mistake is
+      a compile error.
 
 3.  **AI-Native**:
     - Every feature should consider AI augmentation (Co-Pilot, Agents).


### PR DESCRIPTION
Fixes #855

> ⚠️ **这是 repo 指令文件（`AGENTS.md`）的改动，措辞会影响所有后续 agent，维护者可随时否决/回滚。** 事实面（`broker` 不存在、谓词键是 `where`、对象名是 `crm_opportunity`）全部实测；具体怎么措辞不是。与 #852 / PR #857 同处置逻辑：binding 指令文件的硬错误，最小事实修复。

## 1. 前提复核（先于编辑）

基线取最新 `origin/main` = `eb4a7e11`（#855 正文记的是 `9d2c787a`，其后落了 #857 / #859 / #861 三个 merge）。

| 复核项 | 结果 |
|---|---|
| 范例块仍在 | ✅ 第 61-64 行，与 issue 引用的原文**逐字一致** |
| 第 64 行原文 | `- Format: ` + 反引号 `broker.find('opportunity', { filters: [['amount', '>', 50000]] })` |
| `crm_` 强制前缀规则行号 | ✅ 仍是**第 59 行**（issue 记的行号未过期），即范例上方 5 行 |
| 与 #857 改动块是否重叠 | ❌ **无重叠**。#857 动的是「🔒 Schema Validation Requirements」第 120 行 + 其下 126-133 行的引用块，本 PR 动的是「💻 Tech Stack & Protocol」第 61-64 行，中间隔着 §Autonomous Iteration Protocol、§Coding Standards 两节共 50 余行 |

**前提成立**，三处失真全部复现。

## 2. 三处失真的实测证据

### 2.1 `broker` —— 本仓零命中

```
$ grep -rn "broker" src/ --include=*.ts | wc -l
0
$ grep -rn "broker" src/ test/ e2e/ apps/ scripts/ | wc -l
0
```

探针没坏：同一条 grep 打在真实存在的调用面上是 60 命中。本仓真实读路径分两个上下文，**同一个 `ctx.api` surface**：

| 上下文 | 写法 | 命中数 |
|---|---|---|
| `*.hook.ts`（TypeScript，编译期受检） | `const api = ctx.api as HookApi ...` 后 `api.object('crm_x')` | **43** |
| action script body（沙箱 JS 字符串） | `ctx.api.object('crm_x')` | **17**（16 处在 `src/actions/`） |

≥2 处真实文件行（issue 点名的两处，行号在当前 main 上复核）：

```
src/objects/campaign.hook.ts:68:      api.object('crm_campaign_member').find({
src/objects/campaign.hook.ts:69-        where: { crm_campaign: id },
src/objects/lead.hook.ts:84:      const holders = await api.object('sys_user_position').find({
src/objects/lead.hook.ts:85-        where: { position: 'sales_rep' }, fields: ['user_id'], top: 1000,
```

再补两处，证明 `ctx.api.` 前缀形也是真实的、且 hook 侧的 `api` 就是 `ctx.api`：

```
src/actions/global.actions.ts:386:        const raw = await ctx.api.object('crm_case').find({
src/actions/global.actions.ts:387-          where: { id: recordId },
src/objects/campaign.hook.ts:56:    const api = ctx.api as HookApi | undefined;
src/objects/account.hook.ts:129:      const openOpps = await api.object('crm_opportunity').count({
```

### 2.2 `filters` —— HTTP query-param 的已弃用别名，不是进程内 query 的键

出处按裁定在 `node_modules` 里复核（`@objectstack/spec` 17.0.0-rc.2，`src/api/protocol.zod.ts`，行号与 issue 记的 326-327 一致）：

```ts
// 324
  /** @canonical Singular form — the standard going forward. JSON string of filter expression or AST. */
  filter: z.string().optional().describe('JSON-encoded filter expression (canonical, singular).'),
// 326
  /** @deprecated Use `filter` (singular). Accepted for backward compatibility. */
  filters: z.string().optional().describe('JSON-encoded filter expression (deprecated plural alias).'),
```

两点：值是 `z.string()`（JSON **字符串**），且它挂在 `HttpFindQueryParamsSchema` 上 —— HTTP 层。范例给的却是进程内调用。**连单数 `filter` 都不是进程内的键**，`filters` 更不是。

进程内的真相由本仓自己的 `src/objects/_hook-api.ts` 写死（`HookQuery` 只有 `where` / `fields` / `top`），其注释复述了这笔账：`find` 会把 `filter` 归一成 `where`（碰巧对），`findOne` 把 query 直接摊进 AST（`{...query, limit: 1}`）从不做别名 → 返回**该对象第一行**；`count` 只读 `query.where` → 数**全表**。都不报错、不返回 `null`。

本仓 `.changeset/hook-query-where-not-filter.md` 记的就是这笔账：17 处 hook 调用曾写成 `filter:`，代价包括 line-item 定价取错产品、报价接受 / 赢单-合同激活的「是否已在目标状态」判在无关记录上、case 升级把跟进任务派给第一个账户的 owner、删除守卫数全表因而拦下无引用的删除、campaign ROI 把全表计数记成归因。

**类型面反证**（一次性 `tsc --noEmit --ignoreConfig --strict`，跑完即删，探针文件不在工作树内）：

```
probe-where.ts(6,65): error TS2322: Type '(string | number)[][]' is not assignable to type 'Doc'.
  Index signature for type 'string' is missing in type '(string | number)[][]'.
probe-where.ts(10,65): error TS2353: Object literal may only specify known properties, and 'filters' does not exist in type 'HookQuery'.
```

第 6 行是把范例的 AST 数组当 `where` 的值；第 10 行是范例的 `filters:` 键。对照组（对象形 `where: { amount: { $gt: 50000 } }`）无报错。

### 2.3 `'opportunity'` —— 违反同文件第 59 行

第 59 行原文：「**All HotCRM business object names MUST use the `crm_` prefix and the prefix MUST be written explicitly in source**」，且明确 hook `object:` / action `objectName:` 等全用带前缀名、**No automatic prefix injection by the runtime**。`pnpm validate` 报 17 Objects，实测全为 `crm_*`；真实名是 `crm_opportunity`。范例与规则相距 5 行却自相矛盾。

## 3. 新范例

```
- Format: `ctx.api.object('crm_opportunity').find({ where: { amount: { $gt: 50000 } } })`.
```

三处逐一对上：`broker` → `ctx.api`；`filters` → `where`；`opportunity` → `crm_opportunity`。

**谓词的「值」也换了形状，这一点 issue 未提，说明如下**：原范例的 `[['amount', '>', 50000]]` 是 filter AST 数组形，它在**平台层合法**（`spec/src/data/filter.zod.ts:537,592` 有 `[field, operator, value]` 的 lowering，`'>'` → `$gt` 见 `AST_OPERATOR_MAP:405`），所以我没有把它列为「第四处失真」。但它 (a) 不可赋给 `HookQuery['where']`（见上 TS2322），(b) 本仓 60 处一等公民调用**零使用**，全部用对象形（`$in` / `$nin` / `$lt` / `$lte` / `$gte` 实测在用）。范例的职责是给 agent 抄，所以取实际在用的形状。`$gt` 是 `ComparisonOperatorSchema` 的正式成员（`filter.zod.ts:65`，`z.union([z.number(), z.date(), FieldReferenceSchema])`，`50000` 是 number），语义与原范例的 `amount > 50000` 等价。

范例下方补了两条直接说明句（`ctx.api` 是唯一 surface、hook 侧 cast 一次；谓词键只有 `where` 及其静默失败方式 + 指向本仓那份 changeset）。**只动了第 2 条这四行所在的块**，条目 1、3 与其余全文一字未改。

## 4. 改动面

只有两个文件，15 增 2 删：

- `AGENTS.md`：第 61-64 行的 ObjectQL 条目。
- `.changeset/agents-md-objectql-example.md`：`'hotcrm': patch`，站内路径一律反引号（#797：link-check 会扫 `.changeset`）。

`src/**`、`content/**`、`content/docs/releases/`、`@objectstack/*` 依赖版本均未触碰。#856（action 后缀 3:1）已单独立单，本 PR 不动。

## 5. 验证（全量，共享锁 + `NODE_OPTIONS=--max-old-space-size=4096`）

`AGENTS.md` 不在多数闸门的扫描面内，全量跑是为了证明基线没被我破坏：

| 命令 | 退出码 | 关键行 |
|---|---|---|
| `pnpm validate` | **0** | `✓ Validation passed (1654ms)` · `17 Objects 344 Fields` · `24 Flows` —— 5 条 author-time warning 为基线既有（4 条 approval 空审批人 + 1 条 crm_campaign_member group），与本 PR 无关 |
| `pnpm typecheck` | **0** | `tsc --noEmit` 无输出 |
| `pnpm build` | **0** | `✓ Build complete (1561ms)` · `dist/objectstack.json (1921.3 KB)` |
| `pnpm test -- --maxWorkers=2` | **0** | `Test Files 66 passed (66)` · `Tests 1587 passed \| 1 skipped (1588)` |
| `pnpm lint` | **0** | `13 warning(s), 14 suggestion(s)` —— 基线既有 |
| `pnpm hygiene` | **0** | `✓ no raw control bytes in first-party files` · `✓ source hygiene clean` |

test 输出里 source-hygiene 元测试的 `✗ source hygiene: scanned director(y|ies) missing: .changeset` 是该元测试的**预期 stderr**（它断言「扫不到东西的检查比没有检查更糟」），套件仍全绿。

控制字节自扫（超出 `check-source-hygiene` 的盲区）：

```
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' AGENTS.md .changeset/agents-md-objectql-example.md
$ echo $?
1        # 零命中
```

## 6. 顺带发现

无新增。通读时留意到的两处均已有单：#856（`*.action.ts` 单复数 3:1，`finding`）、以及本 PR 已修的 #855 自身。未发现其它需另立的过期指令。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_