### PR TITLE
fix(views): write the measured related-list mechanism to source (#944)

### DIFF
--- a/.changeset/related-list-columns-are-highlightfields.md
+++ b/.changeset/related-list-columns-are-highlightfields.md
@@ -1,0 +1,41 @@
+---
+'hotcrm': patch
+---
+
+Correct what `src/views/event_attendee.view.ts` claims a detail-page related
+list reads, and pin the metadata that actually curates one.
+
+The file header justified the attendee grid and form with a mechanism it stated
+as fact — "the related list renders THIS view's columns, and the quick-create
+modal renders THIS form … for the same reason `crm_campaign_member` has them" —
+and it was the only written account of that rendering path in this repo.
+`crm_campaign_member` has no view metadata at all, so the cited precedent was a
+counter-example, and #944 asked which half was wrong. Measured against the
+shipped Console (17.0.0-rc.3), the answer is the mechanism:
+
+- **A related list never reads the child's `list` view.** It takes its columns
+  from the child's lookup field (`relatedListColumns`, authored nowhere in this
+  app), then falls back to the child object's `highlightFields` minus the lookup
+  the panel is scoped by, capped at six, with columns that are empty on every
+  fetched row dropped. Only an object with no `highlightFields` reaches a
+  heuristic over the whole field map — which is title-ish names first and audit
+  columns last, not "every column in declaration order".
+- **The `form` half is real.** The Console merges a view bundle's `form` onto
+  the object definition, and the drawer a related list opens renders its
+  sections. What it buys is the section split and the field order: with no form
+  the drawer already drops `autonumber`, `formula` and `summary` fields in
+  create mode and sections the rest by the object's own `fieldGroups`, so the
+  raw autonumber was never on offer.
+
+So the campaign detail page's **Campaign Members** panel is not degraded and
+never was: it renders Lead / Contact / Status / Response Date off
+`crm_campaign_member.highlightFields`. Adding a member view would not have
+changed one column of it. Nothing user-visible changes here — the header is
+rewritten to what was measured, and `test/view-references.test.ts` now pins the
+load-bearing metadata for every object reached only through a parent (the two
+junctions and the two line items): `highlightFields` must exist, resolve, and
+survive dropping the panel's own scope field, so that deleting it — the one
+change that really would leave a panel leading with `CM-00001` — fails a test
+instead of shipping.
+
+Refs #944.

--- a/src/views/event_attendee.view.ts
+++ b/src/views/event_attendee.view.ts
@@ -6,14 +6,49 @@ import { defineView } from '@objectstack/spec/ui';
  * Event Attendee Views (#592)
  *
  * A junction object is normally edited inside its parent's related list, and
- * `crm_event_attendee` is no exception — but it still needs a grid and a form,
- * for the same reason `crm_campaign_member` has them: the related list renders
- * THIS view's columns, and the quick-create modal renders THIS form. Without
- * them the panel falls back to every column in declaration order and the
- * create modal offers the raw autonumber.
+ * `crm_event_attendee` is no exception. It carries no `tabs` and no navigation
+ * entry: an attendee is never something you go looking for on its own, you
+ * reach it through the meeting.
  *
- * It carries no `tabs` and no navigation entry: an attendee is never something
- * you go looking for on its own, you reach it through the meeting.
+ * # What each half of this bundle actually renders — measured (#944)
+ *
+ * This header used to justify both halves in one sentence: the related list
+ * renders THIS view's columns, the quick-create modal renders THIS form, and
+ * without them the panel falls back to every column in declaration order while
+ * the modal offers the raw autonumber — "for the same reason
+ * `crm_campaign_member` has them". `crm_campaign_member` has no view metadata
+ * at all, which is what sent #944 looking; re-measuring the paragraph against
+ * the shipped Console (17.0.0-rc.3) left only the form half standing.
+ *
+ * **`form` — live.** The Console merges a view bundle's `form` onto the object
+ * definition it holds, and the record drawer a related list opens ("New" on
+ * the panel, edit on a row) renders that form's `sections`. What the authored
+ * form buys is the section split and the field order — not rescue from a raw
+ * autonumber, because the no-form fallback is not raw either: in `create` mode
+ * the drawer drops `autonumber`, `formula` and `summary` fields (and anything
+ * hidden or readonly) and sections whatever is left by the object's own
+ * `fieldGroups`. `attendee_number` was never on offer.
+ *
+ * **`list` — not what the related list reads.** A detail-page related list
+ * takes its columns from the CHILD's lookup field — `relatedListColumns` on
+ * `crm_event`, which this app authors nowhere — and falls back to the child
+ * object's `highlightFields` minus the parent lookup, capped at six, with
+ * columns that are empty on every fetched row dropped. Only an object with no
+ * `highlightFields` reaches the last resort, and that is a heuristic over the
+ * field map (title-ish names first, audit columns last, `rich_text` / `html` /
+ * `json` excluded) — not declaration order, and never this view. So the
+ * attendee panel on a meeting shows `attendee_type`, `response` and
+ * `is_organizer`, straight off `crm_event_attendee.highlightFields`, whatever
+ * the columns below say.
+ *
+ * The grid is therefore reachable only at this object's own list URL, which no
+ * navigation entry links to. It is kept as the curated answer to "what do you
+ * show about an attendee", and it is what a future `relatedListColumns` would
+ * be copied from — but nothing in this repo may cite it as what makes a
+ * related list readable. The load-bearing metadata is `highlightFields`, and
+ * `test/view-references.test.ts` pins it for every object reached only through
+ * a parent: strip it and the panel really does fall to the heuristic, which
+ * leads with the autonumber these objects use as their `nameField`.
  */
 export const EventAttendeeViews = defineView({
   list: {

--- a/test/view-references.test.ts
+++ b/test/view-references.test.ts
@@ -455,3 +455,111 @@ describe('every named list view is reachable', () => {
     expect(bad, `dangling tabs:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 });
+
+/**
+ * ── What curates a related list, when it is NOT a view (#944) ────────────────
+ *
+ * Four objects in this app are reached only through a parent's detail page —
+ * the two junctions and the two line items. It is a standing temptation to
+ * believe that panel renders the child's list view, and the header of
+ * `src/views/event_attendee.view.ts` said so in as many words until #944.
+ *
+ * It does not. MEASURED against the shipped Console (17.0.0-rc.3): a
+ * detail-page related list takes its columns from the CHILD's lookup field
+ * (`relatedListColumns`, which this app authors nowhere), then falls back to
+ * the child object's `highlightFields` minus the lookup the panel is scoped
+ * by — capped at six, with columns empty on every fetched row dropped. Only
+ * with neither of those does it reach a heuristic over the whole field map.
+ * The child's `list` view is never consulted, which is why
+ * `crm_campaign_member` ships no view at all and its panel on a campaign is
+ * still curated (Lead / Contact / Status / Response Date), while
+ * `crm_event_attendee` ships one whose columns that panel ignores.
+ *
+ * So the thing worth guarding here is not the views — it is `highlightFields`
+ * on the objects that have no other way to be read. Delete it and the panel
+ * drops to the heuristic, which leads with the autonumber these objects carry
+ * as their `nameField`: `CM-00001`, `EA-00001`, one useless column where the
+ * person's name should be. That is exactly the degradation #944 was filed
+ * about, and deleting this metadata is the only way to reach it.
+ *
+ * Derived, not listed: an object qualifies when it holds a REQUIRED lookup to
+ * another `crm_` object and has no navigation entry of its own. A fifth such
+ * object added tomorrow is held to the same bar without anyone extending a
+ * fixture.
+ */
+describe('objects reached only through a parent curate that related list', () => {
+  const apps: AnyRec[] = (stack as any).apps ?? [];
+  const navObjects = new Set(
+    apps.flatMap((app) =>
+      (app.navigation ?? []).flatMap(function walk(n: AnyRec): string[] {
+        return [...(n.objectName ? [n.objectName] : []), ...(n.children ?? []).flatMap(walk)];
+      })),
+  );
+
+  /** The required `crm_` lookups on an object — each one is a panel it appears in. */
+  const parentLookupsOf = (obj: AnyRec): string[] =>
+    Object.entries<AnyRec>(obj.fields ?? {})
+      .filter(([, def]) =>
+        (def?.type === 'lookup' || def?.type === 'master_detail') &&
+        def?.required === true &&
+        String(def?.reference_to ?? def?.reference ?? '').startsWith('crm_'))
+      .map(([name]) => name);
+
+  const parentOnly = objects.filter(
+    (o) => String(o.name).startsWith('crm_') && !navObjects.has(o.name) && parentLookupsOf(o).length > 0,
+  );
+
+  it('the derivation finds the objects it is meant to cover', () => {
+    // Guard the guard. Every assertion below iterates `parentOnly`, and all of
+    // them would pass by checking nothing if the navigation walk stopped
+    // yielding object names or the lookup filter stopped matching — the way
+    // the navigation guard in `test/action-references.test.ts` spent its life
+    // green. The two junctions are named because they are what #944 is about;
+    // the count is a floor, not a roster.
+    expect(navObjects.size, 'no navigation object entries parsed out of the app').toBeGreaterThan(5);
+    const names = parentOnly.map((o) => o.name);
+    expect(names).toContain('crm_campaign_member');
+    expect(names).toContain('crm_event_attendee');
+    expect(names.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each(parentOnly.map((o) => o.name))('%s authors highlightFields', (name) => {
+    const obj = objects.find((o) => o.name === name) as AnyRec;
+    const highlight: string[] = Array.isArray(obj.highlightFields) ? obj.highlightFields : [];
+    expect(
+      highlight.length,
+      `${name} authors no highlightFields — nothing curates its related list, and the ` +
+        'fallback heuristic leads with whatever the field map offers first',
+    ).toBeGreaterThan(0);
+
+    const known = new Set(Object.keys(obj.fields ?? {}));
+    const dangling = highlight.filter((f) => !known.has(f));
+    expect(dangling, `${name}.highlightFields names fields that do not exist: ${dangling.join(', ')}`).toEqual([]);
+  });
+
+  it.each(parentOnly.map((o) => o.name))('%s still has columns once the parent lookup is dropped', (name) => {
+    const obj = objects.find((o) => o.name === name) as AnyRec;
+    const highlight: string[] = Array.isArray(obj.highlightFields) ? obj.highlightFields : [];
+    const nameField = typeof obj.nameField === 'string' ? obj.nameField : undefined;
+    const isAutonumber = !!nameField && obj.fields?.[nameField]?.type === 'autonumber';
+
+    const bad: string[] = [];
+    for (const parent of parentLookupsOf(obj)) {
+      // What the panel on `parent`'s detail page is left with: the related list
+      // drops the field it scoped the query by, since every row shows the same
+      // value for it.
+      const surviving = highlight.filter((f) => f !== parent);
+      if (surviving.length === 0) {
+        bad.push(
+          highlight.length === 0
+            ? `${name} in the ${parent} panel: no highlightFields at all — the panel falls to the heuristic`
+            : `${name} in the ${parent} panel: every highlightField is the panel's own scope — no columns left`,
+        );
+      }
+      if (isAutonumber && surviving.includes(nameField as string)) {
+        bad.push(`${name} in the ${parent} panel: leads with the autonumber "${nameField}"`);
+      }
+    }
+    expect(bad, `related lists with nothing to show:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #944

## 结论:二选一里错的是注释,不是缺元数据

issue 说得对——`event_attendee.view.ts:10` 拿 `crm_campaign_member` 当「已成立的先例」,而后者全仓零 view,两者必有一错。按派发的 measure-first 裁定先测,结果是**注释所述的机制本身就不成立**,于是走修法 B:改注释、不补 view。

## 三项测量

**① 文档承诺(三语一致)。** `content/docs/marketing/campaign-members.mdx`(及 `.zh-Hans` / `.zh-Hant` 第 85-92 行)在《Standard list views》一节向读者承诺:营销活动详情页的 *Members* 选项卡上有 **All Members / Responded / Bounced-Unsubscribed / Converted to Opportunity** 四个标准列表视图。这四个视图在元数据里一个都没有——而且下面的测量说明,即便补上最小 grid,它们也不会出现在那个面板上。该缺口与本单修法无关,已另行留档(见文末)。

**② 注释自述的机制,逐句对着 17.0.0-rc.3 的 Console 产物测。** 两句断言各有下场:

- 「关联列表渲染 THIS view 的列」——**不成立**。详情页关联列表的列来自**子对象 lookup 字段上的 `relatedListColumns`**(本仓一处都没写),其次退到子对象的 `highlightFields` 去掉该面板的作用域字段,上限 6 列,并丢弃在所有已取行上都为空的列;只有两者皆无才落到字段表启发式(name 类字段靠前、审计列靠后,`rich_text` / `html` / `json` 排除)。**从头到尾不读子对象的 list view**,也不是「按声明顺序渲染全部字段」。
- 「快速新建弹窗渲染 THIS form」——**成立**;但配套那句「没有 form 就把 autonumber 当首字段」**不成立**。Console 会把 view bundle 的 `form` 合并到它持有的对象定义上,关联列表的 New / 行编辑抽屉渲染其 `sections`;而没有 form 时抽屉也不裸:create 模式下它先丢掉 `autonumber` / `formula` / `summary`(以及 hidden / readonly)字段,再按对象自己的 `fieldGroups` 分节。`attendee_number` 从来没被端上来过。

**③ dist 产物现状。** 基线 `pnpm build` 产出 14 个 view,`crm_campaign_member` 无任何 view 声明(`crm_event_attendee` 有,记录形如 `{ list, form }`)。

## 由此推出的影响判定(与 issue 正文相反)

`crm_campaign_member` 声明了 `highlightFields: ['crm_campaign', 'crm_lead', 'crm_contact', 'status', 'response_date']`,面板会去掉自己的作用域字段 `crm_campaign`,所以营销活动详情页的成员关联列表今天渲染的是 **Lead / Contact / Status / Response Date**——是策展过的,不是退化态。补一个 grid view **一列都改变不了**。快速新建弹窗同理:autonumber 已被 create 模式剔除,分节走 `fieldGroups`。

也就是说,修法 A(补 `CampaignMemberViews`)在关联列表这一半没有任何可测的业务拉力,唯一真实的一半(form 分节)今天由对象自己的 `fieldGroups` 承担且结果合理;把 grid 补进来只会多出一块「声明了但没人渲染」的表面——正是这条错注释已经制造过一次的那类误导。按仓库的 startup-focus 取舍,不建。

## 本 PR 改了什么

- `src/views/event_attendee.view.ts`:重写文件头注释,把上面测到的两条路径写进源码(哪一半 live、哪一半不读、无 view 时的真实回退),并明确 `crm_campaign_member` 不是反例而是「不需要」的证据。**注释改动,零元数据变更**。
- `test/view-references.test.ts`:新增守卫,钉住真正承重的东西。派生集合 = 只能经父记录抵达的 `crm_` 对象(持有指向 `crm_` 的 required lookup 且无导航项)= 两个 junction + 两个 line item,四个对象都必须声明 `highlightFields`、其中每项都要解析得到真字段、并且在去掉任一父 lookup 后仍剩至少一列且不以 autonumber 打头。
- changeset(patch):面向发布说明读者写清「机制被写反了」这件事。

## 反向验证(方向先判后跑)

预判为**红**:唯一能真把成员面板打回退化态的改动,就是删掉 `crm_campaign_member.highlightFields`。删之实测——新守卫的两条断言同时报红:

```
FAIL  objects reached only through a parent curate that related list
      > crm_campaign_member authors highlightFields
AssertionError: crm_campaign_member authors no highlightFields — nothing curates
its related list, and the fallback heuristic leads with whatever the field map
offers first: expected 0 to be greater than 0

FAIL  objects reached only through a parent curate that related list
      > crm_campaign_member still has columns once the parent lookup is dropped
AssertionError: related lists with nothing to show:
  crm_campaign_member in the crm_campaign panel: no highlightFields at all — the panel falls to the heuristic

Tests  2 failed | 23 passed (25)
```

随即还原。

## 六道门(worktree `hotcrm-944`,均在共享 verify 锁内串行)

| 门 | 结果 |
| --- | --- |
| `pnpm validate` | 0 —— 14 Views / 17 Objects,告警集与基线同(含 #715 的 `field-group-shadowed`,非本单) |
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 —— 13 warning / 14 suggestion,与基线同 |
| `pnpm hygiene` | 0 —— 含控制字节扫描;另按规程对三个改动文件做了 `grep -naP` 自扫,无命中 |
| `pnpm build` | 0 —— **产物与基线逐项一致:14 Views,`dist/objectstack.json` 1921.4 KB**(注释不进产物,符合零元数据变更的预期) |
| `pnpm test -- --maxWorkers=2` | 0 —— `Test Files 70 passed`,`Tests 1611 passed / 1 skipped` |

既有测试语义零变化:本 PR 只新增一个 describe 块,未改动任何既有断言;`views` 清单类对账(i18n `_views` 标签、tabs 可达性)因未新增 view 而无需更新。

## 边界

未起 dev server,无浏览器实测条件——上述机制结论来自对 17.0.0-rc.3 Console 产物中 `RecordDetailView` 关联列表派生、`RelatedList` 列回退链、`MetadataProvider` 的 view→object 合并、以及 form 渲染器 create 模式字段过滤这四处的静态测量,如实标注。未碰 `content/docs/`、`releases/`、`@objectstack/*` 版本;#715(字段组被 highlightFields 提升)机制不同未混改,#597(成员生命周期)不预判。

文档承诺缺口(测量 ①)与 `EventAttendeeViews.list` 的消费面问题按 Prime Directive #10 另行立单,不在本 PR 内修。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_