### PR TITLE
docs(flows): name what the flow nodes do, not what they were once meant to do

### DIFF
--- a/.changeset/flow-node-labels.md
+++ b/.changeset/flow-node-labels.md
@@ -1,0 +1,46 @@
+---
+'hotcrm': patch
+---
+
+Make the flow **node** labels say what those nodes do. #851 corrected the
+Automation page's flow table and the `opportunity_won_alert` description; the
+same three claims survived one layer further in — on the nodes themselves, which
+ship as authored metadata in `dist/objectstack.json`, and in a file-header
+comment that had started contradicting the description right above it.
+
+- **`Notify Management` → `Notify Owner`** (`src/flows/opportunity-won-alert.flow.ts`).
+  The node addresses `{record.owner_id}` and nothing else. The comment directly
+  above it already explained why there is no manager recipient —
+  `{record.owner_id.manager}` cannot traverse a lookup on the raw trigger
+  snapshot, so it interpolates to the literal `undefined` and the message goes to
+  a phantom user — so the label was contradicted by its own header.
+- **`Assign to Senior Agent` → `Flag as Escalated`** (`src/flows/case-escalation.flow.ts`).
+  The `update_record` node writes `is_escalated`, `escalation_reason`,
+  `escalated_date` and `status`. It never touches `owner_id`; the comment inside
+  it opens with *"No owner reassignment"*. The case stays with the agent who had
+  it, exactly as the escalation notice already tells the recipient: *"It remains
+  assigned to you."*
+- **`Notify Support Team` → `Notify Case Owner`** (`src/flows/case-escalation.flow.ts`).
+  Same file, same class of claim: `recipients` is the single entry
+  `{caseRecord.owner_id}`, not a team. The identical node in
+  `src/flows/case-sla-monitor.flow.ts` — same `notify_team` id, same owner-only
+  recipient — already carries the honest label `Alert Owner`; this one had been
+  left behind.
+
+The file-header comment on `src/flows/opportunity-won-alert.flow.ts` still
+described the flow as *"notify the owner and their manager"*, the sentence #851
+removed from the `description` eleven lines below it. It now uses that same
+correction, so the two no longer disagree.
+
+Node **ids** are deliberately untouched — `notify_management`,
+`assign_senior_agent` and `notify_team` keep their original spellings because
+`edges[]` reference nodes by id and `CaseEscalationOnCreateFlow` rewrites the
+node list by id. Renaming one would be a behaviour change wearing a wording
+fix's clothes, so each node now carries a short note saying so, to keep the next
+reader from "tidying" an id that looks stale next to its corrected label.
+
+Labels and comments only. No flow behaviour changed: no recipient, condition,
+field set, edge or id differs, and this takes no position on whether escalation
+*should* reassign or *should* copy a manager — those remain open product
+questions whose answers would be behaviour changes with their own docs.
+Fixes #869.

--- a/src/flows/case-escalation.flow.ts
+++ b/src/flows/case-escalation.flow.ts
@@ -84,7 +84,13 @@ export const CaseEscalationFlow: Flow = {
       config: { objectName: 'crm_case', filter: { id: '{record.id}' }, outputVariable: 'caseRecord' },
     },
     {
-      id: 'assign_senior_agent', type: 'update_record', label: 'Assign to Senior Agent',
+      // The `label` names what this node actually does: it flags the case as
+      // escalated (see `fields` below) and reassigns nothing. The `id` keeps
+      // its original `assign_senior_agent` spelling on purpose — `edges[]`
+      // reference nodes by id, and `CaseEscalationOnCreateFlow` rewrites the
+      // node list by id, so renaming one is a behaviour change, not a wording
+      // fix.
+      id: 'assign_senior_agent', type: 'update_record', label: 'Flag as Escalated',
       config: {
         objectName: 'crm_case', filter: { id: '{record.id}' },
         // `escalation_reason` must be set whenever `is_escalated` flips true — the
@@ -108,7 +114,11 @@ export const CaseEscalationFlow: Flow = {
       // shape is a no-op stub in 7.4 and never delivered anything.
       // Owner only: `{caseRecord.owner_id.manager}` cannot traverse a lookup in
       // flow templates — it interpolates to the literal "undefined".
-      id: 'notify_team', type: 'notify', label: 'Notify Support Team',
+      // The `label` names the single recipient this node has (`recipients`
+      // below); the `id` keeps its `notify_team` spelling because `edges[]`
+      // reference it. Cf. the same node in `case-sla-monitor.flow.ts`, whose
+      // label already says `Alert Owner`.
+      id: 'notify_team', type: 'notify', label: 'Notify Case Owner',
       config: {
         // Owner only. Flow templates cannot traverse a lookup (see the note on
         // `assign_senior_agent` above): `{caseRecord.owner_id.manager}` and

--- a/src/flows/opportunity-won-alert.flow.ts
+++ b/src/flows/opportunity-won-alert.flow.ts
@@ -9,7 +9,8 @@ type Flow = Automation.Flow;
  *
  * Migrated from the removed `notify_on_large_deal_won` object workflow (7.7
  * dropped `workflows[]`). When a deal > $100K is marked closed_won, notify the
- * owner and their manager.
+ * owner — the owner alone, not their manager (see the notify node for why the
+ * manager cannot be reached).
  *
  * NB: `record.amount > 100000` is authored as bare CEL against the (string-
  * serialized) currency field — this relies on the 7.7 numeric-hydration fix
@@ -68,7 +69,11 @@ export const OpportunityWonAlertFlow: Flow = {
       },
     },
     {
-      id: 'notify_management', type: 'notify', label: 'Notify Management',
+      // The `label` names what this node actually does: it notifies the owner
+      // and nobody else. The `id` keeps its original `notify_management`
+      // spelling on purpose — `edges[]` reference nodes by id, so renaming one
+      // is a behaviour change, not a wording fix.
+      id: 'notify_management', type: 'notify', label: 'Notify Owner',
       config: {
         // Owner only: `{record.owner_id.manager}` cannot traverse a lookup on the
         // raw trigger snapshot — it interpolates to the literal "undefined"


### PR DESCRIPTION
Fixes #869

#851 / PR #870 corrected the Automation page's flow table and the `opportunity_won_alert` `description`. The same claims survived one layer further in — on the **nodes** themselves, which ship as authored metadata inside `dist/objectstack.json`, and in a file-header comment that had begun contradicting the description eleven lines below it. Same "write the current behaviour" standard, same wording, no third phrasing.

## Premise re-check against the current baseline

Baseline `origin/main` = 6cd53d2e, which contains **PR #870** (5868728f) and #874. All three sites re-located after #870's edits and all three are still present:

| issue says | after #870 | still there? |
| --- | --- | --- |
| `opportunity-won-alert.flow.ts:71` label `Notify Management` | line 71 | yes |
| `case-escalation.flow.ts:87` label `Assign to Senior Agent` | line 87 | yes |
| `opportunity-won-alert.flow.ts:10-12` JSDoc "notify the owner and their manager" | lines 10-12 | yes |

**Node id reference chains, checked before editing** (the issue flagged these as load-bearing):

```
notify_management    -> declared 1x + referenced by edges e1.target, e2.source
assign_senior_agent  -> declared 1x + referenced by edges e2.target, e3.source + one comment cross-ref
notify_team          -> declared 1x + referenced by edges e3.target, e4.source
CaseEscalationOnCreateFlow rewrites the node list via `n.id === 'start'`
```

No id is touched. Diffing the `id:` / `source:` / `target:` lines against `origin/main` shows every id string byte-identical; only `label:` values and comments differ.

## The three sites

| file | before | after | why |
| --- | --- | --- | --- |
| `src/flows/opportunity-won-alert.flow.ts` | label `Notify Management` | `Notify Owner` | `recipients: ['{record.owner_id}']` — the owner and nobody else. The comment directly above the node already explained why there is no manager recipient: `{record.owner_id.manager}` cannot traverse a lookup on the raw trigger snapshot, so it interpolates to the literal `undefined` and the message goes to a phantom user. The label was contradicted by its own header. |
| `src/flows/case-escalation.flow.ts` | label `Assign to Senior Agent` | `Flag as Escalated` | the `update_record` node writes `is_escalated`, `escalation_reason`, `escalated_date`, `status`. It never touches `owner_id`; the comment inside it opens with `No owner reassignment:`. |
| `src/flows/opportunity-won-alert.flow.ts:10-12` | JSDoc "notify the owner and their manager" | "notify the owner — the owner alone, not their manager" | verbatim the correction #870 landed in the `description` eleven lines below, so the two no longer disagree. |

`Notify Owner` is not a new coinage: `task-urgent-alert`, `task-due-reminder`, `contract-renewal` and `contract-expiration` already label this node exactly that.

### One further label in the same file

The dispatch allows same-file labels that are equally untrue to be corrected in the same pass, listed here:

- `src/flows/case-escalation.flow.ts` — label `Notify Support Team` -> **`Notify Case Owner`**. `recipients` is the single entry `{caseRecord.owner_id}`, not a team. The decisive evidence: the identical node in `src/flows/case-sla-monitor.flow.ts` carries the **same** `notify_team` id and the **same** owner-only recipient, and its label already reads `Alert Owner` — this one had simply been left behind. A prior pass had already corrected this node's message body ("reassigned" was also false: this flow never changes the owner) without correcting its label.

### Why the ids keep their old spellings

`notify_management`, `assign_senior_agent` and `notify_team` now each carry a short comment recording that the id is deliberately stale-looking. After this PR every one of them reads like a drift a future agent might "tidy" — and renaming any would be a behaviour change wearing a wording fix's clothes.

## Artifact landing

`pnpm build` then scanning `dist/objectstack.json`:

```
NEW   "Notify Owner"       -> 5 hits  (4 pre-existing flows + this node)
      "Flag as Escalated"  -> 2 hits  (case_escalation + case_escalation_on_create)
      "Notify Case Owner"  -> 2 hits  (same two flows)

OLD   "Notify Management"      -> 0 hits
      "Assign to Senior Agent" -> 0 hits
      "Notify Support Team"    -> 0 hits

IDS   notify_management -> 3   assign_senior_agent -> 6   notify_team -> 8
```

The 2-hit counts are correct rather than duplicated: `CaseEscalationOnCreateFlow` builds its node list from `CaseEscalationFlow.nodes.map(...)`, so both flows carry the corrected nodes.

## Do any tests pin these labels?

**No — confirmed, as the dispatch predicted.** `test/automation-docs-coverage.test.ts` derives its expectations from each flow's own **top-level** `label` (`labelFor = (flow) => flow.label`), plus row sets, trigger cells and counts. Node labels never enter it. `test/docs-drift.test.ts` extracts only numeric thresholds and cron schedules. A repo-wide grep for the three literals returns the three source lines and nothing else — no test, fixture or doc quotes them.

Re-ran both guards on their own to be sure: `2 passed (2) / 53 passed (53)`.

A "revert it and watch the tests go red" check is therefore **not available** for this change, and reporting one would be fabrication: nothing pins node labels, which is precisely why these three drifted unnoticed. The load-bearing evidence here is the artifact scan above (old strings provably gone, ids provably intact) plus the guards staying green in the direction predicted before running them.

## Not verified (carried over from the issue, unchanged)

The issue states it did **not** verify whether the process monitor / flow run detail actually renders node labels, and this PR does not close that gap either. The fix stands on the labels being authored metadata published in the artifact — a false label is worth correcting whether or not that particular surface paints it.

## Verification

All six gates run under the shared lock with `NODE_OPTIONS=--max-old-space-size=4096`:

| step | exit | evidence |
| --- | --- | --- |
| `pnpm validate` | 0 | 24 Flows; 5 author-time warnings, all pre-existing (approval staffing, campaign_member field group) |
| `pnpm typecheck` | 0 | clean |
| `pnpm build` | 0 | `Build complete (2162ms)`, `Artifact: dist/objectstack.json (1921.4 KB)` |
| `pnpm test --maxWorkers=2` | 0 | `Test Files 66 passed (66)` / `Tests 1587 passed | 1 skipped (1588)` |
| `pnpm lint` | 0 | 13 warnings, 14 suggestions — all pre-existing |
| `pnpm hygiene` | 0 | `no raw control bytes in first-party files` |

Control-byte self-scan over the three changed files, beyond the gate's scan surface: 0 hits.

## Scope

Labels and comments only. No recipient, condition, field set, edge or id differs, and this takes no position on whether escalation *should* reassign or *should* copy a manager — both remain open product questions under #595.

Filed while verifying, not fixed here: **#875** (`src/docs/crm_sales.md` makes the same manager claim twice, and that file ships in the artifact via ADR-0046) and **#876** (`content/docs/service/sla-and-escalation` describes escalation as a reassignment plus a three-way mailout, in three languages).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_