### PR TITLE
docs(service): 按产品里真实存在的名字称呼服务仪表盘 (#937)

### DIFF
--- a/.changeset/service-docs-real-dashboard-name.md
+++ b/.changeset/service-docs-real-dashboard-name.md
@@ -1,0 +1,28 @@
+---
+'hotcrm': patch
+---
+
+Call the service dashboard by a name the product actually shows. The three
+service pages — `content/docs/service/index.mdx`,
+`content/docs/service/cases.mdx` and
+`content/docs/service/sla-and-escalation.mdx`, in all three locales — referred
+to it as **Service Dashboard**, and nothing in the app carries that name: the
+sidebar item is `label: 'Service Overview'` (`src/apps/crm.app.ts`) and the
+dashboard's own title is `label: 'Customer Service'`
+(`src/dashboards/service.dashboard.ts`). A manager told to "read the **SLA
+Violations** tile on the Service Dashboard every morning" had no sidebar entry
+by that name to click.
+
+The pages now use **Service Overview** — the sidebar label, which is how a
+reader finds it — and annotate the dashboard's own title, **Customer Service**,
+once at the first mention on each page, so the heading you land on matches what
+you were told to look for. That title is also the section heading on
+`content/docs/analytics/dashboards.mdx`, where the cross-page links point. The
+Chinese pages use 服务概览 / 服務概覽, which is the navigation label's own
+translation (`src/translations/zh-CN.ts`); the dashboard title stays as the
+Latin **Customer Service**, matching how the dashboards page writes it in every
+locale.
+
+No metadata changed — the two labels are what they were, and whether the app
+*should* show one name in the sidebar and another on the page is a product
+question this leaves open.

--- a/.changeset/sla-views-reports-write-real.md
+++ b/.changeset/sla-views-reports-write-real.md
@@ -35,9 +35,10 @@ percentage.
 (`src/views/case.view.ts`): *All Cases*, *Service Workflow*, *SLA Calendar*,
 *Case Timeline*, *My Open Cases*, *Escalated Cases*, *⏰ SLA at Risk* — and none
 of them filters on `is_sla_violated`. The two surfaces that do are metric tiles
-on the Service Dashboard. The cadence table and the manager tip now point at
-**Escalated Cases** (every case the sweep flags gets escalated into it) plus the
-**SLA Violations** tile, and say plainly that the two old names name nothing.
+on the Service Overview dashboard. The cadence table and the manager tip now
+point at **Escalated Cases** (every case the sweep flags gets escalated into it)
+plus the **SLA Violations** tile, and say plainly that the two old names name
+nothing.
 
 **The kanban board is called Service Workflow.** `case_workflow` carries
 `label: 'Service Workflow'` and appears on the case list as the **Workflow**

--- a/content/docs/service/cases.mdx
+++ b/content/docs/service/cases.mdx
@@ -131,7 +131,7 @@ See [SLA & Escalation](/docs/service/sla-and-escalation) for the full mechanics.
 
 Six names this section used to list are not views at all:
 
-- **Critical Cases** and **Breached SLA** are metric tiles, not lists. The [Service Dashboard](/docs/analytics/dashboards) carries *Critical Cases* (open and Critical) and **SLA Violations** (`is_sla_violated` is true); no list view in this app filters on a breach. For a list you can actually work through, use **Escalated Cases** — the SLA sweep escalates every case it flags, so each breach lands there.
+- **Critical Cases** and **Breached SLA** are metric tiles, not lists. [Service Overview](/docs/analytics/dashboards) — the dashboard's own title is **Customer Service** — carries *Critical Cases* (open and Critical) and **SLA Violations** (`is_sla_violated` is true); no list view in this app filters on a breach. For a list you can actually work through, use **Escalated Cases** — the SLA sweep escalates every case it flags, so each breach lands there.
 - **Service Board** is not this app's name for anything. The kanban is **Service Workflow**, on the *Workflow* tab.
 - **Cases Due Today**, **Recently Closed** and **By Account** do not exist in any form: no view filters on today's due date or on `closed_date`, and `crm_case` has no grouped view.
 
@@ -183,7 +183,7 @@ If the Copilot decides the priority is *Critical*, it will also recommend immedi
 
 ## Tips for service managers
 
-- ✅ There is no **Breached SLA** view to watch, and no red badge either — the only colour rule on a case list is *All Cases*' row tint, and it is keyed on **priority**, not on a breach. Work **Escalated Cases** daily instead, and read the **SLA Violations** tile on the Service Dashboard for the count.
+- ✅ There is no **Breached SLA** view to watch, and no red badge either — the only colour rule on a case list is *All Cases*' row tint, and it is keyed on **priority**, not on a breach. Work **Escalated Cases** daily instead, and read the **SLA Violations** tile on Service Overview for the count.
 - ✅ Use the kanban for daily standups — it is named **Service Workflow** and reaches the case list as the *Workflow* tab.
 - ✅ Coach agents whose **Resolution Time** trends up — but you will be reading it off the cases themselves. There is no agent leaderboard: `case_metrics`, the dataset behind every service report and dashboard widget, declares Status, Priority, Origin, Type and Created as its only dimensions, so nothing in analytics can group cases by agent.
 

--- a/content/docs/service/cases.zh-Hans.mdx
+++ b/content/docs/service/cases.zh-Hans.mdx
@@ -131,7 +131,7 @@ description: 客户支持工单——主题、优先级、状态、解决方案�
 
 本节原先列的七个名字里，有六个根本不是视图：
 
-- **Critical Cases** 与 **Breached SLA** 是指标磁贴，不是列表。[服务仪表盘](/zh-Hans/docs/analytics/dashboards)上有 *Critical Cases*（未结且 Critical）和 **SLA Violations**（`is_sla_violated` 为真）两个磁贴；本应用里没有任何一个列表视图按违约过滤。真要有一份能逐条处理的清单，用 **Escalated Cases**——SLA 扫描会把它标记的每一条都升级，所以每次违约都会落到那里。
+- **Critical Cases** 与 **Breached SLA** 是指标磁贴，不是列表。[服务概览](/zh-Hans/docs/analytics/dashboards)（Service Overview；该仪表盘自身的标题是 **Customer Service**）上有 *Critical Cases*（未结且 Critical）和 **SLA Violations**（`is_sla_violated` 为真）两个磁贴；本应用里没有任何一个列表视图按违约过滤。真要有一份能逐条处理的清单，用 **Escalated Cases**——SLA 扫描会把它标记的每一条都升级，所以每次违约都会落到那里。
 - **Service Board** 不是本应用里任何东西的名字。看板叫 **Service Workflow**，在 *Workflow* 页签上。
 - **Cases Due Today**、**Recently Closed** 与 **By Account** 以任何形式都不存在：没有任何视图按「截止日期 = 今天」或 `closed_date` 过滤，`crm_case` 上也没有任何分组视图。
 
@@ -183,7 +183,7 @@ Activity 标签页是工单上发生过什么的唯一可信来源。它将四�
 
 ## 给服务经理的提示
 
-- ✅ 没有 **Breached SLA** 这个视图可看，也没有什么红色徽章——工单列表上唯一的颜色规则是 *All Cases* 的行底色，它键在**优先级**上，不是违约。每天改看 **Escalated Cases**，数量则看服务仪表盘上的 **SLA Violations** 磁贴。
+- ✅ 没有 **Breached SLA** 这个视图可看，也没有什么红色徽章——工单列表上唯一的颜色规则是 *All Cases* 的行底色，它键在**优先级**上，不是违约。每天改看 **Escalated Cases**，数量则看服务概览上的 **SLA Violations** 磁贴。
 - ✅ 用看板开每日站会——它叫 **Service Workflow**，在工单列表的 *Workflow* 页签上。
 - ✅ 辅导那些 **Resolution Time** 趋势上升的客服——但这个趋势只能从工单本身读出来。不存在什么客服排行榜：`case_metrics` 这个数据集（服务侧每一张报表和每一个仪表盘部件都建在它上面）只声明了 Status、Priority、Origin、Type、Created 五个维度，所以分析层里没有任何东西能按客服分组。
 

--- a/content/docs/service/cases.zh-Hant.mdx
+++ b/content/docs/service/cases.zh-Hant.mdx
@@ -131,7 +131,7 @@ description: 客戶支援工單——主題、優先順序、狀態、解決方�
 
 本節原先列的七個名字裡，有六個根本不是檢視：
 
-- **Critical Cases** 與 **Breached SLA** 是指標磁磚，不是列表。[服務儀表板](/zh-Hant/docs/analytics/dashboards)上有 *Critical Cases*（未結且 Critical）和 **SLA Violations**（`is_sla_violated` 為真）兩個磁磚；本應用裡沒有任何一個列表檢視按違約過濾。真要有一份能逐條處理的清單，用 **Escalated Cases**——SLA 掃描會把它標記的每一條都升級，所以每次違約都會落到那裡。
+- **Critical Cases** 與 **Breached SLA** 是指標磁磚，不是列表。[服務概覽](/zh-Hant/docs/analytics/dashboards)（Service Overview；該儀表板自身的標題是 **Customer Service**）上有 *Critical Cases*（未結且 Critical）和 **SLA Violations**（`is_sla_violated` 為真）兩個磁磚；本應用裡沒有任何一個列表檢視按違約過濾。真要有一份能逐條處理的清單，用 **Escalated Cases**——SLA 掃描會把它標記的每一條都升級，所以每次違約都會落到那裡。
 - **Service Board** 不是本應用裡任何東西的名字。看板叫 **Service Workflow**，在 *Workflow* 頁籤上。
 - **Cases Due Today**、**Recently Closed** 與 **By Account** 以任何形式都不存在：沒有任何檢視按「截止日期 = 今天」或 `closed_date` 過濾，`crm_case` 上也沒有任何分組檢視。
 
@@ -183,7 +183,7 @@ Activity 標籤頁是工單上發生過什麼的唯一可信來源。它將四�
 
 ## 給服務經理的提示
 
-- ✅ 沒有 **Breached SLA** 這個檢視可看，也沒有什麼紅色徽章——工單列表上唯一的顏色規則是 *All Cases* 的列底色，它鍵在**優先順序**上，不是違約。每天改看 **Escalated Cases**，數量則看服務儀表板上的 **SLA Violations** 磁磚。
+- ✅ 沒有 **Breached SLA** 這個檢視可看，也沒有什麼紅色徽章——工單列表上唯一的顏色規則是 *All Cases* 的列底色，它鍵在**優先順序**上，不是違約。每天改看 **Escalated Cases**，數量則看服務概覽上的 **SLA Violations** 磁磚。
 - ✅ 用看板開每日站會——它叫 **Service Workflow**，在工單列表的 *Workflow* 頁籤上。
 - ✅ 輔導那些 **Resolution Time** 趨勢上升的客服——但這個趨勢只能從工單本身讀出來。不存在什麼客服排行榜：`case_metrics` 這個資料集（服務側每一張報表和每一個儀表板部件都建在它上面）只宣告了 Status、Priority、Origin、Type、Created 五個維度，所以分析層裡沒有任何東西能按客服分組。
 

--- a/content/docs/service/index.mdx
+++ b/content/docs/service/index.mdx
@@ -50,7 +50,7 @@ The [service skills](/docs/ai-copilot/service-copilot) are built into every case
 
 ## Standard dashboards & reports
 
-- **Service Dashboard** — open cases by priority, SLA performance, top agents, oldest open cases.
+- **Service Overview** (the dashboard's own title is **Customer Service**) — open cases by priority, SLA performance, top agents, oldest open cases.
 - **Cases Opened by Day × Priority** — daily inflow.
 - **Cases by Status × Priority** — current snapshot.
 - **SLA Performance** — % of cases resolved within SLA target.

--- a/content/docs/service/index.zh-Hans.mdx
+++ b/content/docs/service/index.zh-Hans.mdx
@@ -50,7 +50,7 @@ New ──► In Progress ──► Waiting on Customer ──► Resolved ─�
 
 ## 标准仪表盘与报表
 
-- **服务仪表盘**——按优先级划分的未结工单、SLA 表现、顶尖客服、最久未结工单。
+- **服务概览**（Service Overview；仪表盘自身的标题是 **Customer Service**）——按优先级划分的未结工单、SLA 表现、顶尖客服、最久未结工单。
 - **每日 × 优先级开单数**——每日流入量。
 - **按状态 × 优先级划分的工单**——当前快照。
 - **SLA 表现**——在 SLA 目标内解决的工单百分比。
@@ -63,7 +63,7 @@ New ──► In Progress ──► Waiting on Customer ──► Resolved ─�
 
 - **工单**（Cases）——工单列表。
 - **知识**（Knowledge）——Copilot 读取的知识文章（`crm_knowledge_article`）。
-- **服务概览**（Service Overview）——服务仪表盘。侧边栏上的 label 就是这个；没有任何侧边栏条目叫 *Service Dashboard*。
+- **服务概览**（Service Overview）——服务的那个仪表盘。侧边栏上的 label 就是这个；没有任何侧边栏条目叫 *Service Dashboard*。
 
 有两个名字，人们会到**服务**分组下面找，但它们不在这里：
 

--- a/content/docs/service/index.zh-Hant.mdx
+++ b/content/docs/service/index.zh-Hant.mdx
@@ -50,7 +50,7 @@ New ──► In Progress ──► Waiting on Customer ──► Resolved ─�
 
 ## 標準儀表板與報表
 
-- **服務儀表板**——按優先順序劃分的未結工單、SLA 表現、頂尖客服、最久未結工單。
+- **服務概覽**（Service Overview；儀表板自身的標題是 **Customer Service**）——按優先順序劃分的未結工單、SLA 表現、頂尖客服、最久未結工單。
 - **每日 × 優先順序開單數**——每日流入量。
 - **按狀態 × 優先順序劃分的工單**——當前快照。
 - **SLA 表現**——在 SLA 目標內解決的工單百分比。
@@ -63,7 +63,7 @@ New ──► In Progress ──► Waiting on Customer ──► Resolved ─�
 
 - **工單**（Cases）——工單清單。
 - **知識**（Knowledge）——Copilot 讀取的知識文章（`crm_knowledge_article`）。
-- **服務概覽**（Service Overview）——服務儀表板。側邊欄上的 label 就是這個；沒有任何側邊欄條目叫 *Service Dashboard*。
+- **服務概覽**（Service Overview）——服務的那個儀表板。側邊欄上的 label 就是這個；沒有任何側邊欄條目叫 *Service Dashboard*。
 
 有兩個名字，人們會到**服務**分組下面找，但它們不在這裡：
 

--- a/content/docs/service/sla-and-escalation.mdx
+++ b/content/docs/service/sla-and-escalation.mdx
@@ -123,11 +123,11 @@ If priority resolves to **Critical**, the Copilot immediately recommends escalat
 | Role | What to check | When |
 | --- | --- | --- |
 | **Agent** | My Open Cases — a priority queue, not a deadline queue | Hourly during your shift |
-| **Service Manager** | Escalated Cases and SLA at Risk, plus the Service Dashboard's **SLA Violations** tile | First thing every morning |
+| **Service Manager** | Escalated Cases and SLA at Risk, plus Service Overview's **SLA Violations** tile — that dashboard's own title is **Customer Service** | First thing every morning |
 | **Service Director** | SLA Performance report | Weekly |
-| **Executive** | Service Dashboard | Weekly |
+| **Executive** | Service Overview | Weekly |
 
-Two names this table used to carry are not views at all. **Breached SLA** and **Critical Cases** do not exist as list views: `crm_case` ships seven — *All Cases*, *Service Workflow*, *SLA Calendar*, *Case Timeline*, *My Open Cases*, *Escalated Cases* and *⏰ SLA at Risk* (`src/views/case.view.ts`) — and not one of them filters on **SLA Violated**. The only two surfaces that do filter on a breach are metric tiles on the [Service Dashboard](/docs/analytics/dashboards): **SLA Violations** (`is_sla_violated: true`) and **Critical Cases** (open and Critical). For a list you can actually work through, **Escalated Cases** is the closest thing: `case_sla_monitor` escalates every case it flags as breached, so each breach lands in it — mixed in with the cases escalated on priority alone.
+Two names this table used to carry are not views at all. **Breached SLA** and **Critical Cases** do not exist as list views: `crm_case` ships seven — *All Cases*, *Service Workflow*, *SLA Calendar*, *Case Timeline*, *My Open Cases*, *Escalated Cases* and *⏰ SLA at Risk* (`src/views/case.view.ts`) — and not one of them filters on **SLA Violated**. The only two surfaces that do filter on a breach are metric tiles on [Service Overview](/docs/analytics/dashboards): **SLA Violations** (`is_sla_violated: true`) and **Critical Cases** (open and Critical). For a list you can actually work through, **Escalated Cases** is the closest thing: `case_sla_monitor` escalates every case it flags as breached, so each breach lands in it — mixed in with the cases escalated on priority alone.
 
 **My Open Cases is sorted by priority, not by SLA Due Date.** Its keys are `priority_rank` descending first, and `sla_due_date` ascending only as a tie-breaker (`src/views/case.view.ts`) — so a Low case due within the hour still sits below every Critical one. And because only Critical cases are stamped with a due date at all, the tie-breaker has no values to order the bands below Critical by: inside those bands the order is whatever the store returns. Keep **SLA at Risk** or **SLA Calendar** open next to it if you are working to deadlines.
 
@@ -139,7 +139,7 @@ Two names this table used to carry are not views at all. **Breached SLA** and **
 
 ## Tips for service managers
 
-- ✅ There is no **Breached SLA** list view to run. Work the **Escalated Cases** view instead — every case the SLA sweep flags gets escalated into it — and read the **SLA Violations** tile on the Service Dashboard for the count.
+- ✅ There is no **Breached SLA** list view to run. Work the **Escalated Cases** view instead — every case the SLA sweep flags gets escalated into it — and read the **SLA Violations** tile on Service Overview for the count.
 - ✅ Use the kanban board for daily standups — it is named **Service Workflow** (`case_workflow`) and reaches the case list as the **Workflow** tab. Nothing in this app is called *Service Board*.
 - ✅ Coach agents whose breach rate trends up — surface it 1:1 before it becomes a pattern.
 

--- a/content/docs/service/sla-and-escalation.zh-Hans.mdx
+++ b/content/docs/service/sla-and-escalation.zh-Hans.mdx
@@ -123,11 +123,11 @@ Critical 的 4 小时是系统唯一会盯的目标，而且它写在钩子里�
 | 角色 | 查看什么 | 何时 |
 | --- | --- | --- |
 | **客服** | My Open Cases——一个按优先级排的队列，不是按截止时间排的队列 | 当班期间每小时 |
-| **服务经理** | Escalated Cases 与 SLA at Risk 两个视图，外加服务仪表盘上的 **SLA Violations** 磁贴 | 每天一早 |
+| **服务经理** | Escalated Cases 与 SLA at Risk 两个视图，外加服务概览（Service Overview）上的 **SLA Violations** 磁贴——该仪表盘自身的标题是 **Customer Service** | 每天一早 |
 | **服务总监** | SLA 表现报表 | 每周 |
-| **高管** | 服务仪表盘 | 每周 |
+| **高管** | 服务概览 | 每周 |
 
-这张表过去写的两个名字根本不是视图。**Breached SLA** 与 **Critical Cases** 都不存在于列表视图里：`crm_case` 随产品提供的视图一共七个——*All Cases*、*Service Workflow*、*SLA Calendar*、*Case Timeline*、*My Open Cases*、*Escalated Cases* 与 *⏰ SLA at Risk*（`src/views/case.view.ts`）——其中没有任何一个以 **SLA 已违约**为过滤条件。真正按违约过滤的只有[服务仪表盘](/zh-Hans/docs/analytics/dashboards)上的两个指标磁贴：**SLA Violations**（`is_sla_violated: true`）与 **Critical Cases**（未结 + Critical）。如果你要的是一份能逐条处理的列表，**Escalated Cases** 是最接近的那个：`case_sla_monitor` 会把它标记为违约的每一个工单都升级掉，所以每一次违约都会落进这个视图——只是会和那些仅因优先级而升级的工单混在一起。
+这张表过去写的两个名字根本不是视图。**Breached SLA** 与 **Critical Cases** 都不存在于列表视图里：`crm_case` 随产品提供的视图一共七个——*All Cases*、*Service Workflow*、*SLA Calendar*、*Case Timeline*、*My Open Cases*、*Escalated Cases* 与 *⏰ SLA at Risk*（`src/views/case.view.ts`）——其中没有任何一个以 **SLA 已违约**为过滤条件。真正按违约过滤的只有[服务概览](/zh-Hans/docs/analytics/dashboards)上的两个指标磁贴：**SLA Violations**（`is_sla_violated: true`）与 **Critical Cases**（未结 + Critical）。如果你要的是一份能逐条处理的列表，**Escalated Cases** 是最接近的那个：`case_sla_monitor` 会把它标记为违约的每一个工单都升级掉，所以每一次违约都会落进这个视图——只是会和那些仅因优先级而升级的工单混在一起。
 
 **My Open Cases 是按优先级排序的，不是按 SLA 截止日期。** 它的排序键是 `priority_rank` 降序在先、`sla_due_date` 升序仅作次级键（`src/views/case.view.ts`）——所以一个一小时后就到期的 Low 工单，仍然排在每一个 Critical 工单下面。又因为只有 Critical 工单才会被打上截止日期，次级键在 Critical 以下的各档里根本无值可排：同一档内的先后顺序，取决于存储返回的顺序。如果你是按截止时间在干活，请在它旁边同时开着 **SLA at Risk** 或 **SLA Calendar**。
 
@@ -139,7 +139,7 @@ Critical 的 4 小时是系统唯一会盯的目标，而且它写在钩子里�
 
 ## 给服务经理的提示
 
-- ✅ 没有 **Breached SLA** 这个列表视图可以运行。改去处理 **Escalated Cases** 视图——SLA 扫描标记的每一个工单都会被升级进这个视图——数量则看服务仪表盘上的 **SLA Violations** 磁贴。
+- ✅ 没有 **Breached SLA** 这个列表视图可以运行。改去处理 **Escalated Cases** 视图——SLA 扫描标记的每一个工单都会被升级进这个视图——数量则看服务概览上的 **SLA Violations** 磁贴。
 - ✅ 每日站会用那块看板，但它叫 **Service Workflow**（`case_workflow`），在工单列表上以 **Workflow** 页签出现。本应用里不存在叫 *Service Board* 的东西。
 - ✅ 辅导那些违约率趋升的客服——在它形成模式之前于 1:1 中提出。
 

--- a/content/docs/service/sla-and-escalation.zh-Hant.mdx
+++ b/content/docs/service/sla-and-escalation.zh-Hant.mdx
@@ -123,11 +123,11 @@ Critical 的 4 小時是系統唯一會盯的目標，而且它寫在鉤子裡�
 | 角色 | 查看什麼 | 何時 |
 | --- | --- | --- |
 | **客服** | My Open Cases——一個按優先順序排的佇列，不是按截止時間排的佇列 | 當班期間每小時 |
-| **服務經理** | Escalated Cases 與 SLA at Risk 兩個檢視，外加服務儀表板上的 **SLA Violations** 磁貼 | 每天一早 |
+| **服務經理** | Escalated Cases 與 SLA at Risk 兩個檢視，外加服務概覽（Service Overview）上的 **SLA Violations** 磁貼——該儀表板自身的標題是 **Customer Service** | 每天一早 |
 | **服務總監** | SLA 表現報表 | 每週 |
-| **高管** | 服務儀表板 | 每週 |
+| **高管** | 服務概覽 | 每週 |
 
-這張表過去寫的兩個名字根本不是檢視。**Breached SLA** 與 **Critical Cases** 都不存在於列表檢視裡：`crm_case` 隨產品提供的檢視一共七個——*All Cases*、*Service Workflow*、*SLA Calendar*、*Case Timeline*、*My Open Cases*、*Escalated Cases* 與 *⏰ SLA at Risk*（`src/views/case.view.ts`）——其中沒有任何一個以 **SLA 已違約**為過濾條件。真正按違約過濾的只有[服務儀表板](/zh-Hant/docs/analytics/dashboards)上的兩個指標磁貼：**SLA Violations**（`is_sla_violated: true`）與 **Critical Cases**（未結 + Critical）。如果你要的是一份能逐條處理的列表，**Escalated Cases** 是最接近的那個：`case_sla_monitor` 會把它標記為違約的每一個工單都升級掉，所以每一次違約都會落進這個檢視——只是會和那些僅因優先順序而升級的工單混在一起。
+這張表過去寫的兩個名字根本不是檢視。**Breached SLA** 與 **Critical Cases** 都不存在於列表檢視裡：`crm_case` 隨產品提供的檢視一共七個——*All Cases*、*Service Workflow*、*SLA Calendar*、*Case Timeline*、*My Open Cases*、*Escalated Cases* 與 *⏰ SLA at Risk*（`src/views/case.view.ts`）——其中沒有任何一個以 **SLA 已違約**為過濾條件。真正按違約過濾的只有[服務概覽](/zh-Hant/docs/analytics/dashboards)上的兩個指標磁貼：**SLA Violations**（`is_sla_violated: true`）與 **Critical Cases**（未結 + Critical）。如果你要的是一份能逐條處理的列表，**Escalated Cases** 是最接近的那個：`case_sla_monitor` 會把它標記為違約的每一個工單都升級掉，所以每一次違約都會落進這個檢視——只是會和那些僅因優先順序而升級的工單混在一起。
 
 **My Open Cases 是按優先順序排序的，不是按 SLA 截止日期。** 它的排序鍵是 `priority_rank` 降序在先、`sla_due_date` 升序僅作次級鍵（`src/views/case.view.ts`）——所以一個一小時後就到期的 Low 工單，仍然排在每一個 Critical 工單下面。又因為只有 Critical 工單才會被打上截止日期，次級鍵在 Critical 以下的各檔裡根本無值可排：同一檔內的先後順序，取決於儲存返回的順序。如果你是按截止時間在幹活，請在它旁邊同時開著 **SLA at Risk** 或 **SLA Calendar**。
 
@@ -139,7 +139,7 @@ Critical 的 4 小時是系統唯一會盯的目標，而且它寫在鉤子裡�
 
 ## 給服務經理的提示
 
-- ✅ 沒有 **Breached SLA** 這個列表檢視可以執行。改去處理 **Escalated Cases** 檢視——SLA 掃描標記的每一個工單都會被升級進這個檢視——數量則看服務儀表板上的 **SLA Violations** 磁貼。
+- ✅ 沒有 **Breached SLA** 這個列表檢視可以執行。改去處理 **Escalated Cases** 檢視——SLA 掃描標記的每一個工單都會被升級進這個檢視——數量則看服務概覽上的 **SLA Violations** 磁貼。
 - ✅ 每日站會用那塊看板，但它叫 **Service Workflow**（`case_workflow`），在工單列表上以 **Workflow** 頁籤出現。本應用裡不存在叫 *Service Board* 的東西。
 - ✅ 輔導那些違約率趨升的客服——在它形成模式之前於 1:1 中提出。
 


### PR DESCRIPTION
Fixes #937

## 事实复核（两个源码锚点，逐一重验，均未漂移）

- `src/apps/crm.app.ts:139` — `{ id: 'nav_service_dashboard', type: 'dashboard', dashboardName: 'service_dashboard', label: 'Service Overview', icon: 'gauge' }`
- `src/dashboards/service.dashboard.ts:22` — `label: 'Customer Service'`

立单正文给出的行号与内容在 `origin/main`（`11f62429`）上完全成立，premise 有效。`Service Dashboard` 两者皆非：`service_dashboard` 是标识符，不是展示名。

## 重扫定面（立单的 11 处已漂移）

按 issue 评论的提示，开工先做了全仓三语 grep（`Service Dashboard` / `服务仪表盘` / `服務儀表板`），实际命中 **24 行**，比立单时的 11 处多：

| 文件族 | 命中行 | 说明 |
| --- | --- | --- |
| `content/docs/service/index.{,zh-Hans,zh-Hant}.mdx` | `:53`、`:66` | `:53` 为立单枚举；`:66` 是 PR #932 落地的否定句 |
| `content/docs/service/sla-and-escalation.{,zh-Hans,zh-Hant}.mdx` | `:126` `:128` `:130` `:142` | 立单枚举的 12 处 |
| `content/docs/service/cases.{,zh-Hans,zh-Hant}.mdx` | `:134`、`:186` | **PR #939 新增**，立单时不存在 |
| `.changeset/*.md` | 2 处 | 未发布的历史 changeset |

`content/docs/analytics/dashboards*.mdx` 一并核过：**三语都没有出现过这个名字**，它一直用真实的 `Customer Service`（`## 🎧 Customer Service`，且 `test/docs-drift.test.ts:382` 的 `headingLabel()` 把该标题钉在 dashboard 的 `label` 上）。所以 analytics 页无需改动，同时它也是本 PR 译法裁决的直接依据。

## 口径

- **主要指称 = 导航 label `Service Overview`**（用户经侧边栏找路，导航名才是找路名）。
- **各页首次出现处**附注仪表盘自身标题 `Customer Service`，同页后续只用 Service Overview。这条不是修辞：`:130` / `:134` 的链接指向 `analytics/dashboards`，读者点过去看到的章节标题正是 `Customer Service` —— 不附注就换成了另一次「按名字找不到」。
- **不发明第三名**，src/ 零改动。侧边栏一个名、页面标题另一个名，*是否*该统一是产品决定，本 PR 不预判。

### 三语译法（有据可依，非自创）

- 导航 label 走**语言包**：`src/translations/zh-CN.ts:1209` 的 `nav_service_dashboard: { label: '服务概览' }`。zh-Hans 用「服务概览」、zh-Hant 用「服務概覽」，并沿 PR #932 在 `index:66` 已确立的「**中文译名**（Latin label）」形式。
- 仪表盘标题**保留拉丁原文 `Customer Service`**：`analytics/dashboards.{,zh-Hans,zh-Hant}.mdx` 三语一律这么写，且 drift 测试把那三个章节标题钉在英文 `label` 上。此处若改写成「客户服务」，读者顺链接过去反而找不到对应标题 —— 沿 #913 Critical 的先例，保留原文。

## 逐处处理

**`service/index` 三语 `:53`**（《标准仪表盘与报表》，首次出现处）

```
- **Service Dashboard** — open cases by priority, …
+ **Service Overview** (the dashboard's own title is **Customer Service**) — open cases by priority, …
```

**`service/index` 三语 `:66`**（PR #932 的「点名说清不存在」句）—— 英文页**逐字未动**；中文两页只把描述性小句里的「服务仪表盘 / 服務儀表板」换成「服务的那个仪表盘 / 服務的那個儀表板」，句子其余部分不动。原因：英文原句是小写通名 `the service dashboard`，中文没有大小写区分，那四个字读起来恰好就是紧跟其后的下一句所否定的那个名字（「——服务仪表盘。……没有任何侧边栏条目叫 *Service Dashboard*」），自相矛盾。否定句本身**保留**，这正是本单要传达的事实。

**`sla-and-escalation` 三语 `:126` `:128` `:130` `:142`** —— `:126` 是该页首次出现处，带附注；其余三处只用 Service Overview。表格单元格里的其他措辞、`:130` 那整段的论证与源码引用一律未动。

**`cases` 三语 `:134` `:186`** —— PR #939 刚落地的两处，`:134` 是该页首次出现处带附注。**只替换词面**，`is_sla_violated` / `Escalated Cases` / 磁贴列表等句子其余部分逐字保留。

**`.changeset/sla-views-reports-write-real.md:38`**（PR #924 的未发布 changeset）—— 该句 `The two surfaces that do are metric tiles on the Service Dashboard.` 是对**应用**的事实陈述，不是对那个 PR 做了什么的叙述，不改就会把这个不存在的名字发到 CHANGELOG 里。只换该短语，并重排了那一段的折行。

## 改后重扫：三语归零，四处例外逐条说明

```
./.changeset/service-index-where-to-find-things-navigation.md:9   否定叙述
./content/docs/service/index.mdx:66                               否定句（PR #932）
./content/docs/service/index.zh-Hans.mdx:66                       同上
./content/docs/service/index.zh-Hant.mdx:66                       同上
./src/dashboards/service.dashboard.ts:6                           文件头注释
```

1. **`index*.mdx:66` 三行** —— 「no sidebar item is called *Service Dashboard*」是 PR #932 有意落地的「点名说清不存在」，删掉等于回退它，也等于删掉给「带着旧名来找」的读者的那句指路。零回退保留。
2. **`.changeset/service-index-where-to-find-things-navigation.md:9`** —— 「gives the dashboard entry its actual sidebar label instead of "Service Dashboard"」，是对 PR #932 修掉了什么的历史叙述，写法正确。
3. **`src/dashboards/service.dashboard.ts:6`** —— 文件头注释 `Customer Service Dashboard` = 真实 label + 普通名词，不是幻名；且 src/ 零改动。
4. 另有 `content/docs/guides/email-and-calendar.mdx:52` 的 `The Sales and Customer Service dashboards`（大小写不敏感扫描才会命中）—— 同样是真实 label + 普通名词复数，正确。

## 验证

六道门在共享验证锁内串行跑，全绿：

| 门 | 退出码 | 关键行 |
| --- | --- | --- |
| `pnpm validate` | 0 | 13 warning(s)，皆为既有的 approval/field-group 提示 |
| `pnpm typecheck` | 0 | `tsc --noEmit` |
| `pnpm lint` | 0 | `13 warning(s), 14 suggestion(s)` |
| `pnpm hygiene` | 0 | `✓ no raw control bytes in first-party files` |
| `pnpm build` | 0 | `Artifact: dist/objectstack.json (1921.4 KB)` |
| `pnpm test -- --maxWorkers=2` | 0 | `Test Files 70 passed (70)` / `Tests 1602 passed \| 1 skipped` |

### 反向验证：**预测 GREEN，实测 GREEN（守卫盲区）**

方向是先定后跑的，而且这里**预测就是"不变红"**：把三语 24 行全部还原成幻名（`git checkout HEAD~1 -- content/docs/service`，重扫确认 24 行回来了），再跑全部四个读 `content/docs` 的测试文件 + hygiene ——

```
Test Files  4 passed (4)
     Tests  75 passed (75)
REVERSE_EXIT=0
HYGIENE_EXIT=0
```

结构性原因可直接查证：`test/docs-drift.test.ts:366`-`:368` 的 `DOC_PAGES` 只有 `content/docs/analytics/dashboards{,.zh-Hans,.zh-Hant}.mdx` 三个文件；全仓 `grep -rn "sla-and-escalation\|service/index" test/ scripts/` **无任何命中**；`test/docs-object-coverage.test.ts:138` 只把 `crm_case` 映到 `service/cases`，查的是页面存在与可导航，不读这类措辞。也就是说，**这三页的展示名措辞没有任何守卫在读**，本 PR 无法被任何现有测试钉红，也不是"我忘了加测试"。

本 PR 未新增守卫：能覆盖它的那条规则是「文档里出现的展示名必须解析到真实 label」这一**能力**，已作为观察类 finding 记在 #802 / #809 / #867 名下，在本单里做属于越界。这一段如实写出，而不是造一个"before red / after green"的假证据。

## 并行冲突提示

`content/docs/service/cases.mdx` 的 `:134` 与 #941 dev 正在改的 `:130`（`| **My Open Cases** | … |` 表格行）在 3 行上下文内相邻 —— 两个 hunk 的上下文区间在 `:131`-`:133` 上重叠，两边都落地后 **合并时很可能冲突**。本 PR 未触碰 `:130` 与 `:68`，冲突纯属行距，后合并的一方按各自改动直接取并集即可。

`#921`/`#940`（state-machines + setup 页）与 `#938`（marketing/index）的文件面与本 PR 不相交。

## 变更集

新增 `.changeset/service-docs-real-dashboard-name.md`（patch），另修正了 `.changeset/sla-views-reports-write-real.md` 中同一处幻名。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_