### PR TITLE
docs(administration): list all five objects that have a state machine (#896)

### DIFF
--- a/.changeset/state-machines-roster-five-objects.md
+++ b/.changeset/state-machines-roster-five-objects.md
@@ -1,0 +1,56 @@
+---
+'hotcrm': patch
+---
+
+The State Machines admin page now lists all five objects that have one, and says
+what a state machine actually does when you leave the declared route.
+
+`content/docs/administration/state-machines` opened with a roster of two —
+Leads and Opportunities — and then named case, contract, campaign and quote as
+objects that "have status fields but use simpler status handling rather than
+full state machines". Three of those four were wrong. `crm_case`,
+`crm_contract` and `crm_quote` each carry a named `state_machine` validation
+rule with a complete transition table (`case_status_progression`,
+`contract_status_progression`, `quote_status_progression` — added by #575 B4);
+the roster simply never moved when they landed. An admin read the page as
+licence to change those three lifecycles without maintaining a transition map.
+Campaign was the one the sentence got right.
+
+All three pages now list five objects with their real routes, and state the
+mechanism once: every machine is a named `state_machine` validation rule on the
+object, over its lifecycle field — cases, contracts and quotes use the *same*
+mechanism as leads and opportunities, not a lighter one.
+
+**Measured before writing, and it changed the wording.** All five rules are
+declared at `severity: 'warning'`, and the engine only throws on `error` — so
+an illegal transition is written to the server log and **the save still goes
+through**. Driven end to end on a real ObjectQL over the in-memory driver, one
+object at a time:
+
+| rule | illegal move probed | engine verdict | stored value after |
+| --- | --- | --- | --- |
+| `lead_status_progression` | Qualified → Contacted | logged, not blocked | `contacted` |
+| `opportunity_stage_progression` | Prospecting → Negotiation | logged, not blocked | `negotiation` |
+| `case_status_progression` | Resolved → Waiting on Customer | logged, not blocked | `waiting_customer` |
+| `contract_status_progression` | Draft → Activated | logged, not blocked | `activated` |
+| `quote_status_progression` | Draft → Accepted | logged, not blocked | `accepted` |
+
+The page therefore says the route is **advice, not a gate** — the same reading
+the contracts page already landed for `contract_status_progression` — rather
+than the issue's "the validation rule stops you". It also records that no
+machine declares `initialStates`, so a record *created* directly in a late
+state is never checked: the rules compare a new value against a previous one
+and only run on update.
+
+`test/status-state-machines.test.ts` gains the missing direction. It already
+derived which objects must be governed from the compiled stack; it now also
+reads the bullet roster off all three pages and fails when a governed object is
+absent from it, or when an object whose status is deliberately descriptive
+(campaign, task) appears in it. The roster is checked, not the prose around it,
+so the paragraph that explains *why* campaigns have no machine is free to name
+them. A sixth state machine now turns the page red instead of joining the three
+that were missing.
+
+Documentation and one test only; nothing under `src/` changed.
+
+Fixes #896.

--- a/content/docs/administration/state-machines.mdx
+++ b/content/docs/administration/state-machines.mdx
@@ -9,12 +9,19 @@ Some objects have a strict **lifecycle** — a lead progresses from *New* to *Wo
 
 ## Where state machines apply
 
-HotCRM uses state machines on:
+HotCRM uses state machines on **five** objects:
 
 - **Leads** — *New → Working → Qualified → Converted / Disqualified*
 - **Opportunities** — through the 7 stages *Prospecting → Qualification → Proposal → Negotiation → Closed Won / Closed Lost / Closed Without Decision*
+- **Cases** — *New → In Progress → Resolved → Closed*, with *Waiting on Customer* and *Waiting on Support* to park an open case, *Escalated* reachable from any unresolved status, and both *Resolved* and *Closed* able to reopen to *In Progress*
+- **Contracts** — *Draft → In Approval → Activated → Expired*, with *In Approval* able to send the paperwork back to *Draft*, *Terminated* reachable from all three live statuses, and *Expired* and *Terminated* both final
+- **Quotes** — *Draft → In Review → Presented → Accepted*, with *In Review* able to return to *Draft*, *Rejected* starting over at *Draft*, *Expired* reachable from *Draft*, *In Review* and *Presented*, and *Accepted* and *Expired* both final
 
-Other objects (case, contract, campaign, quote) have status fields but use **simpler status handling** rather than full state machines, because their transitions are less strict.
+All five are declared the same way — a named `state_machine` validation rule on the object, over that object's lifecycle field (`status`, or `stage` on opportunities). Cases, contracts and quotes are not a lighter mechanism than leads and opportunities; they are the same one. The top-level `stateMachines` key was removed in platform 7.7 and every machine moved onto its object.
+
+**A declared route is advice, not a gate.** All five rules carry **warning** severity, so a move outside the transition table is written to the server log — *"Invalid contract status transition"*, and so on — and **the save still goes through**. Nor is a record checked when it is *created*: the rules compare a new value against the previous one, so they only run on update, and a record imported straight into a late state passes untouched. What the table buys you is a declared, machine-readable route that automation, reports and the Copilot can rely on — not a lock on the field.
+
+**Campaigns have no state machine, and that is deliberate.** A campaign's status is descriptive (*Planning / In Progress / Completed / Aborted*) rather than a controlled lifecycle, and the same is true of the status fields on campaign members, events, knowledge articles and tasks. A transition table on any of them would warn on ordinary edits and teach users to ignore the warning.
 
 ## The Lead state machine
 

--- a/content/docs/administration/state-machines.zh-Hans.mdx
+++ b/content/docs/administration/state-machines.zh-Hans.mdx
@@ -9,12 +9,19 @@ description: HotCRM 如何在潜在客户和商机上强制执行有效的状态
 
 ## 状态机在哪里适用
 
-HotCRM 在以下对象上使用状态机：
+HotCRM 在 **五个** 对象上使用状态机：
 
 - **潜在客户** —— *New → Working → Qualified → Converted / Disqualified*
 - **商机** —— 经过 7 个阶段 *Prospecting → Qualification → Proposal → Negotiation → Closed Won / Closed Lost / Closed Without Decision*
+- **案例** —— *New → In Progress → Resolved → Closed*；*Waiting on Customer* 与 *Waiting on Support* 用来把未结案的案例挂起，*Escalated* 从任何未解决的状态都能进入，*Resolved* 与 *Closed* 都可以重新打开回 *In Progress*
+- **合同** —— *Draft → In Approval → Activated → Expired*；*In Approval* 可以把文件退回 *Draft*，三种在途状态都能直接走到 *Terminated*，*Expired* 与 *Terminated* 都是终点
+- **报价** —— *Draft → In Review → Presented → Accepted*；*In Review* 可以退回 *Draft*，*Rejected* 会回到 *Draft* 重来，*Expired* 可从 *Draft*、*In Review*、*Presented* 进入，*Accepted* 与 *Expired* 都是终点
 
-其他对象（案例、合同、活动、报价）有状态字段，但使用 **更简单的状态处理** 而非完整的状态机，因为它们的转换没那么严格。
+五者的声明方式完全相同 —— 都是对象上一条具名的 `state_machine` 验证规则，作用于该对象的生命周期字段（`status`，商机上是 `stage`）。案例、合同、报价用的不是比潜在客户和商机更轻的机制，就是同一套机制。顶层 `stateMachines` 键在平台 7.7 被移除后，所有状态机都迁到了各自的对象上。
+
+**声明出来的路线是建议，不是闸门。** 五条规则都是 **警告** 级：走出转换表的状态变更只会写进服务端日志——比如 *“Invalid contract status transition”*——而 **保存照样通过**。记录在 **新建** 时也根本不受检查：规则拿新值与前一个值比对，因此只在更新时运行，直接导入到后期状态的记录不会被碰。转换表给你的是一条声明出来、机器可读的路线，供自动化、报表和 Copilot 依赖——而不是给字段上锁。
+
+**营销活动没有状态机，这是有意的。** 营销活动的状态是描述性的（*Planning / In Progress / Completed / Aborted*），不是受控的生命周期；营销活动成员、活动、知识文章和任务的状态字段同理。给它们中任何一个加转换表，只会在正常编辑时报警告，教用户忽略警告。
 
 ## 潜在客户状态机
 

--- a/content/docs/administration/state-machines.zh-Hant.mdx
+++ b/content/docs/administration/state-machines.zh-Hant.mdx
@@ -9,12 +9,19 @@ description: HotCRM 如何在潛在客戶和商機上強制執行有效的狀態
 
 ## 狀態機在哪裡適用
 
-HotCRM 在以下物件上使用狀態機：
+HotCRM 在 **五個** 物件上使用狀態機：
 
 - **潛在客戶** —— *New → Working → Qualified → Converted / Disqualified*
 - **商機** —— 經過 7 個階段 *Prospecting → Qualification → Proposal → Negotiation → Closed Won / Closed Lost / Closed Without Decision*
+- **案例** —— *New → In Progress → Resolved → Closed*；*Waiting on Customer* 與 *Waiting on Support* 用來把未結案的案例掛起，*Escalated* 從任何未解決的狀態都能進入，*Resolved* 與 *Closed* 都可以重新開啟回 *In Progress*
+- **合約** —— *Draft → In Approval → Activated → Expired*；*In Approval* 可以把文件退回 *Draft*，三種在途狀態都能直接走到 *Terminated*，*Expired* 與 *Terminated* 都是終點
+- **報價** —— *Draft → In Review → Presented → Accepted*；*In Review* 可以退回 *Draft*，*Rejected* 會回到 *Draft* 重來，*Expired* 可從 *Draft*、*In Review*、*Presented* 進入，*Accepted* 與 *Expired* 都是終點
 
-其他物件（案例、合約、活動、報價）有狀態欄位，但使用 **更簡單的狀態處理** 而非完整的狀態機，因為它們的轉換沒那麼嚴格。
+五者的宣告方式完全相同 —— 都是物件上一條具名的 `state_machine` 驗證規則，作用於該物件的生命週期欄位（`status`，商機上是 `stage`）。案例、合約、報價用的不是比潛在客戶和商機更輕的機制，就是同一套機制。頂層 `stateMachines` 鍵在平台 7.7 被移除後，所有狀態機都遷到了各自的物件上。
+
+**宣告出來的路線是建議，不是閘門。** 五條規則都是 **警告** 級：走出轉換表的狀態變更只會寫進伺服器日誌——比如 *「Invalid contract status transition」*——而 **儲存照樣通過**。記錄在 **新建** 時也根本不受檢查：規則拿新值與前一個值比對，因此只在更新時執行，直接匯入到後期狀態的記錄不會被碰。轉換表給你的是一條宣告出來、機器可讀的路線，供自動化、報表和 Copilot 依賴——而不是給欄位上鎖。
+
+**行銷活動沒有狀態機，這是有意的。** 行銷活動的狀態是描述性的（*Planning / In Progress / Completed / Aborted*），不是受控的生命週期；行銷活動成員、活動、知識文章和任務的狀態欄位同理。給它們中任何一個加轉換表，只會在正常編輯時報警告，教使用者忽略警告。
 
 ## 潛在客戶狀態機
 

--- a/test/status-state-machines.test.ts
+++ b/test/status-state-machines.test.ts
@@ -1,7 +1,10 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import stack from '../objectstack.config';
+import { REPO_ROOT } from './helpers/repo-root';
 
 /**
  * Which status fields are governed by a transition table, and why (#575 B4).
@@ -147,6 +150,103 @@ describe('the new tables agree with the automation that drives them', () => {
     expect(expiring).toEqual(['activated']);
     expect(contract.expired).toEqual([]);
     expect(contract.terminated).toEqual([]);
+  });
+});
+
+/**
+ * The admin page's roster agrees with the ledger above (#896).
+ *
+ * `content/docs/administration/state-machines` opens with "HotCRM uses state
+ * machines on:" and a bullet per object. That roster was written when only
+ * `crm_lead` and `crm_opportunity` had a machine, and it did not move when
+ * #575 B4 added three more — so the page went on listing case, contract and
+ * quote as objects that *lack* a state machine while each of them carried a
+ * named one. Nothing was red: `os validate` and `pnpm lint` never open
+ * `content/docs`, and every guard in this file reads metadata only.
+ *
+ * This block closes that loop in the one direction that rots — the source grows
+ * a machine, the page does not. The expectation is DERIVED from {@link GOVERNED}
+ * / {@link UNGOVERNED}, so a sixth machine turns the page red instead of quietly
+ * joining the three that were missing.
+ *
+ * It reads the bullet list ONLY, not the prose around it: the paragraph below
+ * the list legitimately names campaigns (to say they deliberately have no
+ * machine), and a whole-section substring search would call that a listing.
+ * Bullets are the roster; prose is commentary.
+ */
+describe('the admin docs roster matches the ledger', () => {
+  /**
+   * How each object is named in the roster, per locale. Hand-written on purpose
+   * and NOT taken from `src/translations/` — the docs and the locale pack are
+   * separate surfaces with their own drift (#837 tracks `crm_case` alone being
+   * 服务案例 / 工单 / 案例 in three places), and pinning the page against the
+   * pack here would make this guard fail for a reason that has nothing to do
+   * with the roster being complete.
+   */
+  const DOC_LABEL: Record<string, { en: string; hans: string; hant: string }> = {
+    crm_lead: { en: 'Leads', hans: '潜在客户', hant: '潛在客戶' },
+    crm_opportunity: { en: 'Opportunities', hans: '商机', hant: '商機' },
+    crm_case: { en: 'Cases', hans: '案例', hant: '案例' },
+    crm_contract: { en: 'Contracts', hans: '合同', hant: '合約' },
+    crm_quote: { en: 'Quotes', hans: '报价', hant: '報價' },
+    crm_campaign: { en: 'Campaigns', hans: '营销活动', hant: '行銷活動' },
+    crm_task: { en: 'Tasks', hans: '任务', hant: '任務' },
+  };
+
+  const PAGES = [
+    { locale: 'en' as const, file: 'state-machines.mdx' },
+    { locale: 'hans' as const, file: 'state-machines.zh-Hans.mdx' },
+    { locale: 'hant' as const, file: 'state-machines.zh-Hant.mdx' },
+  ];
+
+  /** The bullet lines of the first `##` section, which is the roster. */
+  const rosterBullets = (file: string): string[] => {
+    const text = readFileSync(join(REPO_ROOT, 'content/docs/administration', file), 'utf8');
+    const sections = text.split(/^## /m);
+    // [0] is the frontmatter + `# Title` + lede; [1] is "Where state machines apply".
+    const section = sections[1];
+    if (!section) throw new Error(`${file}: no '## ' section found`);
+    return section.split('\n').filter((l) => l.startsWith('- '));
+  };
+
+  describe.each(PAGES)('$file', ({ locale, file }) => {
+    it('lists every governed object', () => {
+      const bullets = rosterBullets(file).join('\n');
+      const missing = GOVERNED.map((g) => g.object)
+        .filter((o) => !bullets.includes(DOC_LABEL[o]![locale]))
+        .map((o) => `${o} (${DOC_LABEL[o]![locale]})`);
+      expect(
+        missing,
+        `${file} declares a state machine for these objects but does not list them:\n  ${missing.join('\n  ')}`,
+      ).toEqual([]);
+    });
+
+    it('lists no object whose status is deliberately descriptive', () => {
+      const bullets = rosterBullets(file).join('\n');
+      const wrong = UNGOVERNED.filter((o) => bullets.includes(DOC_LABEL[o]![locale])).map(
+        (o) => `${o} (${DOC_LABEL[o]![locale]})`,
+      );
+      expect(
+        wrong,
+        `${file} lists these as having a state machine, but they deliberately do not — see #575 B4:\n  ${wrong.join('\n  ')}`,
+      ).toEqual([]);
+    });
+
+    it('has a roster to check — the precondition', () => {
+      // The UNGOVERNED assertion passes vacuously on an empty bullet list, so a
+      // section rename or a rewrite into prose would silently stop checking
+      // anything. This is the only signal for that; the GOVERNED assertion
+      // above cannot tell "no roster" from "roster missing an object".
+      expect(rosterBullets(file).length, `${file}: roster has no bullets`).toBeGreaterThan(0);
+    });
+  });
+
+  it('names every ledger object in every locale', () => {
+    // DOC_LABEL is hand-written; this keeps it in step with the ledger rather
+    // than letting a new object silently skip the roster check for want of a
+    // label entry.
+    const named = [...GOVERNED.map((g) => g.object), ...UNGOVERNED];
+    expect(named.filter((o) => !DOC_LABEL[o])).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Fixes #896

`content/docs/administration/state-machines` 的开篇清单只列了 Leads 和 Opportunities 两个对象，随后又把 case / contract / campaign / quote 四个点名为「有状态字段但只做更简单的状态处理，而不是完整状态机」。四个里有三个说反了。

## 一、stale-premise 复核：issue 的事实面成立

在 fresh `origin/main`（`7df29789`，平台 17.0.0-rc.3）上重跑 `grep -rn "type: 'state_machine'" src/objects/`，5 处命中逐条重定位（行号较 issue 各 +1，内容一致）：

| 对象 | 规则名 | 位置 | 页面原本的说法 |
| --- | --- | --- | --- |
| `crm_lead` | `lead_status_progression` | `src/objects/lead.object.ts:512` | 有状态机 ✅ |
| `crm_opportunity` | `opportunity_stage_progression` | `src/objects/opportunity.object.ts:413` | 有状态机 ✅ |
| `crm_case` | `case_status_progression` | `src/objects/case.object.ts:346` | ❌ 「没有完整状态机」 |
| `crm_contract` | `contract_status_progression` | `src/objects/contract.object.ts:259` | ❌ 同上 |
| `crm_quote` | `quote_status_progression` | `src/objects/quote.object.ts:263` | ❌ 同上 |

campaign 是四个里唯一说对的。issue 的核心事实成立。

## 二、severity 实测（⚠️ 这一步改掉了措辞）

按裁定不照抄 issue 的「会被校验规则拦下」。写了一次性探针（跑完即删），对 5 条规则逐条：真实 `ObjectQL` + `InMemoryDriver`，用各对象**真实的** object schema 建记录，停在合法状态，然后尝试一次**转换表之外**的跳转，并同时做一次表内跳转作对照。

引擎侧机制先看清（`@objectstack/objectql/dist/core.mjs:2433-2443`）：`evaluateRule` 产生 violation 后，只有 `severity === 'error'` 才 push 进 errors 数组、最终 `throw new ValidationError(errors)`；其余 severity 走 `logger.warn`，**不进 errors**。`checkStateMachine` 在 `mode === 'insert'` 时若规则未声明 `initialStates` 直接 `return null` —— 而 `grep -rn "initialStates" src/objects/` 零命中，故**新建路径完全不检查**。

探针实测结果（5/5 一致，无分档）：

| 规则 | 声明 severity | 实测非法跳转 | 引擎行为 | 落库后的值 |
| --- | --- | --- | --- | --- |
| `lead_status_progression` | `warning` | qualified 到 contacted | 未阻断，记日志 | `contacted` |
| `opportunity_stage_progression` | `warning` | prospecting 到 negotiation | 未阻断，记日志 | `negotiation` |
| `case_status_progression` | `warning` | resolved 到 waiting_customer | 未阻断，记日志 | `waiting_customer` |
| `contract_status_progression` | `warning` | draft 到 activated | 未阻断，记日志 | `activated` |
| `quote_status_progression` | `warning` | draft 到 accepted | 未阻断，记日志 | `accepted` |

探针原始输出节选：

```
crm_case.status — rule 'case_status_progression'
  declared severity : warning
  transitions[resolved] : [closed, in_progress]
  probe: resolved -> waiting_customer  (outside the table? true)
  stored before     : resolved
  ILLEGAL verdict   : SAVED (not blocked)
  value after       : waiting_customer
  engine log lines  :
      WARN Validation rule 'case_status_progression' (warning): Invalid status transition
  CONTROL resolved -> in_progress (in table? true) : saved, value=in_progress

crm_contract.status — rule 'contract_status_progression'
  declared severity : warning
  transitions[draft] : [in_approval, terminated]
  probe: draft -> activated  (outside the table? true)
  ILLEGAL verdict   : SAVED (not blocked)
  value after       : activated
  engine log lines  :
      WARN Validation rule 'contract_status_progression' (warning): Invalid contract status transition
  CONTROL draft -> in_approval (in table? true) : saved, value=in_approval

crm_quote.status — rule 'quote_status_progression'
  declared severity : warning
  transitions[draft] : [in_review, expired]
  probe: draft -> accepted  (outside the table? true)
  ILLEGAL verdict   : SAVED (not blocked)
  value after       : accepted
  engine log lines  :
      WARN Validation rule 'quote_status_progression' (warning): Invalid quote status transition
  CONTROL draft -> in_review (in table? true) : saved, value=in_review
```

lead / opportunity 与 case / contract / quote **没有分档** —— 五条同为 `warning`、同为「记日志后照样保存」。所以页面按实况写「声明出来的路线是**建议，不是闸门**」，沿用 #832 / PR #874 已在 contracts 页落地的口径（`advice, not a gate` / `保存照样通过` / `儲存照樣通過`），而不是 issue 里那句「会被校验规则拦下」。另附一句写实：新建路径不受检查。

（对照探针第一版：opportunity 用 prospecting 到 closed_won 时确实抛了异常，但抛的是 `win_reason` 的 `requiredWhen`，不是状态机 —— 换成 prospecting 到 negotiation 隔离掉后即 SAVED。这类串扰不算状态机拦截。）

## 三、`:12-17` 三语改法

清单补 case / contract / quote 三条，路线按各自 `transitions` 表逐条边核对后写（例如 case 的 `resolved` 只能从 `in_progress` / `escalated` 进入，所以没有写成 `Waiting on Customer` 直达 `Resolved` 的链）。随后一段讲清「五者同为对象上一条具名 `state_machine` 验证规则，作用于生命周期字段（商机是 `stage`），7.7 顶层 `stateMachines` 键移除后统一迁到这里」。

**`:17` 的取舍：改写，不删句。** 删掉的话，「campaign 有状态字段却没有状态机」这个**有意为之**的事实会连带消失，而 `test/status-state-machines.test.ts` 的注释恰好点出：「deliberately absent」和「forgotten」在元数据里长得一模一样，只有一种应该保持原状 —— 这正是值得留在页面上的信息。所以改写为只讲 campaign（页面原句里唯一说对的那个），并补上同类的其余几个。这里也没有照抄「只讲 campaign」的字面：实测 `status` 字段无状态机的不止 campaign，还有 campaign member / event / knowledge article / task，所以句子点名 campaign 之后以「同理」带过其余，而**不逐一枚举成一份会腐烂的清单**。

三语用词：
- convert 词汇沿 PR #906 已落口径，本次未触碰（本节也不涉及 convert；`状态转换` 属 #906 明确判定的另一个词，保持不变）。
- 语言包对齐：`crm_campaign` 简体 `营销活动`、`crm_campaign_member` 简体 `营销活动成员`（语言包里有专门注释说明不能简写成「活动成员」，因为「活动」已是 `crm_event` 的标签）；繁体按现有 18 页既有用词 `行銷活動` / `行銷活動成員`。
- 简体用 `验证规则`（与同目录 `administration/automation.zh-Hans.mdx` 一致），繁体 `驗證規則`。
- case 的中文称呼沿用**本页既有**的「案例」，不引入语言包的「服务案例」或其他页的「工单」—— 这三种叫法的分歧由 #837 单独跟踪，不在本单顺手动。

## 四、守卫

`test/status-state-machines.test.ts` 原本只有「元数据 to 元数据」一个方向：从编译后的 stack 推出必须被治理的对象集。#896 这类缺陷正好在它够不到的另一个方向 —— **源码长出了状态机，页面没跟上**，而 `os validate` / `pnpm lint` 从不打开 `content/docs`。

新增 block 从同一份 `GOVERNED` / `UNGOVERNED` ledger **推导**期望，读三语页面首个 `##` 小节的**列表项**：每个被治理的对象必须出现在清单里；每个状态是描述性的对象（campaign / task）不得出现在清单里。只读列表项、不读散文 —— 因为讲「campaign 为什么没有状态机」的那一段合法地点了 campaign 的名，整节做子串搜索会把它误判成清单条目。另有一条 precondition 断言清单非空，防止改成表格或散文后 UNGOVERNED 那条空转变绿。

**反向验证（方向为预测的 RED）**：把三个 mdx 还原到 `origin/main` 后单跑该文件，新断言在三个 locale 全红，且点名的恰好是 crm_case / crm_contract / crm_quote：

```
AssertionError: state-machines.mdx declares a state machine for these objects but does not list them:
  crm_case (Cases)
  crm_quote (Quotes)
  crm_contract (Contracts)
AssertionError: state-machines.zh-Hans.mdx ... crm_case (案例) / crm_quote (报价) / crm_contract (合同)
AssertionError: state-machines.zh-Hant.mdx ... crm_case (案例) / crm_quote (報價) / crm_contract (合約)
```

`DOC_LABEL` 是手写的、**刻意不**取自 `src/translations/` —— 文档与语言包是两个各自会漂移的面（#837 就是 `crm_case` 一个对象在三处三种叫法），拿语言包去钉页面会让这个守卫因为与「清单是否完整」无关的原因变红。另有一条断言保证 ledger 里每个对象都在 `DOC_LABEL` 里有词条，避免新对象因为缺词条而悄悄跳过检查。

## 五、验证

全部在 `flock -w 7200 /tmp/os-heavy-verify.lock` 内串行执行，`NODE_OPTIONS=--max-old-space-size=4096`：

| 门 | 退出码 | 关键行 |
| --- | --- | --- |
| `pnpm validate` | 0 | `✓ Validation passed (2119ms)` |
| `pnpm typecheck` | 0 | `tsc --noEmit`，无输出 |
| `pnpm lint` | 0 | `13 warning(s), 14 suggestion(s)`，与 main 同（均为既有 approval / naming 提示） |
| `pnpm build` | 0 | `✓ Build complete (1523ms)` |
| `pnpm hygiene` | 0 | `✓ source hygiene clean`（含 `content` / `.changeset` 的控制字节扫描） |
| `pnpm test -- --maxWorkers=2` | 0 | `Test Files 66 passed (66)`；`Tests 1597 passed, 1 skipped (1598)` |

单跑本次改动的守卫文件：`Test Files 1 passed (1)` / `Tests 39 passed (39)`。

push 前另做控制字节自扫（`grep -naP` 覆盖 `[\x00-\x08\x0b\x0c\x0e-\x1f]`，超出 `check:nul-bytes` 的扫描面）：四个改动文件 + changeset 均零命中。未起 dev server；探针为一次性文件，跑完已删，仓库无残留。

## 六、范围与边界

- 只动 `:12-17` 这一节 ×3 + 一个测试 + changeset。`src/**` 零改动，`content/docs/releases/` 未触碰，`@objectstack/*` 版本未动。
- `service/cases.mdx:78` 只引用未改 —— 但它与实测**冲突**（见越界发现）。
- 本页 `:14-15` 两条既有列表项**保持原样**：它们用的状态词（`Working` / `Disqualified` / `Closed Without Decision`）在 `src/` 里查无此值，但同一套词贯穿本页的 ASCII 图、转换表、Copilot 小节，只改列表项会让页面与 5 行外的自家图自相矛盾 —— 作为越界发现另行归档，不在本 PR 顺手改。