### PR TITLE
docs+test: 教学面两处小订正 — 注释改历史口径 + 示例 lookup 参数改 field-backed (#778, #821)

### DIFF
--- a/.changeset/teaching-surface-fixes.md
+++ b/.changeset/teaching-surface-fixes.md
@@ -1,0 +1,41 @@
+---
+'hotcrm': patch
+---
+
+Two teaching-surface corrections. No runtime metadata changes — one test-file
+comment and one developer-doc example.
+
+**The action-sandbox rationale comment no longer asserts a fixed bug in the
+present tense.** The file header of `test/case-first-response.test.ts` explains
+why these tests run the shipped body under the real QuickJS sandbox instead of
+the handler-as-JS shortcut, and cited `mass_update_stage` as "the action in this
+repo that got that wrong and silently never wrote". Both halves had expired:
+`src/actions/opportunity.actions.ts` now calls
+`update({ id, stage }, { where: { id } })`, and the action path was never the
+silent one — a wrong option spelling comes back as a 400 with a red toast in the
+console. Only the hook-side writes failed silently, because those hooks carry
+`onError: 'log'`. The example is now written in the past tense with the two
+failure modes told apart; the technical point it exists to make — the engine
+facade's `update` takes a document rather than an id, so only a real sandbox
+catches this class of bug — is unchanged.
+
+**The "Add An Action" doc example now declares a lookup param that renders a
+record picker.** The Campaign param in `docs/developers/code_examples.md` was a
+bare `{ name: 'campaign', type: 'lookup' }` with no picker target. That parses
+and submits fine, so nothing warns — but with no target object to resolve, the
+console degrades the control to a text box asking the user to paste a record id
+by hand. The example now uses the field-backed form the repo actually ships in
+`src/actions/lead.actions.ts`:
+
+```ts
+{ field: 'crm_campaign', objectOverride: 'crm_campaign_member',
+  label: 'Campaign', required: true }
+```
+
+which resolves the widget from `crm_campaign_member.crm_campaign` and renders a
+real picker, with a comment beside it stating why a bare lookup does not. Since
+a field-backed param defaults its request-body key to the field name, the
+example body's one read moves with it, `input.campaign` → `input.crm_campaign`
+— otherwise the copied example would collect a campaign and then fail its own
+"Campaign is required" check. The `_selectedIds` teaching added to this example
+earlier is untouched. Fixes #778, #821.

--- a/docs/developers/code_examples.md
+++ b/docs/developers/code_examples.md
@@ -107,10 +107,16 @@ export const AddLeadsToCampaignAction: Action = {
   type: 'script',
   locations: ['list_toolbar'],
   params: [
+    // Field-backed param: `field` + `objectOverride` make the console resolve
+    // the widget from crm_campaign_member.crm_campaign (a lookup → crm_campaign),
+    // rendering a RECORD PICKER. A bare `{ type: 'lookup' }` with no field can't
+    // resolve a target object and silently falls back to a paste-the-ID textbox.
+    // The value key is the field name (`crm_campaign`) because the param omits
+    // an explicit `name` — that is the key the body reads below.
     {
-      name: 'campaign',
+      field: 'crm_campaign',
+      objectOverride: 'crm_campaign_member',
       label: 'Campaign',
-      type: 'lookup',
       required: true,
     },
     // NOTE: `_selectedIds` is NOT declared here. See "Bulk actions" below.
@@ -128,7 +134,7 @@ export const AddLeadsToCampaignAction: Action = {
       const ids = selected.length ? selected : (ctx.recordId ? [ctx.recordId] : []);
       if (!ids.length) throw new Error('No lead selected');
 
-      const campaignId = input.campaign;
+      const campaignId = input.crm_campaign;
       if (!campaignId) throw new Error('Campaign is required');
 
       for (const leadId of ids) {

--- a/test/case-first-response.test.ts
+++ b/test/case-first-response.test.ts
@@ -24,8 +24,11 @@ import { makeSandboxEngine, runActionBody, type Rec } from './helpers/action-san
  * These run the SHIPPED body under the real QuickJS sandbox rather than the
  * handler-as-JS shortcut, because two of the things that can break this stamp
  * only exist there: the `api.read` capability the new lookup needs, and the
- * engine facade's `update(data, options)` signature (`mass_update_stage` is the
- * action in this repo that got that wrong and silently never wrote).
+ * engine facade's `update(data, options)` signature. `mass_update_stage` was
+ * the action in this repo that got that signature wrong (fixed in #777); the
+ * hook-side writes in #616 failed *silently* because those hooks are
+ * `onError: 'log'`, while the action path always failed loudly — a 400 from
+ * the dispatch and a red toast in the console.
  */
 
 type AnyRec = Record<string, any>;


### PR DESCRIPTION
Fixes #778
Fixes #821

两单同为教学面小订正,文件互斥,并单一个 PR。均不改任何运行时元数据行为:一处是测试文件头注释,一处是开发者文档示例。

## #778 — `test/case-first-response.test.ts` 文件头注释改为历史口径

**前提复核(仍成立)**:`src/actions/opportunity.actions.ts` 的 `mass_update_stage` 现在确实已写成 `update({ id, stage }, { where: { id } })`(#777 落地,见该文件 :127-130),所以注释里「is the action … that got that wrong」的现在时确已失真;`onError: 'log'` 在 `src/objects/*.hook.ts` 共 8 处仍在(#616 的静默来源)。

改前:

```
 * engine facade's `update(data, options)` signature (`mass_update_stage` is the
 * action in this repo that got that wrong and silently never wrote).
```

改后:

```
 * engine facade's `update(data, options)` signature. `mass_update_stage` was
 * the action in this repo that got that signature wrong (fixed in #777); the
 * hook-side writes in #616 failed *silently* because those hooks are
 * `onError: 'log'`, while the action path always failed loudly — a 400 from
 * the dispatch and a red toast in the console.
```

两处失真各自订正:时态改成过去时并标注已由 #777 修掉;「silently never wrote」拆成写实的两半——静默的是 `onError: 'log'` 的 hook 侧(#616),action 侧从来是响的(400 + toast)。注释真正要表达的技术点(facade 的 `update` 收文档不收 id,这类 bug 只有真实 QuickJS sandbox 抓得到)一字未动,前面那句「two of the things … only exist there」的结构也保留原样。

## #821 — `docs/developers/code_examples.md` 的 lookup 参数改成 field-backed 形

**前提复核(仍成立)**:示例参数在最新 `origin/main` 上仍是 bare lookup(既无 `reference` 也无 `field`)。该文件最近一次改动是 #822(commit 6f6ed9ae,`_selectedIds` 教学面),行号已重定位,其内容零回退——示例里 `_selectedIds` 的 NOTE 与 body 注释原样保留。

按裁定走 field-backed 形,照抄 `src/actions/lead.actions.ts` 中 `create_campaign` 的落地写法(该文件只读,未改):

```ts
{ field: 'crm_campaign', objectOverride: 'crm_campaign_member',
  label: 'Campaign', required: true }
```

并在参数旁加了说明:bare `{ type: 'lookup' }` 没有 picker target,解析不出目标对象,console 会静默降级成「粘贴记录 ID」文本框;field-backed 让它从 `crm_campaign_member.crm_campaign` 解析出真正的记录选择器。

**一处随动改动,说明如下**:field-backed 参数省略 `name` 时,请求体 key 默认取字段名——这是 spec 的明文契约(`node_modules/@objectstack/spec/src/ui/action.zod.ts`:「`name` is required unless `field` is provided (in which case it defaults to the field name and is used as the request-body key)」),`lead.actions.ts` 的 body 注释也写着同一件事并据此读 `input.crm_campaign`。所以示例 body 里那一行读取必须跟着走:`input.campaign` → `input.crm_campaign`。不动它的话,照抄示例的作者会拿到一个能选记录、却在自己的 `Campaign is required` 检查上抛错的 action——比现状的粘贴 ID 文本框更糟。这不是额外修复,是同一处参数声明改动的必然后果,故一并计入本单。

## 验证

工作树基线 `origin/main` @ `0d3f3216`,全程共享锁 + `NODE_OPTIONS=--max-old-space-size=4096`:

| 步骤 | 退出码 | 关键行 |
| --- | --- | --- |
| `pnpm validate` | 0 | 17 Objects / 26 Actions,5 条既有 author-time 警告与基线一致 |
| `pnpm typecheck` | 0 | `tsc --noEmit` 无输出 |
| `pnpm build` | 0 | `✓ Build complete`,`dist/objectstack.json` 1921.4 KB |
| `pnpm test --maxWorkers=2` | 0 | `Test Files 66 passed (66)` / `Tests 1587 passed \| 1 skipped` |
| `vitest run test/case-first-response.test.ts` | 0 | `Tests 17 passed (17)` — 改动文件自身全绿 |
| `pnpm lint` | 0 | 13 warning / 14 suggestion,与基线同 |
| `check-source-hygiene.mjs` | 0 | `✓ source hygiene clean`(含 `.changeset` 的控制字节扫描) |

注释与文档改动不应影响任何测试,test 全绿即是这一点的证明。test 输出里的 `✗ source hygiene failed: …` 是 source-hygiene 元测试自身的预期 stderr(它断言检查器在坏输入上会报错),非失败。控制字节对三个改动文件另做 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,零命中。

changeset:`.changeset/teaching-surface-fixes.md`(`'hotcrm': patch`)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_