### PR TITLE
chore(deps): 升级 @objectstack/* 17.0.0-rc.2 → 17.0.0-rc.3(零后果修复),并实测四条在案上游镜像

### DIFF
--- a/.changeset/platform-rc3-upgrade.md
+++ b/.changeset/platform-rc3-upgrade.md
@@ -1,0 +1,36 @@
+---
+'hotcrm': patch
+---
+
+Move the platform baseline from ObjectStack 17.0.0-rc.2 to 17.0.0-rc.3. Every
+`@objectstack/*` dependency is bumped together, and `specVersion` /
+`engines.protocol` in `objectstack.manifest.json` follow.
+
+Unlike the rc.1 → rc.2 window, this one migrates nothing: rc.3 carries exactly
+one substantive platform change, and it is a loosening. `BulkActionParamSchema`'s
+`options[]` entry became `.passthrough()` (upstream #4001), so keys beyond
+`label` / `value` on a bulk-action param option — `color`, `icon`, `disabled`,
+`visibleWhen` — are preserved at parse instead of being silently removed. Every
+other `@objectstack/*` package in this release is a version-bump republish whose
+changelog entry is `Updated dependencies` alone.
+
+HotCRM authors two bulk-action params with options, both on
+`src/views/account.view.ts` (`update_tier`, `transfer_owner`), and both spell
+their options with exactly `label` and `value`. Nothing was being stripped here,
+so the loosening is a no-op for this app today — it is now simply possible to
+give a bulk-action option a colour or an icon and have it survive to the
+renderer.
+
+The full suite was re-run against the installed rc.3 with `dist/` deleted first:
+`validate`, `typecheck`, `build`, `test`, `lint` and `hygiene` are all green with
+no source, metadata, test or documentation change required. The pre-existing
+author-time warnings (four approval-approver warnings on the two opportunity
+approval flows, one shadowed field group on `crm_campaign_member`) are unchanged
+in number and wording.
+
+Version-string references elsewhere in the repo are deliberately untouched. Every
+remaining `17.0.0-rc.2` in `src/`, `test/`, `content/` and `.changeset/` is a
+record of when a behaviour was measured ("measured on 17.0.0-rc.2", "from
+17.0.0-rc.2 the engine rejects the write"), not a declaration of what this app
+depends on; rewriting them to rc.3 would falsely claim a re-measurement that did
+not happen.

--- a/objectstack.manifest.json
+++ b/objectstack.manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://schemas.objectstack.dev/template-manifest.json",
   "name": "hotcrm",
-  "specVersion": "^17.0.0-rc.2",
+  "specVersion": "^17.0.0-rc.3",
   "engines": {
-    "protocol": "^17.0.0-rc.2"
+    "protocol": "^17.0.0-rc.3"
   },
   "manifestId": "app.objectstack.hotcrm",
   "displayName": "HotCRM",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
       "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/account": "17.0.0-rc.2",
-        "@objectstack/cli": "17.0.0-rc.2",
-        "@objectstack/driver-memory": "17.0.0-rc.2",
-        "@objectstack/driver-sql": "17.0.0-rc.2",
-        "@objectstack/driver-sqlite-wasm": "17.0.0-rc.2",
-        "@objectstack/metadata": "17.0.0-rc.2",
-        "@objectstack/objectql": "17.0.0-rc.2",
-        "@objectstack/runtime": "17.0.0-rc.2",
-        "@objectstack/service-analytics": "17.0.0-rc.2",
-        "@objectstack/service-automation": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/account": "17.0.0-rc.3",
+        "@objectstack/cli": "17.0.0-rc.3",
+        "@objectstack/driver-memory": "17.0.0-rc.3",
+        "@objectstack/driver-sql": "17.0.0-rc.3",
+        "@objectstack/driver-sqlite-wasm": "17.0.0-rc.3",
+        "@objectstack/metadata": "17.0.0-rc.3",
+        "@objectstack/objectql": "17.0.0-rc.3",
+        "@objectstack/runtime": "17.0.0-rc.3",
+        "@objectstack/service-analytics": "17.0.0-rc.3",
+        "@objectstack/service-automation": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "devDependencies": {
         "@changesets/cli": "^2.31.1",
-        "@objectstack/formula": "17.0.0-rc.2",
+        "@objectstack/formula": "17.0.0-rc.3",
         "@playwright/test": "^1.61.1",
         "@vitest/coverage-v8": "^4.1.10",
         "tsx": "^4.23.1",
@@ -964,9 +964,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
-      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -1282,72 +1282,72 @@
       }
     },
     "node_modules/@objectstack/account": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/account/-/account-17.0.0-rc.2.tgz",
-      "integrity": "sha512-hUs3DVw9hp5mP2sbqHDeDLb/ffT523/r26/5yfd7+YnvlyUDDucGWvl2x5BQlVQ9PvMYbrNF0WnZeWSCxU2OTg==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/account/-/account-17.0.0-rc.3.tgz",
+      "integrity": "sha512-Es65tMPC6kQFRzrBzxDTMB5AFsacEZvzT+LwKR8wIg96UiRXjL943AbVaBbZiYNNYZxl1LF2GZi/LUKEYR7OfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/cli": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/cli/-/cli-17.0.0-rc.2.tgz",
-      "integrity": "sha512-XznKd0y16uPJCq9g1mJNMHlwwHtjd1Zc4DnpQ917/VGjuiE3QY8sYN0oXY9xW4QFeYk6tMvUnKwBqinM71O3bQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/cli/-/cli-17.0.0-rc.3.tgz",
+      "integrity": "sha512-ycQE6LbzIEVBD03GB677vdSWuatKZiSzYbBRSRHsCiHfI4D3fn9kFVP1Ge18N2TYRod2ZNv4gQ7LJfkuAvWb7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/account": "17.0.0-rc.2",
-        "@objectstack/client": "17.0.0-rc.2",
-        "@objectstack/cloud-connection": "17.0.0-rc.2",
-        "@objectstack/console": "17.0.0-rc.2",
-        "@objectstack/core": "^17.0.0-rc.2",
-        "@objectstack/driver-memory": "^17.0.0-rc.2",
-        "@objectstack/driver-mongodb": "^17.0.0-rc.2",
-        "@objectstack/driver-sql": "^17.0.0-rc.2",
-        "@objectstack/driver-sqlite-wasm": "^17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/lint": "17.0.0-rc.2",
-        "@objectstack/mcp": "17.0.0-rc.2",
-        "@objectstack/metadata": "17.0.0-rc.2",
-        "@objectstack/metadata-protocol": "17.0.0-rc.2",
-        "@objectstack/objectql": "^17.0.0-rc.2",
-        "@objectstack/observability": "^17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/plugin-approvals": "17.0.0-rc.2",
-        "@objectstack/plugin-audit": "17.0.0-rc.2",
-        "@objectstack/plugin-auth": "17.0.0-rc.2",
-        "@objectstack/plugin-email": "17.0.0-rc.2",
-        "@objectstack/plugin-hono-server": "17.0.0-rc.2",
-        "@objectstack/plugin-pinyin-search": "17.0.0-rc.2",
-        "@objectstack/plugin-reports": "17.0.0-rc.2",
-        "@objectstack/plugin-security": "17.0.0-rc.2",
-        "@objectstack/plugin-sharing": "17.0.0-rc.2",
-        "@objectstack/plugin-webhooks": "17.0.0-rc.2",
-        "@objectstack/rest": "17.0.0-rc.2",
-        "@objectstack/runtime": "^17.0.0-rc.2",
-        "@objectstack/service-analytics": "17.0.0-rc.2",
-        "@objectstack/service-automation": "17.0.0-rc.2",
-        "@objectstack/service-cache": "17.0.0-rc.2",
-        "@objectstack/service-datasource": "17.0.0-rc.2",
-        "@objectstack/service-job": "17.0.0-rc.2",
-        "@objectstack/service-messaging": "17.0.0-rc.2",
-        "@objectstack/service-package": "17.0.0-rc.2",
-        "@objectstack/service-queue": "17.0.0-rc.2",
-        "@objectstack/service-realtime": "17.0.0-rc.2",
-        "@objectstack/service-settings": "17.0.0-rc.2",
-        "@objectstack/service-sms": "17.0.0-rc.2",
-        "@objectstack/service-storage": "17.0.0-rc.2",
-        "@objectstack/setup": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/trigger-api": "17.0.0-rc.2",
-        "@objectstack/trigger-record-change": "17.0.0-rc.2",
-        "@objectstack/trigger-schedule": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
-        "@objectstack/verify": "17.0.0-rc.2",
+        "@objectstack/account": "17.0.0-rc.3",
+        "@objectstack/client": "17.0.0-rc.3",
+        "@objectstack/cloud-connection": "17.0.0-rc.3",
+        "@objectstack/console": "17.0.0-rc.3",
+        "@objectstack/core": "^17.0.0-rc.3",
+        "@objectstack/driver-memory": "^17.0.0-rc.3",
+        "@objectstack/driver-mongodb": "^17.0.0-rc.3",
+        "@objectstack/driver-sql": "^17.0.0-rc.3",
+        "@objectstack/driver-sqlite-wasm": "^17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/lint": "17.0.0-rc.3",
+        "@objectstack/mcp": "17.0.0-rc.3",
+        "@objectstack/metadata": "17.0.0-rc.3",
+        "@objectstack/metadata-protocol": "17.0.0-rc.3",
+        "@objectstack/objectql": "^17.0.0-rc.3",
+        "@objectstack/observability": "^17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/plugin-approvals": "17.0.0-rc.3",
+        "@objectstack/plugin-audit": "17.0.0-rc.3",
+        "@objectstack/plugin-auth": "17.0.0-rc.3",
+        "@objectstack/plugin-email": "17.0.0-rc.3",
+        "@objectstack/plugin-hono-server": "17.0.0-rc.3",
+        "@objectstack/plugin-pinyin-search": "17.0.0-rc.3",
+        "@objectstack/plugin-reports": "17.0.0-rc.3",
+        "@objectstack/plugin-security": "17.0.0-rc.3",
+        "@objectstack/plugin-sharing": "17.0.0-rc.3",
+        "@objectstack/plugin-webhooks": "17.0.0-rc.3",
+        "@objectstack/rest": "17.0.0-rc.3",
+        "@objectstack/runtime": "^17.0.0-rc.3",
+        "@objectstack/service-analytics": "17.0.0-rc.3",
+        "@objectstack/service-automation": "17.0.0-rc.3",
+        "@objectstack/service-cache": "17.0.0-rc.3",
+        "@objectstack/service-datasource": "17.0.0-rc.3",
+        "@objectstack/service-job": "17.0.0-rc.3",
+        "@objectstack/service-messaging": "17.0.0-rc.3",
+        "@objectstack/service-package": "17.0.0-rc.3",
+        "@objectstack/service-queue": "17.0.0-rc.3",
+        "@objectstack/service-realtime": "17.0.0-rc.3",
+        "@objectstack/service-settings": "17.0.0-rc.3",
+        "@objectstack/service-sms": "17.0.0-rc.3",
+        "@objectstack/service-storage": "17.0.0-rc.3",
+        "@objectstack/setup": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/trigger-api": "17.0.0-rc.3",
+        "@objectstack/trigger-record-change": "17.0.0-rc.3",
+        "@objectstack/trigger-schedule": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
+        "@objectstack/verify": "17.0.0-rc.3",
         "@oclif/core": "^4.13.2",
         "bundle-require": "^5.1.0",
         "chalk": "^6.0.0",
@@ -1384,46 +1384,46 @@
       }
     },
     "node_modules/@objectstack/client": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/client/-/client-17.0.0-rc.2.tgz",
-      "integrity": "sha512-tM4jm2R6UnR2+ymA94BSefco9DbrgeZFytL6b/mTVaUv7uy/joSZKWWrcEG5FiBzcyxJCevDvQixRHuiYzcHHg==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/client/-/client-17.0.0-rc.3.tgz",
+      "integrity": "sha512-7izcBXx4s1dGsEi2Uwpppfyp9hEgpKBJwR+IgToXfh42fgU/8hT9nLgUUfKIjU0nvmQgNkPe/Qmu4Pwm2mkVQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/cloud-connection": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/cloud-connection/-/cloud-connection-17.0.0-rc.2.tgz",
-      "integrity": "sha512-Fc2ySjnC33b3/oJd4lHagUW3BhEyU161x/UHQS7lBfYA6JzcL3c85TdbKI/nAp8uyq7JmbJ7Dz3hiz9m8c7Dxw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/cloud-connection/-/cloud-connection-17.0.0-rc.3.tgz",
+      "integrity": "sha512-+h5Wo0iKB0BzUBPF8fRjiYTCVxXvxic3ZwvmWTRfrQe8G1Lz6OahYU7Xt4Lg55ocwGL9EqK8QW8H/Ixs+V8L4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/runtime": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/runtime": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/console": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/console/-/console-17.0.0-rc.2.tgz",
-      "integrity": "sha512-kaNdZsAp7Bdw9Zx9puwgq6dZcNCMyU8LeEvG9PbqF6KWssT1GQMqeiRtq5HNc25tt9KOXR/U+ule8V6sGOmGYw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/console/-/console-17.0.0-rc.3.tgz",
+      "integrity": "sha512-LzBVNPCBxUyWuiRMP2Tzq3Ug6wXMaUoNqEwsWWCMg7v1gZO0YsAP94y3JhBhOTH91v60xaH1D7D9uqdcLsuTMA==",
       "license": "Apache-2.0"
     },
     "node_modules/@objectstack/core": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/core/-/core-17.0.0-rc.2.tgz",
-      "integrity": "sha512-5hAtKmjBbzEWA7qWXCN8WB12+BhGZ8jZYg7Y5r8PHYH+jOf5ZLX4KkD3bQw6oTUBpBhWclLVREKSlah9truGRA==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/core/-/core-17.0.0-rc.3.tgz",
+      "integrity": "sha512-99WgLYEq6xh1lfywBOcH3RhvvD/YLxR9CI/icYuQtWf5bf/EEftx88juUBTKNdq4G5T8DQ+NyZPPTJNP7KGd/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/spec": "17.0.0-rc.2",
+        "@objectstack/spec": "17.0.0-rc.3",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -1431,13 +1431,13 @@
       }
     },
     "node_modules/@objectstack/driver-memory": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/driver-memory/-/driver-memory-17.0.0-rc.2.tgz",
-      "integrity": "sha512-zpfVQv1FcH4xRkDuvQwFuwBjtPiEa7jJcooBfIEpnirmgKtXC//93bFuQh62wwBTzaUSSvh33s+2oI+9QW4KQA==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/driver-memory/-/driver-memory-17.0.0-rc.3.tgz",
+      "integrity": "sha512-BpgRFW/Y8JfqvIl1cFP2Hd3GmWm5tiZOa/3zQcNw8hGz4pUscfjhQ0c7+1ZB3K2tw3MQ7nKODmW+rug9wSuRew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
         "mingo": "^7.2.2"
       },
       "engines": {
@@ -1445,14 +1445,14 @@
       }
     },
     "node_modules/@objectstack/driver-mongodb": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/driver-mongodb/-/driver-mongodb-17.0.0-rc.2.tgz",
-      "integrity": "sha512-a3A+liqxuLEQMBl6qP8dn5La4f36BnLJIx5oMv4V5z3kiLkRh6sa8z+VhsbBG08tkbdnb6FhO740+4GUG/DG1g==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/driver-mongodb/-/driver-mongodb-17.0.0-rc.3.tgz",
+      "integrity": "sha512-SoFpX29pOvJ1z1MuRgfGMANtkPkSTiPRAkYqLQSYcHUcxo89ytobWcbX1Q3t/5dcLID5diJyppBFt+Q9OrYEGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "mongodb": "^7.5.0",
         "nanoid": "^6.0.0"
       },
@@ -1461,15 +1461,15 @@
       }
     },
     "node_modules/@objectstack/driver-sql": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/driver-sql/-/driver-sql-17.0.0-rc.2.tgz",
-      "integrity": "sha512-7IUaaq0SEJlxp4CO+b0RnlDtn1O1q+zmfbeOCDNRtmUVnaLzfGheAmrKbwNghHhez2RS9VvlrRfEk+V1gZiIUA==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/driver-sql/-/driver-sql-17.0.0-rc.3.tgz",
+      "integrity": "sha512-NLmP5cBFaurEfKnGQDaJP+SD7oNbJ58XDH1eaD9yNxGb93V8DBiZCppc8H09AdsKrdRyLrGzy1jBSifVg9J2oA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/observability": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/observability": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "knex": "^3.3.0",
         "nanoid": "^6.0.0"
       },
@@ -1497,9 +1497,9 @@
       }
     },
     "node_modules/@objectstack/driver-sql/node_modules/better-sqlite3": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.2.tgz",
-      "integrity": "sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g==",
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1510,14 +1510,14 @@
       }
     },
     "node_modules/@objectstack/driver-sqlite-wasm": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/driver-sqlite-wasm/-/driver-sqlite-wasm-17.0.0-rc.2.tgz",
-      "integrity": "sha512-h4p4Cve7MH1fHCzWvM43Z+ixsXHosdvrDqkLjFsCvRS7yR1ahQuUc0n3XvTsPiFfjJanR4y4ilXow1L+UKT1hw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/driver-sqlite-wasm/-/driver-sqlite-wasm-17.0.0-rc.3.tgz",
+      "integrity": "sha512-9rs6ntg/Qc1DHquQvhZpxWFGfDOmqCSJ+2InZJ5oQhB7j6NQz9HZTdEOLx9S2bYjuQ6VDIih896bi2fcn4H5uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/driver-sql": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/driver-sql": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
         "knex": "^3.3.0",
         "nanoid": "^6.0.0",
         "sql.js": "^1.14.1"
@@ -1527,25 +1527,25 @@
       }
     },
     "node_modules/@objectstack/formula": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/formula/-/formula-17.0.0-rc.2.tgz",
-      "integrity": "sha512-+4H3nESU3fH+pjjV4b1P8llvSPff/vQF0Th5/FdbZrYz0fKxoNNL+MtLBAzpu+ME3ZLFMwwsKRH7obPyCS9wmQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/formula/-/formula-17.0.0-rc.3.tgz",
+      "integrity": "sha512-nPV2c6m1pEdiRVfNpmSdEjdw5c0lD9vgtovFV3jIC8QUPqErLgkPfgTzRrhQuVJlspjUEWC8npYqJZJRw2p8Pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@marcbachmann/cel-js": "^8.0.0",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/spec": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/lint": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/lint/-/lint-17.0.0-rc.2.tgz",
-      "integrity": "sha512-S571+BtsXhyBpfZSNh9Ic0ljH8cVKyhgaVbQjqPc0ICgzvwh9/b4PEB7ElbgWUvTNje2KOriLgCjgNGGnTGfuw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/lint/-/lint-17.0.0-rc.3.tgz",
+      "integrity": "sha512-6MV/3o7tgziMy7KSX0Zu7g8XK4oFq3SL3QjTw0vys3NtT84WDxcul1Oac8ibvOkl8cVusjoRaezB4kvcuBhi6A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@marcbachmann/cel-js": "^8.0.0",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/sdui-parser": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/sdui-parser": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
         "sucrase": "^3.35.1",
         "typescript": "^6.0.3"
       },
@@ -1567,16 +1567,16 @@
       }
     },
     "node_modules/@objectstack/mcp": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/mcp/-/mcp-17.0.0-rc.2.tgz",
-      "integrity": "sha512-GluJpCZ5UHCjlSTR5cAJagpv3CSDotPpN4kU2mGqpXNUf7j7/THIjppi74Ejlc9hWTcUm7F+BfSMoSb6JZjuVA==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/mcp/-/mcp-17.0.0-rc.3.tgz",
+      "integrity": "sha512-ko05LsABrYSKxk0+UCFeDJpts8xj8KJT4lGqcdZIB4IpevYY5mfwoVVbN2B4zuHXkOgJWBA1/EtJY+fqcaXGeQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -1584,17 +1584,17 @@
       }
     },
     "node_modules/@objectstack/metadata": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/metadata/-/metadata-17.0.0-rc.2.tgz",
-      "integrity": "sha512-AR0u/gVd/Ew9oa0hPBl1K+3QN4Zeraw2xXgi1iG4lVx7BEnx30mxG2e2spiKo6KOnwO1NAeaHs+gxwKnaZj7LQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/metadata/-/metadata-17.0.0-rc.3.tgz",
+      "integrity": "sha512-PtgPCk1nirMcsfQgce2N9KwUrOuhNlG4SPygPm3cFvVt77O7B5I6LDwTL52KmJ2yZ/RXuaNRINxxgXyfjzfI1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/metadata-core": "17.0.0-rc.2",
-        "@objectstack/metadata-fs": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/metadata-core": "17.0.0-rc.3",
+        "@objectstack/metadata-fs": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "chokidar": "^5.0.0",
         "glob": "^13.0.6",
         "js-yaml": "^5.2.2",
@@ -1605,12 +1605,12 @@
       }
     },
     "node_modules/@objectstack/metadata-core": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/metadata-core/-/metadata-core-17.0.0-rc.2.tgz",
-      "integrity": "sha512-to12UP5HnC5/PUj0BQc8FS6Yh2PxiQL7jXaAQ+dubxK/T7IRdSKOZ5Dn0C7ss7MINg7NlobFMee4wlwuP3BsBQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/metadata-core/-/metadata-core-17.0.0-rc.3.tgz",
+      "integrity": "sha512-/EYnxm98By3VdgptSY8O0cU4D/hKCuemlL7PNSTerlHsj8Wj3hM7aKnSFtUixh0GBdp43+OQ6XluIBLP/rnZ9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/spec": "17.0.0-rc.2",
+        "@objectstack/spec": "17.0.0-rc.3",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -1626,12 +1626,12 @@
       }
     },
     "node_modules/@objectstack/metadata-fs": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/metadata-fs/-/metadata-fs-17.0.0-rc.2.tgz",
-      "integrity": "sha512-SQHZoO4szNGZfo059MXnS9f5XEEH65QDb473bR8Vw8WJZV6kfCrw//+9HRw/4td0Jq4XqvvOp145/wwwB/klDQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/metadata-fs/-/metadata-fs-17.0.0-rc.3.tgz",
+      "integrity": "sha512-fN3kHxlV4Yf8pUenEaVbsDxDiVs01bk3uAOjXsjWMq1vGeplaHXmxwv4EKEVtCsGY1eiw/ppr/yasnU6BLC4ow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/metadata-core": "17.0.0-rc.2",
+        "@objectstack/metadata-core": "17.0.0-rc.3",
         "chokidar": "^5.0.0"
       },
       "engines": {
@@ -1639,17 +1639,17 @@
       }
     },
     "node_modules/@objectstack/metadata-protocol": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/metadata-protocol/-/metadata-protocol-17.0.0-rc.2.tgz",
-      "integrity": "sha512-NlubR8Osa0P2htJ5B2CSxYC5SH7QbEfykSmoJqkY96cNJP7MNVL+1ROMmgwEl7d+R0DPt6DL5D6X4lTIGRwp9g==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/metadata-protocol/-/metadata-protocol-17.0.0-rc.3.tgz",
+      "integrity": "sha512-HeWHHkKxoBty8J4uWofVr5gOD7ddu73CUCTqYwXFoiIugSS3IF9mFYVtAFkOA30CU0xYShHgQpSpdCYPOay+VQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/lint": "17.0.0-rc.2",
-        "@objectstack/metadata-core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/lint": "17.0.0-rc.3",
+        "@objectstack/metadata-core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -1679,17 +1679,17 @@
       }
     },
     "node_modules/@objectstack/objectql": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/objectql/-/objectql-17.0.0-rc.2.tgz",
-      "integrity": "sha512-J1wKVnS1a/WwkDbBF8OnGCFg7uKzpepg36Ku30Dak9dQvrj3Fh4r4b8DJZ4HH/Plx2+mQYC+3+9UZL1ijsXKZw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/objectql/-/objectql-17.0.0-rc.3.tgz",
+      "integrity": "sha512-1w7mvViIThJGW490NYFkbU1LEitgU8IoO+ll6HwMfr1EZrqQE7nDxux5DYLbih/0hgdS+NkgcY3fj9rxu4oliQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/metadata-core": "17.0.0-rc.2",
-        "@objectstack/metadata-protocol": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/metadata-core": "17.0.0-rc.3",
+        "@objectstack/metadata-protocol": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "ajv": "^8.20.0",
         "zod": "^4.4.3"
       },
@@ -1698,62 +1698,62 @@
       }
     },
     "node_modules/@objectstack/observability": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/observability/-/observability-17.0.0-rc.2.tgz",
-      "integrity": "sha512-04f/B6ZrkJC/dmvSWj+gNlhYUHr8hvFvDxb9ROjlM9u7dJTRmVKeHqmfEImgFbTOQN95lmKJkE/7OOR5WIamTw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/observability/-/observability-17.0.0-rc.3.tgz",
+      "integrity": "sha512-vvYyz/E2EHd4dQwWsDoDU9xfDkLu5xgnJ7RxtPhcXFllYuQQsuzViw9tiSEHJwgslhVDUto1OgYZB1m2q4wiHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/platform-objects": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/platform-objects/-/platform-objects-17.0.0-rc.2.tgz",
-      "integrity": "sha512-MvinidIaLaIt7AT8a0URwJqkd3JmLocbnAzPXDgs8bi84FKiqyNd8QxvkJZQBwhapzpfvu9c2XftWpZ0/omMvw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/platform-objects/-/platform-objects-17.0.0-rc.3.tgz",
+      "integrity": "sha512-+v6IO+GvG//Tho29dy9Fzprd86J4XmIxde47FZUyXpbPyDQvWMG71Z8psZEEUJG558Vp6sWW2N1LcP08e1uIPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/metadata-core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/metadata-core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/plugin-approvals": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-approvals/-/plugin-approvals-17.0.0-rc.2.tgz",
-      "integrity": "sha512-+1tPfw0if1IbuQT2GBXLV9DXL2b20el7msh33SQfQP6HKPyQvURkO8rchJVUpgTeQ68LkT/38racrVpI2sktGg==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-approvals/-/plugin-approvals-17.0.0-rc.3.tgz",
+      "integrity": "sha512-crnhsVhcTbccw6vfxVBR+EWlWRLzu7BEsnC+GX0kUOVI1jCEmCKIpsMjDeDpI2GQjzH/TXCOzGPTrH1kkXy/8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/metadata-core": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/metadata-core": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/plugin-audit": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-audit/-/plugin-audit-17.0.0-rc.2.tgz",
-      "integrity": "sha512-P4eXHAaFj4709ngljhipnPckTQbN14WVcNIIKUHd4jNl6QyAwzOEPoVTLzpYkKwesuiSO+2am0YuN8kxY41Oiw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-audit/-/plugin-audit-17.0.0-rc.3.tgz",
+      "integrity": "sha512-JNER9/NQaJlJiqRAPJQnX9RbiD0Qr4+t6tBxFdqdRqi3KR8V1NrIP2hyxcvc0+5TIh4LOYMGEdKDhT1dzfnjBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/plugin-auth": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-auth/-/plugin-auth-17.0.0-rc.2.tgz",
-      "integrity": "sha512-WCKP0MJucKbGfqhl/w8eZU94xY1bDhbLa1mxYR2g41UQ7UXQrqSEQ8vHvxDH2qiYK3xxcLNnQq6uUKo5T2qDog==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-auth/-/plugin-auth-17.0.0-rc.3.tgz",
+      "integrity": "sha512-aDdCybhy9zw3g8kRoXsB7s1uIzXL5OjmyAmo6afmeiaUr6KeGGiruCMb3+6UuJijlIWjbuA+XlJ45B+v8kfAcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@better-auth/core": "1.7.0-rc.2",
@@ -1761,11 +1761,11 @@
         "@better-auth/scim": "1.7.0-rc.1",
         "@better-auth/sso": "1.7.0-rc.2",
         "@noble/hashes": "^2.2.0",
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/rest": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/rest": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "better-auth": "1.7.0-rc.2",
         "jose": "^6.2.5"
       },
@@ -1931,28 +1931,28 @@
       }
     },
     "node_modules/@objectstack/plugin-email": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-email/-/plugin-email-17.0.0-rc.2.tgz",
-      "integrity": "sha512-lCnTFc6NgOQJxJUacZ4BRBptkwebrBwz3wgAASEMt9VHFQSsRVycRKo6GXDy/Y11pRvDERsRT4kgU9q4ESZ2rQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-email/-/plugin-email-17.0.0-rc.3.tgz",
+      "integrity": "sha512-Y9Sbndss0IutHRsmFeKr6Y58wpOGpCC21bI9g2nv+3Vw66MCKkiAN1LrdeKyqWBCktwHABtky2MvijHb0mrNmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/plugin-hono-server": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-hono-server/-/plugin-hono-server-17.0.0-rc.2.tgz",
-      "integrity": "sha512-YEynyWF4Q96qHI+4VpNo4yRnVXCTz6WXu6RbUUQNx2ODxIglO4ehmlgX33BLbaKXD6aOwoTgeuh6xu3QAHFVrg==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-hono-server/-/plugin-hono-server-17.0.0-rc.3.tgz",
+      "integrity": "sha512-qH3zkY2p/eYhzib+MRAqKsqvhKwlpTEid44z40qbb8ccnl07eX/I2kGAQBv2Tqm0Mrk9Edsp4JxJY3a/m7g+2A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/observability": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/observability": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "hono": "^4.12.32"
       },
       "engines": {
@@ -1960,81 +1960,81 @@
       }
     },
     "node_modules/@objectstack/plugin-pinyin-search": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-pinyin-search/-/plugin-pinyin-search-17.0.0-rc.2.tgz",
-      "integrity": "sha512-maBKVGnL4l9tP1LUGFpFJ/V+U7roR3LjbRLQM/01TT4S3zfTUm2y3xoTHo6XFf2q9zwdjyOzsK+gs1jo+G57Ow==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-pinyin-search/-/plugin-pinyin-search-17.0.0-rc.3.tgz",
+      "integrity": "sha512-27FV465YyeAlNiSa6AY7j+J8Stk1/YjSVPr3uuLMACaYorqiPB69wKx6X2GEf3kLfkcRpSR/t0Ba3aZ+eoNfiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/objectql": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/objectql": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "pinyin-pro": "^3.28.2"
       }
     },
     "node_modules/@objectstack/plugin-reports": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-reports/-/plugin-reports-17.0.0-rc.2.tgz",
-      "integrity": "sha512-Jf7jy5XeZ6sEPNulXDZeCZVHh0cCS/OuJGCdQzGkznpK3oHwzY4iVd7i0Ub/xie9H6XAoULFaBJrUzz3klyNJw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-reports/-/plugin-reports-17.0.0-rc.3.tgz",
+      "integrity": "sha512-D6CKQZ7Qfb+PqR5gMHov2OHrwdNTc3TQv5bL/Q19Nvj3E1mHfO/gizKbthLngtlsnNzAeuWJC0P9qWnlRhxUTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
         "croner": "^10.0.1"
       }
     },
     "node_modules/@objectstack/plugin-security": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-security/-/plugin-security-17.0.0-rc.2.tgz",
-      "integrity": "sha512-wIxcORDDD8p3Cl8HelHA4J3lF25zegMv7uIXTi1G1Y34Trj1Vjl2igUY3wJORZ84kLldfoJMKx7b42gRu7/uAQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-security/-/plugin-security-17.0.0-rc.3.tgz",
+      "integrity": "sha512-SM+gYdZT4HMUxAMkPcd8hcCIoohIZtI0Rw2okKWftOGftTn0nNDnFmrUO0OreSylcveQ3kR+dA+U1ccqmKA3Mg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/plugin-sharing": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-sharing/-/plugin-sharing-17.0.0-rc.2.tgz",
-      "integrity": "sha512-yTB3DDPOn+XnCEcm77fV1bmGUohQmwcVxQDqYjzvSbtTL8gsD/FOiWnoOaR6j6FO1kVVT3T2g5G6523SWM3pHQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-sharing/-/plugin-sharing-17.0.0-rc.3.tgz",
+      "integrity": "sha512-zyZyVKoV2F4OUHUyRbZ1ZTID5EP3yFsqVKFbgihmrUNWGBxNnNMkQGAcVO6UZBCiURMjyPFq7ZcIA2WJ2EXRYA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/objectql": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/objectql": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/plugin-webhooks": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-webhooks/-/plugin-webhooks-17.0.0-rc.2.tgz",
-      "integrity": "sha512-IrmkE03ewhF1yXNcPuwU5sGU9QVf8XnbCjs1dZrIVAiUeFGbp8ndnkdBQujDYowiI2afA/rP/eAw0iYyJ5cWAQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-webhooks/-/plugin-webhooks-17.0.0-rc.3.tgz",
+      "integrity": "sha512-ydHGRdp4yX/LaeA+8/8zqFEXYYlNZRRVzvU10QJB+TZ+glC+aEC+wTCSdMaBUFhEeM9LwQsHIed75fSR2yWmYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/service-messaging": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/service-messaging": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/rest": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/rest/-/rest-17.0.0-rc.2.tgz",
-      "integrity": "sha512-Z0S1BK1pmIlBFqEtTgUMDaNco0szskzNZ01sTPZa2HEY8QrmEfVJIKLqPLjuBPzMRsI4cLNoRtCM2ZadrhbL0g==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/rest/-/rest-17.0.0-rc.3.tgz",
+      "integrity": "sha512-szvI1nYMvTexQottLjW7R2t/I8OMPtpUW1x9Oobpnujw30k6VgLceImup62ZiZ+w5KY2hPFVL1aMhT3rJg6MLw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/observability": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/service-package": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/observability": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/service-package": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "exceljs": "^4.4.0",
         "zod": "^4.4.3"
       },
@@ -2043,29 +2043,29 @@
       }
     },
     "node_modules/@objectstack/runtime": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/runtime/-/runtime-17.0.0-rc.2.tgz",
-      "integrity": "sha512-mHS1F0i8VE2NQHbDFrj72/wZb4tpsJaUefqUbIENhmaFFJJDvSykha1EA8pNYADEtod7mbWtrvJYrR1roGi46w==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/runtime/-/runtime-17.0.0-rc.3.tgz",
+      "integrity": "sha512-SAE7y0hB4Zq70MBmmoyG/dRCp8+Tqec7VtIyY9fhqhLgqMwVaPay6ongi8DRW+9SO1KGVWtvF82TZix4Cqtyfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/driver-memory": "17.0.0-rc.2",
-        "@objectstack/driver-sql": "17.0.0-rc.2",
-        "@objectstack/driver-sqlite-wasm": "17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/metadata": "17.0.0-rc.2",
-        "@objectstack/metadata-core": "17.0.0-rc.2",
-        "@objectstack/metadata-protocol": "17.0.0-rc.2",
-        "@objectstack/objectql": "17.0.0-rc.2",
-        "@objectstack/observability": "17.0.0-rc.2",
-        "@objectstack/plugin-auth": "17.0.0-rc.2",
-        "@objectstack/plugin-security": "17.0.0-rc.2",
-        "@objectstack/rest": "17.0.0-rc.2",
-        "@objectstack/service-cluster": "17.0.0-rc.2",
-        "@objectstack/service-datasource": "17.0.0-rc.2",
-        "@objectstack/service-i18n": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/driver-memory": "17.0.0-rc.3",
+        "@objectstack/driver-sql": "17.0.0-rc.3",
+        "@objectstack/driver-sqlite-wasm": "17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/metadata": "17.0.0-rc.3",
+        "@objectstack/metadata-core": "17.0.0-rc.3",
+        "@objectstack/metadata-protocol": "17.0.0-rc.3",
+        "@objectstack/objectql": "17.0.0-rc.3",
+        "@objectstack/observability": "17.0.0-rc.3",
+        "@objectstack/plugin-auth": "17.0.0-rc.3",
+        "@objectstack/plugin-security": "17.0.0-rc.3",
+        "@objectstack/rest": "17.0.0-rc.3",
+        "@objectstack/service-cluster": "17.0.0-rc.3",
+        "@objectstack/service-datasource": "17.0.0-rc.3",
+        "@objectstack/service-i18n": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3",
         "quickjs-emscripten": "^0.32.0",
         "zod": "^4.4.3"
       },
@@ -2073,100 +2073,100 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@objectstack/driver-mongodb": "17.0.0-rc.2"
+        "@objectstack/driver-mongodb": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/sdui-parser": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/sdui-parser/-/sdui-parser-17.0.0-rc.2.tgz",
-      "integrity": "sha512-Xc2ftxDFaDWyKmPWh+nAhgrMXmakKEXACdU/0fTrWertmfv9vRSrKomdCgFSvLksMxS/JcDT2O9EkMxGMQbj2g==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/sdui-parser/-/sdui-parser-17.0.0-rc.3.tgz",
+      "integrity": "sha512-eBXwncn1l66d6snDiywEYd7ByW/CW7Ou1KEbk+b68/giR4nia3akHKPyxWnKhdDl6FVOhfEy9EOJIuuV+TrBxQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@objectstack/service-analytics": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-analytics/-/service-analytics-17.0.0-rc.2.tgz",
-      "integrity": "sha512-Goz9nWuOZvyTFdqY6VvuiBfq2G+GCOnyRUOzHpkqlhsRKh0j2aVZoUH9Xj++8t2VYZqlu+eFhtsSgVOefOzBqQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-analytics/-/service-analytics-17.0.0-rc.3.tgz",
+      "integrity": "sha512-JW1PqHyzSXSLxES2RyRzycaXWzceLojPP+QV0sNsmsavmOqKIijXRRjfCbMnfxfCdnTf4zBDTX7j1QYXvMyALg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-automation": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-automation/-/service-automation-17.0.0-rc.2.tgz",
-      "integrity": "sha512-8FNnmB8CFeK4ApLFNJH6QkMWu/P7aSFhVjNNFJRMWTUVwkuvPy76mq2zpl1pdG0+E2kusBBtM1hZaXwOCwJykg==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-automation/-/service-automation-17.0.0-rc.3.tgz",
+      "integrity": "sha512-KL71FIEE4DuT+lINTMfImfFhkTYb2SWs0++Xa5/xg29vtZS58IfLEHhP96tQDcpD9cYQY++MbOH+u7gkYBKnBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/formula": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/formula": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-cache": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-cache/-/service-cache-17.0.0-rc.2.tgz",
-      "integrity": "sha512-HzwxtHxqIYaWvoqZSiuRqOAZpFvthhLSHHp5hBXbswnvuPpMnA8MX0ni9PwAIpu4ObHcAOi/6Kghn0OUeViP5w==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-cache/-/service-cache-17.0.0-rc.3.tgz",
+      "integrity": "sha512-Fc0nwAnyNyHXNk8hpxpoJyOyvh/zuc4/SfrSCQOsFODLVNZctkFSqf5UgXJqZjZ8Ootdg0HEaSDz0tISjVUI1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/observability": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/observability": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-cluster": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-cluster/-/service-cluster-17.0.0-rc.2.tgz",
-      "integrity": "sha512-idl7mdcB3hIkbq5BfCAdSt2jE6ePoG5MWrWa8JcYWkuBdbBcEC60vPeRcJeJaBcNYXsDIQsIGNsF2iiUBs2tSA==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-cluster/-/service-cluster-17.0.0-rc.3.tgz",
+      "integrity": "sha512-fy2OIrtGN6+ESchjROfSkMAdHvFZJ+DSh780UlabjuJjGeSxpG/IFo4KEkKxliO+Xi6zFV7oeDAaH6K5Rpo2cw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/service-datasource": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-datasource/-/service-datasource-17.0.0-rc.2.tgz",
-      "integrity": "sha512-VLHAn4IltqWhlxt30EjB7/aVAdwGl+mqDtbEtcO1tt8IWCgODmLkXFdcouPxEPLuhDNJL6PwoJo/OawmDacH7Q==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-datasource/-/service-datasource-17.0.0-rc.3.tgz",
+      "integrity": "sha512-QYB4zNmABNmqKscQFv349Ro7shLFFuHq/w6lIiZrpee4A7WQtXC+1oFFVh8bFubhkYkY1aSqsPVsTMCMuUklHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/service-i18n": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-i18n/-/service-i18n-17.0.0-rc.2.tgz",
-      "integrity": "sha512-uXqsblSgL5eR1GG15uAXFmbIjod6xcIfPx0LEA0Y+Fh3z+oOhVvlMwnX+5gXvudPDhX2hwLy2RHldjQYOR41Bg==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-i18n/-/service-i18n-17.0.0-rc.3.tgz",
+      "integrity": "sha512-g7yuymgg6BbjhxlCbbmfDeoyaqxbqLa/zCm9GyUbBdXFjiRELfWGaEbHGGA+attktbdG1C57JSNZ95VrJMpUNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-job": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-job/-/service-job-17.0.0-rc.2.tgz",
-      "integrity": "sha512-BoIL6qJjnL9AOdLmnA01ugapiuKa4zueTpMGNPSqMNaSg76pN+kwt559y5KUfMM8pUYAbluJviSMi7+9WOnFPw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-job/-/service-job-17.0.0-rc.3.tgz",
+      "integrity": "sha512-UpcT3zyPc2Jn7zOmy57iUvqfX4v4otwjtF3e/jeR1r/eWhMUDLfFFJLLIeJCpOPcPAbNCo5hWlYMavmM10lweg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
         "croner": "^10.0.1"
       },
       "engines": {
@@ -2174,98 +2174,98 @@
       }
     },
     "node_modules/@objectstack/service-messaging": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-messaging/-/service-messaging-17.0.0-rc.2.tgz",
-      "integrity": "sha512-CmOIY8USFsrscCTU+Xi/zKLhU2JqrG0REotvnIANS5jVYuJSnX8/L3lFWvNiIDrjDhzFTdBlIME7EE693vOxbA==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-messaging/-/service-messaging-17.0.0-rc.3.tgz",
+      "integrity": "sha512-4zlk8Z5z/6wVmgZdRNeV+QMrZMKy+Atx+wR23H5hAY4eXlKznc+PVfEI7IlnCwbVW358iQYjpa/ZvNQ84XfLMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-package": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-package/-/service-package-17.0.0-rc.2.tgz",
-      "integrity": "sha512-ZaMDhu4OlJmM45S3aXn8UE02tAY4UGeFoMSQwltIM2/Ry+9sKqpSfjBxSXnNr3HAl5crMZdWU1HjyOBA4jhHyw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-package/-/service-package-17.0.0-rc.3.tgz",
+      "integrity": "sha512-Qk2hP7Wtj1sMgB6pTKgcwRYuomtfMdEIO8Y26RtK01IJRyZ98OwHg7iTdf680qJSSYBTVqjeR1e+P1hmuVg/1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/metadata-core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/metadata-core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-queue": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-queue/-/service-queue-17.0.0-rc.2.tgz",
-      "integrity": "sha512-rDCCMDYNUDEggoZ6GvaTlkXy+9x6mFHOEmmbvM0WBHe6AkDJ0S9jagqjfhzkLHK5tOk/yv1KCQEqAD885BWgAw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-queue/-/service-queue-17.0.0-rc.3.tgz",
+      "integrity": "sha512-FhQRdmXX3VI6KOtM5mq9pKdqTl3WaiyeiTc4NldDW7NmoBMjRk5pZcN2IENo25rVgOgAa3Eg37P3pxLN/t6BTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-realtime": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-realtime/-/service-realtime-17.0.0-rc.2.tgz",
-      "integrity": "sha512-uj4iQ1nvGxJ5yj5PHNTLEmZ1wfXAnF9foDKphiGWJ5h4Pb5ixd3gYyZwz3IuRPwai04Rbt77jlx270X2QdeqJw==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-realtime/-/service-realtime-17.0.0-rc.3.tgz",
+      "integrity": "sha512-jZj/mqVf0diUAfk7BYtIwP6l+vHtQn+gY/Bdwglx0kvh5A9w5ePqFKhDlSj3P4CZQfqHJqCOC1GOrSjKGVFW7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-settings": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-settings/-/service-settings-17.0.0-rc.2.tgz",
-      "integrity": "sha512-9+zMUgDV/d38Abn1JVPtHXC2/ZPy+RaOCEhTLpC6dOviPMciJLWtZMxLubZecrFCdZZtuAalabSI2q+7DCImJA==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-settings/-/service-settings-17.0.0-rc.3.tgz",
+      "integrity": "sha512-LKzC+EJye/a/CEJqpDN9V7iffANifSp1MnRnJnUFKsDFKZ4T9q7LwL9tcQPsqJIn2/S3C0P96ELgD4zR4h3+Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-sms": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-sms/-/service-sms-17.0.0-rc.2.tgz",
-      "integrity": "sha512-PQB4buIXpMOrL+s9NNhRVFL3/IgcrNE4IGiBfAEqF4vgTmBxqYUzv+I5WFT+btgRD5j/GIoWzgck3yggHDuC2g==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-sms/-/service-sms-17.0.0-rc.3.tgz",
+      "integrity": "sha512-nwInTNv0FXyO1QM7PWSuILFTOmFq520CYTJHpt0rdNvu5zPI0P/gfDbni+NZnr3NxgFL5iTs3B7yLIdvE6sk6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/service-storage": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-storage/-/service-storage-17.0.0-rc.2.tgz",
-      "integrity": "sha512-XNrtYKuQWe8ehpYhy7U29S1IqDr/WhqNJ2lZyPyjynvoF9CJz+hBYvtTj9uQkVKpfx8QF4lw/LM51pSfAhCpeg==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-storage/-/service-storage-17.0.0-rc.3.tgz",
+      "integrity": "sha512-hMP2I1Df/qLazaOKIfvQBSnTUXJAY4pgKmfaHMemOViHFeKf6As6Dgwp7y+oYEccMb1qSdrmUC5rMvNlmK/qEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/observability": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/observability": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -2284,22 +2284,22 @@
       }
     },
     "node_modules/@objectstack/setup": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/setup/-/setup-17.0.0-rc.2.tgz",
-      "integrity": "sha512-8KCjobU5s62D4OK+Getrt72lDI/M1Y3s9KNxD8gdQBfg0VEy4y/vkwcdSxW4756Iu6M+auU6DVGyFdH/braELA==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/setup/-/setup-17.0.0-rc.3.tgz",
+      "integrity": "sha512-BEF9bXlKmor1fYvnYARcvR9lZm8fnm7cNzDvbIH123ZEUCYKvdLKPUxMZa5j8wrsUbV7EWVL2ZGrHPL6byB/Aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/spec": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/spec/-/spec-17.0.0-rc.2.tgz",
-      "integrity": "sha512-gvybztXuGTaqAlUzSOP4xeTpjl44ty2RZ67JQfiCma/engMG8pKqfv4/18nYitFktiWUVLsr2U6AquZAidmcRQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/spec/-/spec-17.0.0-rc.3.tgz",
+      "integrity": "sha512-hCwqLEkIcmapxRX+skfHg7aLSwzbSkhDT2AEpVY/e8Bu5+rsM2v397pqn8liPQAaz7ybykzUK3HrSiNAEMz2+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2317,74 +2317,74 @@
       }
     },
     "node_modules/@objectstack/trigger-api": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/trigger-api/-/trigger-api-17.0.0-rc.2.tgz",
-      "integrity": "sha512-/ikaIDgoax78u75ep1ynNrrlpqXqIBwAPftwZ/gMrEwczRFVxD0jitWlgDDfqBOE3FUnC3FG3NxPTUUog+/PsQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/trigger-api/-/trigger-api-17.0.0-rc.3.tgz",
+      "integrity": "sha512-mpIXqL83f+Pvq1QddD2LUMMUR/R9yPtwh/1ny7mOBwl+eVcA8PYPUhuF6y92x8zFeOeJC0Wr32pBLBOHICOTaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       }
     },
     "node_modules/@objectstack/trigger-record-change": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/trigger-record-change/-/trigger-record-change-17.0.0-rc.2.tgz",
-      "integrity": "sha512-mcogAAYFKlBQFOyeDBOWEEGKCIWpKr3EGjqOiUCbgTsDi+CSUdnA6KMFrsJriod/6p8pnIIUH9X1dHolHWCKHQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/trigger-record-change/-/trigger-record-change-17.0.0-rc.3.tgz",
+      "integrity": "sha512-EO6C/oOnKC41ydmEhgjalpA+Bmu6tAj+CWY5kGHvSonfTr03++eOMkwHsFsV8kCu8RKP0yNlrKGzpd9r+GpO0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/trigger-schedule": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/trigger-schedule/-/trigger-schedule-17.0.0-rc.2.tgz",
-      "integrity": "sha512-lA/9IisY+cJyXb7ZOOU/5tQ+4w9bZxtqT+jrcuo/aDtoVcVeE1pbgZ/HJXnZZWNlMHLGNB7FYy7jbTsfG9UuIg==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/trigger-schedule/-/trigger-schedule-17.0.0-rc.3.tgz",
+      "integrity": "sha512-2u8Kh/21YlpoqZEaMi5uOFNchEDQeBG3X42J7ULZcEia0Bo1vFqeBLlck43pwQZfd5W2hj+jIbCiDNEllRJ7ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/types": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/types/-/types-17.0.0-rc.2.tgz",
-      "integrity": "sha512-2aFKni6C6bt0NbrOrTFmfAbeWAoZivH4e8eh1lHRRgnq8UWYHZCwZgfQI+UIB37+yvCT58O2weQSYNwGTJxglQ==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/types/-/types-17.0.0-rc.3.tgz",
+      "integrity": "sha512-M5qk5MYfH3ifWKdjhGF92Zjs9il9ALOmDpZq9qX3nJbbeUkR3IBaaY2RHdarTA1dVDWZhbUe+GjrOY9+RWsDKA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/spec": "17.0.0-rc.2"
+        "@objectstack/spec": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/verify": {
-      "version": "17.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@objectstack/verify/-/verify-17.0.0-rc.2.tgz",
-      "integrity": "sha512-GlpN1Quo0DdZn2n3nXxz4iKTUIPmdTYo5/oxhK7eL+Wlshkjx0LYPMicKvOyF/a2Fw0IlgtYF0npL02Lh8kw/A==",
+      "version": "17.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@objectstack/verify/-/verify-17.0.0-rc.3.tgz",
+      "integrity": "sha512-/3GYHSdH8fEaNram8hgm4cQgPklPwEUARSy2UbrStg9LsY6T0FYoYZslCmvtItVuFXJvEQ4qkHHIn1EhmNeLjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.2",
-        "@objectstack/objectql": "17.0.0-rc.2",
-        "@objectstack/platform-objects": "17.0.0-rc.2",
-        "@objectstack/plugin-auth": "17.0.0-rc.2",
-        "@objectstack/plugin-hono-server": "17.0.0-rc.2",
-        "@objectstack/plugin-security": "17.0.0-rc.2",
-        "@objectstack/plugin-sharing": "17.0.0-rc.2",
-        "@objectstack/rest": "17.0.0-rc.2",
-        "@objectstack/runtime": "17.0.0-rc.2",
-        "@objectstack/service-analytics": "17.0.0-rc.2",
-        "@objectstack/service-automation": "17.0.0-rc.2",
-        "@objectstack/service-datasource": "17.0.0-rc.2",
-        "@objectstack/service-settings": "17.0.0-rc.2",
-        "@objectstack/spec": "17.0.0-rc.2",
-        "@objectstack/types": "17.0.0-rc.2"
+        "@objectstack/core": "17.0.0-rc.3",
+        "@objectstack/objectql": "17.0.0-rc.3",
+        "@objectstack/platform-objects": "17.0.0-rc.3",
+        "@objectstack/plugin-auth": "17.0.0-rc.3",
+        "@objectstack/plugin-hono-server": "17.0.0-rc.3",
+        "@objectstack/plugin-security": "17.0.0-rc.3",
+        "@objectstack/plugin-sharing": "17.0.0-rc.3",
+        "@objectstack/rest": "17.0.0-rc.3",
+        "@objectstack/runtime": "17.0.0-rc.3",
+        "@objectstack/service-analytics": "17.0.0-rc.3",
+        "@objectstack/service-automation": "17.0.0-rc.3",
+        "@objectstack/service-datasource": "17.0.0-rc.3",
+        "@objectstack/service-settings": "17.0.0-rc.3",
+        "@objectstack/spec": "17.0.0-rc.3",
+        "@objectstack/types": "17.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -4626,9 +4626,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
-      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -5090,9 +5090,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6248,9 +6248,9 @@
       }
     },
     "node_modules/mingo": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/mingo/-/mingo-7.2.2.tgz",
-      "integrity": "sha512-ll8DV+C5RnV2zF3Jwendxhgqknofzp7KaDwmlpvqo4xrdMC5F7JTc2ToZOz//de84QymZTFY7LPHMViE8uNHhA==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-7.2.3.tgz",
+      "integrity": "sha512-G83Ig4MLFlqGSLzopA4+/4p0WQpnOAwqZUSKiKUHjeH/mdDv1dGC83wkfr3VM0dp4yZtApjw+F0WM33GliN+8w==",
       "license": "MIT"
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -34,24 +34,24 @@
   },
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
-    "@objectstack/account": "17.0.0-rc.2",
-    "@objectstack/cli": "17.0.0-rc.2",
-    "@objectstack/driver-memory": "17.0.0-rc.2",
-    "@objectstack/driver-sql": "17.0.0-rc.2",
-    "@objectstack/driver-sqlite-wasm": "17.0.0-rc.2",
-    "@objectstack/metadata": "17.0.0-rc.2",
-    "@objectstack/objectql": "17.0.0-rc.2",
-    "@objectstack/runtime": "17.0.0-rc.2",
-    "@objectstack/service-analytics": "17.0.0-rc.2",
-    "@objectstack/service-automation": "17.0.0-rc.2",
-    "@objectstack/spec": "17.0.0-rc.2"
+    "@objectstack/account": "17.0.0-rc.3",
+    "@objectstack/cli": "17.0.0-rc.3",
+    "@objectstack/driver-memory": "17.0.0-rc.3",
+    "@objectstack/driver-sql": "17.0.0-rc.3",
+    "@objectstack/driver-sqlite-wasm": "17.0.0-rc.3",
+    "@objectstack/metadata": "17.0.0-rc.3",
+    "@objectstack/objectql": "17.0.0-rc.3",
+    "@objectstack/runtime": "17.0.0-rc.3",
+    "@objectstack/service-analytics": "17.0.0-rc.3",
+    "@objectstack/service-automation": "17.0.0-rc.3",
+    "@objectstack/spec": "17.0.0-rc.3"
   },
   "optionalDependencies": {
     "better-sqlite3": "^12.11.1"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
-    "@objectstack/formula": "17.0.0-rc.2",
+    "@objectstack/formula": "17.0.0-rc.3",
     "@playwright/test": "^1.61.1",
     "@vitest/coverage-v8": "^4.1.10",
     "tsx": "^4.23.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,45 +9,45 @@ importers:
   .:
     dependencies:
       '@objectstack/account':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2(vitest@4.1.10)
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3(vitest@4.1.10)
       '@objectstack/cli':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
       '@objectstack/driver-memory':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3
       '@objectstack/driver-sql':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3
       '@objectstack/driver-sqlite-wasm':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2(better-sqlite3@12.11.1)
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3(better-sqlite3@12.11.1)
       '@objectstack/metadata':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2(vitest@4.1.10)
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3(vitest@4.1.10)
       '@objectstack/objectql':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2(vitest@4.1.10)
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3(vitest@4.1.10)
       '@objectstack/runtime':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
       '@objectstack/service-analytics':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3
       '@objectstack/service-automation':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3
       '@objectstack/spec':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.1
         version: 2.31.1
       '@objectstack/formula':
-        specifier: 17.0.0-rc.2
-        version: 17.0.0-rc.2
+        specifier: 17.0.0-rc.3
+        version: 17.0.0-rc.3
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.62.0
@@ -526,40 +526,40 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@objectstack/account@17.0.0-rc.2':
-    resolution: {integrity: sha512-hUs3DVw9hp5mP2sbqHDeDLb/ffT523/r26/5yfd7+YnvlyUDDucGWvl2x5BQlVQ9PvMYbrNF0WnZeWSCxU2OTg==}
+  '@objectstack/account@17.0.0-rc.3':
+    resolution: {integrity: sha512-Es65tMPC6kQFRzrBzxDTMB5AFsacEZvzT+LwKR8wIg96UiRXjL943AbVaBbZiYNNYZxl1LF2GZi/LUKEYR7OfQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/cli@17.0.0-rc.2':
-    resolution: {integrity: sha512-XznKd0y16uPJCq9g1mJNMHlwwHtjd1Zc4DnpQ917/VGjuiE3QY8sYN0oXY9xW4QFeYk6tMvUnKwBqinM71O3bQ==}
+  '@objectstack/cli@17.0.0-rc.3':
+    resolution: {integrity: sha512-ycQE6LbzIEVBD03GB677vdSWuatKZiSzYbBRSRHsCiHfI4D3fn9kFVP1Ge18N2TYRod2ZNv4gQ7LJfkuAvWb7Q==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  '@objectstack/client@17.0.0-rc.2':
-    resolution: {integrity: sha512-tM4jm2R6UnR2+ymA94BSefco9DbrgeZFytL6b/mTVaUv7uy/joSZKWWrcEG5FiBzcyxJCevDvQixRHuiYzcHHg==}
+  '@objectstack/client@17.0.0-rc.3':
+    resolution: {integrity: sha512-7izcBXx4s1dGsEi2Uwpppfyp9hEgpKBJwR+IgToXfh42fgU/8hT9nLgUUfKIjU0nvmQgNkPe/Qmu4Pwm2mkVQQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/cloud-connection@17.0.0-rc.2':
-    resolution: {integrity: sha512-Fc2ySjnC33b3/oJd4lHagUW3BhEyU161x/UHQS7lBfYA6JzcL3c85TdbKI/nAp8uyq7JmbJ7Dz3hiz9m8c7Dxw==}
+  '@objectstack/cloud-connection@17.0.0-rc.3':
+    resolution: {integrity: sha512-+h5Wo0iKB0BzUBPF8fRjiYTCVxXvxic3ZwvmWTRfrQe8G1Lz6OahYU7Xt4Lg55ocwGL9EqK8QW8H/Ixs+V8L4w==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/console@17.0.0-rc.2':
-    resolution: {integrity: sha512-kaNdZsAp7Bdw9Zx9puwgq6dZcNCMyU8LeEvG9PbqF6KWssT1GQMqeiRtq5HNc25tt9KOXR/U+ule8V6sGOmGYw==}
+  '@objectstack/console@17.0.0-rc.3':
+    resolution: {integrity: sha512-LzBVNPCBxUyWuiRMP2Tzq3Ug6wXMaUoNqEwsWWCMg7v1gZO0YsAP94y3JhBhOTH91v60xaH1D7D9uqdcLsuTMA==}
 
-  '@objectstack/core@17.0.0-rc.2':
-    resolution: {integrity: sha512-5hAtKmjBbzEWA7qWXCN8WB12+BhGZ8jZYg7Y5r8PHYH+jOf5ZLX4KkD3bQw6oTUBpBhWclLVREKSlah9truGRA==}
+  '@objectstack/core@17.0.0-rc.3':
+    resolution: {integrity: sha512-99WgLYEq6xh1lfywBOcH3RhvvD/YLxR9CI/icYuQtWf5bf/EEftx88juUBTKNdq4G5T8DQ+NyZPPTJNP7KGd/A==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/driver-memory@17.0.0-rc.2':
-    resolution: {integrity: sha512-zpfVQv1FcH4xRkDuvQwFuwBjtPiEa7jJcooBfIEpnirmgKtXC//93bFuQh62wwBTzaUSSvh33s+2oI+9QW4KQA==}
+  '@objectstack/driver-memory@17.0.0-rc.3':
+    resolution: {integrity: sha512-BpgRFW/Y8JfqvIl1cFP2Hd3GmWm5tiZOa/3zQcNw8hGz4pUscfjhQ0c7+1ZB3K2tw3MQ7nKODmW+rug9wSuRew==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/driver-mongodb@17.0.0-rc.2':
-    resolution: {integrity: sha512-a3A+liqxuLEQMBl6qP8dn5La4f36BnLJIx5oMv4V5z3kiLkRh6sa8z+VhsbBG08tkbdnb6FhO740+4GUG/DG1g==}
+  '@objectstack/driver-mongodb@17.0.0-rc.3':
+    resolution: {integrity: sha512-SoFpX29pOvJ1z1MuRgfGMANtkPkSTiPRAkYqLQSYcHUcxo89ytobWcbX1Q3t/5dcLID5diJyppBFt+Q9OrYEGw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/driver-sql@17.0.0-rc.2':
-    resolution: {integrity: sha512-7IUaaq0SEJlxp4CO+b0RnlDtn1O1q+zmfbeOCDNRtmUVnaLzfGheAmrKbwNghHhez2RS9VvlrRfEk+V1gZiIUA==}
+  '@objectstack/driver-sql@17.0.0-rc.3':
+    resolution: {integrity: sha512-NLmP5cBFaurEfKnGQDaJP+SD7oNbJ58XDH1eaD9yNxGb93V8DBiZCppc8H09AdsKrdRyLrGzy1jBSifVg9J2oA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       mysql2: ^3.0.0
@@ -573,23 +573,23 @@ packages:
       tedious:
         optional: true
 
-  '@objectstack/driver-sqlite-wasm@17.0.0-rc.2':
-    resolution: {integrity: sha512-h4p4Cve7MH1fHCzWvM43Z+ixsXHosdvrDqkLjFsCvRS7yR1ahQuUc0n3XvTsPiFfjJanR4y4ilXow1L+UKT1hw==}
+  '@objectstack/driver-sqlite-wasm@17.0.0-rc.3':
+    resolution: {integrity: sha512-9rs6ntg/Qc1DHquQvhZpxWFGfDOmqCSJ+2InZJ5oQhB7j6NQz9HZTdEOLx9S2bYjuQ6VDIih896bi2fcn4H5uw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/formula@17.0.0-rc.2':
-    resolution: {integrity: sha512-+4H3nESU3fH+pjjV4b1P8llvSPff/vQF0Th5/FdbZrYz0fKxoNNL+MtLBAzpu+ME3ZLFMwwsKRH7obPyCS9wmQ==}
+  '@objectstack/formula@17.0.0-rc.3':
+    resolution: {integrity: sha512-nPV2c6m1pEdiRVfNpmSdEjdw5c0lD9vgtovFV3jIC8QUPqErLgkPfgTzRrhQuVJlspjUEWC8npYqJZJRw2p8Pw==}
 
-  '@objectstack/lint@17.0.0-rc.2':
-    resolution: {integrity: sha512-S571+BtsXhyBpfZSNh9Ic0ljH8cVKyhgaVbQjqPc0ICgzvwh9/b4PEB7ElbgWUvTNje2KOriLgCjgNGGnTGfuw==}
+  '@objectstack/lint@17.0.0-rc.3':
+    resolution: {integrity: sha512-6MV/3o7tgziMy7KSX0Zu7g8XK4oFq3SL3QjTw0vys3NtT84WDxcul1Oac8ibvOkl8cVusjoRaezB4kvcuBhi6A==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/mcp@17.0.0-rc.2':
-    resolution: {integrity: sha512-GluJpCZ5UHCjlSTR5cAJagpv3CSDotPpN4kU2mGqpXNUf7j7/THIjppi74Ejlc9hWTcUm7F+BfSMoSb6JZjuVA==}
+  '@objectstack/mcp@17.0.0-rc.3':
+    resolution: {integrity: sha512-ko05LsABrYSKxk0+UCFeDJpts8xj8KJT4lGqcdZIB4IpevYY5mfwoVVbN2B4zuHXkOgJWBA1/EtJY+fqcaXGeQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/metadata-core@17.0.0-rc.2':
-    resolution: {integrity: sha512-to12UP5HnC5/PUj0BQc8FS6Yh2PxiQL7jXaAQ+dubxK/T7IRdSKOZ5Dn0C7ss7MINg7NlobFMee4wlwuP3BsBQ==}
+  '@objectstack/metadata-core@17.0.0-rc.3':
+    resolution: {integrity: sha512-/EYnxm98By3VdgptSY8O0cU4D/hKCuemlL7PNSTerlHsj8Wj3hM7aKnSFtUixh0GBdp43+OQ6XluIBLP/rnZ9w==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       vitest: ^4.0.0
@@ -597,126 +597,126 @@ packages:
       vitest:
         optional: true
 
-  '@objectstack/metadata-fs@17.0.0-rc.2':
-    resolution: {integrity: sha512-SQHZoO4szNGZfo059MXnS9f5XEEH65QDb473bR8Vw8WJZV6kfCrw//+9HRw/4td0Jq4XqvvOp145/wwwB/klDQ==}
+  '@objectstack/metadata-fs@17.0.0-rc.3':
+    resolution: {integrity: sha512-fN3kHxlV4Yf8pUenEaVbsDxDiVs01bk3uAOjXsjWMq1vGeplaHXmxwv4EKEVtCsGY1eiw/ppr/yasnU6BLC4ow==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/metadata-protocol@17.0.0-rc.2':
-    resolution: {integrity: sha512-NlubR8Osa0P2htJ5B2CSxYC5SH7QbEfykSmoJqkY96cNJP7MNVL+1ROMmgwEl7d+R0DPt6DL5D6X4lTIGRwp9g==}
+  '@objectstack/metadata-protocol@17.0.0-rc.3':
+    resolution: {integrity: sha512-HeWHHkKxoBty8J4uWofVr5gOD7ddu73CUCTqYwXFoiIugSS3IF9mFYVtAFkOA30CU0xYShHgQpSpdCYPOay+VQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/metadata@17.0.0-rc.2':
-    resolution: {integrity: sha512-AR0u/gVd/Ew9oa0hPBl1K+3QN4Zeraw2xXgi1iG4lVx7BEnx30mxG2e2spiKo6KOnwO1NAeaHs+gxwKnaZj7LQ==}
+  '@objectstack/metadata@17.0.0-rc.3':
+    resolution: {integrity: sha512-PtgPCk1nirMcsfQgce2N9KwUrOuhNlG4SPygPm3cFvVt77O7B5I6LDwTL52KmJ2yZ/RXuaNRINxxgXyfjzfI1Q==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/objectql@17.0.0-rc.2':
-    resolution: {integrity: sha512-J1wKVnS1a/WwkDbBF8OnGCFg7uKzpepg36Ku30Dak9dQvrj3Fh4r4b8DJZ4HH/Plx2+mQYC+3+9UZL1ijsXKZw==}
+  '@objectstack/objectql@17.0.0-rc.3':
+    resolution: {integrity: sha512-1w7mvViIThJGW490NYFkbU1LEitgU8IoO+ll6HwMfr1EZrqQE7nDxux5DYLbih/0hgdS+NkgcY3fj9rxu4oliQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/observability@17.0.0-rc.2':
-    resolution: {integrity: sha512-04f/B6ZrkJC/dmvSWj+gNlhYUHr8hvFvDxb9ROjlM9u7dJTRmVKeHqmfEImgFbTOQN95lmKJkE/7OOR5WIamTw==}
+  '@objectstack/observability@17.0.0-rc.3':
+    resolution: {integrity: sha512-vvYyz/E2EHd4dQwWsDoDU9xfDkLu5xgnJ7RxtPhcXFllYuQQsuzViw9tiSEHJwgslhVDUto1OgYZB1m2q4wiHA==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/platform-objects@17.0.0-rc.2':
-    resolution: {integrity: sha512-MvinidIaLaIt7AT8a0URwJqkd3JmLocbnAzPXDgs8bi84FKiqyNd8QxvkJZQBwhapzpfvu9c2XftWpZ0/omMvw==}
+  '@objectstack/platform-objects@17.0.0-rc.3':
+    resolution: {integrity: sha512-+v6IO+GvG//Tho29dy9Fzprd86J4XmIxde47FZUyXpbPyDQvWMG71Z8psZEEUJG558Vp6sWW2N1LcP08e1uIPA==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-approvals@17.0.0-rc.2':
-    resolution: {integrity: sha512-+1tPfw0if1IbuQT2GBXLV9DXL2b20el7msh33SQfQP6HKPyQvURkO8rchJVUpgTeQ68LkT/38racrVpI2sktGg==}
+  '@objectstack/plugin-approvals@17.0.0-rc.3':
+    resolution: {integrity: sha512-crnhsVhcTbccw6vfxVBR+EWlWRLzu7BEsnC+GX0kUOVI1jCEmCKIpsMjDeDpI2GQjzH/TXCOzGPTrH1kkXy/8A==}
 
-  '@objectstack/plugin-audit@17.0.0-rc.2':
-    resolution: {integrity: sha512-P4eXHAaFj4709ngljhipnPckTQbN14WVcNIIKUHd4jNl6QyAwzOEPoVTLzpYkKwesuiSO+2am0YuN8kxY41Oiw==}
+  '@objectstack/plugin-audit@17.0.0-rc.3':
+    resolution: {integrity: sha512-JNER9/NQaJlJiqRAPJQnX9RbiD0Qr4+t6tBxFdqdRqi3KR8V1NrIP2hyxcvc0+5TIh4LOYMGEdKDhT1dzfnjBw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-auth@17.0.0-rc.2':
-    resolution: {integrity: sha512-WCKP0MJucKbGfqhl/w8eZU94xY1bDhbLa1mxYR2g41UQ7UXQrqSEQ8vHvxDH2qiYK3xxcLNnQq6uUKo5T2qDog==}
+  '@objectstack/plugin-auth@17.0.0-rc.3':
+    resolution: {integrity: sha512-aDdCybhy9zw3g8kRoXsB7s1uIzXL5OjmyAmo6afmeiaUr6KeGGiruCMb3+6UuJijlIWjbuA+XlJ45B+v8kfAcg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-email@17.0.0-rc.2':
-    resolution: {integrity: sha512-lCnTFc6NgOQJxJUacZ4BRBptkwebrBwz3wgAASEMt9VHFQSsRVycRKo6GXDy/Y11pRvDERsRT4kgU9q4ESZ2rQ==}
+  '@objectstack/plugin-email@17.0.0-rc.3':
+    resolution: {integrity: sha512-Y9Sbndss0IutHRsmFeKr6Y58wpOGpCC21bI9g2nv+3Vw66MCKkiAN1LrdeKyqWBCktwHABtky2MvijHb0mrNmQ==}
 
-  '@objectstack/plugin-hono-server@17.0.0-rc.2':
-    resolution: {integrity: sha512-YEynyWF4Q96qHI+4VpNo4yRnVXCTz6WXu6RbUUQNx2ODxIglO4ehmlgX33BLbaKXD6aOwoTgeuh6xu3QAHFVrg==}
+  '@objectstack/plugin-hono-server@17.0.0-rc.3':
+    resolution: {integrity: sha512-qH3zkY2p/eYhzib+MRAqKsqvhKwlpTEid44z40qbb8ccnl07eX/I2kGAQBv2Tqm0Mrk9Edsp4JxJY3a/m7g+2A==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-pinyin-search@17.0.0-rc.2':
-    resolution: {integrity: sha512-maBKVGnL4l9tP1LUGFpFJ/V+U7roR3LjbRLQM/01TT4S3zfTUm2y3xoTHo6XFf2q9zwdjyOzsK+gs1jo+G57Ow==}
+  '@objectstack/plugin-pinyin-search@17.0.0-rc.3':
+    resolution: {integrity: sha512-27FV465YyeAlNiSa6AY7j+J8Stk1/YjSVPr3uuLMACaYorqiPB69wKx6X2GEf3kLfkcRpSR/t0Ba3aZ+eoNfiQ==}
 
-  '@objectstack/plugin-reports@17.0.0-rc.2':
-    resolution: {integrity: sha512-Jf7jy5XeZ6sEPNulXDZeCZVHh0cCS/OuJGCdQzGkznpK3oHwzY4iVd7i0Ub/xie9H6XAoULFaBJrUzz3klyNJw==}
+  '@objectstack/plugin-reports@17.0.0-rc.3':
+    resolution: {integrity: sha512-D6CKQZ7Qfb+PqR5gMHov2OHrwdNTc3TQv5bL/Q19Nvj3E1mHfO/gizKbthLngtlsnNzAeuWJC0P9qWnlRhxUTw==}
 
-  '@objectstack/plugin-security@17.0.0-rc.2':
-    resolution: {integrity: sha512-wIxcORDDD8p3Cl8HelHA4J3lF25zegMv7uIXTi1G1Y34Trj1Vjl2igUY3wJORZ84kLldfoJMKx7b42gRu7/uAQ==}
+  '@objectstack/plugin-security@17.0.0-rc.3':
+    resolution: {integrity: sha512-SM+gYdZT4HMUxAMkPcd8hcCIoohIZtI0Rw2okKWftOGftTn0nNDnFmrUO0OreSylcveQ3kR+dA+U1ccqmKA3Mg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-sharing@17.0.0-rc.2':
-    resolution: {integrity: sha512-yTB3DDPOn+XnCEcm77fV1bmGUohQmwcVxQDqYjzvSbtTL8gsD/FOiWnoOaR6j6FO1kVVT3T2g5G6523SWM3pHQ==}
+  '@objectstack/plugin-sharing@17.0.0-rc.3':
+    resolution: {integrity: sha512-zyZyVKoV2F4OUHUyRbZ1ZTID5EP3yFsqVKFbgihmrUNWGBxNnNMkQGAcVO6UZBCiURMjyPFq7ZcIA2WJ2EXRYA==}
 
-  '@objectstack/plugin-webhooks@17.0.0-rc.2':
-    resolution: {integrity: sha512-IrmkE03ewhF1yXNcPuwU5sGU9QVf8XnbCjs1dZrIVAiUeFGbp8ndnkdBQujDYowiI2afA/rP/eAw0iYyJ5cWAQ==}
+  '@objectstack/plugin-webhooks@17.0.0-rc.3':
+    resolution: {integrity: sha512-ydHGRdp4yX/LaeA+8/8zqFEXYYlNZRRVzvU10QJB+TZ+glC+aEC+wTCSdMaBUFhEeM9LwQsHIed75fSR2yWmYw==}
 
-  '@objectstack/rest@17.0.0-rc.2':
-    resolution: {integrity: sha512-Z0S1BK1pmIlBFqEtTgUMDaNco0szskzNZ01sTPZa2HEY8QrmEfVJIKLqPLjuBPzMRsI4cLNoRtCM2ZadrhbL0g==}
+  '@objectstack/rest@17.0.0-rc.3':
+    resolution: {integrity: sha512-szvI1nYMvTexQottLjW7R2t/I8OMPtpUW1x9Oobpnujw30k6VgLceImup62ZiZ+w5KY2hPFVL1aMhT3rJg6MLw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/runtime@17.0.0-rc.2':
-    resolution: {integrity: sha512-mHS1F0i8VE2NQHbDFrj72/wZb4tpsJaUefqUbIENhmaFFJJDvSykha1EA8pNYADEtod7mbWtrvJYrR1roGi46w==}
+  '@objectstack/runtime@17.0.0-rc.3':
+    resolution: {integrity: sha512-SAE7y0hB4Zq70MBmmoyG/dRCp8+Tqec7VtIyY9fhqhLgqMwVaPay6ongi8DRW+9SO1KGVWtvF82TZix4Cqtyfw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/sdui-parser@17.0.0-rc.2':
-    resolution: {integrity: sha512-Xc2ftxDFaDWyKmPWh+nAhgrMXmakKEXACdU/0fTrWertmfv9vRSrKomdCgFSvLksMxS/JcDT2O9EkMxGMQbj2g==}
+  '@objectstack/sdui-parser@17.0.0-rc.3':
+    resolution: {integrity: sha512-eBXwncn1l66d6snDiywEYd7ByW/CW7Ou1KEbk+b68/giR4nia3akHKPyxWnKhdDl6FVOhfEy9EOJIuuV+TrBxQ==}
 
-  '@objectstack/service-analytics@17.0.0-rc.2':
-    resolution: {integrity: sha512-Goz9nWuOZvyTFdqY6VvuiBfq2G+GCOnyRUOzHpkqlhsRKh0j2aVZoUH9Xj++8t2VYZqlu+eFhtsSgVOefOzBqQ==}
+  '@objectstack/service-analytics@17.0.0-rc.3':
+    resolution: {integrity: sha512-JW1PqHyzSXSLxES2RyRzycaXWzceLojPP+QV0sNsmsavmOqKIijXRRjfCbMnfxfCdnTf4zBDTX7j1QYXvMyALg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-automation@17.0.0-rc.2':
-    resolution: {integrity: sha512-8FNnmB8CFeK4ApLFNJH6QkMWu/P7aSFhVjNNFJRMWTUVwkuvPy76mq2zpl1pdG0+E2kusBBtM1hZaXwOCwJykg==}
+  '@objectstack/service-automation@17.0.0-rc.3':
+    resolution: {integrity: sha512-KL71FIEE4DuT+lINTMfImfFhkTYb2SWs0++Xa5/xg29vtZS58IfLEHhP96tQDcpD9cYQY++MbOH+u7gkYBKnBQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-cache@17.0.0-rc.2':
-    resolution: {integrity: sha512-HzwxtHxqIYaWvoqZSiuRqOAZpFvthhLSHHp5hBXbswnvuPpMnA8MX0ni9PwAIpu4ObHcAOi/6Kghn0OUeViP5w==}
+  '@objectstack/service-cache@17.0.0-rc.3':
+    resolution: {integrity: sha512-Fc0nwAnyNyHXNk8hpxpoJyOyvh/zuc4/SfrSCQOsFODLVNZctkFSqf5UgXJqZjZ8Ootdg0HEaSDz0tISjVUI1Q==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-cluster@17.0.0-rc.2':
-    resolution: {integrity: sha512-idl7mdcB3hIkbq5BfCAdSt2jE6ePoG5MWrWa8JcYWkuBdbBcEC60vPeRcJeJaBcNYXsDIQsIGNsF2iiUBs2tSA==}
+  '@objectstack/service-cluster@17.0.0-rc.3':
+    resolution: {integrity: sha512-fy2OIrtGN6+ESchjROfSkMAdHvFZJ+DSh780UlabjuJjGeSxpG/IFo4KEkKxliO+Xi6zFV7oeDAaH6K5Rpo2cw==}
 
-  '@objectstack/service-datasource@17.0.0-rc.2':
-    resolution: {integrity: sha512-VLHAn4IltqWhlxt30EjB7/aVAdwGl+mqDtbEtcO1tt8IWCgODmLkXFdcouPxEPLuhDNJL6PwoJo/OawmDacH7Q==}
+  '@objectstack/service-datasource@17.0.0-rc.3':
+    resolution: {integrity: sha512-QYB4zNmABNmqKscQFv349Ro7shLFFuHq/w6lIiZrpee4A7WQtXC+1oFFVh8bFubhkYkY1aSqsPVsTMCMuUklHQ==}
 
-  '@objectstack/service-i18n@17.0.0-rc.2':
-    resolution: {integrity: sha512-uXqsblSgL5eR1GG15uAXFmbIjod6xcIfPx0LEA0Y+Fh3z+oOhVvlMwnX+5gXvudPDhX2hwLy2RHldjQYOR41Bg==}
+  '@objectstack/service-i18n@17.0.0-rc.3':
+    resolution: {integrity: sha512-g7yuymgg6BbjhxlCbbmfDeoyaqxbqLa/zCm9GyUbBdXFjiRELfWGaEbHGGA+attktbdG1C57JSNZ95VrJMpUNw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-job@17.0.0-rc.2':
-    resolution: {integrity: sha512-BoIL6qJjnL9AOdLmnA01ugapiuKa4zueTpMGNPSqMNaSg76pN+kwt559y5KUfMM8pUYAbluJviSMi7+9WOnFPw==}
+  '@objectstack/service-job@17.0.0-rc.3':
+    resolution: {integrity: sha512-UpcT3zyPc2Jn7zOmy57iUvqfX4v4otwjtF3e/jeR1r/eWhMUDLfFFJLLIeJCpOPcPAbNCo5hWlYMavmM10lweg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-messaging@17.0.0-rc.2':
-    resolution: {integrity: sha512-CmOIY8USFsrscCTU+Xi/zKLhU2JqrG0REotvnIANS5jVYuJSnX8/L3lFWvNiIDrjDhzFTdBlIME7EE693vOxbA==}
+  '@objectstack/service-messaging@17.0.0-rc.3':
+    resolution: {integrity: sha512-4zlk8Z5z/6wVmgZdRNeV+QMrZMKy+Atx+wR23H5hAY4eXlKznc+PVfEI7IlnCwbVW358iQYjpa/ZvNQ84XfLMw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-package@17.0.0-rc.2':
-    resolution: {integrity: sha512-ZaMDhu4OlJmM45S3aXn8UE02tAY4UGeFoMSQwltIM2/Ry+9sKqpSfjBxSXnNr3HAl5crMZdWU1HjyOBA4jhHyw==}
+  '@objectstack/service-package@17.0.0-rc.3':
+    resolution: {integrity: sha512-Qk2hP7Wtj1sMgB6pTKgcwRYuomtfMdEIO8Y26RtK01IJRyZ98OwHg7iTdf680qJSSYBTVqjeR1e+P1hmuVg/1A==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-queue@17.0.0-rc.2':
-    resolution: {integrity: sha512-rDCCMDYNUDEggoZ6GvaTlkXy+9x6mFHOEmmbvM0WBHe6AkDJ0S9jagqjfhzkLHK5tOk/yv1KCQEqAD885BWgAw==}
+  '@objectstack/service-queue@17.0.0-rc.3':
+    resolution: {integrity: sha512-FhQRdmXX3VI6KOtM5mq9pKdqTl3WaiyeiTc4NldDW7NmoBMjRk5pZcN2IENo25rVgOgAa3Eg37P3pxLN/t6BTQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-realtime@17.0.0-rc.2':
-    resolution: {integrity: sha512-uj4iQ1nvGxJ5yj5PHNTLEmZ1wfXAnF9foDKphiGWJ5h4Pb5ixd3gYyZwz3IuRPwai04Rbt77jlx270X2QdeqJw==}
+  '@objectstack/service-realtime@17.0.0-rc.3':
+    resolution: {integrity: sha512-jZj/mqVf0diUAfk7BYtIwP6l+vHtQn+gY/Bdwglx0kvh5A9w5ePqFKhDlSj3P4CZQfqHJqCOC1GOrSjKGVFW7g==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-settings@17.0.0-rc.2':
-    resolution: {integrity: sha512-9+zMUgDV/d38Abn1JVPtHXC2/ZPy+RaOCEhTLpC6dOviPMciJLWtZMxLubZecrFCdZZtuAalabSI2q+7DCImJA==}
+  '@objectstack/service-settings@17.0.0-rc.3':
+    resolution: {integrity: sha512-LKzC+EJye/a/CEJqpDN9V7iffANifSp1MnRnJnUFKsDFKZ4T9q7LwL9tcQPsqJIn2/S3C0P96ELgD4zR4h3+Dw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-sms@17.0.0-rc.2':
-    resolution: {integrity: sha512-PQB4buIXpMOrL+s9NNhRVFL3/IgcrNE4IGiBfAEqF4vgTmBxqYUzv+I5WFT+btgRD5j/GIoWzgck3yggHDuC2g==}
+  '@objectstack/service-sms@17.0.0-rc.3':
+    resolution: {integrity: sha512-nwInTNv0FXyO1QM7PWSuILFTOmFq520CYTJHpt0rdNvu5zPI0P/gfDbni+NZnr3NxgFL5iTs3B7yLIdvE6sk6w==}
 
-  '@objectstack/service-storage@17.0.0-rc.2':
-    resolution: {integrity: sha512-XNrtYKuQWe8ehpYhy7U29S1IqDr/WhqNJ2lZyPyjynvoF9CJz+hBYvtTj9uQkVKpfx8QF4lw/LM51pSfAhCpeg==}
+  '@objectstack/service-storage@17.0.0-rc.3':
+    resolution: {integrity: sha512-hMP2I1Df/qLazaOKIfvQBSnTUXJAY4pgKmfaHMemOViHFeKf6As6Dgwp7y+oYEccMb1qSdrmUC5rMvNlmK/qEQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@aws-sdk/client-s3': ^3.0.0
@@ -727,12 +727,12 @@ packages:
       '@aws-sdk/s3-request-presigner':
         optional: true
 
-  '@objectstack/setup@17.0.0-rc.2':
-    resolution: {integrity: sha512-8KCjobU5s62D4OK+Getrt72lDI/M1Y3s9KNxD8gdQBfg0VEy4y/vkwcdSxW4756Iu6M+auU6DVGyFdH/braELA==}
+  '@objectstack/setup@17.0.0-rc.3':
+    resolution: {integrity: sha512-BEF9bXlKmor1fYvnYARcvR9lZm8fnm7cNzDvbIH123ZEUCYKvdLKPUxMZa5j8wrsUbV7EWVL2ZGrHPL6byB/Aw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/spec@17.0.0-rc.2':
-    resolution: {integrity: sha512-gvybztXuGTaqAlUzSOP4xeTpjl44ty2RZ67JQfiCma/engMG8pKqfv4/18nYitFktiWUVLsr2U6AquZAidmcRQ==}
+  '@objectstack/spec@17.0.0-rc.3':
+    resolution: {integrity: sha512-hCwqLEkIcmapxRX+skfHg7aLSwzbSkhDT2AEpVY/e8Bu5+rsM2v397pqn8liPQAaz7ybykzUK3HrSiNAEMz2+A==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       ai: ^7.0.0
@@ -740,23 +740,23 @@ packages:
       ai:
         optional: true
 
-  '@objectstack/trigger-api@17.0.0-rc.2':
-    resolution: {integrity: sha512-/ikaIDgoax78u75ep1ynNrrlpqXqIBwAPftwZ/gMrEwczRFVxD0jitWlgDDfqBOE3FUnC3FG3NxPTUUog+/PsQ==}
+  '@objectstack/trigger-api@17.0.0-rc.3':
+    resolution: {integrity: sha512-mpIXqL83f+Pvq1QddD2LUMMUR/R9yPtwh/1ny7mOBwl+eVcA8PYPUhuF6y92x8zFeOeJC0Wr32pBLBOHICOTaQ==}
 
-  '@objectstack/trigger-record-change@17.0.0-rc.2':
-    resolution: {integrity: sha512-mcogAAYFKlBQFOyeDBOWEEGKCIWpKr3EGjqOiUCbgTsDi+CSUdnA6KMFrsJriod/6p8pnIIUH9X1dHolHWCKHQ==}
+  '@objectstack/trigger-record-change@17.0.0-rc.3':
+    resolution: {integrity: sha512-EO6C/oOnKC41ydmEhgjalpA+Bmu6tAj+CWY5kGHvSonfTr03++eOMkwHsFsV8kCu8RKP0yNlrKGzpd9r+GpO0g==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/trigger-schedule@17.0.0-rc.2':
-    resolution: {integrity: sha512-lA/9IisY+cJyXb7ZOOU/5tQ+4w9bZxtqT+jrcuo/aDtoVcVeE1pbgZ/HJXnZZWNlMHLGNB7FYy7jbTsfG9UuIg==}
+  '@objectstack/trigger-schedule@17.0.0-rc.3':
+    resolution: {integrity: sha512-2u8Kh/21YlpoqZEaMi5uOFNchEDQeBG3X42J7ULZcEia0Bo1vFqeBLlck43pwQZfd5W2hj+jIbCiDNEllRJ7ww==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/types@17.0.0-rc.2':
-    resolution: {integrity: sha512-2aFKni6C6bt0NbrOrTFmfAbeWAoZivH4e8eh1lHRRgnq8UWYHZCwZgfQI+UIB37+yvCT58O2weQSYNwGTJxglQ==}
+  '@objectstack/types@17.0.0-rc.3':
+    resolution: {integrity: sha512-M5qk5MYfH3ifWKdjhGF92Zjs9il9ALOmDpZq9qX3nJbbeUkR3IBaaY2RHdarTA1dVDWZhbUe+GjrOY9+RWsDKA==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/verify@17.0.0-rc.2':
-    resolution: {integrity: sha512-GlpN1Quo0DdZn2n3nXxz4iKTUIPmdTYo5/oxhK7eL+Wlshkjx0LYPMicKvOyF/a2Fw0IlgtYF0npL02Lh8kw/A==}
+  '@objectstack/verify@17.0.0-rc.3':
+    resolution: {integrity: sha512-/3GYHSdH8fEaNram8hgm4cQgPklPwEUARSy2UbrStg9LsY6T0FYoYZslCmvtItVuFXJvEQ4qkHHIn1EhmNeLjA==}
     engines: {node: '>=22.0.0'}
 
   '@oclif/core@4.13.2':
@@ -3389,64 +3389,64 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@objectstack/account@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/account@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/cli@17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/cli@17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/account': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/client': 17.0.0-rc.2
-      '@objectstack/cloud-connection': 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/console': 17.0.0-rc.2
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/driver-memory': 17.0.0-rc.2
-      '@objectstack/driver-mongodb': 17.0.0-rc.2
-      '@objectstack/driver-sql': 17.0.0-rc.2
-      '@objectstack/driver-sqlite-wasm': 17.0.0-rc.2(better-sqlite3@13.0.2)
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/lint': 17.0.0-rc.2
-      '@objectstack/mcp': 17.0.0-rc.2
-      '@objectstack/metadata': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/metadata-protocol': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/objectql': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/observability': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-approvals': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-audit': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-auth': 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/plugin-email': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-hono-server': 17.0.0-rc.2
-      '@objectstack/plugin-pinyin-search': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-reports': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-security': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-sharing': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-webhooks': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/runtime': 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/service-analytics': 17.0.0-rc.2
-      '@objectstack/service-automation': 17.0.0-rc.2
-      '@objectstack/service-cache': 17.0.0-rc.2
-      '@objectstack/service-datasource': 17.0.0-rc.2
-      '@objectstack/service-job': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/service-messaging': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/service-package': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/service-queue': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/service-realtime': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/service-settings': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/service-sms': 17.0.0-rc.2
-      '@objectstack/service-storage': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/setup': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/trigger-api': 17.0.0-rc.2
-      '@objectstack/trigger-record-change': 17.0.0-rc.2
-      '@objectstack/trigger-schedule': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
-      '@objectstack/verify': 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/account': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/client': 17.0.0-rc.3
+      '@objectstack/cloud-connection': 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/console': 17.0.0-rc.3
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/driver-memory': 17.0.0-rc.3
+      '@objectstack/driver-mongodb': 17.0.0-rc.3
+      '@objectstack/driver-sql': 17.0.0-rc.3
+      '@objectstack/driver-sqlite-wasm': 17.0.0-rc.3(better-sqlite3@13.0.2)
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/lint': 17.0.0-rc.3
+      '@objectstack/mcp': 17.0.0-rc.3
+      '@objectstack/metadata': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/metadata-protocol': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/objectql': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/observability': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-approvals': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-audit': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-auth': 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/plugin-email': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-hono-server': 17.0.0-rc.3
+      '@objectstack/plugin-pinyin-search': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-reports': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-security': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-sharing': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-webhooks': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/runtime': 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/service-analytics': 17.0.0-rc.3
+      '@objectstack/service-automation': 17.0.0-rc.3
+      '@objectstack/service-cache': 17.0.0-rc.3
+      '@objectstack/service-datasource': 17.0.0-rc.3
+      '@objectstack/service-job': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/service-messaging': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/service-package': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/service-queue': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/service-realtime': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/service-settings': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/service-sms': 17.0.0-rc.3
+      '@objectstack/service-storage': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/setup': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/trigger-api': 17.0.0-rc.3
+      '@objectstack/trigger-record-change': 17.0.0-rc.3
+      '@objectstack/trigger-schedule': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
+      '@objectstack/verify': 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
       '@oclif/core': 4.13.2
       bundle-require: 5.1.0(esbuild@0.28.1)
       chalk: 6.0.0
@@ -3504,19 +3504,19 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/client@17.0.0-rc.2':
+  '@objectstack/client@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/cloud-connection@17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/cloud-connection@17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/runtime': 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/runtime': 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -3560,28 +3560,28 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/console@17.0.0-rc.2': {}
+  '@objectstack/console@17.0.0-rc.3': {}
 
-  '@objectstack/core@17.0.0-rc.2':
+  '@objectstack/core@17.0.0-rc.3':
     dependencies:
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/spec': 17.0.0-rc.3
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-memory@17.0.0-rc.2':
+  '@objectstack/driver-memory@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
       mingo: 7.2.2
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-mongodb@17.0.0-rc.2':
+  '@objectstack/driver-mongodb@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       mongodb: 7.5.0
       nanoid: 6.0.0
     transitivePeerDependencies:
@@ -3594,12 +3594,12 @@ snapshots:
       - snappy
       - socks
 
-  '@objectstack/driver-sql@17.0.0-rc.2':
+  '@objectstack/driver-sql@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/observability': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/observability': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       knex: 3.3.0(better-sqlite3@13.0.2)
       nanoid: 6.0.0
     optionalDependencies:
@@ -3613,11 +3613,11 @@ snapshots:
       - sqlite3
       - supports-color
 
-  '@objectstack/driver-sqlite-wasm@17.0.0-rc.2(better-sqlite3@12.11.1)':
+  '@objectstack/driver-sqlite-wasm@17.0.0-rc.3(better-sqlite3@12.11.1)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/driver-sql': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/driver-sql': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
       knex: 3.3.0(better-sqlite3@12.11.1)
       nanoid: 6.0.0
       sql.js: 1.14.1
@@ -3634,11 +3634,11 @@ snapshots:
       - supports-color
       - tedious
 
-  '@objectstack/driver-sqlite-wasm@17.0.0-rc.2(better-sqlite3@13.0.2)':
+  '@objectstack/driver-sqlite-wasm@17.0.0-rc.3(better-sqlite3@13.0.2)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/driver-sql': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/driver-sql': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
       knex: 3.3.0(better-sqlite3@13.0.2)
       nanoid: 6.0.0
       sql.js: 1.14.1
@@ -3655,75 +3655,75 @@ snapshots:
       - supports-color
       - tedious
 
-  '@objectstack/formula@17.0.0-rc.2':
+  '@objectstack/formula@17.0.0-rc.3':
     dependencies:
       '@marcbachmann/cel-js': 8.0.0
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/lint@17.0.0-rc.2':
+  '@objectstack/lint@17.0.0-rc.3':
     dependencies:
       '@marcbachmann/cel-js': 8.0.0
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/sdui-parser': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/sdui-parser': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
       sucrase: 3.35.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/mcp@17.0.0-rc.2':
+  '@objectstack/mcp@17.0.0-rc.3':
     dependencies:
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - ai
       - supports-color
 
-  '@objectstack/metadata-core@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/metadata-core@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/spec': 17.0.0-rc.3
       zod: 4.4.3
     optionalDependencies:
       vitest: 4.1.10(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-fs@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/metadata-fs@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/metadata-core': 17.0.0-rc.2(vitest@4.1.10)
+      '@objectstack/metadata-core': 17.0.0-rc.3(vitest@4.1.10)
       chokidar: 5.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/metadata-protocol@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/metadata-protocol@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/lint': 17.0.0-rc.2
-      '@objectstack/metadata-core': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/lint': 17.0.0-rc.3
+      '@objectstack/metadata-core': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/metadata@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/metadata@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/metadata-core': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/metadata-fs': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/metadata-core': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/metadata-fs': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       chokidar: 5.0.0
       glob: 13.0.6
       js-yaml: 5.2.2
@@ -3732,67 +3732,67 @@ snapshots:
       - ai
       - vitest
 
-  '@objectstack/objectql@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/objectql@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/metadata-core': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/metadata-protocol': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/metadata-core': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/metadata-protocol': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       ajv: 8.20.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/observability@17.0.0-rc.2':
+  '@objectstack/observability@17.0.0-rc.3':
     dependencies:
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/platform-objects@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/platform-objects@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/metadata-core': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/plugin-approvals@17.0.0-rc.2(vitest@4.1.10)':
-    dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/metadata-core': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/metadata-core': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-audit@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/plugin-approvals@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/metadata-core': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-auth@17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/plugin-audit@17.0.0-rc.3(vitest@4.1.10)':
+    dependencies:
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/plugin-auth@17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
       '@better-auth/core': 1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2)
       '@better-auth/oauth-provider': 1.7.0-rc.2(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.2(better-sqlite3@12.11.1)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/scim': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(better-auth@1.7.0-rc.2(better-sqlite3@12.11.1)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/sso': 1.7.0-rc.2(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.2(better-sqlite3@12.11.1)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@noble/hashes': 2.2.0
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       better-auth: 1.7.0-rc.2(better-sqlite3@12.11.1)(mongodb@7.5.0)(vitest@4.1.10)
       jose: 6.2.5
     transitivePeerDependencies:
@@ -3824,18 +3824,18 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/plugin-auth@17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/plugin-auth@17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
       '@better-auth/core': 1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2)
       '@better-auth/oauth-provider': 1.7.0-rc.2(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.2(better-sqlite3@13.0.2)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/scim': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(better-auth@1.7.0-rc.2(better-sqlite3@13.0.2)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/sso': 1.7.0-rc.2(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.2(better-sqlite3@13.0.2)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@noble/hashes': 2.2.0
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       better-auth: 1.7.0-rc.2(better-sqlite3@13.0.2)(mongodb@7.5.0)(vitest@4.1.10)
       jose: 6.2.5
     transitivePeerDependencies:
@@ -3867,116 +3867,116 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/plugin-email@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/plugin-email@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-hono-server@17.0.0-rc.2':
+  '@objectstack/plugin-hono-server@17.0.0-rc.3':
     dependencies:
       '@hono/node-server': 2.0.12(hono@4.12.33)
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/observability': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/observability': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       hono: 4.12.33
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-pinyin-search@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/plugin-pinyin-search@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/objectql': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/objectql': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/types': 17.0.0-rc.3
       pinyin-pro: 3.28.2
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-reports@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/plugin-reports@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
       croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-security@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/plugin-security@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-sharing@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/plugin-sharing@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/objectql': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/objectql': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-webhooks@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/plugin-webhooks@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/service-messaging': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/service-messaging': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/rest@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/rest@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/observability': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/service-package': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/observability': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/service-package': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       exceljs: 4.4.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/runtime@17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/runtime@17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/driver-memory': 17.0.0-rc.2
-      '@objectstack/driver-sql': 17.0.0-rc.2
-      '@objectstack/driver-sqlite-wasm': 17.0.0-rc.2(better-sqlite3@12.11.1)
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/metadata': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/metadata-core': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/metadata-protocol': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/objectql': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/observability': 17.0.0-rc.2
-      '@objectstack/plugin-auth': 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/plugin-security': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/service-cluster': 17.0.0-rc.2
-      '@objectstack/service-datasource': 17.0.0-rc.2
-      '@objectstack/service-i18n': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/driver-memory': 17.0.0-rc.3
+      '@objectstack/driver-sql': 17.0.0-rc.3
+      '@objectstack/driver-sqlite-wasm': 17.0.0-rc.3(better-sqlite3@12.11.1)
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/metadata': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/metadata-core': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/metadata-protocol': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/objectql': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/observability': 17.0.0-rc.3
+      '@objectstack/plugin-auth': 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/plugin-security': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/service-cluster': 17.0.0-rc.3
+      '@objectstack/service-datasource': 17.0.0-rc.3
+      '@objectstack/service-i18n': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       quickjs-emscripten: 0.32.0
       zod: 4.4.3
     optionalDependencies:
-      '@objectstack/driver-mongodb': 17.0.0-rc.2
+      '@objectstack/driver-mongodb': 17.0.0-rc.3
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -4020,30 +4020,30 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/runtime@17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/runtime@17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/driver-memory': 17.0.0-rc.2
-      '@objectstack/driver-sql': 17.0.0-rc.2
-      '@objectstack/driver-sqlite-wasm': 17.0.0-rc.2(better-sqlite3@13.0.2)
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/metadata': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/metadata-core': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/metadata-protocol': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/objectql': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/observability': 17.0.0-rc.2
-      '@objectstack/plugin-auth': 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/plugin-security': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/service-cluster': 17.0.0-rc.2
-      '@objectstack/service-datasource': 17.0.0-rc.2
-      '@objectstack/service-i18n': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/driver-memory': 17.0.0-rc.3
+      '@objectstack/driver-sql': 17.0.0-rc.3
+      '@objectstack/driver-sqlite-wasm': 17.0.0-rc.3(better-sqlite3@13.0.2)
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/metadata': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/metadata-core': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/metadata-protocol': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/objectql': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/observability': 17.0.0-rc.3
+      '@objectstack/plugin-auth': 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/plugin-security': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/service-cluster': 17.0.0-rc.3
+      '@objectstack/service-datasource': 17.0.0-rc.3
+      '@objectstack/service-i18n': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
       quickjs-emscripten: 0.32.0
       zod: 4.4.3
     optionalDependencies:
-      '@objectstack/driver-mongodb': 17.0.0-rc.2
+      '@objectstack/driver-mongodb': 17.0.0-rc.3
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -4087,185 +4087,185 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/sdui-parser@17.0.0-rc.2': {}
+  '@objectstack/sdui-parser@17.0.0-rc.3': {}
 
-  '@objectstack/service-analytics@17.0.0-rc.2':
+  '@objectstack/service-analytics@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-automation@17.0.0-rc.2':
+  '@objectstack/service-automation@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/formula': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/formula': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cache@17.0.0-rc.2':
+  '@objectstack/service-cache@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/observability': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/observability': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cluster@17.0.0-rc.2':
+  '@objectstack/service-cluster@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-datasource@17.0.0-rc.2':
+  '@objectstack/service-datasource@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-i18n@17.0.0-rc.2':
+  '@objectstack/service-i18n@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-job@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/service-job@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
       croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-messaging@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/service-messaging@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-package@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/service-package@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/metadata-core': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/metadata-core': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-queue@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/service-queue@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-realtime@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/service-realtime@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-settings@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/service-settings@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
       '@noble/ciphers': 2.2.0
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-sms@17.0.0-rc.2':
+  '@objectstack/service-sms@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-storage@17.0.0-rc.2(vitest@4.1.10)':
+  '@objectstack/service-storage@17.0.0-rc.3(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/observability': 17.0.0-rc.2
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/setup@17.0.0-rc.2(vitest@4.1.10)':
-    dependencies:
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/observability': 17.0.0-rc.3
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/spec@17.0.0-rc.2':
+  '@objectstack/setup@17.0.0-rc.3(vitest@4.1.10)':
+    dependencies:
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/spec@17.0.0-rc.3':
     dependencies:
       zod: 4.4.3
 
-  '@objectstack/trigger-api@17.0.0-rc.2':
+  '@objectstack/trigger-api@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/trigger-record-change@17.0.0-rc.2':
+  '@objectstack/trigger-record-change@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/trigger-schedule@17.0.0-rc.2':
+  '@objectstack/trigger-schedule@17.0.0-rc.3':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/types@17.0.0-rc.2':
+  '@objectstack/types@17.0.0-rc.3':
     dependencies:
-      '@objectstack/spec': 17.0.0-rc.2
+      '@objectstack/spec': 17.0.0-rc.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/verify@17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/verify@17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.2
-      '@objectstack/objectql': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/platform-objects': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-auth': 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/plugin-hono-server': 17.0.0-rc.2
-      '@objectstack/plugin-security': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/plugin-sharing': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/runtime': 17.0.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/service-analytics': 17.0.0-rc.2
-      '@objectstack/service-automation': 17.0.0-rc.2
-      '@objectstack/service-datasource': 17.0.0-rc.2
-      '@objectstack/service-settings': 17.0.0-rc.2(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.2
-      '@objectstack/types': 17.0.0-rc.2
+      '@objectstack/core': 17.0.0-rc.3
+      '@objectstack/objectql': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-auth': 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/plugin-hono-server': 17.0.0-rc.3
+      '@objectstack/plugin-security': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/plugin-sharing': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/runtime': 17.0.0-rc.3(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/service-analytics': 17.0.0-rc.3
+      '@objectstack/service-automation': 17.0.0-rc.3
+      '@objectstack/service-datasource': 17.0.0-rc.3
+      '@objectstack/service-settings': 17.0.0-rc.3(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0-rc.3
+      '@objectstack/types': 17.0.0-rc.3
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'


### PR DESCRIPTION
Fixes #901

把 hotcrm 的平台基线从 `17.0.0-rc.2` 提到 npm `rc` dist-tag 当前指向的 `17.0.0-rc.3`。**升级本身没有触发任何后果修复**——六道门全绿，源码 / 元数据 / 测试 / 文档一行未改。下面把「为什么没有」写实，而不是把空表当成没跑。

---

## 1. 版本对照

`npm view @objectstack/spec dist-tags` 复测(2026-08-06):

```
{ "latest": "16.1.0", "rc": "17.0.0-rc.3" }
```

`versions` 尾部到 `17.0.0-rc.3` 为止,无 rc.4。

| 位置 | FROM | TO |
| :--- | :--- | :--- |
| `package.json` `dependencies` 的 11 个 `@objectstack/*` | `17.0.0-rc.2` | `17.0.0-rc.3` |
| `package.json` `devDependencies` 的 `@objectstack/formula` | `17.0.0-rc.2` | `17.0.0-rc.3` |
| `objectstack.manifest.json` `specVersion` | `^17.0.0-rc.2` | `^17.0.0-rc.3` |
| `objectstack.manifest.json` `engines.protocol` | `^17.0.0-rc.2` | `^17.0.0-rc.3` |
| `pnpm-lock.yaml` | 刷新 | 刷新 |
| `package-lock.json` | 刷新(`npm install --package-lock-only`) | 刷新 |

`package-lock.json` 是在案的第二把锁——`.stackblitzrc` 的 `startCommand` 走 `npm install`,且上一次 rc.1→rc.2 升级(5a11631d / #663)同批刷过它,本单沿用同一处置。它里面残留的 41 处 `rc.2` 全部是 `better-auth@1.7.0-rc.2` 及其 adapter,与 `@objectstack/*` 无关,属正确保留;两把锁里 `@objectstack/*` 的 `17.0.0-rc.2` 已归零(`grep -n "objectstack.*17\.0\.0-rc\.2"` 双锁均无命中)。

安装后逐包核实:`spec / runtime / metadata / objectql / cli / service-automation / service-analytics / account / formula / driver-memory / driver-sql / driver-sqlite-wasm` 均为 `17.0.0-rc.3`。`pnpm install --frozen-lockfile` 退出码 0(CI 安装步等价复现)。

### rc.2 → rc.3 这个窗口里平台到底改了什么

对 `node_modules/@objectstack/*` 全部 50+ 个包的 `CHANGELOG.md` 机械抽取 `## 17.0.0-rc.3` 段落、剔除 `Updated dependencies` 与版本提升行后,**只剩一条实质变更**:

- **`@objectstack/spec` — `BulkActionParamSchema` 的 `options[]` 条目改为 `.passthrough()`(上游 #4001)**。`label` / `value` 以外的键(`color`、`icon`、`disabled`、`visibleWhen`)过去在 parse 时被静默删掉,现在保留。changelog 自述 "Behaviour change, loosening only"——过去能 parse 的现在都能 parse,无迁移项。

其余每一个包的 rc.3 段落都只有 `Updated dependencies` + 版本号列表。这是本单「零后果修复」的根因,不是没查。

**对本仓的实际影响:无。** hotcrm 只有两处带 `options` 的 bulk-action param,都在 `src/views/account.view.ts`(`update_tier` / `transfer_owner`),选项逐条只写了 `label` 与 `value`——过去没有任何东西被剥掉,所以这次放宽是今天的 no-op;变化只是从此可以给 bulk-action 选项配色/配图标并且它能活到渲染层。

---

## 2. 逐红项修复表

**空表,且是真的空。** 六道门在删掉 `dist/` 后的真实 rc.3 上依次跑完,全部退出码 0:

| 门 | 退出码 | 关键行 |
| :--- | :---: | :--- |
| `pnpm validate` | 0 | `✓ Validation passed (1459ms)` — 17 Objects / 344 Fields / 24 Flows |
| `pnpm typecheck` | 0 | `tsc --noEmit`,无输出 |
| `pnpm build` | 0 | `✓ Build complete`,`Artifact: dist/objectstack.json (1921.4 KB)` |
| `pnpm test -- --maxWorkers=2` | 0 | `Test Files 66 passed (66)` / `Tests 1587 passed, 1 skipped (1588)` |
| `pnpm lint` | 0 | `13 warning(s), 14 suggestion(s)` |
| `pnpm hygiene` | 0 | `✓ source hygiene clean` |

**「钉子红」也是零。** 本仓有大量把 rc.2 特定行为钉死的测试(`object-validation-predicates` 的 fail-closed、`flow-scheduled` 的 #4336 双形态、`parent-derived-reach` 的权限矩阵、`view-predicate-dialect` 的 49 个 CEL envelope 计数……),rc.3 一条都没有动到它们所钉的行为,所以没有钉子需要更新到 rc.3 实况。

作者期告警在**条数与措辞上逐字不变**(4 条 approval-approver + 1 条 `crm_campaign_member` field-group-shadowed),即升级没有新增也没有消除任何告警。

`pnpm install` 打出的 `better-sqlite3` peer 警告(`better-auth 1.7.0-rc.2` 要 `^12.0.0`,`@objectstack/cli` 带 13.0.2)是随平台包一起进来的既有 peer 冲突,rc.2 上同形,不因本单产生。

---

## 3. 在案上游镜像行为测量

探针一次性写、跑完即删,未入库。四条镜像分别对应本仓 issue #779 / #788 / #786 / #651。

**三档结论:已修复 0 条,仍复现 4 条,需专项复测 8 条。**

### 3.1 objectstack#5574(镜像 #779)— `multi: true` 批量更新 `ctx.previous` 恒空 — 仍复现

按镜像探针复刻:真 `crm_knowledge_article` schema + 真 `knowledge_article.hook` + `sys_fetch_previous_update` 内建复刻(priority 5 / `beforeUpdate` / object `*`)+ priority 299 观测 hook。

```
[PROBE] single-row update  => [{"hasInputId":true,"previousDefined":true,"previousStatus":"published", ...}]
[PROBE] MULTI update       => [{"hasInputId":false,"previousDefined":false,"input":"{\"category\":\"troubleshooting\"}"}]
[PROBE] MULTI null-stamp   => [{"hasInputId":false,"previousDefined":false,"input":"{\"last_reviewed_at\":null}"}]
```

引擎源码侧同样逐字未变(`@objectstack/objectql@17.0.0-rc.3` `dist/index.mjs`):

- 内建 `sys_fetch_previous_update` 的首行仍是 `if (hookCtx.input?.id && !hookCtx.previous)`(:8640 起);
- `beforeUpdate` 的 `hookContext` 构造里**没有** `previous`(:6453 起),`hookContext.previous` 唯一一次赋值在 driver 写之后、供 `afterUpdate` 用(:6556)。

**补充实测(镜像未记,本单新增,措辞照实):** 镜像第 3 条后果「批量写能把已发布文章的 `last_reviewed_at` 写成 null」在 rc.3 上**只在 system 上下文下复现**。同一探针三种上下文:

| 调用上下文 | 落库 `last_reviewed_at` |
| :--- | :--- |
| 非 system(`createContext({ userId: 'u1' })`) | 保持原值(未被写成 null) |
| 完全不传 context | 保持原值(未被写成 null) |
| system(`isSystem: true`) | **A / B 双双落成 `null`** |

根因在 multi 分支的 `if (!opCtx.context?.isSystem) { … stripReadonlyFields(…) }`(:6522-6525):非 system 调用方的 `last_reviewed_at`(`readonly: true`)先被 readonly 剥离,null 根本到不了 driver。rc.3 的 objectql **没有任何变更**(其 rc.3 段落只有 `Updated dependencies`),所以这不是 rc.2→rc.3 的行为差,而是镜像探针与本探针在上下文构造上的差别——本单据实记录,不改写镜像的结论。需要留意的是:镜像所论证的现实路径(批量导入 / seed / record-change flow)本仓恰恰是 **system** 上下文运行的(见 `.changeset/record-change-flows-run-as-system.md`),所以影响判断依然成立。

镜像的**核心主张**(`ctx.previous` 在批量路径恒空,15 个读 previous 的 hook 在该路径空转)无条件复现。

### 3.2 objectstack#5591(镜像 #788)— `readonly` 的两个相邻事实 — 仍复现(两半都在)

真 `ObjectQL.create` + `InMemoryDriver` + 真 schema + 真 hook,非 system 上下文 `createContext({ userId: 'u1' })`:

**第 1 点 · insert 路径不剥离 readonly:**

```
[PROBE] insert(non-system) published_at => "2024-03-01T00:00:00.000Z"
```

原样落库,无 read-only 警告。源码侧一致:`stripReadonlyFields(` 在整个 objectql dist 里只有两个调用点(:6489 单行、:6524 multi),**都在 update 分支**,insert 分支没有。

**第 2 点 · update 路径的剥离连坐删掉 hook 自己写的戳(按镜像的 draft→published 整记录回传探针):**

```
payload 带 published_at? false (undefined) => status=published  'published_at' in row=true  value="2026-08-06T..."  ← 正常
payload 带 published_at? true  (null)      => status=published  'published_at' in row=false value=null            ← 复现
payload 带 published_at? true  ("2024-03-01T00:00:00.000Z")
                                           => status=published  'published_at' in row=false value=null            ← 复现
```

也就是:调用方回传了 `published_at` 这一个键,hook 在同一次写里打的戳就被连坐删掉,落成一篇 **status 为 published 而 published_at 不存在**的文章。`suppliedKeys` 仍是在 hook 运行**之前**从调用方 payload 快照的(:6438 `const suppliedKeys = new Set(Object.keys(opCtx.data ?? {}))`,:6465 才 `triggerHooks("beforeUpdate")`,:6489 才 strip),机制与镜像记录的逐字一致。

(镜像在 rc.2 上记为 `published_at = null`,本探针读回是「该键不存在」——`driver-memory` 只存写过的列,同一事实的两种读法。)

### 3.3 objectstack#5586(镜像 #786)— `UnknownFilterTokenError` 对含非 word 字符的类占位符漏诊 — 仍复现

`classifyFilterToken` 探针:

```
[PROBE] classifyFilterToken "{today}"           => {"kind":"date-macro","token":"today"}
[PROBE] classifyFilterToken "{TODAY}"           => {"kind":"unknown","token":"TODAY"}
[PROBE] classifyFilterToken "{TODAY()}"         => null
[PROBE] classifyFilterToken "{current-user-id}" => null
[PROBE] classifyFilterToken "{30 days ago}"     => null
[PROBE] classifyFilterToken "{user.id}"         => null
```

读路径探针(四行 `crm_task`,`due_date` 分别在 30 天前 / 1 天前 / 今天 / 7 天后):

```
[PROBE] find due_date  <  '{today}'    => 2 row(s) ["t-30","t-1"]
[PROBE] find due_date  <  '{TODAY}'    => THROWS UnknownFilterTokenError / FILTER_TOKEN_UNKNOWN
[PROBE] find due_date  <  '{TODAY()}'  => 4 row(s) ["t-30","t-1","t0","t+7"]   ← 全表,含下周才到期那行
[PROBE] find due_date  =  '{TODAY()}'  => 0 row(s) []
```

与镜像在 rc.2 上的记录**逐行相同**。源码侧亦然:`@objectstack/spec@17.0.0-rc.3` `dist/data/index.js:909` 仍是
`var DATE_MACRO_WRAPPED_RE = /^\$?\{([a-zA-Z0-9_]+)\}$/;`,`:993` 仍是 `CONTEXT_TOKEN_WRAPPED_RE = DATE_MACRO_WRAPPED_RE`,`classifyFilterToken`(`:1022`)第二行仍是 `if (!m) return null;`。

### 3.4 objectstack#4697(镜像 #651)— `FlowVariableSchema` 是否新增 `defaultValue` — 仍复现(未新增)

读 spec 源码判定,`node_modules/@objectstack/spec/dist/flow.zod-koL_4VyN.d.ts:41`:

```ts
declare const FlowVariableSchema: z.ZodObject< {
    name: z.ZodString;
    type: z.ZodString;
    isInput: z.ZodDefault< z.ZodBoolean >;
    isOutput: z.ZodDefault< z.ZodBoolean >;
}, z.core.$strict >;
```

运行时确认仍是 strict、仍然四个键:

```
[PROBE] FlowVariableSchema keys => ["name","type","isInput","isOutput"]
[PROBE] safeParse({name,type,defaultValue}) success => false
[PROBE]   issues => [{"code":"unrecognized_keys","keys":["defaultValue"],"path":[]}]
```

`lead_conversion` 里 `init_defaults` 那个 `assignment` 节点的 workaround 仍然是唯一可写法,暂不能撤。

### 3.5 需专项复测(本单不展开)

以下八条没有廉价探针,按派发口径只标注、不强行展开:

| 镜像 | 主题 | 档位 |
| :--- | :--- | :--- |
| objectstack#5491–5495 | 权限矩阵五条 | 需专项复测 |
| objectstack#5386 | `controlled_by_parent` 可达范围 | 需专项复测 |
| objectstack#5149 | UI 侧 | 需专项复测 |
| objectstack#5019 | UI 侧 | 需专项复测 |

---

## 4. 文档版本引用清单

全仓(排除 `node_modules` / `dist` / `.git`)grep `rc.2` 得 68 个文件。逐处判定后:

**同批更新为 rc.3(纯版本号引用,4 处 / 2 文件)**

- `package.json` — 12 个 `@objectstack/*` 依赖版本
- `objectstack.manifest.json` — `specVersion`、`engines.protocol`
- 两把锁文件随之刷新

**不动(语义性引用,66 个文件)**

它们全部是「某行为在哪个版本上被实测/开始生效」的历史记录,不是本仓依赖什么的声明。改成 rc.3 等于伪造一次没做过的复测。分布:

| 面 | 文件数 | 形态举例 |
| :--- | :---: | :--- |
| `src/**`(objects / views / flows / profiles / actions / sharing / dashboards) | 30 | `MEASURED on 17.0.0-rc.2 and pinned by test/parent-derived-reach.test.ts`;`从 17.0.0-rc.2 起该 abort 拒绝写入` |
| `test/**` | 18 | `Measured on 17.0.0-rc.2, on this exact harness:` 后接实测输出块 |
| `.changeset/*.md`(含 `upgrade-objectstack-17-rc2.md`) | 15 | 待发布 changeset 里的实测叙述与上次升级的历史条目 |
| `content/docs/administration/sharing-and-security{,.zh-Hans,.zh-Hant}.mdx` | 3 | `Measured against the shipped stack (platform 17.0.0-rc.2)` |
| `CHANGELOG.md` | 1 | 上次升级的历史条目 |
| `AGENTS.md` | 1 | `≤ 17.0.0-rc.1 … / ≥ 17.0.0-rc.2 …` 的行为阈值表(在 rc.3 上依然成立) |

`README.md` / `docs/**` / `e2e/**` / `scripts/**` / `.github/**` 无 `rc.2` 命中。

---

## 5. rc.3 使已合并文档断言失效的条目

**逐条核对结果:零条。** rc.3 唯一的实质变更是 `BulkActionParamSchema.options[]` 的 passthrough 放宽,而:

- **#854 的平台退休证据**:涉及的是 rc.2 窗口的退休项(`crypto.hash`、`translation.validationMessages` 等),rc.3 没有新增或撤销任何退休,证据面不动。
- **#857 / #862 的导出面**:rc.3 没有任何导出改名或移除(rc.2 的 `ActionLocationSchema` → `ActionContributionLocationSchema` 是上一窗口的事),导出面不动。
- **`content/docs/administration/sharing-and-security*.mdx` 的「平台 17.0.0-rc.2 实测」段**:所述的 `controlled_by_parent` 组织级可达行为对应 objectstack#5386,rc.3 无相关变更;该断言的**内容**仍然成立,只是它写死了「rc.2 实测」这个测量时点。是否随基线推进补一次 rc.3 复测并改写时点,属于文档语义翻新,按派发口径不在本单——已在报告里作为 out-of-scope 记录。

因此本单**没有**需要另立单的失效断言。

---

## 验证输出

```
### validate  EXIT=0   ✓ Validation passed (1459ms)
### typecheck EXIT=0   tsc --noEmit(无输出)
### build     EXIT=0   ✓ Build complete — Artifact: dist/objectstack.json (1921.4 KB)
### lint      EXIT=0   13 warning(s), 14 suggestion(s)
### hygiene   EXIT=0   ✓ source hygiene clean
### test      EXIT=0   Test Files 66 passed (66) / Tests 1587 passed, 1 skipped (1588)
```

全部在 `rm -rf dist` 之后、`pnpm install` 刷新出的真实 rc.3 上跑(#5148 防 stale artifact),并在共享验证锁 `/tmp/os-heavy-verify.lock` 内串行、`NODE_OPTIONS=--max-old-space-size=4096` 限堆。未起任何 dev server。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_