### PR TITLE
docs(marketing): name Products in the index page's "Where to find things" (#938)

### DIFF
--- a/.changeset/marketing-index-where-to-find-things-products.md
+++ b/.changeset/marketing-index-where-to-find-things-products.md
@@ -1,0 +1,15 @@
+---
+'hotcrm': patch
+---
+
+Write the marketing overview page's *Where to find things* list to the app's real
+navigation. The **Marketing** group in `src/apps/crm.app.ts` has two children, not
+one: alongside Campaigns it carries **Products**, and that item is the product
+catalog's only sidebar entry anywhere in the app — the page had been telling
+readers the group held Campaigns alone, so anyone hunting for the catalog under
+Marketing would not have expanded it. The list now names both items with their
+real labels, points at `content/docs/revenue/products` for the catalog's own
+documentation, records that a product is otherwise reached only through global
+search or a quote/opportunity line item, and notes that this group — unlike
+Sales, My Work, Activity and Service — is collapsed by default. All three locales
+updated.

--- a/content/docs/marketing/index.mdx
+++ b/content/docs/marketing/index.mdx
@@ -69,9 +69,12 @@ See [Analytics › Reports](/docs/analytics/reports).
 
 ## Where to find things
 
-In the Enterprise CRM app, the **Marketing** group contains:
+In the Enterprise CRM app, the **Marketing** group contains two items:
 
-- **Campaigns**
+- **Campaigns** — the campaign list (`crm_campaign`).
+- **Products** — the product catalog (`crm_product`). This is the catalog's only sidebar entry anywhere in the app, even though the product documentation lives under [Revenue › Products](/docs/revenue/products). Apart from this item and global search, a product record is only reached from a quote or opportunity line item.
+
+The **Marketing** group is **collapsed by default** — unlike Sales, My Work, Activity and Service, it does not open itself when the app loads. Click it open before deciding something isn't there.
 
 Leads enrolled in campaigns are accessed from the campaign detail page or via global search.
 

--- a/content/docs/marketing/index.zh-Hans.mdx
+++ b/content/docs/marketing/index.zh-Hans.mdx
@@ -69,9 +69,12 @@ Planning ──► In Progress ──► Completed
 
 ## 在哪里可以找到
 
-在 Enterprise CRM 应用中，**Marketing** 组包含：
+在 Enterprise CRM 应用中，**Marketing** 组包含两项：
 
-- **营销活动**
+- **营销活动**（Campaigns）——营销活动列表（`crm_campaign`）。
+- **产品**（Products）——产品目录（`crm_product`）。这是产品目录在整个应用侧边栏里唯一的入口，尽管产品的文档挂在 [Revenue › Products](/zh-Hans/docs/revenue/products) 下。除了这一项和全局搜索之外，只能从报价或商机的明细行反查到产品记录。
+
+**Marketing** 组**默认是折叠的**——与 Sales、My Work、Activity、Service 不同，它不会在应用加载时自动展开。先把它点开，再判断某样东西在不在这里。
 
 加入营销活动的线索可从营销活动详情页或通过全局搜索访问。
 

--- a/content/docs/marketing/index.zh-Hant.mdx
+++ b/content/docs/marketing/index.zh-Hant.mdx
@@ -69,9 +69,12 @@ Planning ──► In Progress ──► Completed
 
 ## 在哪裡可以找到
 
-在 Enterprise CRM 應用中，**Marketing** 群組包含：
+在 Enterprise CRM 應用中，**Marketing** 群組包含兩項：
 
-- **行銷活動**
+- **行銷活動**（Campaigns）——行銷活動清單（`crm_campaign`）。
+- **產品**（Products）——產品目錄（`crm_product`）。這是產品目錄在整個應用側邊欄裡唯一的入口，儘管產品的文件掛在 [Revenue › Products](/zh-Hant/docs/revenue/products) 下。除了這一項和全域搜尋之外，只能從報價或商機的明細列反查到產品記錄。
+
+**Marketing** 群組**預設是摺疊的**——與 Sales、My Work、Activity、Service 不同，它不會在應用載入時自動展開。先把它點開，再判斷某樣東西在不在這裡。
 
 加入行銷活動的潛在客戶可從行銷活動詳情頁或透過全域搜尋存取。
 


### PR DESCRIPTION
Fixes #938

《Where to find things》这一节是给新读者指路的，它说 **Marketing** 分组只有一项。实际是两项。

## 前提复核（fresh main = `11f62429`）

Issue 的基线是 `4855d50b`，我在 `origin/main` 上重新定位，行号与断言全部成立：

- `src/apps/crm.app.ts:120`-`:128` 的 `group_marketing` 恰有两个 children——`nav_campaign`（label `Campaigns`）与 `nav_product`（label `Products`，`:126`）。
- `content/docs/marketing/index.mdx:70`-`:76` 的清单只列了 Campaigns；`index.zh-Hans.mdx` / `index.zh-Hant.mdx` 同址同形（:74）。

前提成立，未过期。

## 分组 children 全量核对结果

按裁定「核对该分组全部 children，漏项/假项一并按实况处理」，逐条比对如下：

| crm.app.ts 里的 child | 文档原状 | 处置 |
| --- | --- | --- |
| `nav_campaign` → `crm_campaign`，label `Campaigns` | 已列，label 正确 | 保留，补上对象名 |
| `nav_product` → `crm_product`，label `Products` | **漏列** | 补上 |

没有第三个 child，也没有假项——本页的问题是纯粹的「少一项」，方向与 #927 / PR #932 相反（那边是列了不存在的东西）。所以本 PR 不需要 #932 那样的「不静默删名」段落：没有名字需要被保留指向。

## 一并写实的两条源码事实

1. **`nav_product` 是 `crm_product` 在整个应用里唯一的侧边栏入口**——`grep -rn "crm_product" src/apps/` 只返回 `crm.app.ts:126` 这一行。但 issue 正文里「除此之外只能从报价/商机的明细行反查」这句话我没有照抄：`crm_product` 声明了 `searchableFields: ['name', 'product_code', 'sku']`（`src/objects/product.object.ts:27`），全局搜索是能找到产品记录的。所以文档写成「除了这一项和全局搜索之外，只能从报价或商机的明细行反查」——另两条路径是 `crm_quote_line_item:62` 与 `crm_opportunity_line_item:69` 的 `crm_product` lookup。

2. **`group_marketing` 默认折叠。** 它没有声明 `expanded`，而 Sales / My Work / Activity / Service 四个分组都写了 `expanded: true`；`GroupNavItemSchema` 里 `expanded: z.boolean().default(false)`（`node_modules/@objectstack/spec/dist/index.js`）。这正是 issue 描述的失效路径——分组是收起来的，文档又说里面只有 Campaigns，读者就不会点开去看。所以这一节现在明说：先把分组点开，再判断东西在不在。

产品目录自己的文档页在 `content/docs/revenue/products`，所以新条目链过去，而不是把内容复制进 Marketing。

## 面与边界

- 只改三份 `content/docs/marketing/index*.mdx` 的《Where to find things》一节 + 一份 changeset。`src/` 零改动，`@objectstack/*` 版本未动，`content/docs/releases/` 未碰。
- 三语同步，同一位置；zh 内链不带锚（`/zh-Hans/docs/revenue/products`、`/zh-Hant/docs/revenue/products`）。
- 本节末尾关于 campaign member 的那句原文未改动——它不是本单的对象，且断言仍成立。
- #595 / #596 不预判：Products 该不该单独成组、该不该挪到 Revenue 分组，本 PR 不作判断，只记录当前形状。

## 验证

六道门在共享锁 `flock -w 7200 /tmp/os-heavy-verify.lock` 内串行跑完，全绿：

```
validate  exit=0
typecheck exit=0
lint      exit=0
hygiene   exit=0   （含 no raw control bytes，扫描 content/ 与 .changeset/ 共 429 个文本文件）
build     exit=0
test      exit=0   （Test Files 70 passed，Tests 1602 passed | 1 skipped）
```

**全绿是事先预测的结果，不是本次改动的功劳。** 这是守卫盲区：仓库里没有任何一道门把《Where to find things》的清单与 `crm.app.ts` 的 navigation 对读——`docs-drift.test.ts` 只钉 flow 阈值，`docs-object-coverage.test.ts` 只管对象是否有文档页。证据是 main 本身：`11f62429` 带着这份错清单合入，六道门当时同样全绿。所以这一类缺陷只能靠人/agent 读源码发现，绿不能当作正确性证据。

push 前另做了控制字节自扫（`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`，四个改动文件均无命中）。未起 dev server。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_