### PR TITLE
docs(service): write the index page's dashboards & reports section to source (#948)

### DIFF
--- a/.changeset/service-index-dashboards-reports-real.md
+++ b/.changeset/service-index-dashboards-reports-real.md
@@ -1,0 +1,36 @@
+---
+'hotcrm': patch
+---
+
+Write the service index page's "Standard dashboards & reports" section to what
+the app actually ships. All four bullets on
+`content/docs/service/index.mdx` (and its `zh-Hans` / `zh-Hant` translations)
+were wrong, in two different ways.
+
+The dashboard bullet promised a **top agents** tile and an **oldest open cases**
+tile. Neither exists on `service_dashboard`, and neither is simply a widget
+nobody built yet: `case_metrics` — the dataset every service widget and report
+binds — declares no owner dimension, so nothing in analytics can rank agents,
+and every tile on that dashboard aggregates the dataset rather than listing
+records, so the oldest individual cases cannot be shown there either.
+`content/docs/service/cases.mdx` had already said exactly that about the agent
+half, so a reader comparing the two service pages was told both that a
+leaderboard exists and that it cannot. The bullet now names the ten tiles the
+dashboard ships — Open Cases, Critical Cases, Avg Resolution Time, SLA
+Violations, Cases by Status / Priority / Origin, Daily Case Volume, SLA
+Compliance and Open Cases by Priority — and says why the other two are absent.
+
+The three report bullets named reports that carry different labels in
+`src/reports/case.report.ts`: **Cases Opened by Priority × Day** had its two
+dimensions the wrong way round (priority is the rows, the day is the columns —
+the SLA page already wrote it correctly), **Cases by Status and Priority** was
+spelled with a `×`, and **SLA Performance Report** was missing the last word of
+its own name. A reader searching the reports list for any of the three found
+nothing. The SLA bullet also still promised "% of cases resolved within SLA
+target": that measure does not exist. The report gives case count, **SLA
+Violation Rate** and average resolution time by priority, over closed cases
+only.
+
+No metadata changed. Whether the product *should* offer an agent ranking or an
+oldest-cases queue is a product question this leaves open — it would mean adding
+a dimension to `case_metrics` first.

--- a/content/docs/service/index.mdx
+++ b/content/docs/service/index.mdx
@@ -50,10 +50,10 @@ The [service skills](/docs/ai-copilot/service-copilot) are built into every case
 
 ## Standard dashboards & reports
 
-- **Service Overview** (the dashboard's own title is **Customer Service**) — open cases by priority, SLA performance, top agents, oldest open cases.
-- **Cases Opened by Day × Priority** — daily inflow.
-- **Cases by Status × Priority** — current snapshot.
-- **SLA Performance** — % of cases resolved within SLA target.
+- **Service Overview** (the dashboard's own title is **Customer Service**) — the KPIs **Open Cases**, **Critical Cases**, **Avg Resolution Time** and **SLA Violations**; the charts **Cases by Status**, **Cases by Priority** and **Cases by Origin**; **Daily Case Volume**; an **SLA Compliance** gauge; and an **Open Cases by Priority** table. What it does not carry is a *top agents* tile or an *oldest open cases* tile, and neither is merely a widget nobody has built yet: `case_metrics`, the dataset behind every service widget, declares no owner dimension, so nothing in analytics can rank agents — the [Cases](/docs/service/cases) page says the same — and a dashboard table aggregates its dataset instead of listing records, so the oldest individual cases cannot be shown there either.
+- **Cases Opened by Priority × Day** — daily inflow, as a matrix of priority in the rows against day in the columns, in that order.
+- **Cases by Status and Priority** — current snapshot: case count and average resolution time, by status and priority.
+- **SLA Performance Report** — case count, **SLA Violation Rate** and average resolution time, by priority, over closed cases only. It does not report a compliance percentage: the share of cases resolved inside the target is not a measure `case_metrics` defines. See [SLA & Escalation](/docs/service/sla-and-escalation).
 
 See [Analytics › Dashboards](/docs/analytics/dashboards) and [Reports](/docs/analytics/reports).
 

--- a/content/docs/service/index.zh-Hans.mdx
+++ b/content/docs/service/index.zh-Hans.mdx
@@ -50,10 +50,10 @@ New ──► In Progress ──► Waiting on Customer ──► Resolved ─�
 
 ## 标准仪表盘与报表
 
-- **服务概览**（Service Overview；仪表盘自身的标题是 **Customer Service**）——按优先级划分的未结工单、SLA 表现、顶尖客服、最久未结工单。
-- **每日 × 优先级开单数**——每日流入量。
-- **按状态 × 优先级划分的工单**——当前快照。
-- **SLA 表现**——在 SLA 目标内解决的工单百分比。
+- **服务概览**（Service Overview；仪表盘自身的标题是 **Customer Service**）——KPI 有 **Open Cases**、**Critical Cases**、**Avg Resolution Time**、**SLA Violations**；分布图有 **Cases by Status**、**Cases by Priority**、**Cases by Origin**；再加 **Daily Case Volume**、一个 **SLA Compliance** 仪表图，以及一张 **Open Cases by Priority** 表格。它没有 *顶尖客服* 部件，也没有 *最久未结工单* 部件，而且这两个都不是"只是还没做"那么简单：`case_metrics`——服务侧每个部件都建在它上面的那个数据集——没有负责人维度，所以分析层里没有任何东西能给客服排名（[工单](/zh-Hans/docs/service/cases)页写的是同一件事）；而仪表盘表格聚合的是数据集，不列出单条记录，所以最久未结的那几张单也放不进去。
+- **Cases Opened by Priority × Day**（按优先级 × 天的建单量）——每日流入量：一张优先级作行、天作列的矩阵，顺序就是这个。
+- **Cases by Status and Priority**（按状态与优先级划分的工单）——当前快照：按状态与优先级给出工单数与平均解决时长。
+- **SLA Performance Report**（SLA 表现报表）——按优先级给出工单数、**SLA Violation Rate**（SLA 违约率）与平均解决时长，并且只统计已关闭的工单。它报的不是达成率百分比："在目标内解决的工单占比"不是 `case_metrics` 定义的任何一个度量。参见 [SLA 与升级](/zh-Hans/docs/service/sla-and-escalation)。
 
 参见 [分析 › 仪表盘](/zh-Hans/docs/analytics/dashboards) 与 [报表](/zh-Hans/docs/analytics/reports)。
 

--- a/content/docs/service/index.zh-Hant.mdx
+++ b/content/docs/service/index.zh-Hant.mdx
@@ -50,10 +50,10 @@ New ──► In Progress ──► Waiting on Customer ──► Resolved ─�
 
 ## 標準儀表板與報表
 
-- **服務概覽**（Service Overview；儀表板自身的標題是 **Customer Service**）——按優先順序劃分的未結工單、SLA 表現、頂尖客服、最久未結工單。
-- **每日 × 優先順序開單數**——每日流入量。
-- **按狀態 × 優先順序劃分的工單**——當前快照。
-- **SLA 表現**——在 SLA 目標內解決的工單百分比。
+- **服務概覽**（Service Overview；儀表板自身的標題是 **Customer Service**）——KPI 有 **Open Cases**、**Critical Cases**、**Avg Resolution Time**、**SLA Violations**；分布圖有 **Cases by Status**、**Cases by Priority**、**Cases by Origin**；再加 **Daily Case Volume**、一個 **SLA Compliance** 量表圖，以及一張 **Open Cases by Priority** 表格。它沒有 *頂尖客服* 部件，也沒有 *最久未結工單* 部件，而且這兩個都不是"只是還沒做"那麼簡單：`case_metrics`——服務側每個部件都建在它上面的那個資料集——沒有負責人維度，所以分析層裡沒有任何東西能給客服排名（[工單](/zh-Hant/docs/service/cases)頁寫的是同一件事）；而儀表板表格聚合的是資料集，不列出單筆記錄，所以最久未結的那幾張單也放不進去。
+- **Cases Opened by Priority × Day**（按優先順序 × 天的建單量）——每日流入量：一張優先順序作列、天作欄的矩陣，順序就是這個。
+- **Cases by Status and Priority**（按狀態與優先順序劃分的工單）——當前快照：按狀態與優先順序給出工單數與平均解決時長。
+- **SLA Performance Report**（SLA 表現報表）——按優先順序給出工單數、**SLA Violation Rate**（SLA 違約率）與平均解決時長，並且只統計已關閉的工單。它報的不是達成率百分比："在目標內解決的工單占比"不是 `case_metrics` 定義的任何一個度量。參見 [SLA 與升級](/zh-Hant/docs/service/sla-and-escalation)。
 
 參見 [分析 › 儀表板](/zh-Hant/docs/analytics/dashboards) 與 [報表](/zh-Hant/docs/analytics/reports)。
 

--- a/test/docs-service-index-analytics.test.ts
+++ b/test/docs-service-index-analytics.test.ts
@@ -1,0 +1,239 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { REPO_ROOT } from './helpers/repo-root';
+import { CrmApp } from '../src/apps/crm.app';
+import { ServiceDashboard } from '../src/dashboards/service.dashboard';
+import { CaseDataset } from '../src/datasets/case.dataset';
+import {
+  CasesByStatusPriorityReport,
+  CasesOpenedByDayPriorityReport,
+  SlaPerformanceReport,
+} from '../src/reports/case.report';
+
+/**
+ * The service index page's "Standard dashboards & reports" section, pinned to
+ * source (#948).
+ *
+ * All four bullets were wrong in every locale, and in two different ways:
+ *
+ *  1. The dashboard bullet advertised a **top agents** tile and an **oldest open
+ *     cases** tile. Neither exists, and neither is a widget somebody merely
+ *     forgot to build — `case_metrics` declares no owner dimension (so nothing
+ *     in analytics can group, let alone rank, by agent) and every widget on the
+ *     dashboard binds that dataset, i.e. aggregates it, so no tile there lists
+ *     individual records by age. `content/docs/service/cases.mdx` had already
+ *     written the agent half to source in #912/PR #939 — the two pages
+ *     contradicted each other, and this was the page that was lying.
+ *  2. The three report bullets named reports that do not exist under those
+ *     names: the dimension order was inverted (`Cases Opened by Day × Priority`
+ *     vs the real `Cases Opened by Priority × Day`, which #917/PR #924 had
+ *     already written the right way round on the SLA page), `×` stood where the
+ *     label says `and`, and `Report` was missing from the SLA report's label.
+ *     The SLA bullet also repeated the "% of cases resolved within SLA target"
+ *     claim PR #924 removed from the SLA page: `case_metrics` defines no such
+ *     measure — what the report carries is the **SLA Violation Rate**.
+ *
+ * Nothing checks prose: `os validate` and `pnpm lint` walk authored metadata and
+ * never open `content/docs`, so — as with the dashboards-page tile guard in
+ * `docs-drift.test.ts` — the check has to live where the claim lives.
+ *
+ * The rules below are deliberately two-directional, because the section makes
+ * both positive and negative claims:
+ *
+ *  - listed ⇒ exists: every **bolded** Latin name in the section must resolve to
+ *    a real widget title, report label, dataset label, or the dashboard's two
+ *    names. (Bold runs containing CJK are the locale prose's own emphasis and
+ *    are skipped — product names stay English in every locale, which is the
+ *    same convention `docs-drift.test.ts` leans on.) Phantom names are written
+ *    in *italics*, the spelling this page already uses for a name the product
+ *    does not carry (`*Service Dashboard*`, #927/PR #932), so a phantom can
+ *    never satisfy this rule by accident.
+ *  - exists ⇒ listed: every widget title on `service_dashboard` must appear, so
+ *    a new tile cannot land while the summary silently goes stale.
+ *  - the source side of the two negative claims is pinned too: build an
+ *    agent-ranking tile, or give `case_metrics` an owner dimension, and this
+ *    file goes red — which is the point, because the prose would then be wrong
+ *    in the other direction.
+ */
+
+type AnyRec = Record<string, any>;
+
+const NAV_LABEL: string = (() => {
+  const walk = (nodes: AnyRec[]): AnyRec[] =>
+    nodes.flatMap((n) => [n, ...walk((n.children ?? []) as AnyRec[])]);
+  const item = walk(((CrmApp as AnyRec).navigation ?? []) as AnyRec[]).find(
+    (n) => n.dashboardName === ServiceDashboard.name,
+  );
+  if (!item?.label) throw new Error('no navigation item binds service_dashboard — pin out of date');
+  return item.label as string;
+})();
+
+const WIDGET_TITLES: string[] = (ServiceDashboard.widgets ?? [])
+  .map((w) => (w as AnyRec).title as string)
+  .filter(Boolean);
+
+const REPORT_LABELS: string[] = [
+  CasesOpenedByDayPriorityReport.label,
+  CasesByStatusPriorityReport.label,
+  SlaPerformanceReport.label,
+].filter(Boolean) as string[];
+
+const DATASET_LABELS: string[] = [
+  ...CaseDataset.dimensions.map((d) => d.label),
+  ...CaseDataset.measures.map((m) => m.label),
+].filter(Boolean) as string[];
+
+/** Every Latin name the section is allowed to bold. */
+const ALLOWED_BOLD = new Set<string>([
+  ...WIDGET_TITLES,
+  ...REPORT_LABELS,
+  ...DATASET_LABELS,
+  NAV_LABEL,
+  ServiceDashboard.label as string,
+]);
+
+const PAGES = [
+  {
+    file: 'content/docs/service/index.mdx',
+    lang: 'en',
+    heading: '## Standard dashboards & reports',
+    /** The section must say WHY an agent ranking is impossible, not just that it is missing. */
+    impossibility: /no owner dimension/,
+    /** The exact claims #948 removed. None may come back in any spelling below. */
+    retired: [
+      'SLA performance, top agents, oldest open cases',
+      'Cases Opened by Day × Priority',
+      'Cases by Status × Priority',
+      '% of cases resolved within SLA target',
+    ],
+  },
+  {
+    file: 'content/docs/service/index.zh-Hans.mdx',
+    lang: 'zh-Hans',
+    heading: '## 标准仪表盘与报表',
+    impossibility: /没有负责人维度/,
+    retired: [
+      'SLA 表现、顶尖客服、最久未结工单',
+      '每日 × 优先级开单数',
+      '按状态 × 优先级划分的工单',
+      '在 SLA 目标内解决的工单百分比',
+    ],
+  },
+  {
+    file: 'content/docs/service/index.zh-Hant.mdx',
+    lang: 'zh-Hant',
+    heading: '## 標準儀表板與報表',
+    impossibility: /沒有負責人維度/,
+    retired: [
+      'SLA 表現、頂尖客服、最久未結工單',
+      '每日 × 優先順序開單數',
+      '按狀態 × 優先順序劃分的工單',
+      '在 SLA 目標內解決的工單百分比',
+    ],
+  },
+] as const;
+
+/** The `## …` section named by `heading`, up to the next `## `. */
+const sectionOf = (file: string, heading: string): string => {
+  const lines = readFileSync(join(REPO_ROOT, file), 'utf8').split('\n');
+  const start = lines.findIndex((l) => l.trim() === heading);
+  expect(start, `${file}: heading '${heading}' not found`).toBeGreaterThanOrEqual(0);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => l.startsWith('## '));
+  return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+};
+
+/**
+ * Bold runs carrying no CJK — i.e. the product names, in every locale. The
+ * range is written as escapes rather than literal characters so the pattern
+ * stays greppable in a repo whose tooling scans this file as text.
+ */
+const CJK = /[\u3400-\u9fff]/;
+
+const boldNames = (section: string): string[] =>
+  [...section.matchAll(/\*\*([^*\n]+)\*\*/g)]
+    .map((m) => m[1].trim())
+    .filter((s) => !CJK.test(s));
+
+describe('service/index names the dashboard and reports that exist (#948)', () => {
+  describe.each(PAGES)('$file', ({ file, heading, impossibility, retired }) => {
+    const section = () => sectionOf(file, heading);
+
+    it('bolds only names the app actually carries', () => {
+      const unknown = boldNames(section()).filter((n) => !ALLOWED_BOLD.has(n));
+      expect(
+        unknown,
+        `${file}: bolded name(s) that are not a service_dashboard widget title, a case ` +
+          'report label, a case_metrics label, or the dashboard\'s own two names. Bold is ' +
+          'reserved for real names in this section — emphasis goes in *italics*.',
+      ).toEqual([]);
+    });
+
+    it('lists every tile the service dashboard ships', () => {
+      const text = section();
+      const missing = WIDGET_TITLES.filter((t) => !text.includes(t));
+      expect(
+        missing,
+        `${file}: the Service Overview summary omits tile(s) the dashboard now ships`,
+      ).toEqual([]);
+    });
+
+    it('names the three case reports by their source labels, verbatim', () => {
+      const text = section();
+      const missing = REPORT_LABELS.filter((l) => !text.includes(l));
+      expect(missing, `${file}: report label(s) missing or renamed`).toEqual([]);
+    });
+
+    it('does not resurrect the claims #948 removed', () => {
+      const text = section();
+      expect(retired.filter((phrase) => text.includes(phrase))).toEqual([]);
+      // `SLA Performance` alone is the retired short name; the report is
+      // `SLA Performance Report`.
+      expect(text).not.toMatch(/SLA Performance(?!\s+Report)/);
+    });
+
+    it('states why an agent ranking cannot be built, not merely that it is absent', () => {
+      const text = section();
+      expect(text).toMatch(impossibility);
+      expect(text).toContain(CaseDataset.name);
+    });
+  });
+});
+
+describe('the source facts those four bullets now rest on (#948)', () => {
+  it('case_metrics declares no owner or agent dimension', () => {
+    const dims = CaseDataset.dimensions.map((d) => `${d.name} ${d.field ?? ''}`.toLowerCase());
+    expect(dims.filter((d) => /owner|agent|assign/.test(d))).toEqual([]);
+  });
+
+  it('no service dashboard widget ranks agents or ages cases', () => {
+    const offenders = WIDGET_TITLES.filter((t) => /agent|oldest|owner/i.test(t));
+    expect(
+      offenders,
+      'a tile like this would make the docs\' negative claim wrong — update both, not one',
+    ).toEqual([]);
+  });
+
+  it('every service dashboard widget binds the dataset, so none lists individual cases', () => {
+    const unbound = (ServiceDashboard.widgets ?? [])
+      .filter((w) => (w as AnyRec).dataset !== CaseDataset.name)
+      .map((w) => (w as AnyRec).id);
+    expect(unbound).toEqual([]);
+  });
+
+  it('the SLA report carries a violation rate over closed cases, not a compliance percentage', () => {
+    expect(SlaPerformanceReport.values).toContain('avg_sla_violated');
+    expect(SlaPerformanceReport.runtimeFilter).toMatchObject({ is_closed: true });
+    const measures = CaseDataset.measures.map((m) => m.name);
+    expect(measures.filter((m) => /compl|within_sla|sla_met/i.test(m))).toEqual([]);
+  });
+
+  it('the daily-inflow report puts priority in the rows and the day in the columns', () => {
+    expect(CasesOpenedByDayPriorityReport.rows).toEqual(['priority']);
+    expect(CasesOpenedByDayPriorityReport.columns).toEqual(['created_date']);
+    expect(CasesOpenedByDayPriorityReport.label).toBe('Cases Opened by Priority × Day');
+  });
+});


### PR DESCRIPTION
Fixes #948

`content/docs/service/index{,.zh-Hans,.zh-Hant}.mdx` 的《Standard dashboards & reports》四行,三语全部写实。原文四行的失实分两类,本 PR 逐行核过源码后重写。

## stale-premise 复核结论:issue 的四项事实全部成立

| issue 的说法 | 复核 | 证据 |
| --- | --- | --- |
| `top agents` 磁贴不存在 | ✅ 成立 | `src/dashboards/service.dashboard.ts` 十个 widget:Open Cases / Critical Cases / Avg Resolution Time / SLA Violations / Cases by Status / Cases by Priority / Cases by Origin / Daily Case Volume / SLA Compliance / Open Cases by Priority |
| `oldest open cases` 磁贴不存在 | ✅ 成立 | 同上;且十个 widget 全部 `dataset: 'case_metrics'`,即全部是聚合,没有任何一个列单条记录 |
| 三报表名对不上 | ✅ 成立 | `src/reports/case.report.ts:41` `Cases Opened by Priority × Day`(文档把两个维度写反了)、`:7` `Cases by Status and Priority`(文档写成 `×`)、`:19` `SLA Performance Report`(文档少了 `Report`) |
| 「% of cases resolved within SLA target」度量不存在 | ✅ 成立 | `src/datasets/case.dataset.ts` 的 measures 只有 `case_count` / `avg_resolution` / `avg_sla_violated`,没有任何达成率度量 |

`top agents` 的「为什么做不出来」也复核到源:`case_metrics` 的 dimensions 只有 status / priority / origin / type / created_date,**没有 owner 维度**——与 `content/docs/service/cases.mdx:188`(#912 / PR #939)、`sla-and-escalation.mdx:51`(#917 / PR #924)已落地的口径一致。两页矛盾就此消除:本页原来是撒谎的那一页。

## 改了什么

- **第一行(仪表盘)**:改为逐字列出十个真实磁贴,并写明缺的那两个不是「还没做的部件」——没有 owner 维度所以分析层排不出客服榜;仪表盘表格聚合数据集、不列记录,所以也放不出「最久未结」的清单。是否**应该**做这两个磁贴属产品决策,按 issue 的边界不预判,只说明要先动 `case_metrics`。
- **第二 / 三 / 四行(报表)**:报表名逐字对源码 label;zh 保留 #924 已立的中文说法(「按优先级 × 天的建单量」「SLA 表现报表」)并在括号内给出。SLA 行按 #924 已在 `sla-and-escalation` 页立好的写法改成 **SLA Violation Rate** + 只统计已关闭工单,并显式否掉「达成率百分比」。

零回退:PR #947 的 `Service Overview` 指称与首现 `Customer Service` 附注原样保留;#913 / #922 / #932 落地的其它行未触碰。`src/` 零改动,`releases/` 未触碰,zh 内链不带锚。

## 新增守卫 `test/docs-service-index-analytics.test.ts`(20 assertions)

散文没有任何东西检查(`os validate` / `pnpm lint` 不看 `content/docs`),所以检查写在断言所在处,双向:

1. **listed ⇒ exists**:本节里每一个不含 CJK 的 `**加粗**` 名字都必须解析到真实 widget title / report label / dataset label / 仪表盘的两个名字。不存在的名字一律用 *斜体*(本页 #927 / PR #932 已用 `*Service Dashboard*` 立过这个写法),所以幻影名字不可能靠加粗蒙混过关。
2. **exists ⇒ listed**:`service_dashboard` 的每个 widget title 都必须出现——新增磁贴而摘要不更新,这里就红。
3. **两条否定断言的源码侧也钉住**:给 `case_metrics` 加 owner 维度、或加一个按客服排名 / 按工单年龄的磁贴,本文件立刻红——因为那时散文就在另一个方向上错了。
4. 三行报表名逐字比对源码 label,并禁止四条已退役说法回潮(含 `SLA Performance` 后面不跟 `Report` 的短名)。

**逆向验证(方向为事前预测的 RED)**:`git stash` 掉三个 mdx、只留守卫跑,20 条里 **13 条红**(三语各 4 条 + en 的加粗规则);其余 7 条是纯源码事实断言与 zh 两页的加粗规则(旧 zh 加粗名全是 CJK,被规则按设计跳过),本就与文档词面无关,保持绿——这是预期,不是漏检。

## 验证

| 门 | 结果 |
| --- | --- |
| `pnpm typecheck` | exit 0 |
| `pnpm validate` | exit 0(仅既有 5 条 author-time warning) |
| `pnpm lint` | exit 0(13 warning / 14 suggestion,均为既有) |
| `node scripts/check-source-hygiene.mjs` | exit 0 — `no raw control bytes in first-party files`,扫描面含 `content` 与 `.changeset` |
| `pnpm build` | exit 0 — `Build complete`,`10 Reports / 5 Dashboards` |
| `pnpm test -- --maxWorkers=2` | exit 0 — `Test Files 71 passed`;`Tests 1622 passed`,1 skipped |

控制字节自扫(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`)对五个改动文件均无命中。未起 dev server。

Refs #937 #947 #917 #924 #912 #939 #927 #932
