### PR TITLE
docs(service): write the index page's 《Where to find things》 list to the real navigation (#927)

### DIFF
--- a/.changeset/service-index-where-to-find-things-navigation.md
+++ b/.changeset/service-index-where-to-find-things-navigation.md
@@ -1,0 +1,13 @@
+---
+'hotcrm': patch
+---
+
+Write the service overview page's *Where to find things* list to the app's real
+navigation. The **Service** group in `src/apps/crm.app.ts` holds three items —
+Cases, Knowledge and **Service Overview** — so the list now names Knowledge
+(it was missing), gives the dashboard entry its actual sidebar label instead of
+"Service Dashboard", sends readers looking for Tasks to **My Tasks** /
+**All Tasks** under **My Work**, and records that no *Service Board* exists:
+the kanban is the `case_workflow` view labelled **Service Workflow**, reached
+from the **Workflow** tab in the case list, not from the sidebar. All three
+locales updated.

--- a/content/docs/service/index.mdx
+++ b/content/docs/service/index.mdx
@@ -59,12 +59,16 @@ See [Analytics › Dashboards](/docs/analytics/dashboards) and [Reports](/docs/a
 
 ## Where to find things
 
-In the Enterprise CRM app, the **Service** group contains:
+In the Enterprise CRM app, the **Service** group contains three items:
 
-- **Cases**
-- **Tasks**
-- **Service Board** — kanban-style case workflow
-- **Service Dashboard**
+- **Cases** — the case list.
+- **Knowledge** — the knowledge articles the Copilot reads from (`crm_knowledge_article`).
+- **Service Overview** — the service dashboard. That is its sidebar label; no sidebar item is called *Service Dashboard*.
+
+Two names people look for under **Service** are not there:
+
+- **Tasks** — `crm_task` reaches the sidebar as **My Tasks** and **All Tasks**, both under the **My Work** group, not under Service.
+- **Service Board** — nothing in this app carries that name. The kanban is the view `case_workflow`, labelled **Service Workflow**, and it is not a sidebar item at all: you reach it from the **Workflow** tab in the case list's view switcher.
 
 ## Start here
 

--- a/content/docs/service/index.zh-Hans.mdx
+++ b/content/docs/service/index.zh-Hans.mdx
@@ -59,12 +59,16 @@ New ──► In Progress ──► Waiting on Customer ──► Resolved ─�
 
 ## 在哪里找到这些内容
 
-在 Enterprise CRM 应用中，**服务**分组包含：
+在 Enterprise CRM 应用中，**服务**分组包含三项：
 
-- **工单**
-- **任务**
-- **服务看板**——看板式工单工作流
-- **服务仪表盘**
+- **工单**（Cases）——工单列表。
+- **知识**（Knowledge）——Copilot 读取的知识文章（`crm_knowledge_article`）。
+- **服务概览**（Service Overview）——服务仪表盘。侧边栏上的 label 就是这个；没有任何侧边栏条目叫 *Service Dashboard*。
+
+有两个名字，人们会到**服务**分组下面找，但它们不在这里：
+
+- **任务**——`crm_task` 在侧边栏上是 **My Tasks**（我的任务）与 **All Tasks**（全部任务）两项，都挂在**我的工作**分组下，不在**服务**分组里。
+- **服务看板**——本应用里不存在叫这个名字的东西。看板是视图 `case_workflow`，label 为 **Service Workflow**，而且它根本不是侧边栏条目：要从工单列表视图切换器里的 **Workflow** 页签进入。
 
 ## 从这里开始
 

--- a/content/docs/service/index.zh-Hant.mdx
+++ b/content/docs/service/index.zh-Hant.mdx
@@ -59,12 +59,16 @@ New ──► In Progress ──► Waiting on Customer ──► Resolved ─�
 
 ## 在哪裡找到這些內容
 
-在 Enterprise CRM 應用中，**服務**分組包含：
+在 Enterprise CRM 應用中，**服務**分組包含三項：
 
-- **工單**
-- **任務**
-- **服務看板**——看板式工單工作流
-- **服務儀表板**
+- **工單**（Cases）——工單清單。
+- **知識**（Knowledge）——Copilot 讀取的知識文章（`crm_knowledge_article`）。
+- **服務概覽**（Service Overview）——服務儀表板。側邊欄上的 label 就是這個；沒有任何側邊欄條目叫 *Service Dashboard*。
+
+有兩個名字，人們會到**服務**分組下面找，但它們不在這裡：
+
+- **任務**——`crm_task` 在側邊欄上是 **My Tasks**（我的任務）與 **All Tasks**（全部任務）兩項，都掛在**我的工作**分組下，不在**服務**分組裡。
+- **服務看板**——本應用裡不存在叫這個名字的東西。看板是視圖 `case_workflow`，label 為 **Service Workflow**，而且它根本不是側邊欄條目：要從工單清單視圖切換器裡的 **Workflow** 頁籤進入。
 
 ## 從這裡開始
 


### PR DESCRIPTION
Fixes #927

《Where to find things》是新用户在这一页上找路的第一站，它列了四项；对着 `src/apps/crm.app.ts` 读一遍，其中三项站不住，而这个分组里真实存在的一项反而被漏掉了。

## 逐条复核(stale-premise)

基线 `origin/main` = `4855d50b`（rc.3）。本页经 #913 / #922 两轮修改后重定位：该节现在是 `:60`-`:67`（issue 正文记的 `:63`-`:67` 是改动前的行号），三语同行号。四项逐一对着源码复核，issue 的前提**全部成立**：

| 清单原文 | 源码实况 | 结论 |
| --- | --- | --- |
| **Cases** | `crm.app.ts:137` `nav_case` → `crm_case`，label `Cases` | ✅ 对 |
| **Tasks** | `group_service` 的 children 里没有 `crm_task`；它的两个导航项是 `nav_my_tasks`（`:84`，label `My Tasks`）与 `nav_all_tasks`（`:93`，label `All Tasks`），都挂在 `group_work` / **My Work** 下 | ❌ 分组错 |
| **Service Board** | 全仓元数据里没有这个名字。看板是视图 `case_workflow`，`label: 'Service Workflow'`（`src/views/case.view.ts:72`-`:75`），经工单列表视图切换器的 **Workflow** 页签进入（`:59`），根本不是侧边栏条目 | ❌ 名字不存在，且不是导航项 |
| **Service Dashboard** | `nav_service_dashboard`（`:139`）确实存在，但 label 是 **Service Overview** | ⚠️ label 写错 |
| （漏） **Knowledge** | `nav_knowledge`（`:138`）→ `crm_knowledge_article`，label `Knowledge`，真实存在于该分组 | ⚠️ 被漏掉 |

即 `group_service`（`:131`-`:140`）实有且仅有三项：Cases、Knowledge、Service Overview。

## 改法

三项写实 + 两个读者会带着来的名字给出真实归属，沿 #870 / #877 / #885 / #894 / #913 / #924 已立的口径——**点名说清不存在，并给出真名 / 真实所在分组 / 真实 label，不静默删名**。`Service Board` 的措辞与 #924 在 `sla-and-escalation` 上落的那句保持一致（真名 `Service Workflow` / `case_workflow` / **Workflow** 页签 / 本应用里不存在叫 Service Board 的东西）。

**不预判产品**（#595 / #596）：看板*是否应该*成为独立导航项、Tasks *是否应该*进 Service 分组，都是产品决定，本 PR 只记录当前形状。

## 边界

- 只动《Where to find things》一节：三份文件的 diff hunk 都只有 `@@ -62 +62 @@` 与 `@@ -64,4 +64,8 @@`。
- #913 / #922 已落地行（`:27` / `:30` / `:36` / `:37` / `:38` / `:40` / `:48`）**零回退**，未进 diff。
- `src/` 零改动；`@objectstack/*` 版本未动；`content/docs/releases/` 未动。
- 与 #926（`service/cases` 页的视图清单）不重叠——`cases.mdx:124` / `:175` 上的 `Service Board` 属于那一单，本 PR 不碰。
- 三语同步，行号对齐（三份均 77 行，该节均起于 `:60`）；zh 内链未新增，故不涉及锚点。

## 验证

六道门在共享锁内串行，全绿：

| 门 | 退出码 | 关键行 |
| --- | --- | --- |
| `pnpm validate` | 0 | `Security: 12 Positions 6 Permissions`（余为既有 approval/campaign_member 警告） |
| `pnpm typecheck` | 0 | `tsc --noEmit` 无输出 |
| `pnpm lint` | 0 | `13 warning(s), 14 suggestion(s)`，均为既有 |
| `pnpm hygiene` | 0 | `✓ no raw control bytes in first-party files`（扫描面含 `content` / `.changeset` 共 425 个文件） |
| `pnpm build` | 0 | `Artifact: dist/objectstack.json (1921.4 KB)` |
| `pnpm test` | 0 | `Test Files 70 passed (70)` / `Tests 1602 passed \| 1 skipped (1603)` |

**守卫盲区，如实报告**：本仓没有任何检查读这一节的导航散文——`test/docs-drift.test.ts` 的规则覆盖 flow 文档、目录引用、agent 名、dashboard 磁贴（`content/docs/analytics/dashboards*.mdx`）与译文 callout 数量，没有一条比对左侧导航清单。所以这里**没有 before-red / after-green 可拿**：把旧的四项写回去，六道门同样全绿。唯一读到本文件的规则是 callout 数量对齐（`docs-drift.test.ts:575`），本改动未增删 callout，故三语仍然对齐——这也是它 predicted GREEN 且实测 GREEN 的原因，而不是它验证了本次改动的正确性。改动的正确性由上表的源码 file:line 逐条支撑。

控制字节：除 gate 4 外另做自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`（三份 mdx + changeset），无命中；`file` 对四个文件均报 UTF-8 text，未被判为 binary。（`scripts/check-nul-bytes.mjs` 在本仓不存在，等价扫描在 `scripts/check-source-hygiene.mjs` 里，即 gate 4。）

未起 dev server。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_