### PR TITLE
docs(revenue): write the index page's "Where to find things" section to the real navigation (#943)

### DIFF
--- a/.changeset/revenue-index-where-to-find-things-navigation.md
+++ b/.changeset/revenue-index-where-to-find-things-navigation.md
@@ -1,0 +1,19 @@
+---
+'hotcrm': patch
+---
+
+Write the revenue overview page's *Where to find things* section to the app's real
+navigation. `src/apps/crm.app.ts` has no **Products** group at all — the catalog's
+only sidebar entry is `nav_product`, labelled **Products**, under **Marketing** —
+and `group_approvals` carries exactly one child, labelled **Inbox**, not the three
+items the page listed. So the section now sends readers hunting for a Products
+group to **Marketing** (linking `content/docs/marketing/index.mdx`), keeps
+**Contracts** where it really is under **Sales**, names the approvals item by its
+real label, and records what happened to the two phantom entries instead of
+deleting them silently: no sidebar item anywhere is called **Action History** (the
+audit trail exists as the plugin object `sys_approval_action`, reachable from no
+navigation entry), and **Processes** was removed on purpose because no
+`sys_approval_process` object exists in any installed plugin, so its
+`requiresObject` guard hid it on every install. It also notes that **Marketing**
+and **Approvals** are collapsed by default, unlike Sales, My Work, Activity and
+Service. All three locales updated; `src/` untouched.

--- a/content/docs/revenue/index.mdx
+++ b/content/docs/revenue/index.mdx
@@ -47,17 +47,20 @@ Renewal task ──► Renewal opportunity
 
 ## Where to find things
 
-In the Enterprise CRM app, the **Products** group contains:
+There is no **Products** group in the Enterprise CRM app. The catalog's only sidebar entry is **Products**, and it sits under the **Marketing** group — see [Marketing](/docs/marketing/index). Apart from that item and global search, a product record is reached only from a quote or an opportunity line item.
 
-- **Products** — the catalog
+**Contracts** is under the **Sales** group, alongside Leads, Accounts, Contacts, Opportunities, Pipeline and Quotes, because contracts belong to the sales process. That entry is the app's only sidebar route to a contract.
 
-And the **Sales** group contains **Contracts** (because they belong to the sales process).
+The **Approvals** group holds exactly one item:
 
-Approvals live in the **Approvals** group:
+- **Inbox** — the approval requests waiting on you (`sys_approval_request`). **Inbox** is the label you see in the sidebar; nothing in the app is called *Approval Requests*.
 
-- **Approval Requests** — what's pending
-- **Action History** — who approved what, when
-- **Processes** — admin view of the approval rules
+Two names this page used to list are not in that group:
+
+- **Action History** — no sidebar item carries that name. The audit trail is real data — the approvals plugin stores it as `sys_approval_action` — but no navigation entry in this app opens it.
+- **Processes** — deliberately removed, not an oversight: no `sys_approval_process` object exists in any installed plugin, so the item's *requires object* guard hid it on every install, forever. It stays out until such an object ships.
+
+**Marketing** and **Approvals** are both **collapsed by default** — unlike Sales, My Work, Activity and Service, they do not open when the app loads. Click a group open before deciding something isn't there.
 
 ## Start here
 

--- a/content/docs/revenue/index.zh-Hans.mdx
+++ b/content/docs/revenue/index.zh-Hans.mdx
@@ -47,17 +47,20 @@ Renewal task ──► Renewal opportunity
 
 ## 在哪里找到这些内容
 
-在 Enterprise CRM 应用中，**产品**分组包含：
+Enterprise CRM 应用里**没有 Products（产品）分组**。产品目录在侧边栏上唯一的入口是 **Marketing**（市场营销）分组下的 **Products**（产品）——参见 [Marketing](/zh-Hans/docs/marketing/index)。除了这一项和全局搜索之外，只能从报价或商机的明细行反查到产品记录。
 
-- **产品**——目录
+**Contracts**（合同）挂在 **Sales**（销售）分组下，与 Leads、Accounts、Contacts、Opportunities、Pipeline、Quotes 并列——因为合同属于销售流程。这也是整个应用侧边栏里通往合同的唯一入口。
 
-而**销售**分组包含**合同**（因为它们属于销售流程）。
+**Approvals**（审批）分组只有一项：
 
-审批位于**审批**分组中：
+- **Inbox**——等着你处理的审批请求（`sys_approval_request`）。侧边栏上的 label 就是 **Inbox**，简体中文界面下显示为**待我审批**；应用里没有任何条目叫 *Approval Requests*（审批请求）。
 
-- **审批请求**——待处理的内容
-- **操作历史**——谁在何时审批了什么
-- **流程**——审批规则的管理员视图
+本页过去列出的另外两个名字，不在这个分组里：
+
+- **Action History**（操作历史）——侧边栏上没有叫这个名字的条目。审批的操作留痕本身是真实数据，由审批插件以 `sys_approval_action` 存储，但本应用里没有任何导航条目能打开它。
+- **Processes**（流程）——是被**刻意删掉**的，不是漏掉的：任何已安装的插件里都不存在 `sys_approval_process` 对象，该条目的 *requires object* 守卫会在每一次安装里把它永远隐藏。除非将来有这样一个对象上线，它不会回来。
+
+**Marketing** 与 **Approvals** 两个分组都**默认折叠**——与 Sales、My Work、Activity、Service 不同，它们不会在应用加载时自动展开。先把分组点开，再判断某样东西在不在这里。
 
 ## 从这里开始
 

--- a/content/docs/revenue/index.zh-Hant.mdx
+++ b/content/docs/revenue/index.zh-Hant.mdx
@@ -47,17 +47,20 @@ Renewal task ──► Renewal opportunity
 
 ## 在哪裡找到這些內容
 
-在 Enterprise CRM 應用中，**產品**分組包含：
+Enterprise CRM 應用裡**沒有 Products（產品）群組**。產品目錄在側邊欄上唯一的入口是 **Marketing**（市場行銷）群組下的 **Products**（產品）——參見 [Marketing](/zh-Hant/docs/marketing/index)。除了這一項和全域搜尋之外，只能從報價或商機的明細列反查到產品記錄。
 
-- **產品**——目錄
+**Contracts**（合約）掛在 **Sales**（銷售）群組下，與 Leads、Accounts、Contacts、Opportunities、Pipeline、Quotes 並列——因為合約屬於銷售流程。這也是整個應用側邊欄裡通往合約的唯一入口。
 
-而**銷售**分組包含**合約**（因為它們屬於銷售流程）。
+**Approvals**（審批）群組只有一項：
 
-審批位於**審批**分組中：
+- **Inbox**——等著你處理的審批請求（`sys_approval_request`）。側邊欄上的 label 就是 **Inbox**（本應用提供 en / zh-CN / ja-JP / es-ES 四種介面語言，簡體中文介面下這一項顯示為「待我审批」）；應用裡沒有任何條目叫 *Approval Requests*（審批請求）。
 
-- **審批請求**——待處理的內容
-- **操作歷史**——誰在何時審批了什麼
-- **流程**——審批規則的管理員檢視
+本頁過去列出的另外兩個名字，不在這個群組裡：
+
+- **Action History**（操作歷史）——側邊欄上沒有叫這個名字的條目。審批的操作留痕本身是真實資料，由審批外掛以 `sys_approval_action` 儲存，但本應用裡沒有任何導覽條目能打開它。
+- **Processes**（流程）——是被**刻意刪掉**的，不是漏掉的：任何已安裝的外掛裡都不存在 `sys_approval_process` 物件，該條目的 *requires object* 守衛會在每一次安裝裡把它永遠隱藏。除非將來有這樣一個物件上線，它不會回來。
+
+**Marketing** 與 **Approvals** 兩個群組都**預設摺疊**——與 Sales、My Work、Activity、Service 不同，它們不會在應用載入時自動展開。先把群組點開，再判斷某樣東西在不在這裡。
 
 ## 從這裡開始
 


### PR DESCRIPTION
Fixes #943

《Where to find things》一节告诉读者去哪里点击，它点名了四样东西：三样在 `src/apps/crm.app.ts` 里读不到，剩下那一样写的是应用从不显示的名字。

## 逐条对源码（基线 `origin/main` = `b7791caf`，平台 17.0.0-rc.3）

| 文档原断言 | 源码实况 | 处理 |
| --- | --- | --- |
| 存在 **Products** 分组 | 不存在。全应用只有 7 个分组：Sales / My Work / Activity / Marketing / Service / Insights / Approvals。产品目录唯一的侧边栏入口是 `group_marketing` 下的 `nav_product`（label **Products**，`:126`）；`grep -rn "crm_product" src/apps/` 只有这一行 | 保留读者带来的名字，明说没有这个分组，并指向 **Marketing** 分组（内链到 #938 / PR #942 刚写实的 Marketing 概览页） |
| **Sales** 分组含 **Contracts** | ✅ 成立，`nav_contract`（`:60`），且是全应用通往合同的唯一侧边栏入口 | 保留，并补上"唯一入口"这一事实 |
| Approvals 含 **Approval Requests** | label 不对。`group_approvals`（`:159`-`:171`）只有 1 个 child `nav_approval_requests`，label 是 **Inbox**（`:165`）；全仓没有任何元数据叫 *Approval Requests* | 改为 **Inbox**，并注明"没有任何条目叫 Approval Requests" |
| Approvals 含 **Action History** | 侧边栏无此条目。但它背后的数据是真的：`@objectstack/plugin-approvals` 注册了 `sys_approval_action`（连同 `sys_approval` / `sys_approval_approver` / `sys_approval_delegation` / `sys_approval_request` / `sys_approval_token`，从已安装包里枚举得出），只是本应用没有任何导航条目能打开它 | 不静默删名：保留名字，写清"数据真实存在、导航打不开" |
| Approvals 含 **Processes** | 不存在，且是**刻意删掉**的——`:166`-`:169` 的注释写明：任何已安装插件里都不存在 `sys_approval_process` 对象，旧条目的 `requiresObject` 守卫会在每一次安装里把它永远隐藏。上面的枚举独立复核了这一缺席 | 保留名字，把源码给出的删除原因如实写进页面 |

## 全量核对补记

本节涉及的三个分组 children 逐个核过，另外两条源码事实一并写实：

- `group_marketing` 与 `group_approvals` 都**没有声明** `expanded`，而 Sales / My Work / Activity / Service 都是 `expanded: true`；`GroupNavItemSchema.expanded` 的默认值是 `false`（`z.boolean().default(false)`），所以这两个分组加载时是折叠的——这正是"照文档找不到产品目录"的现场。
- zh-Hans 页补上简体界面下这一项真正显示的 label **待我审批**（`src/translations/zh-CN.ts:1219`），与源码 label **Inbox** 并列。zh-Hant 页注明本应用只提供 en / zh-CN / ja-JP / es-ES 四种界面语言。

产品判断不预判（#595 / #596 同族）：Products 该不该有自己的分组、Approvals 该不该补审计轨迹条目，都是产品决定，本 PR 只记录当前形状。

三语同址同改；zh 内链不带锚；`src/` 零改动；`@objectstack/*` 版本未动；`content/docs/releases/` 未动。

## 验证

守卫盲区如实报告：仓内**没有**任何测试把 `content/docs/**` 的导航断言对 `src/apps/crm.app.ts` 做钉子（`test/docs-object-coverage.test.ts` 只查"每个对象有没有页面"，`test/docs-drift.test.ts` 查 flow / 仪表盘磁贴 / callout 数量），所以本改动**预期全绿**，六道门是回归保护而非正向证据。

| 门 | 退出码 | 关键行 |
| --- | --- | --- |
| `pnpm validate` | 0 | `Data: 17 Objects 344 Fields` / `UI: 1 Apps 14 Views …`（既有 5 条 author-time warning，与本改动无关） |
| `pnpm typecheck` | 0 | `tsc --noEmit` 无输出 |
| `pnpm lint` | 0 | `13 warning(s), 14 suggestion(s) (960ms)`（全部为既有项） |
| `pnpm hygiene` | 0 | `✓ no raw control bytes in first-party files` / `✓ source hygiene clean`（扫描面含 `content`、`.changeset`） |
| `pnpm build` | 0 | `✓ Build complete (1555ms)` / `Artifact: dist/objectstack.json (1921.4 KB)` |
| `pnpm test -- --maxWorkers=2` | 0 | `Test Files 70 passed (70)` / `Tests 1602 passed \| 1 skipped (1603)` |

推送前另做控制字节自扫：`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 覆盖三个 mdx 与 changeset，无命中。未启动任何 dev server。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_