### PR TITLE
docs(sales): name the real recipient of the two opportunity alerts (#875)

### DIFF
--- a/.changeset/crm-sales-md-recipients.md
+++ b/.changeset/crm-sales-md-recipients.md
@@ -1,0 +1,32 @@
+---
+'hotcrm': patch
+---
+
+Correct the two sentences in the packaged Sales guide that still promised a
+manager notification neither flow sends.
+
+`src/docs/crm_sales.md` is a package doc: ADR-0046 collects it whole into
+`dist/objectstack.json`, so it ships to every reader of the app, not just to
+whoever opens the file in the repo. Two of its automation paragraphs named a
+recipient that does not exist:
+
+- **Stalled-deal nudge** — *"The owner and their manager are notified"*. The
+  daily sweep in `src/flows/opportunity-stagnation.flow.ts` has exactly one
+  `notify` node, addressing `{currentOpp.owner_id}` on inbox + email. There is
+  no manager, position or team recipient anywhere in the flow; the node header
+  records why (`{currentOpp.owner_id.manager}` cannot traverse a lookup in flow
+  templates and interpolates to the literal `undefined`).
+- **Won-deal alert** — *"the owner and manager are notified automatically"*.
+  This is the same claim #851 already removed from the Automation page table and
+  from the flow's own `description`, surviving here because it is spelled
+  *"owner and manager"* rather than *"owner and their manager"* and so escaped
+  that search. `src/flows/opportunity-won-alert.flow.ts` notifies
+  `{record.owner_id}` alone, for the same lookup-traversal reason.
+
+Both now read *the owner alone, not their manager* — the wording already landed
+in the flow `description` (#851) and the node `label` (#869), so the app tells
+one story about who gets paged. Everything else in the two paragraphs is
+accurate and untouched: the 07:30 schedule, the 14-day threshold, the
+high-priority follow-up task, and the $100,000 trigger amount.
+
+Documentation only. No flow, node, condition or recipient changed. Fixes #875.

--- a/src/docs/crm_sales.md
+++ b/src/docs/crm_sales.md
@@ -70,13 +70,13 @@ and **close date** current — the automation below keys off all three.
 
 ### Stalled-deal nudge (automatic)
 A daily **07:30** sweep finds any open opportunity that has sat in its current
-stage for **more than 14 days**. The owner and their manager are notified, and a
-**high-priority follow-up task** is created. Advance the stage or re-qualify the
-deal to clear it.
+stage for **more than 14 days**. The owner is notified — the owner alone, not
+their manager — and a **high-priority follow-up task** is created. Advance the
+stage or re-qualify the deal to clear it.
 
 ### Won-deal alert (automatic)
-When a deal over **$100,000** is marked **Closed Won**, the owner and manager are
-notified automatically.
+When a deal over **$100,000** is marked **Closed Won**, the owner is notified
+automatically — the owner alone, not their manager.
 
 ## 4. Large-deal approval — when a deal pauses for sign-off
 


### PR DESCRIPTION
Fixes #875

`src/docs/crm_sales.md` 第 73、78 行两句仍称通知「负责人及其经理」，而 `opportunity_stagnation` 与 `opportunity_won_alert` 两条 flow 的 notify 收件人都只有负责人一人。本 PR 只把这两句按 #851/#869 已落地的口径写实，不动任何 flow、不加守卫。

## 一、前提复核

基线取最新 `origin/main` = `716bd4d3`（issue 记录的 6cd53d2e 之后又落了 #877 / #878 / #879）。两行**未被重定位、原文仍在**，issue 前提成立：

| 位置 | 复核结果 |
|---|---|
| `src/docs/crm_sales.md:73` | 仍为 `The owner and their manager are notified, and a` |
| `src/docs/crm_sales.md:78` | 仍为 `the owner and manager are` / 79 行 `notified automatically.` |

逐节点重读两条 flow 源码，确认收件人：

- `src/flows/opportunity-stagnation.flow.ts` — 全流程节点为 `start` → `query_stalled` → `loop_opps`（循环体内 `find_existing_task` → `check_not_nudged` → `notify_owner` → `create_followup_task`）→ `end`。**唯一** notify 节点是第 89-97 行的 `notify_owner`，`recipients: ['{currentOpp.owner_id}']`，channels 为 inbox + email。全文件无任何 manager / position / team 收件目标；节点上方注释已写明原因：`{currentOpp.owner_id.manager}` 在 flow 模板里无法穿透 lookup，会插值成字面量 `undefined`。
- `src/flows/opportunity-won-alert.flow.ts` — 节点为 `start` → `notify_management` → `end`。唯一 notify 节点第 76-88 行，`recipients: ['{record.owner_id}']`（`id` 保留历史拼写 `notify_management` 是 #869 的有意决定：`edges[]` 按 id 引用节点，改名是行为变更）。该 flow 的 `description` 与文件头 JSDoc 已经是 `the owner alone, not their manager`。

即：第 78 行正是 #851 已从 Automation 页表行和 flow `description` 里删掉的那句话——因为它拼作 `owner and manager` 而非 `owner and their manager`，当时按后者检索故漏网。

## 二、两句改文对照

措辞沿用 #870 落地的 `description` 与 #877 落地的 `label` 同一说法（`the owner alone, not their manager`），不造第三种说法；两段里其余承载信息的部分（07:30、14 天、高优先级跟进任务、$100,000）全部准确，原样保留。

**第 72-75 行（停滞商机提醒）**

改前：

```
A daily **07:30** sweep finds any open opportunity that has sat in its current
stage for **more than 14 days**. The owner and their manager are notified, and a
**high-priority follow-up task** is created. Advance the stage or re-qualify the
deal to clear it.
```

改后：

```
A daily **07:30** sweep finds any open opportunity that has sat in its current
stage for **more than 14 days**. The owner is notified — the owner alone, not
their manager — and a **high-priority follow-up task** is created. Advance the
stage or re-qualify the deal to clear it.
```

**第 77-79 行（大额赢单提醒）**

改前：

```
When a deal over **$100,000** is marked **Closed Won**, the owner and manager are
notified automatically.
```

改后：

```
When a deal over **$100,000** is marked **Closed Won**, the owner is notified
automatically — the owner alone, not their manager.
```

## 三、产物落位证据（ADR-0046）

该文件经 ADR-0046 整篇进 `dist/objectstack.json`（build 日志 `→ Collecting package docs (ADR-0046)...`），所以这两句是随 app 发布的读者伤害，不是纯注释问题。

**反向验证——方向是事先预判的**：先在本分支上把 md 改动 stash 掉重新 build（即基线态），断言产物里旧句应当**存在**；恢复改动再 build，断言旧句归零、新句落位。两次都按预判走：

| 断言（在 `dist/objectstack.json` 内计数） | 基线 build | 本 PR build |
|---|---|---|
| `The owner and their manager are notified` | **1** | **0** |
| `the owner and manager are` | **1** | **0** |
| `The owner is notified — the owner alone` | 0 | **1** |
| `automatically — the owner alone, not their manager` | 0 | **1** |

全产物范围内 `and their manager` 与 `owner and manager` 现均为 0 命中。产物中该 doc 的上下文确认整篇原样收录（`### Stalled-deal nudge (automatic)` 段落连同 07:30 / 14 days / $100,000 一并在内）。

## 四、docs-drift 守卫的敏感度（如实报告）

`test/docs-drift.test.ts` 的 `docs: [...]` 里确实列着 `crm_sales.md`，但每条 `RULES` 的 `extract` 只从 flow 源码抓**数值与 cron**：审批阈值 `record.amount > (\d+)`、赢单阈值、`STALE_THRESHOLD_DAYS = (\d+)`、报价有效期 `defaultValue: (\d+)`、热线索星级 `record.rating >= (\d+)`，以及各 sweep 的 `schedule: '(...)'`。收件人不在任何一条规则的检查面内，因此**该守卫对本次改动零敏感**——它既没抓到这两句漂移，也不会因本次改写变红（被它钉住的 `14 days` / `07:30` / `$100,000` 我原样保留了）。按 issue「不必混进文案修复」的边界，本 PR **不新增**收件人守卫；若认为该能力面值得做，应单独立单。

## 五、验证输出

共享锁 `flock -w 7200 /tmp/os-heavy-verify.lock` + `NODE_OPTIONS=--max-old-space-size=4096`，依次：

| 步骤 | 退出码 | 关键行 |
|---|---|---|
| `pnpm validate` | **0** | — |
| `pnpm typecheck` | **0** | — |
| `pnpm build` | **0** | `✓ Build complete (1595ms)` / `Artifact: dist/objectstack.json (1921.4 KB)` |
| `pnpm test -- --maxWorkers=2` | **0** | `Test Files  66 passed (66)` / `Tests  1587 passed \| 1 skipped (1588)` / `Duration  48.21s` |
| `pnpm lint` | **0** | 13 条既有 `naming/namespace-prefix` warning，与本改动无关 |
| `pnpm hygiene` | **0** | 含「no raw control bytes in first-party files」 |

test 里出现的 `✗ source hygiene failed: ...` 是 source-hygiene 元测试自身打印的预期 stderr（该套件全绿）。改动文件另做控制字节自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`：零命中，两文件均为 UTF-8 text。

## 六、边界

- `src/**` 中仅改 `src/docs/crm_sales.md` 一个文件的两句；未动 `content/**`、未动 `content/docs/releases/`、未升级 `@objectstack/*`、未改任何 flow 行为/节点/条件/收件人。
- changeset：`.changeset/crm-sales-md-recipients.md`（`'hotcrm': patch`）。
- 同文件其它疑似漂移不在本 PR 内处理，已随报告回给 PM 判定。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_