### PR TITLE
docs: 修掉两处悬空锚点 —— sla-and-escalation 指向 automation 的 Flows 一节，zh 版 mobile 的 roadmap 去锚点

### DIFF
--- a/.changeset/dangling-anchors.md
+++ b/.changeset/dangling-anchors.md
@@ -1,0 +1,26 @@
+---
+'hotcrm': patch
+---
+
+Fix two dangling in-page anchors in the docs, so both links land on the section
+they promise instead of the top of the page.
+
+`service/sla-and-escalation` (all three locales) pointed the escalation-trigger
+sentence at `/docs/administration/automation#case-escalation`. The automation
+page has no *Case Escalation* heading — *Case Escalation Process* is a row in
+the table under `## Flows (multi-step)`, which is where a reader chasing the
+trigger condition actually has to go. The English page now links
+`/docs/administration/automation#flows-multi-step`. The Chinese pages link the
+page with no anchor (`/zh-Hans/docs/administration/automation`,
+`/zh-Hant/docs/administration/automation`): the heading there is
+「流程（多步骤）」/「流程（多步驟）」, whose slug is not `flows-multi-step`,
+and un-anchored is the form already used for cross-locale links elsewhere in
+the guides.
+
+`guides/mobile` in Chinese pointed the roadmap link at
+`/zh-Hans/docs/whats-new#roadmap` (and the `zh-Hant` twin). The heading on the
+translated What's New pages is 「路线图」/「路線圖」 — the heading was
+translated, the anchor was not — so `#roadmap` resolved to nothing. Both now
+link `/zh-Hans/docs/whats-new` and `/zh-Hant/docs/whats-new`. The English
+`guides/mobile` keeps `#roadmap`, which resolves to the `## Roadmap` heading it
+has always had.

--- a/content/docs/guides/mobile.zh-Hans.mdx
+++ b/content/docs/guides/mobile.zh-Hans.mdx
@@ -7,7 +7,7 @@ description: 在你的手机或平板上使用 HotCRM —— 哪些可用、哪�
 
 HotCRM 通过**响应式 Web 应用**在手机和平板上运行 —— 在任何现代移动浏览器中打开 `your-hotcrm-url`，你就会获得为该设备优化的布局。
 
-> 原生 iOS / Android 应用已在[路线图](/zh-Hans/docs/whats-new#roadmap)上。
+> 原生 iOS / Android 应用已在[路线图](/zh-Hans/docs/whats-new)上。
 
 ## 在移动端运行良好的功能
 

--- a/content/docs/guides/mobile.zh-Hant.mdx
+++ b/content/docs/guides/mobile.zh-Hant.mdx
@@ -7,7 +7,7 @@ description: 在你的手機或平板上使用 HotCRM —— 哪些可用、哪�
 
 HotCRM 透過**響應式 Web 應用**在手機和平板上執行 —— 在任何現代行動瀏覽器中開啟 `your-hotcrm-url`，你就會獲得為該裝置最佳化的版面配置。
 
-> 原生 iOS / Android 應用已在[路線圖](/zh-Hant/docs/whats-new#roadmap)上。
+> 原生 iOS / Android 應用已在[路線圖](/zh-Hant/docs/whats-new)上。
 
 ## 在行動版執行良好的功能
 

--- a/content/docs/service/sla-and-escalation.mdx
+++ b/content/docs/service/sla-and-escalation.mdx
@@ -125,5 +125,5 @@ If priority resolves to **Critical**, the Copilot immediately recommends escalat
 
 - The SLA target per priority is set via the case object's automation (a SLA-calculation hook). To adjust, edit `src/objects/case.hook.ts` (binds to `crm_case`) or change the underlying configuration — see [Administration › Automation](/docs/administration/automation).
 - Business-hours vs. calendar-hours behaviour is controlled by your tenant's business-hours setup. See [Administration › Setup](/docs/administration/setup).
-- Escalation triggers (Critical, or High+Customer) live in the [Case Escalation flow definition](/docs/administration/automation#case-escalation). Adjust the condition there to change when escalation fires.
+- Escalation triggers (Critical, or High+Customer) live in the [Case Escalation flow definition](/docs/administration/automation#flows-multi-step). Adjust the condition there to change when escalation fires.
 - The recipient lists for *Notify on Critical* and *Notify on Escalation* are configurable in the case workflow rules.

--- a/content/docs/service/sla-and-escalation.zh-Hans.mdx
+++ b/content/docs/service/sla-and-escalation.zh-Hans.mdx
@@ -125,5 +125,5 @@ SLA 目标可按优先级配置——参见下方的*给管理员的提示*部�
 
 - 每个优先级的 SLA 目标通过工单对象的自动化（一个 SLA 计算钩子）设置。要调整，请编辑 `src/objects/case.hook.ts`（绑定到 `crm_case`）或更改底层配置——参见 [管理 › 自动化](/zh-Hans/docs/administration/automation)。
 - 营业时间与日历时间的行为由你租户的营业时间设置控制。参见 [管理 › 设置](/zh-Hans/docs/administration/setup)。
-- 升级触发条件（Critical，或 High+Customer）存在于 [工单升级流程定义](/zh-Hans/docs/administration/automation#case-escalation)中。在那里调整条件即可更改升级何时触发。
+- 升级触发条件（Critical，或 High+Customer）存在于 [工单升级流程定义](/zh-Hans/docs/administration/automation)中。在那里调整条件即可更改升级何时触发。
 - *紧急时通知*和*升级时通知*的收件人列表可在工单工作流规则中配置。

--- a/content/docs/service/sla-and-escalation.zh-Hant.mdx
+++ b/content/docs/service/sla-and-escalation.zh-Hant.mdx
@@ -125,5 +125,5 @@ SLA 目標可按優先順序配置——參見下方的*給管理員的提示*�
 
 - 每個優先順序的 SLA 目標透過工單物件的自動化（一個 SLA 計算鉤子）設定。要調整，請編輯 `src/objects/case.hook.ts`（綁定到 `crm_case`）或更改底層配置——參見 [管理 › 自動化](/zh-Hant/docs/administration/automation)。
 - 營業時間與日曆時間的行為由你租戶的營業時間設定控制。參見 [管理 › 設定](/zh-Hant/docs/administration/setup)。
-- 升級觸發條件（Critical，或 High+Customer）存在於 [工單升級流程定義](/zh-Hant/docs/administration/automation#case-escalation)中。在那裡調整條件即可更改升級何時觸發。
+- 升級觸發條件（Critical，或 High+Customer）存在於 [工單升級流程定義](/zh-Hant/docs/administration/automation)中。在那裡調整條件即可更改升級何時觸發。
 - *緊急時通知*和*升級時通知*的收件人列表可在工單工作流規則中配置。


### PR DESCRIPTION
Fixes #749
Fixes #764

两单同缺陷类（站内链接的锚点在目标页不存在），文件面互斥，按 #749 的 PM 认领裁定并单一个 PR。

## slug 规则先钉死（两单共用的判据）

不推断，实测：`apps/docs` 用 fumadocs-core 16.9.3，`source.config.ts` 的 `mdxOptions` 是空的，走默认 `remark-heading` —— 也就是 `github-slugger`。装 `github-slugger@2` 逐个跑出来：

```
"Flows (multi-step)"  -> "flows-multi-step"
"流程（多步骤）"        -> "流程多步骤"
"流程（多步驟）"        -> "流程多步驟"
"Roadmap"             -> "roadmap"
"路线图"               -> "路线图"
"路線圖"               -> "路線圖"
```

对照组佐证这套规则与仓库现状一致：`content/docs/administration/sharing-and-security.zh-Hans.mdx:169` 的既有链接 `#字段级安全`，目标 `profiles.zh-Hans.mdx` 的 `## 字段级安全` 算出来正是 `字段级安全` —— 现有能跳的锚点按这套规则算得出来，所以它就是渲染时用的那套。

## #749 —— sla-and-escalation 三语的 automation 锚点

**前提复核**：issue 正文列的 automation 页标题清单已经过期（#854 重构过），所以按裁定实测了当前 `main`：

```
content/docs/administration/automation.mdx
  12:## The four kinds        ← issue 里写的是 "The five kinds"
  21:## Validation rules
  39:## Flows (multi-step)    ← 仍在
  ...
```

`## Workflow rules` 这个标题已经不存在了（#833 把那节退休成了 Flows 节里的一段说明）。但 issue 的核心断言仍然成立：**automation 页三语都没有 Case Escalation 这个标题**，`#case-escalation` 确实悬空；*Case Escalation Process* 是 `## Flows (multi-step)` 一节内置流程表里的一行（`automation.mdx:73`）。前提有效。

改法按裁定：

- **en** —— 改成 `/docs/administration/automation#flows-multi-step`。`## Flows (multi-step)` 在，slug 实测 `flows-multi-step`。
- **zh-Hans / zh-Hant** —— 去锚点，只链 `/zh-Hans/docs/administration/automation` 与 `/zh-Hant/docs/administration/automation`。zh 标题是「流程（多步骤）」「流程（多步驟）」，slug 分别是 `流程多步骤` / `流程多步驟`，与英文不同名；按 PR #755 / #762 已立的写法，zh 侧不带锚点。

⚠️ `sla-and-escalation` 是 #850 八页族之一（未派）。本 PR 只动 `:128` 这一行的链接，该页其它内容（包括 `:129` 的「工作流规则」字样）一概未碰 —— 那是 #850 的面。

## #764 —— zh 版 mobile 的 roadmap 锚点

**前提复核**：实测确认 `content/docs/whats-new.zh-Hans.mdx:98` 是 `## 路线图`、`whats-new.zh-Hant.mdx:98` 是 `## 路線圖`，slug 里不含 `roadmap`，两处 `#roadmap` 悬空；英文侧 `whats-new.mdx:116` 的 `## Roadmap` 在，`guides/mobile.mdx:10` 的 `#roadmap` 正常。前提有效。

zh 两处去锚点（`/zh-Hans/docs/whats-new`、`/zh-Hant/docs/whats-new`），en 侧不动。

## 全仓同类扫尾（只报不改）

按裁定第 3 条做了一次全量抽检：解析 `content/docs` 下所有带锚点的站内链接，用 `github-slugger` 算目标页每个标题的 slug 比对。其它链接形式（`href=`、reference-style 链接定义、fumadocs Card 的 `url=`、`content/blog`）实测零命中，内联 markdown 链接即全集。

`main` 上 36 条带锚点站内链接，**22 条悬空**。本 PR 修掉其中属于两单的 5 条；**其余 17 条已另开 #866 记录**，含逐条的「链接位置 / 锚点 / 目标标题 / 实际 slug」表和三类新成因（emoji 标题产生前导连字符的 slug、标题后来加了后缀、zh 页沿用英文锚点）。本 PR 后：

```
before: total anchored internal links: 36; dangling: 22
after : total anchored internal links: 32; dangling: 17
✓ content/docs/service/sla-and-escalation.mdx:128 /docs/administration/automation#flows-multi-step
```

（32 = 36 − 4，因为 4 条 zh 链接去掉了锚点、1 条 en 链接换了锚点。）

顺带记一条：`.github/workflows/link-check.yml` 配的是 `file-extension: '.md'`，而 `content/docs` 全是 `.mdx` —— 这个 workflow 对产品文档实际是空转的，所以这批悬空锚点在 CI 里从来没有信号。已写进 #867。

守卫能力单已另立 **#867**（不带标签、不指派，交 PM 分级）：记录四种已证成因、现有门禁为何都抓不到、以及 #749 评论建议的「链接语言前缀一致性」检查（本轮扫尾该类零命中，属防复发而非修存量，已在单里注明以免定级虚高）。按裁定本 PR 不加测试。

## 验证

worktree `hotcrm-issue-749`，共享锁 + `NODE_OPTIONS=--max-old-space-size=4096`：

```
VALIDATE_EXIT=0    ⚠ 5 author-time warning(s) —— 均为 main 上既有（approval 空审批人 ×4、campaign_member field-group ×1）
TYPECHECK_EXIT=0   tsc --noEmit
LINT_EXIT=0        objectstack lint --skip-i18n
HYGIENE_EXIT=0     ✓ no raw control bytes in first-party files
BUILD_EXIT=0       ✓ Build complete (1688ms) — 17 Objects / 24 Flows
TEST_EXIT=0        Test Files 66 passed (66) · Tests 1587 passed | 1 skipped (1588)
```

`test` 里 source-hygiene 元测试打印的 `✗ source hygiene: scanned director(y|ies) missing: .changeset` 是该用例的预期 stderr，不是失败（`TEST_EXIT=0`）。

控制字节自扫（5 个改动文件 + changeset）零命中：

```
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' ... → exit 1（无匹配）
```

changeset：`.changeset/dangling-anchors.md`（`'hotcrm': patch`），站内路径一律反引号写（#797）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_