### PR TITLE
docs(automation): spell the merge-field example with this app's real names (#863)

### DIFF
--- a/.changeset/automation-docs-merge-field-spelling.md
+++ b/.changeset/automation-docs-merge-field-spelling.md
@@ -1,0 +1,35 @@
+---
+'hotcrm': patch
+---
+
+Spell the Automation page's merge-field example the way this app spells names, in
+all three languages. The "Email templates" section on
+`content/docs/administration/automation.mdx` (and its `.zh-Hans` / `.zh-Hant`
+siblings) opened its bullet list with `{{Opportunity.Name}}` and
+`{{Account.Owner.Email}}` — Salesforce-style PascalCase that names nothing here.
+HotCRM's objects are `crm_opportunity` and `crm_contact`; its fields are `name`,
+`owner_id`, `email`. AGENTS.md holds that parity as a hard rule — *the name in
+source = the name at runtime = the name in DB = the name in URL = the name in
+docs. No translation layer* — and the rest of the same page already keeps it
+(`end_date`, `expiration_date`, `owner_id`). Only this bullet was borrowing
+another product's vocabulary, which an admin authoring a template under
+**Setup → Email Templates** would have copied into paths that resolve to nothing.
+
+The placeholder *syntax* was never the problem and is unchanged.
+`EmailTemplateDefinitionSchema` in `@objectstack/spec` 17.0.0-rc.3 documents
+subject and body as carrying simple `{{path.to.value}}` placeholders rendered
+against a per-send `data` payload, and describes each declared variable's `name`
+as "snake_case or dotted path".
+
+What the bullet deliberately does *not* do is invent a payload shape. Whether a
+template reads `{{name}}`, `{{record.name}}` or `{{crm_opportunity.name}}` depends
+on the `data` payload the caller passes to `sendTemplate()`, the caller decides
+that shape, and this repo has no caller to measure it from — `sendTemplate` and
+`email_template` have zero occurrences under `src/`, consistent with the compiled
+artifact carrying no email-template metadata (#834). So the bullet now gives the
+real spellings, says plainly that where the path is rooted is the sender's choice,
+and points template authors at the template's own `variables` list rather than at
+a shape nobody in this repo has exercised.
+
+Documentation only — one bullet per language file. No metadata, behaviour or field
+changes. Fixes #863.

--- a/content/docs/administration/automation.mdx
+++ b/content/docs/administration/automation.mdx
@@ -119,7 +119,7 @@ Understanding this order helps debug *"why didn't my flow fire?"* questions.
 
 Most automation actions send email. Templates live in **Setup → Email Templates** and support:
 
-- **Merge fields** — `{{Opportunity.Name}}`, `{{Account.Owner.Email}}`.
+- **Merge fields** — `{{path.to.value}}` placeholders, rendered against the `data` payload passed on that send. Spell every segment the way HotCRM spells it — objects are `crm_opportunity` and `crm_contact`, fields are `name`, `owner_id`, `email` — never Salesforce-style `Opportunity.Name`. What the path is rooted at depends on the payload shape the sender passes, and this app ships no `sendTemplate()` caller to copy one from, so declare the names your template reads in its `variables` list and agree the shape with whoever sends the mail.
 - **Conditional blocks** — show only if a condition is true.
 - **HTML + plain text** versions.
 - **Attachments** — quote PDFs, contract PDFs.

--- a/content/docs/administration/automation.zh-Hans.mdx
+++ b/content/docs/administration/automation.zh-Hans.mdx
@@ -119,7 +119,7 @@ HotCRM 内置的 **商机审批** 流程串联两个 approval 节点实现分级
 
 大多数自动化操作会发送电子邮件。模板位于 **设置 → 电子邮件模板**，并支持：
 
-- **合并字段** —— `{{Opportunity.Name}}`、`{{Account.Owner.Email}}`。
+- **合并字段** —— `{{path.to.value}}` 占位符，按每次发送传入的 `data` 载荷渲染。路径的每一段都写 HotCRM 自己的拼写 —— 对象是 `crm_opportunity`、`crm_contact`，字段是 `name`、`owner_id`、`email` —— 而不是 Salesforce 式的 `Opportunity.Name`。路径从哪一层写起，取决于发送方传入的载荷形状；本应用没有任何 `sendTemplate()` 调用方可供照抄，所以请把模板要读的名字声明在它的 `variables` 列表里，并与发送方约定好载荷形状。
 - **条件块** —— 仅在条件为真时显示。
 - **HTML + 纯文本** 版本。
 - **附件** —— 报价 PDF、合同 PDF。

--- a/content/docs/administration/automation.zh-Hant.mdx
+++ b/content/docs/administration/automation.zh-Hant.mdx
@@ -119,7 +119,7 @@ HotCRM 內建的 **商機審批** 流程串聯兩個 approval 節點實作分級
 
 大多數自動化操作會傳送電子郵件。範本位於 **設定 → 電子郵件範本**，並支援：
 
-- **合併欄位** —— `{{Opportunity.Name}}`、`{{Account.Owner.Email}}`。
+- **合併欄位** —— `{{path.to.value}}` 佔位符，依每次傳送傳入的 `data` 酬載渲染。路徑的每一段都寫 HotCRM 自己的拼寫 —— 物件是 `crm_opportunity`、`crm_contact`，欄位是 `name`、`owner_id`、`email` —— 而不是 Salesforce 式的 `Opportunity.Name`。路徑從哪一層寫起，取決於傳送方傳入的酬載形狀；本應用沒有任何 `sendTemplate()` 呼叫方可供照抄，因此請把範本要讀取的名稱宣告在它的 `variables` 清單裡，並與傳送方約定好酬載形狀。
 - **條件區塊** —— 僅在條件為真時顯示。
 - **HTML + 純文字** 版本。
 - **附件** —— 報價 PDF、合約 PDF。


### PR DESCRIPTION
Fixes #863

## 改了什么

`content/docs/administration/automation{,.zh-Hans,.zh-Hant}.mdx`「电子邮件模板」节的**合并字段 bullet 一行 ×3 语言**,其余一行未动。

改前(三语同形):

```
- **Merge fields** — {{Opportunity.Name}}, {{Account.Owner.Email}}.
```

`Opportunity` / `Name` / `Account.Owner.Email` 在本仓不是任何对象或字段的拼写,是 Salesforce 式 PascalCase 的借用。本仓的对象是 `crm_opportunity` / `crm_account` / `crm_contact`,字段是 `name` / `owner_id` / `email`,而 AGENTS.md 对此是硬约束(复核仍在):

> The name in source = the name at runtime = the name in DB = the name in URL = the name in docs. No translation layer.

同页其余引用字段的地方(flow 表的 `end_date`、`expiration_date`、`owner_id`)用的都是真实拼写,只有这一条例外。管理员在 **设置 → 电子邮件模板** 里照抄它,写出来的路径对不上任何值。

改后(英文,中文两版同义):

```
- **Merge fields** — {{path.to.value}} placeholders, rendered against the data payload
  passed on that send. Spell every segment the way HotCRM spells it — objects are
  crm_opportunity and crm_contact, fields are name, owner_id, email — never
  Salesforce-style Opportunity.Name. What the path is rooted at depends on the payload
  shape the sender passes, and this app ships no sendTemplate() caller to copy one from,
  so declare the names your template reads in its variables list and agree the shape with
  whoever sends the mail.
```

## stale-premise 复核(rc.3 基线)

issue 的两条 spec 主张在 **17.0.0-rc.3** 上逐字复核,均成立 —— `node_modules/@objectstack/spec/src/system/email-template.zod.ts`:

- 头注释:*"subject/body strings carry simple `{{path.to.value}}` placeholders rendered against a per-send `data` payload"* → **占位符语法本身是对的**,本 PR 不动语法,只动路径拼写。
- `EmailTemplateDefinitionVariableSchema.name` 的 describe:*"Variable name as referenced in placeholders (snake_case or dotted path)"* → snake_case 正是本仓的命名法。

`{{Opportunity.Name}}` / `{{Account.Owner.Email}}` 在本仓 `content/` 内仅这 3 处命中,全部改掉。

## 为什么不写 `{{record.name}}` 这类前缀形状

issue 给的两个选项里采用「不依赖载荷形状」的一个。占位符路径**从哪一层写起**,取决于每次发送传入的 `data` 载荷形状,该形状由 `sendTemplate()` 的调用方决定;而本仓**没有任何调用方**可供实测 —— `sendTemplate` 与 `email_template` 在 `src/` / `content/` / `objectstack.config.ts` 下**零命中**,与 #834 在编译产物里的结论一致。

所以这一行只承诺两件本仓能证明的事:**拼写用真名**,以及**路径根部由发送方决定**;并把作者指向模板自己的 `variables` 列表(spec 里声明占位符名字的地方),而不虚构 `{{record.name}}` / `{{crm_opportunity.name}}` 之类未经实测的形状当作「正确答案」。

## 边界

- 同页其余部分(含 #834/#854/#870/#879/#906 已落地内容)**一行未动**;与本轮并行的 #899 明确排除 automation 页,无交叠。
- 三语同步,术语沿本仓既有口径:载荷 / 酬載(对齐 `integrations` 页 payload 的三语译法)、调用方 / 呼叫方。
- 纯文档,不涉及元数据、行为或字段;`@objectstack/*` 版本与 `releases/` 未触碰。
- changeset:`.changeset/automation-docs-merge-field-spelling.md`。

## 验证

本地全绿(退出码均为 0):

| 门 | 结果 |
| --- | --- |
| `pnpm validate` | ✓ Validation passed (3278ms);警告与 main 同(approval 空审批人 ×4、campaign_member 分组) |
| `pnpm typecheck` | ✓ `tsc --noEmit` 无输出 |
| `pnpm lint` | ✓ 13 warning(s), 14 suggestion(s) —— 与 main 同,均非本改动引入 |
| `pnpm hygiene` | ✓ 415 files under content/.changeset 控制字节扫描通过 |
| `pnpm build` | ✓ Build complete;`dist/objectstack.json` 1921.4 KB |
| `pnpm test -- --maxWorkers=2` | ✓ Test Files 66 passed / Tests 1587 passed, 1 skipped |

守卫盲区如实说明:本仓**没有**针对文档正文的断言测试(仅 `scripts/check-source-hygiene.mjs` 对 `content/` 做控制字节与体积扫描),因此这三行文字的正确性由上面的源码比对承担,而不是由某个门把守 —— 对这三行,所有门的 predicted 结果都是 **GREEN**,实测亦然。push 前对四个改动文件做了控制字节自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,无命中。未起 dev server。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_