### PR TITLE
docs(analytics): 把 reports 页剩余三节与 cubes 整页写到 src/ (#962, #965)

### DIFF
--- a/.changeset/analytics-reports-cubes-to-source.md
+++ b/.changeset/analytics-reports-cubes-to-source.md
@@ -1,0 +1,54 @@
+---
+'hotcrm': patch
+---
+
+Write the analytics reports page's Sales / Revenue / Marketing sections and the
+whole cubes page to source, in all three locales.
+
+**Thirteen report names, none of them published (#962).** `src/reports/` ships ten
+reports and the page's remaining three sections named thirteen that exist nowhere,
+while the six real ones — `account.report.ts`'s **Accounts by Industry and Type**,
+`churn.report.ts`'s **Customer Churn Signals** and the four in
+`opportunity.report.ts` — had never appeared on the page at all. Two of the
+thirteen were real names attached to the wrong thing: **Pipeline by Stage** is the
+funnel tile shared by CRM Overview / Sales Performance / Executive Overview
+(`src/dashboards/shared-widgets.ts`) and the chart title of the real report
+**Opportunities by Stage**, and **Stale Opportunities** is the *Stale* list view
+(`src/views/opportunity.view.ts`), which applies no 14-day cut — it ranks every
+open deal by **Stage Entry Date**, the 14 days belonging to the
+`opportunity_stagnation` flow. Each remaining name is now judged individually
+against the semantic layer: *Forecast vs Actual*, *Win/Loss Analysis*, *Big Deals
+Won* and the renewal pipeline are a custom report away, while *Sales Cycle
+Length*, *Discount Approval Activity* and the three contract reports cannot be
+built at all — no dataset reads `crm_contract` or either line-item object, and the
+one duration on the deal, **Days in Current Stage**, is a post-query formula that
+nothing can aggregate. The subscription example, the permissions bullet and the
+manager tips no longer name reports that do not exist.
+
+**The four built-in cubes do not exist (#965).** The page was built on *Sales*,
+*Pipeline*, *Service* and *Marketing* cubes; this app declares no cube at all —
+every semantic definition is a `defineDataset(...)` under `src/datasets/`, and the
+analytics service compiles each one into its cube internally (ADR-0021, and
+`objectstack.config.ts` registers no `analyticsCubes`). The page now lists the nine
+real datasets with their actual dimensions and measures, folds Sales and Pipeline
+into the single `opportunity_metrics` they both described, and names per item what
+is unreachable and why — weighted pipeline (the **Expected Revenue** field carries
+it per record, no measure aggregates it), average discount (a line-item percent no
+dataset reads), product/family, account tier and size, team and region (positions
+and **Billing Country**, i.e. access-control machinery), day/week/year grains, and
+snapshot dates (nothing snapshots the pipeline; `forecast_metrics` holds the only
+per-period rows). **Marketing has no data source**: `crm_campaign` and
+`crm_campaign_member` carry the spend, the counters and the **ROI %** / **Response
+Rate %** formulas on the record, and no dataset reads either, so nothing aggregates
+them and `crm_opportunity.crm_campaign` cannot attribute revenue either.
+
+The platform-side sections are left explicitly unclaimed rather than declared
+false: the drag-and-drop cube UI, the refresh cadence and the cube access log are
+runtime questions this repo cannot answer, so the page says so and points the
+reader at their deployment. What it does state is the app-side half — no skill
+under `src/skills/` names a dataset or a cube, and **Live Data Access** answers
+data questions through the platform's object tools (`describe_object`,
+`aggregate_data`, …), not off a compiled cube — and that a new cube here starts as
+a new dataset in source.
+
+Documentation only; nothing under `src/` changed.

--- a/content/docs/analytics/cubes.mdx
+++ b/content/docs/analytics/cubes.mdx
@@ -1,178 +1,140 @@
 ---
 title: Cubes
-description: The data layer that powers HotCRM analytics — four built-in cubes for self-service slice and dice.
+description: The semantic layer under HotCRM analytics — nine datasets, what each one can answer, and what it cannot.
 ---
 
 # Cubes
 
-A **cube** is a pre-modeled, multi-dimensional dataset designed for fast analytics. Cubes are the layer underneath [dashboards](/docs/analytics/dashboards) and [reports](/docs/analytics/reports) — they're what makes analytics fast, consistent, and self-service.
+A **cube** is a pre-modeled, multi-dimensional dataset: a set of named **measures** (the numbers) over named **dimensions** (the ways you cut them). Cubes are the layer underneath [dashboards](/docs/analytics/dashboards) and [reports](/docs/analytics/reports) — they are what makes a number mean the same thing in two places.
 
-## Why cubes (instead of querying raw tables)
+**In HotCRM that layer is a set of datasets.** This app declares no cube of its own: every semantic definition it ships is a `defineDataset(...)` under `src/datasets/`, registered through `objectstack.config.ts`, and the analytics service compiles each dataset into its cube internally (ADR-0021). A second, hand-written cube layer did exist here once and was removed — it duplicated every measure and drifted from the datasets that reports and tiles actually bind to. So wherever this page says *dataset*, that is the object a report or a dashboard tile binds **by name**, and the thing the platform turns into a cube.
 
-Cubes solve three problems:
+## Why a semantic layer (instead of querying raw tables)
 
-1. **Consistency** — *"bookings"* means the same thing in every dashboard.
-2. **Speed** — pre-aggregated, sub-second response on millions of records.
-3. **Self-service** — business users can slice and dice without writing queries.
+1. **Consistency** — *"pipeline"* means the same thing in every dashboard, because every widget selects the same named measure.
+2. **Speed** — pre-aggregated, rather than one ad-hoc scan per question.
+3. **Reuse** — a measure is declared once and picked by name. `win_rate` carries its own two halves with it, so no widget has to improvise a denominator.
 
-## The four built-in cubes
+## The nine datasets
 
-| Cube | Built for | Slices by |
-| --- | --- | --- |
-| 💰 **Sales Cube** | Revenue analysis | Account, owner, region, product, period |
-| 📊 **Pipeline Cube** | Pipeline analysis | Stage, owner, age, source, probability |
-| 🎧 **Service Cube** | Case and SLA analysis | Priority, status, agent, origin, account |
-| 📣 **Marketing Cube** | Campaign performance | Campaign, source, channel, period |
+`src/datasets/index.ts` is the whole semantic layer:
 
-## 💰 Sales Cube
+| Dataset | Reads | Dimensions | Measures |
+| --- | --- | --- | --- |
+| **Opportunity Metrics** (`opportunity_metrics`) | `crm_opportunity`, joined to `crm_account` | Stage, Lead Source, Forecast Category, Deal Type, Owner, Win Reason, Loss Reason, Close Date (month), Close Quarter, Account Industry | Opportunities, Total Amount, Avg Deal Size, Avg Probability, Won Deals, Lost Deals, Settled Deals, Won Revenue, Lost Revenue, Win Rate |
+| **Case Metrics** (`case_metrics`) | `crm_case` | Status, Priority, Origin, Type, Created (day) | Cases, Avg Resolution (h), SLA Violation Rate |
+| **Lead Metrics** (`lead_metrics`) | `crm_lead` | Status, Source, Created, Last Contacted (month) | Leads |
+| **Account Metrics** (`account_metrics`) | `crm_account` | Industry, Type, Created (month) | Accounts, Annual Revenue |
+| **Forecast Metrics** (`forecast_metrics`) | `crm_forecast` | Owner, Period Type, Period, Period Start | Quota, Closed, Pipeline, Commit, Attainment |
+| **Activity Metrics** (`event_metrics`) | `crm_event` | Activity Type, Status, Owner, Related To, Activity Week | Activities, Minutes, Avg Duration |
+| **Task Metrics** (`task_metrics`) | `crm_task` | Status, Priority, Urgency, Type, Due Date, Overdue, Completed | Tasks, Avg Progress |
+| **Product Metrics** (`product_metrics`) | `crm_product` | Category | Products, Total List Price |
+| **Contact Metrics** (`contact_metrics`) | `crm_contact` | *none* | Contacts |
 
-The cube that powers all "how much did we book?" questions.
+Two things to read off that table before anything else. **Contact Metrics declares no dimension at all** — it counts contacts and nothing more. And **no dataset reads `crm_campaign`, `crm_contract`, `crm_quote` or either line-item object**, which is where most of the gaps below come from.
 
-**Measures**:
-- Bookings (closed-won $)
-- Deal count
-- Average deal size
-- Win rate
-- Sales cycle (days)
-- Average discount %
+This page used to describe four cubes — *Sales*, *Pipeline*, *Service* and *Marketing*. None of those four names exists in the app. Three of them map onto datasets that do exist, under different names and with different contents; the fourth has no data source at all. Each section below says which.
 
-**Dimensions**:
-- Account (and account tier, industry, size)
-- Owner (and team, region)
-- Product (and category, family)
-- Period (day, week, month, quarter, year)
-- Won/Lost reason
-- Lead source
+## 💰 Sales and 📊 pipeline — one dataset, not two
 
-**Sample questions**:
-- *"Bookings by region by quarter."*
-- *"Win rate by lead source over the last year."*
-- *"Average deal size by product family."*
+Both cubes this page described are answered by the same place: **Opportunity Metrics**, the dataset every pipeline widget and all four opportunity reports bind.
 
-## 📊 Pipeline Cube
+**Reachable today**, with the name the app uses:
 
-For "what's in the funnel?" questions. A snapshot view + a time-series view.
+- *Bookings* → **Won Revenue** (closed-won amount), with **Won Deals** beside it.
+- *Deal count* → **Opportunities**; *pipeline value* → **Total Amount**; *average deal size* → **Avg Deal Size**.
+- *Win rate* → **Win Rate**, declared as a ratio with **Won Deals**, **Lost Deals** and **Settled Deals** published next to it so the arithmetic behind the percentage can be checked.
+- *Stage*, *owner*, *source*, *won/lost reason* → **Stage**, **Owner**, **Lead Source**, **Win Reason**, **Loss Reason**.
+- *Probability bucket (commit / best case / pipeline)* → **Forecast Category**. The page's own name for it was the only thing missing.
+- *Account industry* → **Account Industry**, reached through the `crm_account` join this dataset includes.
+- *Period* → **Close Date**, bucketed by **month**, and **Close Quarter**, bucketed by **quarter**.
 
-**Measures**:
-- Pipeline value ($)
-- Pipeline count
-- Weighted pipeline (value × probability)
-- Days in stage
-- Days in pipeline
+**Not reachable, and why:**
 
-**Dimensions**:
-- Stage
-- Owner (and team)
-- Source
-- Product
-- Probability bucket (commit / best case / pipeline)
-- Snapshot date (for trend analysis)
+- **Sales cycle days** and **Days in pipeline** — nothing stores a duration. The opportunity carries **Stage Entry Date** and **Close Date** but no elapsed-days column, and the one duration it does carry, **Days in Current Stage**, is a formula evaluated *after* the query (`src/objects/opportunity.object.ts`), so it cannot be aggregated, filtered or sorted, and no dataset exposes it.
+- **Days in stage** — same field, same reason.
+- **Weighted pipeline (value × probability)** — the number exists per record: **Expected Revenue** is the amount times the stage probability, recomputed by `src/objects/opportunity.hook.ts` on every save, and the opportunity list views total that column. `opportunity_metrics` declares no measure over it, so no tile and no report can.
+- **Average discount %** — the discount is a percent on the line item (`crm_opportunity_line_item.discount`), and no dataset reads line items.
+- **Product, category, family** — same reason. **Product Metrics** covers the catalogue (**Category**, product count, list-price sum) and never joins to deals, so *"average deal size by product family"* has no path even though **Family** is a real field on the product.
+- **Account, account tier, account size** — `crm_account.tier` and **Number of Employees** are real fields, but the only account cut reachable from deals is **Account Industry**; **Account Metrics** adds **Type** and **Created** and stops there.
+- **Team, region** — no dataset declares either, and neither is a field on the deal to expose. Team and territory exist in this app as **positions** (*NA Sales Team*, *EU Sales Team* in `src/sharing/positions.ts`) and as **Billing Country** on the account, a flat projection the territory sharing rules match on — both are access-control machinery, and no dataset reads either. *"Bookings by region by quarter"* cannot be asked; the nearest answerable cut is by **Owner**.
+- **Period at day, week or year grain** — the two buckets declared are month and quarter. Another grain means another dimension.
+- **Snapshot date** — nothing snapshots the pipeline. *"Pipeline by stage today vs 30 days ago"* has no history to compare against. The nearest real thing is **Forecast Metrics**, which holds one row per owner per period — a settled snapshot of quota, closed, pipeline and commit — and answers the coverage question instead: *"coverage ratio (pipeline ÷ quota) by rep"*, provided the period is pinned (group by **Period**, or filter to a single **Period Type** + **Period Start**).
 
-**Sample questions**:
-- *"Pipeline by stage today vs 30 days ago."*
-- *"Average days-in-stage for the Proposal stage."*
-- *"Coverage ratio (pipeline ÷ quota) by team."*
+## 🎧 Service — `case_metrics`
 
-## 🎧 Service Cube
+The dataset behind every case-related dashboard tile and all three case reports. Five dimensions — **Status**, **Priority**, **Origin**, **Type**, **Created** (bucketed by day) — and three measures:
 
-The cube behind every case-related dashboard and SLA report.
-
-**Measures**:
-- Open case count
-- New case count
-- Resolved case count
-- Resolution time (hours)
+- **Cases** — the case count.
+- **Avg Resolution (h)** — average resolution time.
 - **SLA Violation Rate** — the average of the **SLA Violated** flag (`avg_sla_violated` in `case_metrics`), which is a breach rate and not a compliance percentage
-- CSAT score
 
 **There is no first-response measure here**, and no "SLA met %". `case_metrics` (`src/datasets/case.dataset.ts`) declares neither, so nothing in analytics can aggregate, compare or chart a first response. The **First Response Date** stamp on the case is real — see [Cases](/docs/service/cases) for when it is written — but it stops there: nothing measures it, and nothing alerts on it.
 
-**Dimensions**:
-- Status, priority, category, origin
-- Agent (and team)
-- Account (and tier)
-- Product
-- Period
+The rest of what this section used to list is not reachable either:
 
-**Sample questions**:
+- **Open / New / Resolved case count** — there is one count measure, not three. **Status** is a dimension, so a count *split by* status gives the same breakdown; what does not exist is a pre-filtered measure you can drop on a tile by itself.
+- **Agent (and team)** — `case_metrics` declares **no owner dimension**, so nothing in analytics can group, rank or filter cases by agent. `owner_id` is a field on the case; no dimension exposes it. This is why the service pages carry no agent leaderboard and *"reopened cases by agent"* is doubly impossible — nothing records a reopen either.
+- **Account (and tier)** — the dataset reads `crm_case` alone and never crosses to `crm_account`.
+- **Product** — cases carry no product link that analytics can read, so *"cases by category by product"* has no path.
+- **Category** — the nearest real dimension is **Type** (*Question / Problem / Feature Request / Bug*).
+- **Period** — **Created** buckets by **day** only.
+- **CSAT score** — **Customer Satisfaction** (`customer_rating`) is a real 1–5 field on the case, and no measure aggregates it.
+
+**Sample questions this dataset answers**:
 - *"SLA Violation Rate by priority."*
-- *"Cases by category by product — which products generate the most support load?"*
-- *"Reopened cases by agent — quality signal."*
+- *"Case volume by origin — where is the load coming in?"*
+- *"Average resolution time by type."*
 
-## 📣 Marketing Cube
+## 📣 Marketing — no dataset, no cube
 
-Powers campaign and lead-source ROI analysis.
+**There is no marketing dataset, so there is nothing to slice.** `src/datasets/` reads nine objects and `crm_campaign` is not one of them, which makes this the one section on the page where the gap is not a missing measure but a missing data source: all seven measures and all five dimensions it used to list are unreachable, and none of them can be added from a report or a cube screen.
 
-**Measures**:
-- Members enrolled
-- Members responded
-- Conversion count (member → opportunity)
-- Sourced revenue (closed-won where campaign was first touch)
-- Influenced revenue (closed-won where campaign was any touch)
-- Campaign spend
-- Cost per lead, cost per opportunity, ROI %
+The records do carry the numbers. `crm_campaign` has **Budgeted Cost**, **Actual Cost**, **Expected Revenue**, **Actual Revenue**, the **Num Sent / Responses / Leads / Converted Leads / Opportunities / Won Opportunities** counters, and two formula fields — **Response Rate %** and **ROI %** — shown in the **Performance** section of the campaign record. `crm_campaign_member` stamps **First Opened**, **First Clicked**, **Response Date** and **Responded** per member. Every one of those is a per-record figure that nothing aggregates.
 
-**Dimensions**:
-- Campaign (and type)
-- Channel (email, webinar, event, etc.)
-- Period
-- Lead source
-- Persona (job role)
+Name by name:
 
-**Sample questions**:
-- *"ROI by campaign type."*
-- *"Cost per opportunity by channel."*
-- *"Conversion rate by persona."*
+- **Members enrolled / responded**, **conversion count** — per-campaign counters on the record; no measure, so no total and no ranking across campaigns.
+- **Sourced and influenced revenue** — unreachable from the deal side too: `crm_opportunity.crm_campaign` is a real lookup, but `opportunity_metrics` declares no campaign dimension, so revenue cannot be attributed to a campaign anywhere in analytics.
+- **Campaign spend**, **cost per lead**, **cost per opportunity**, **ROI %** — the ROI percentage exists on each record as a formula; nothing sums the spend or compares campaigns.
+- **Campaign (and type)**, **channel**, **period** — real fields on `crm_campaign`, and dimensions nowhere.
+- **Lead source** — a dimension on **Lead Metrics** and on **Opportunity Metrics**, so *"which sources produce deals"* is answerable; the *campaign* behind the source is not.
+- **Persona (job role)** — no path at all: **Title** is free text on the contact and the lead, and **Contact Metrics** declares no dimensions.
 
-## How users interact with cubes
+So the three questions this section offered — *"ROI by campaign type"*, *"cost per opportunity by channel"*, *"conversion rate by persona"* — cannot be answered here today. Closing the gap means adding `src/datasets/campaign.dataset.ts`: a source change and a redeploy, not a setting. See [Campaigns](/docs/marketing/campaigns) for what the campaign record shows today.
 
-The cube UI lets anyone:
+## How users interact with datasets
 
-1. **Pick** a cube.
-2. **Drag** dimensions to rows and columns.
-3. **Pick** measures to display.
-4. **Filter** to narrow the view.
-5. **Pivot** instantly to see the data differently.
-6. **Chart** the result as bar, line, area, heatmap, or table.
-7. **Save** the view as a report.
-8. **Pin** the view to a dashboard.
+What the app guarantees is the binding: a report or a dashboard tile names a dataset and selects its measures and dimensions by name, and `test/analytics-integrity.test.ts` fails the build if any of those names does not resolve. That is what keeps two tiles showing the same number.
 
-No SQL, no formulas — just drag and drop.
+The drag-and-drop pivot experience this section used to describe — pick a cube, drag dimensions to rows and columns, filter, pivot, chart, save the view as a report, pin it to a dashboard — is a **platform** surface rather than something HotCRM declares. Nothing in this app's metadata configures such a screen, and nothing here tests one, so this page makes no claim about it in either direction. If your workflow depends on self-service pivoting, verify it against your deployment rather than against this page.
 
 ## How cubes stay fresh
 
-- **Incremental refresh** every few minutes for hot data (today's activity).
-- **Full refresh** nightly.
-- **Snapshots** for time-series analysis (e.g., daily pipeline snapshots that power trend charts).
+Refresh belongs to the analytics service, not to this app. HotCRM declares no refresh schedule, no incremental-versus-full-refresh policy and no snapshot job anywhere in `src/` — the only scheduled work it declares is its own flows (`src/flows/`). The figures this section used to quote — incremental refresh every few minutes, a nightly full refresh, daily snapshots, a refresh status screen in the admin console — are not configured here and are not measured here; treat them as questions for your deployment.
 
-Refresh status is visible in the admin console.
+One half of it *is* in the app's hands, and it is the half that fails today: a trend chart needs a snapshot dimension to compare against, and no dataset declares one. Time-series questions are answerable only along a date dimension a dataset already carries — **Close Date** by month, **Close Quarter**, **Created** by day, **Activity Week**, **Last Contacted** by month.
 
 ## AI Copilot and cubes
 
-The AI Copilot reads directly from cubes — when you ask *"What's our win rate by region?"*, it's the Sales Cube responding. This means:
+**On this app's side, nothing connects the Copilot to a dataset.** The six skills under `src/skills/` name no dataset, no cube and no measure. The one that answers data questions, **Live Data Access**, is wired to the platform's object tools — `describe_object`, `list_objects`, `query_records`, `get_record`, `aggregate_data` — and its instructions tell the agent to re-read the object's schema first and aggregate over records. So a Copilot answer about win rate is computed from the objects, not read off the compiled cube, and this app declares nothing that would make the two consistent by construction.
 
-- **AI answers are consistent** with dashboards and reports (same source of truth).
-- **AI can explain** the answer by referencing the cube measure and dimension.
-- **Admins can audit** AI queries through the cube access log.
+Whether the platform's own agent additionally reads the compiled cubes, and whether cube access is audited for admins, are questions about the runtime rather than about this app — so this page makes no claim about them in either direction. If you are relying on Copilot answers matching a dashboard to the decimal, check it against your deployment.
 
 ## Custom cubes
 
-Admins and developers can build new cubes for domain-specific analysis:
+In HotCRM a new cube starts as a new **dataset in source**: a `defineDataset(...)` in `src/datasets/<object>.dataset.ts`, exported from `src/datasets/index.ts`, registered by `objectstack.config.ts`, then deployed. That is the route all nine above took, and the reason the marketing gap is a code change rather than a configuration one.
 
-- A **Subscriptions Cube** for SaaS revenue (ARR, NRR, churn).
-- A **Renewal Cube** for renewal pipeline visibility.
-- A **Partner Cube** if you sell through channels.
-
-See [Customization › Extending Objects](/docs/customization/extending-objects) for how to define new cubes, dimensions, and measures.
+The three examples this section used to offer — a *Subscriptions Cube*, a *Renewal Cube*, a *Partner Cube* — exist in no form; there is no subscription or partner object to build them on. Whether the console additionally offers an admin-facing cube builder is, again, a platform question this page does not answer.
 
 ## Tips for analysts
 
-- ✅ Start every new analysis from a cube — don't build dashboards on raw queries.
-- ✅ Use **snapshot dimensions** for trend questions ("How did this metric change?").
-- ✅ Save **shared views** that the team can subscribe to.
+- ✅ Start from a dataset and its declared measures — the number a tile shows is the measure it names, so quoting the measure name makes an answer checkable.
+- ✅ Pin the period when you touch **Forecast Metrics**: its measures are plain sums over a table that holds several periods at once, so an unscoped query adds a quarter's quota to a month's.
+- ✅ Read **Win Rate** together with **Won Deals** and **Lost Deals** — a blank rate means "no settled deals", not "no wins".
 
 ## Tips for admins
 
-- ✅ When a measure is computed inconsistently across reports, **promote it to a cube measure** — single source of truth.
-- ✅ Monitor cube refresh times — if they slow down, prune unused dimensions.
-- ✅ Document each cube's measures and dimensions for end users — discoverability is the #1 adoption blocker.
+- ✅ When a measure is computed inconsistently across reports, **promote it into the dataset** — one declaration, selected by name everywhere.
+- ✅ Adding a dimension is how you close an "unreachable" gap above; adding a dataset is how you close a missing-source one. Both are source changes, so they go through review like any other metadata.
+- ✅ Document what each dataset can and cannot answer — the gaps in this page are exactly the questions users kept asking.

--- a/content/docs/analytics/cubes.zh-Hans.mdx
+++ b/content/docs/analytics/cubes.zh-Hans.mdx
@@ -1,178 +1,140 @@
 ---
 title: 多维数据集
-description: 为 HotCRM 分析提供支持的数据层——四个内置多维数据集，用于自助式切片分析。
+description: HotCRM 分析底下的语义层——九个 dataset，各自能回答什么、不能回答什么。
 ---
 
 # 多维数据集
 
-**多维数据集**（cube）是为快速分析而设计的预建模多维数据集。多维数据集是 [仪表盘](/zh-Hans/docs/analytics/dashboards) 和 [报表](/zh-Hans/docs/analytics/reports) 底层的数据层——它们让分析变得快速、一致且自助。
+**多维数据集**（cube）是预先建好模的多维数据集：一组具名的**度量**（数字）架在一组具名的**维度**（切法）之上。它是 [仪表盘](/zh-Hans/docs/analytics/dashboards) 与 [报表](/zh-Hans/docs/analytics/reports) 底下的那一层——正是它让同一个数字在两个地方含义相同。
 
-## 为什么用多维数据集（而非查询原始表）
+**在 HotCRM 里，这一层是一组 dataset。** 本应用自己不声明任何 cube：它发布的每一个语义定义都是 `src/datasets/` 下的一个 `defineDataset(...)`，经 `objectstack.config.ts` 注册，再由分析服务在内部把每个 dataset 编译成它的 cube（ADR-0021）。这里曾经确实有过第二层手写 cube，后来被移除了——它把每个度量都复制了一份，并与报表和磁贴真正绑定的那些 dataset 各走各的。所以本页凡是说 *dataset*，指的就是报表或仪表盘磁贴**按名字**绑定的那个东西，也是平台拿去编译成 cube 的那个东西。
 
-多维数据集解决三个问题：
+## 为什么要有语义层（而非查询原始表）
 
-1. **一致性** — *"bookings"* 在每个仪表盘中含义相同。
-2. **速度** — 预聚合，在数百万条记录上实现亚秒级响应。
-3. **自助** — 业务用户无需编写查询即可切片分析。
+1. **一致性** — *"pipeline"* 在每个仪表盘里含义相同，因为每个小部件选的是同一个具名度量。
+2. **速度** — 预聚合，而不是每问一个问题就临时全表扫一遍。
+3. **复用** — 度量只声明一次，之后按名字取用。`win_rate` 把自己的分子分母一起带着，任何小部件都不必临时凑一个分母。
 
-## 四个内置多维数据集
+## 九个 dataset
 
-| 多维数据集 | 用途 | 切片维度 |
-| --- | --- | --- |
-| 💰 **Sales Cube** | 收入分析 | 客户、所有者、地区、产品、周期 |
-| 📊 **Pipeline Cube** | 管道分析 | 阶段、所有者、停留时长、来源、概率 |
-| 🎧 **Service Cube** | 工单与 SLA 分析 | 优先级、状态、客服、来源、客户 |
-| 📣 **Marketing Cube** | 营销活动绩效 | 营销活动、来源、渠道、周期 |
+`src/datasets/index.ts` 就是整个语义层：
 
-## 💰 Sales Cube
+| Dataset | 读取 | 维度 | 度量 |
+| --- | --- | --- | --- |
+| **Opportunity Metrics**（`opportunity_metrics`） | `crm_opportunity`，并联接 `crm_account` | Stage、Lead Source、Forecast Category、Deal Type、Owner、Win Reason、Loss Reason、Close Date（按月）、Close Quarter、Account Industry | Opportunities、Total Amount、Avg Deal Size、Avg Probability、Won Deals、Lost Deals、Settled Deals、Won Revenue、Lost Revenue、Win Rate |
+| **Case Metrics**（`case_metrics`） | `crm_case` | Status、Priority、Origin、Type、Created（按天） | Cases、Avg Resolution (h)、SLA Violation Rate |
+| **Lead Metrics**（`lead_metrics`） | `crm_lead` | Status、Source、Created、Last Contacted（按月） | Leads |
+| **Account Metrics**（`account_metrics`） | `crm_account` | Industry、Type、Created（按月） | Accounts、Annual Revenue |
+| **Forecast Metrics**（`forecast_metrics`） | `crm_forecast` | Owner、Period Type、Period、Period Start | Quota、Closed、Pipeline、Commit、Attainment |
+| **Activity Metrics**（`event_metrics`） | `crm_event` | Activity Type、Status、Owner、Related To、Activity Week | Activities、Minutes、Avg Duration |
+| **Task Metrics**（`task_metrics`） | `crm_task` | Status、Priority、Urgency、Type、Due Date、Overdue、Completed | Tasks、Avg Progress |
+| **Product Metrics**（`product_metrics`） | `crm_product` | Category | Products、Total List Price |
+| **Contact Metrics**（`contact_metrics`） | `crm_contact` | *无* | Contacts |
 
-为所有"我们签了多少单？"的问题提供支持的多维数据集。
+先从这张表上读出两件事。**Contact Metrics 一个维度都没有声明** —— 它只数联系人，别的什么都不做。以及**没有任何 dataset 读 `crm_campaign`、`crm_contract`、`crm_quote` 或两个行项目对象**，下面大多数缺口都由此而来。
 
-**度量**：
-- Bookings（成交赢单金额）
-- 交易数量
-- 平均交易规模
-- 赢单率
-- 销售周期（天数）
-- 平均折扣 %
+本页曾经描述过四个 cube —— *Sales*、*Pipeline*、*Service*、*Marketing*。这四个名字在应用里一个都不存在。其中三个能对应到确实存在的 dataset，只是名字不同、内容也不同；第四个则连数据源都没有。下面每一节分别说清楚。
 
-**维度**：
-- 客户（及客户层级、行业、规模）
-- 所有者（及团队、地区）
-- 产品（及类别、系列）
-- 周期（日、周、月、季、年）
-- 赢单/丢单原因
-- 线索来源
+## 💰 销售与 📊 管道 —— 是一个 dataset，不是两个
 
-**示例问题**：
-- *"按地区按季度的成交额。"*
-- *"过去一年按线索来源的赢单率。"*
-- *"按产品系列的平均交易规模。"*
+本页描述的这两个 cube，答案都在同一个地方：**Opportunity Metrics** —— 每个管道小部件和全部四份商机报表绑定的那个 dataset。
 
-## 📊 Pipeline Cube
+**今天够得着的**，按应用里用的名字：
 
-用于"漏斗里有什么？"的问题。提供快照视图 + 时间序列视图。
+- *Bookings* → **Won Revenue**（赢单金额），旁边还有 **Won Deals**。
+- *交易数* → **Opportunities**；*管道金额* → **Total Amount**；*平均交易额* → **Avg Deal Size**。
+- *赢单率* → **Win Rate**，它被声明为一个比值，并把 **Won Deals**、**Lost Deals** 与 **Settled Deals** 一并发布在旁边，好让这个百分比背后的算术可以被核对。
+- *阶段*、*负责人*、*来源*、*赢单/丢单原因* → **Stage**、**Owner**、**Lead Source**、**Win Reason**、**Loss Reason**。
+- *概率分档（commit / best case / pipeline）* → **Forecast Category**。缺的只是本页当时用的那个叫法。
+- *客户行业* → **Account Industry**，经这个 dataset 已包含的 `crm_account` 联接取到。
+- *周期* → **Close Date**（按**月**分桶）与 **Close Quarter**（按**季度**分桶）。
 
-**度量**：
-- 管道价值（$）
-- 管道数量
-- 加权管道（价值 × 概率）
-- 阶段停留天数
-- 管道停留天数
+**够不着的，以及为什么：**
 
-**维度**：
-- 阶段
-- 所有者（及团队）
-- 来源
-- 产品
-- 概率分组（承诺 / 最佳情况 / 管道）
-- 快照日期（用于趋势分析）
+- **Sales cycle days** 与 **Days in pipeline** —— 没有任何地方存着时长。商机上有 **Stage Entry Date** 与 **Close Date**，但没有「已过天数」这样的列；而它唯一带的时长 **Days in Current Stage** 是查询*之后*才求值的公式（`src/objects/opportunity.object.ts`），因此无法被聚合、筛选或排序，也没有任何 dataset 把它暴露出来。
+- **Days in stage** —— 同一个字段，同一个原因。
+- **Weighted pipeline（金额 × 概率）** —— 这个数字在记录上是有的：**Expected Revenue** 就是金额乘以阶段概率，由 `src/objects/opportunity.hook.ts` 在每次保存时重算，商机列表视图也会对这一列求和。但 `opportunity_metrics` 没有为它声明任何度量，所以没有磁贴、也没有报表能给出它。
+- **Average discount %** —— 折扣是行项目上的百分比（`crm_opportunity_line_item.discount`），而没有任何 dataset 读行项目。
+- **Product、category、family** —— 同样的原因。**Product Metrics** 覆盖的是产品目录（**Category**、产品数、目录价合计），它从不联接到交易，所以「按产品系列看平均交易额」根本没有路径 —— 尽管 **Family** 是产品上真实存在的字段。
+- **Account、account tier、account size** —— `crm_account.tier` 与 **Number of Employees** 都是真实字段，但从交易这一侧够得着的客户切法只有 **Account Industry**；**Account Metrics** 再多给 **Type** 与 **Created**，也就到此为止。
+- **Team、region** —— 没有任何 dataset 声明这两者，交易上也没有对应字段可暴露。团队与地区在本应用里是以**岗位**（`src/sharing/positions.ts` 里的 *NA Sales Team*、*EU Sales Team*）和客户上的 **Billing Country**（territory 共享规则匹配的那个扁平投影）形式存在的 —— 两者都是访问控制的机件，没有任何 dataset 读它们。「按地区按季度看签单」问不出来；最接近的、答得出来的切法是按 **Owner**。
+- **按天 / 周 / 年的周期粒度** —— 声明出来的分桶只有月和季度。换一个粒度就意味着再加一个维度。
+- **Snapshot date** —— 没有任何东西给管道打快照。「今天的按阶段管道 vs 30 天前」没有历史可比。最接近的真实存在物是 **Forecast Metrics**：一位负责人一个周期一行，是配额、已成交、管道与 commit 的结算快照，它回答的是另一个问题 ——「按代表看覆盖率（管道 ÷ 配额）」，前提是把周期钉死（按 **Period** 分组，或筛到单个 **Period Type** + **Period Start**）。
 
-**示例问题**：
-- *"今天与 30 天前按阶段的管道对比。"*
-- *"Proposal 阶段的平均停留天数。"*
-- *"按团队的覆盖率（管道 ÷ 配额）。"*
+## 🎧 服务 —— `case_metrics`
 
-## 🎧 Service Cube
+每个工单相关的仪表盘磁贴与全部三份工单报表背后的那个 dataset。五个维度 —— **Status**、**Priority**、**Origin**、**Type**、**Created**（按天分桶）—— 与三个度量：
 
-每个与工单相关的仪表盘和 SLA 报表背后的多维数据集。
-
-**度量**：
-- 未结工单数
-- 新建工单数
-- 已解决工单数
-- 解决时间（小时）
+- **Cases** —— 工单数。
+- **Avg Resolution (h)** —— 平均解决时长。
 - **SLA 违约率** —— **SLA Violated** 标志的平均值（`case_metrics` 里的 `avg_sla_violated`），它是违约率，不是达标率
-- CSAT 评分
 
 **这里没有首次响应度量**，也没有「SLA 达标 %」。`case_metrics`（`src/datasets/case.dataset.ts`）两者都没有声明，所以分析侧根本无法对首次响应做聚合、比较或出图。工单上的 **First Response Date** 时间戳是真的 —— 它何时被写入见 [工单](/zh-Hans/docs/service/cases) —— 但也就到此为止：没有任何东西度量它，也没有任何东西为它告警。
 
-**维度**：
-- 状态、优先级、类别、来源
-- 客服（及团队）
-- 客户（及层级）
-- 产品
-- 周期
+本节曾经列出的其余条目同样够不着：
 
-**示例问题**：
+- **未结 / 新建 / 已解决工单数** —— 这里只有一个计数度量，不是三个。**Status** 是维度，所以按状态*拆开*的计数能给出同样的分解；不存在的是那种可以单独丢到磁贴上的预筛度量。
+- **客服（及团队）** —— `case_metrics` **没有负责人维度**，所以分析侧无法按客服分组、排名或筛选。`owner_id` 是工单上的字段，没有任何维度把它暴露出来。这也是服务侧各页都没有客服排行榜的原因，而「按客服看重开工单」更是两头都不成立 —— 也没有任何东西在记录「重开」。
+- **客户（及层级）** —— 这个 dataset 只读 `crm_case`，从不跨到 `crm_account`。
+- **产品** —— 工单上没有分析侧读得到的产品关联，所以「按类别按产品看工单」没有路径。
+- **类别** —— 最接近的真实维度是 **Type**（*Question / Problem / Feature Request / Bug*）。
+- **周期** —— **Created** 只按**天**分桶。
+- **CSAT 评分** —— **Customer Satisfaction**（`customer_rating`）是工单上真实的 1–5 星字段，但没有任何度量在聚合它。
+
+**这个 dataset 答得出来的示例问题**：
 - *"按优先级的 SLA 违约率。"*
-- *"按类别按产品的工单——哪些产品产生的支持负荷最大？"*
-- *"按客服的重开工单——质量信号。"*
+- *"按来源的工单量——负荷是从哪儿进来的？"*
+- *"按类型的平均解决时长。"*
 
-## 📣 Marketing Cube
+## 📣 市场营销 —— 没有 dataset，也就没有 cube
 
-为营销活动和线索来源 ROI 分析提供支持。
+**没有营销 dataset，也就没有任何东西可切。** `src/datasets/` 读九个对象，`crm_campaign` 不在其中 —— 这让本节成为全页唯一一处：缺的不是某个度量，而是数据源本身。它曾经列出的七个度量与五个维度全都够不着，而且没有一个能从报表或 cube 界面上补出来。
 
-**度量**：
-- 加入的成员数
-- 已响应的成员数
-- 转化数量（成员 → 商机）
-- 来源收入（首次触点为该营销活动的成交赢单）
-- 影响收入（任一触点为该营销活动的成交赢单）
-- 营销活动支出
-- 每线索成本、每商机成本、ROI %
+记录本身是带着这些数字的。`crm_campaign` 上有 **Budgeted Cost**、**Actual Cost**、**Expected Revenue**、**Actual Revenue**，有 **Num Sent / Responses / Leads / Converted Leads / Opportunities / Won Opportunities** 这一组计数器，还有两个公式字段 —— **Response Rate %** 与 **ROI %** —— 它们都摆在营销活动记录的 **Performance** 分区里。`crm_campaign_member` 则逐个成员盖上 **First Opened**、**First Clicked**、**Response Date** 与 **Responded**。以上每一项都是记录级的数字，而没有任何东西在聚合它们。
 
-**维度**：
-- 营销活动（及类型）
-- 渠道（email、网络研讨会、活动等）
-- 周期
-- 线索来源
-- 人物画像（职位角色）
+逐条来看：
 
-**示例问题**：
-- *"按营销活动类型的 ROI。"*
-- *"按渠道的每商机成本。"*
-- *"按人物画像的转化率。"*
+- **入组成员数 / 响应成员数**、**转化数量** —— 都是记录上的单活动计数器；没有度量，也就没有跨活动的合计与排名。
+- **来源收入与影响收入** —— 从交易这一侧同样够不着：`crm_opportunity.crm_campaign` 是真实的 lookup，但 `opportunity_metrics` 没有声明营销活动维度，所以分析侧任何地方都无法把收入归因到某个营销活动。
+- **营销活动支出**、**每线索成本**、**每商机成本**、**ROI %** —— ROI 百分比作为公式在每条记录上是有的；但没有任何东西在汇总支出、也没有任何东西在比较活动之间的高低。
+- **营销活动（及类型）**、**渠道**、**周期** —— 都是 `crm_campaign` 上真实的字段，而在任何地方都不是维度。
+- **线索来源** —— 它是 **Lead Metrics** 与 **Opportunity Metrics** 上的维度，所以「哪些来源带来了交易」答得出来；来源背后的那个*营销活动*则答不出来。
+- **人物画像（职位角色）** —— 完全没有路径：**Title** 在联系人和线索上都是自由文本，而 **Contact Metrics** 一个维度都没有声明。
 
-## 用户如何与多维数据集交互
+所以本节给出的那三个问题 —— 「按营销活动类型的 ROI」「按渠道的每商机成本」「按人物画像的转化率」 —— 今天在这里一个都答不出来。要补上这个缺口，得新增 `src/datasets/campaign.dataset.ts`：那是改源码加重新部署，不是一个设置项。营销活动记录今天能看到什么，见 [营销活动](/zh-Hans/docs/marketing/campaigns)。
 
-多维数据集 UI 让任何人都可以：
+## 用户如何与 dataset 打交道
 
-1. **选择**一个多维数据集。
-2. **拖动**维度到行和列。
-3. **选择**要显示的度量。
-4. **筛选**以缩小视图范围。
-5. 即时**透视**，以不同方式查看数据。
-6. 将结果以柱状图、折线图、面积图、热力图或表格形式**绘图**。
-7. 将视图**保存**为报表。
-8. 将视图**固定**到仪表盘。
+应用能保证的是这层绑定：报表或仪表盘磁贴按名字点出一个 dataset，并按名字选它的度量与维度，而 `test/analytics-integrity.test.ts` 会在其中任何一个名字解析不到时让构建失败。正是这一点让两个磁贴显示同一个数字。
 
-无需 SQL，无需公式——只需拖放。
+本节曾经描述的那套拖放透视体验 —— 选一个 cube、把维度拖到行和列、筛选、透视、出图、把视图存成报表、钉到仪表盘 —— 是**平台**侧的界面，而不是 HotCRM 声明出来的东西。本应用的元数据里没有任何东西配置这样一块屏，本仓也没有任何测试覆盖它，所以本页对它不做任何方向上的断言。如果你的工作流依赖自助透视，请对着你自己的部署去验证，而不是对着本页。
 
 ## 多维数据集如何保持新鲜
 
-- **增量刷新** — 热数据（当天活动）每隔几分钟刷新一次。
-- **全量刷新** — 每晚一次。
-- **快照** — 用于时间序列分析（例如为趋势图表提供支持的每日管道快照）。
+刷新是分析服务的事，不是本应用的事。HotCRM 在 `src/` 里没有声明任何刷新计划、没有增量与全量刷新策略、也没有快照作业 —— 它声明的定时工作只有自己的流程（`src/flows/`）。本节曾经引用的那些数字 —— 每几分钟增量刷新、每晚全量刷新、每日快照、管理控制台里可见的刷新状态 —— 在这里既没有被配置，也没有被实测；请把它们当作面向你自己部署的问题。
 
-刷新状态可在管理控制台中查看。
+其中有一半确实握在应用手里，而且正是今天不成立的那一半：趋势图需要一个快照维度作为比较对象，而没有任何 dataset 声明快照维度。时间序列问题只能沿着 dataset 已经带着的日期维度来问 —— **Close Date**（按月）、**Close Quarter**、**Created**（按天）、**Activity Week**、**Last Contacted**（按月）。
 
 ## AI Copilot 与多维数据集
 
-AI Copilot 直接从多维数据集读取数据——当你问 *"我们按地区的赢单率是多少？"* 时，是 Sales Cube 在响应。这意味着：
+**在本应用这一侧，没有任何东西把 Copilot 连到某个 dataset 上。** `src/skills/` 下的六个技能，没有一个点名任何 dataset、cube 或度量。其中负责回答数据问题的那个 —— **Live Data Access** —— 接的是平台的对象工具：`describe_object`、`list_objects`、`query_records`、`get_record`、`aggregate_data`，而它的指令要求 agent 先重新读一遍对象的 schema，再在记录上做聚合。所以关于赢单率的 Copilot 回答是从对象上算出来的，而不是从编译好的 cube 上读出来的；本应用也没有声明任何能让两者天然一致的东西。
 
-- **AI 答案与仪表盘和报表一致**（同一可信来源）。
-- **AI 能够解释**答案，引用多维数据集的度量和维度。
-- **管理员可以审计** AI 查询，通过多维数据集访问日志。
+平台自带的 agent 是否另外也读编译后的 cube、cube 访问是否为管理员留下审计，都是关于运行时而不是关于本应用的问题 —— 所以本页对它们不做任何方向上的断言。如果你要求 Copilot 的回答与仪表盘小数点后都对得上，请对着你自己的部署去核。
 
 ## 自定义多维数据集
 
-管理员和开发人员可以为特定领域的分析构建新的多维数据集：
+在 HotCRM 里，一个新 cube 的起点是**源码里的一个新 dataset**：在 `src/datasets/<object>.dataset.ts` 写一个 `defineDataset(...)`，从 `src/datasets/index.ts` 导出，由 `objectstack.config.ts` 注册，然后部署。上面那九个走的都是这条路，这也正是营销侧的缺口是一次代码改动、而不是一次配置改动的原因。
 
-- 用于 SaaS 收入的 **Subscriptions Cube**（ARR、NRR、流失率）。
-- 用于续约管道可见性的 **Renewal Cube**。
-- 如果你通过渠道销售，可使用 **Partner Cube**。
-
-有关如何定义新的多维数据集、维度和度量，请参阅 [自定义 › 扩展对象](/zh-Hans/docs/customization/extending-objects)。
+本节曾经给出的三个例子 —— *Subscriptions Cube*、*Renewal Cube*、*Partner Cube* —— 以任何形式都不存在；本应用里既没有订阅对象，也没有合作伙伴对象可以拿来建。至于控制台是否另外提供面向管理员的 cube 构建器，同样是本页不作答的平台问题。
 
 ## 给分析师的提示
 
-- ✅ 每个新分析都从多维数据集开始——不要在原始查询上构建仪表盘。
-- ✅ 对趋势类问题使用**快照维度**（"这个指标如何变化？"）。
-- ✅ 保存团队可订阅的**共享视图**。
+- ✅ 从 dataset 与它声明的度量出发 —— 磁贴显示的数字就是它点名的那个度量，所以把度量名一起报出来，回答才可核对。
+- ✅ 用 **Forecast Metrics** 时务必把周期钉死：它的度量都是普通求和，而表里同时存着好几个周期，不加限定的查询会把一个季度的配额加到一个月的配额上。
+- ✅ 把 **Win Rate** 与 **Won Deals**、**Lost Deals** 放在一起读 —— 空白的赢单率意味着「没有已结的交易」，不是「没有赢单」。
 
 ## 给管理员的提示
 
-- ✅ 当某个度量在各报表间计算不一致时，**将其提升为多维数据集度量**——单一可信来源。
-- ✅ 监控多维数据集刷新时间——如果变慢，请删减未使用的维度。
-- ✅ 为终端用户记录每个多维数据集的度量和维度——可发现性是头号采用障碍。
+- ✅ 当同一个度量在不同报表里算法不一致时，**把它提升进 dataset** —— 声明一次，各处按名字取用。
+- ✅ 补一个维度，是用来关掉上面那些「够不着」的缺口的；补一个 dataset，则是用来关掉「连数据源都没有」的缺口。两者都是源码改动，因此和其他元数据一样要走评审。
+- ✅ 把每个 dataset 能答什么、不能答什么写下来 —— 本页里的这些缺口，恰恰就是用户一直在问的那些问题。

--- a/content/docs/analytics/cubes.zh-Hant.mdx
+++ b/content/docs/analytics/cubes.zh-Hant.mdx
@@ -1,178 +1,140 @@
 ---
 title: 多維資料集
-description: 為 HotCRM 分析提供支援的資料層——四個內建多維資料集，用於自助式切片分析。
+description: HotCRM 分析底下的語義層——九個 dataset，各自能回答什麼、不能回答什麼。
 ---
 
 # 多維資料集
 
-**多維資料集**（cube）是為快速分析而設計的預建模多維資料集。多維資料集是 [儀表板](/zh-Hant/docs/analytics/dashboards) 和 [報表](/zh-Hant/docs/analytics/reports) 底層的資料層——它們讓分析變得快速、一致且自助。
+**多維資料集**（cube）是預先建好模的多維資料集：一組具名的**度量**（數字）架在一組具名的**維度**（切法）之上。它是 [儀表板](/zh-Hant/docs/analytics/dashboards) 與 [報表](/zh-Hant/docs/analytics/reports) 底下的那一層——正是它讓同一個數字在兩個地方含義相同。
 
-## 為什麼用多維資料集（而非查詢原始資料表）
+**在 HotCRM 裡，這一層是一組 dataset。** 本應用自己不宣告任何 cube：它發布的每一個語義定義都是 `src/datasets/` 下的一個 `defineDataset(...)`，經 `objectstack.config.ts` 註冊，再由分析服務在內部把每個 dataset 編譯成它的 cube（ADR-0021）。這裡曾經確實有過第二層手寫 cube，後來被移除了——它把每個度量都複製了一份，並與報表和磁貼真正繫結的那些 dataset 各走各的。所以本頁凡是說 *dataset*，指的就是報表或儀表板磁貼**按名字**繫結的那個東西，也是平台拿去編譯成 cube 的那個東西。
 
-多維資料集解決三個問題：
+## 為什麼要有語義層（而非查詢原始資料表）
 
-1. **一致性** — *"bookings"* 在每個儀表板中含義相同。
-2. **速度** — 預彙總，在數百萬筆記錄上實現亞秒級回應。
-3. **自助** — 業務使用者無需撰寫查詢即可切片分析。
+1. **一致性** — *"pipeline"* 在每個儀表板裡含義相同，因為每個小工具選的是同一個具名度量。
+2. **速度** — 預彙總，而不是每問一個問題就臨時全表掃一遍。
+3. **重用** — 度量只宣告一次，之後按名字取用。`win_rate` 把自己的分子分母一起帶著，任何小工具都不必臨時湊一個分母。
 
-## 四個內建多維資料集
+## 九個 dataset
 
-| 多維資料集 | 用途 | 切片維度 |
-| --- | --- | --- |
-| 💰 **Sales Cube** | 收入分析 | 客戶、擁有者、地區、產品、週期 |
-| 📊 **Pipeline Cube** | 管道分析 | 階段、擁有者、停留時長、來源、機率 |
-| 🎧 **Service Cube** | 工單與 SLA 分析 | 優先順序、狀態、客服、來源、客戶 |
-| 📣 **Marketing Cube** | 行銷活動績效 | 行銷活動、來源、通路、週期 |
+`src/datasets/index.ts` 就是整個語義層：
 
-## 💰 Sales Cube
+| Dataset | 讀取 | 維度 | 度量 |
+| --- | --- | --- | --- |
+| **Opportunity Metrics**（`opportunity_metrics`） | `crm_opportunity`，並聯結 `crm_account` | Stage、Lead Source、Forecast Category、Deal Type、Owner、Win Reason、Loss Reason、Close Date（按月）、Close Quarter、Account Industry | Opportunities、Total Amount、Avg Deal Size、Avg Probability、Won Deals、Lost Deals、Settled Deals、Won Revenue、Lost Revenue、Win Rate |
+| **Case Metrics**（`case_metrics`） | `crm_case` | Status、Priority、Origin、Type、Created（按天） | Cases、Avg Resolution (h)、SLA Violation Rate |
+| **Lead Metrics**（`lead_metrics`） | `crm_lead` | Status、Source、Created、Last Contacted（按月） | Leads |
+| **Account Metrics**（`account_metrics`） | `crm_account` | Industry、Type、Created（按月） | Accounts、Annual Revenue |
+| **Forecast Metrics**（`forecast_metrics`） | `crm_forecast` | Owner、Period Type、Period、Period Start | Quota、Closed、Pipeline、Commit、Attainment |
+| **Activity Metrics**（`event_metrics`） | `crm_event` | Activity Type、Status、Owner、Related To、Activity Week | Activities、Minutes、Avg Duration |
+| **Task Metrics**（`task_metrics`） | `crm_task` | Status、Priority、Urgency、Type、Due Date、Overdue、Completed | Tasks、Avg Progress |
+| **Product Metrics**（`product_metrics`） | `crm_product` | Category | Products、Total List Price |
+| **Contact Metrics**（`contact_metrics`） | `crm_contact` | *無* | Contacts |
 
-為所有"我們簽了多少單？"的問題提供支援的多維資料集。
+先從這張表上讀出兩件事。**Contact Metrics 一個維度都沒有宣告** —— 它只數聯絡人，別的什麼都不做。以及**沒有任何 dataset 讀 `crm_campaign`、`crm_contract`、`crm_quote` 或兩個行項目物件**，下面大多數缺口都由此而來。
 
-**度量**：
-- Bookings（成交贏單金額）
-- 交易數量
-- 平均交易規模
-- 贏單率
-- 銷售週期（天數）
-- 平均折扣 %
+本頁曾經描述過四個 cube —— *Sales*、*Pipeline*、*Service*、*Marketing*。這四個名字在應用裡一個都不存在。其中三個能對應到確實存在的 dataset，只是名字不同、內容也不同；第四個則連資料來源都沒有。下面每一節分別說清楚。
 
-**維度**：
-- 客戶（及客戶層級、產業、規模）
-- 擁有者（及團隊、地區）
-- 產品（及類別、系列）
-- 週期（日、週、月、季、年）
-- 贏單/丟單原因
-- 潛在客戶來源
+## 💰 銷售與 📊 管道 —— 是一個 dataset，不是兩個
 
-**範例問題**：
-- *"按地區按季的成交額。"*
-- *"過去一年按潛在客戶來源的贏單率。"*
-- *"按產品系列的平均交易規模。"*
+本頁描述的這兩個 cube，答案都在同一個地方：**Opportunity Metrics** —— 每個管道小工具和全部四份商機報表繫結的那個 dataset。
 
-## 📊 Pipeline Cube
+**今天夠得著的**，按應用裡用的名字：
 
-用於"漏斗裡有什麼？"的問題。提供快照檢視 + 時間序列檢視。
+- *Bookings* → **Won Revenue**（贏單金額），旁邊還有 **Won Deals**。
+- *交易數* → **Opportunities**；*管道金額* → **Total Amount**；*平均交易額* → **Avg Deal Size**。
+- *贏單率* → **Win Rate**，它被宣告為一個比值，並把 **Won Deals**、**Lost Deals** 與 **Settled Deals** 一併發布在旁邊，好讓這個百分比背後的算術可以被核對。
+- *階段*、*負責人*、*來源*、*贏單/丟單原因* → **Stage**、**Owner**、**Lead Source**、**Win Reason**、**Loss Reason**。
+- *機率分檔（commit / best case / pipeline）* → **Forecast Category**。缺的只是本頁當時用的那個叫法。
+- *客戶產業* → **Account Industry**，經這個 dataset 已包含的 `crm_account` 聯結取到。
+- *週期* → **Close Date**（按**月**分桶）與 **Close Quarter**（按**季度**分桶）。
 
-**度量**：
-- 管道價值（$）
-- 管道數量
-- 加權管道（價值 × 機率）
-- 階段停留天數
-- 管道停留天數
+**夠不著的，以及為什麼：**
 
-**維度**：
-- 階段
-- 擁有者（及團隊）
-- 來源
-- 產品
-- 機率分組（承諾 / 最佳情況 / 管道）
-- 快照日期（用於趨勢分析）
+- **Sales cycle days** 與 **Days in pipeline** —— 沒有任何地方存著時長。商機上有 **Stage Entry Date** 與 **Close Date**，但沒有「已過天數」這樣的欄；而它唯一帶的時長 **Days in Current Stage** 是查詢*之後*才求值的公式（`src/objects/opportunity.object.ts`），因此無法被彙總、篩選或排序，也沒有任何 dataset 把它暴露出來。
+- **Days in stage** —— 同一個欄位，同一個原因。
+- **Weighted pipeline（金額 × 機率）** —— 這個數字在記錄上是有的：**Expected Revenue** 就是金額乘以階段機率，由 `src/objects/opportunity.hook.ts` 在每次儲存時重算，商機清單檢視也會對這一欄求和。但 `opportunity_metrics` 沒有為它宣告任何度量，所以沒有磁貼、也沒有報表能給出它。
+- **Average discount %** —— 折扣是行項目上的百分比（`crm_opportunity_line_item.discount`），而沒有任何 dataset 讀行項目。
+- **Product、category、family** —— 同樣的原因。**Product Metrics** 涵蓋的是產品目錄（**Category**、產品數、目錄價合計），它從不聯結到交易，所以「按產品系列看平均交易額」根本沒有路徑 —— 儘管 **Family** 是產品上真實存在的欄位。
+- **Account、account tier、account size** —— `crm_account.tier` 與 **Number of Employees** 都是真實欄位，但從交易這一側夠得著的客戶切法只有 **Account Industry**；**Account Metrics** 再多給 **Type** 與 **Created**，也就到此為止。
+- **Team、region** —— 沒有任何 dataset 宣告這兩者，交易上也沒有對應欄位可暴露。團隊與地區在本應用裡是以**職位**（`src/sharing/positions.ts` 裡的 *NA Sales Team*、*EU Sales Team*）和客戶上的 **Billing Country**（territory 共享規則比對的那個扁平投影）形式存在的 —— 兩者都是存取控制的機件，沒有任何 dataset 讀它們。「按地區按季度看簽單」問不出來；最接近的、答得出來的切法是按 **Owner**。
+- **按天 / 週 / 年的週期粒度** —— 宣告出來的分桶只有月和季度。換一個粒度就意味著再加一個維度。
+- **Snapshot date** —— 沒有任何東西給管道打快照。「今天的按階段管道 vs 30 天前」沒有歷史可比。最接近的真實存在物是 **Forecast Metrics**：一位負責人一個週期一列，是配額、已成交、管道與 commit 的結算快照，它回答的是另一個問題 ——「按代表看覆蓋率（管道 ÷ 配額）」，前提是把週期釘死（按 **Period** 分組，或篩到單個 **Period Type** + **Period Start**）。
 
-**範例問題**：
-- *"今天與 30 天前按階段的管道對比。"*
-- *"Proposal 階段的平均停留天數。"*
-- *"按團隊的覆蓋率（管道 ÷ 配額）。"*
+## 🎧 服務 —— `case_metrics`
 
-## 🎧 Service Cube
+每個工單相關的儀表板磁貼與全部三份工單報表背後的那個 dataset。五個維度 —— **Status**、**Priority**、**Origin**、**Type**、**Created**（按天分桶）—— 與三個度量：
 
-每個與工單相關的儀表板和 SLA 報表背後的多維資料集。
-
-**度量**：
-- 未結工單數
-- 新建工單數
-- 已解決工單數
-- 解決時間（小時）
+- **Cases** —— 工單數。
+- **Avg Resolution (h)** —— 平均解決時長。
 - **SLA 違約率** —— **SLA Violated** 標誌的平均值（`case_metrics` 裡的 `avg_sla_violated`），它是違約率，不是達標率
-- CSAT 評分
 
 **這裡沒有首次回應度量**，也沒有「SLA 達標 %」。`case_metrics`（`src/datasets/case.dataset.ts`）兩者都沒有宣告，所以分析側根本無法對首次回應做彙總、比較或出圖。工單上的 **First Response Date** 時間戳是真的 —— 它何時被寫入見 [工單](/zh-Hant/docs/service/cases) —— 但也就到此為止：沒有任何東西度量它，也沒有任何東西為它告警。
 
-**維度**：
-- 狀態、優先順序、類別、來源
-- 客服（及團隊）
-- 客戶（及層級）
-- 產品
-- 週期
+本節曾經列出的其餘條目同樣夠不著：
 
-**範例問題**：
+- **未結 / 新建 / 已解決工單數** —— 這裡只有一個計數度量，不是三個。**Status** 是維度，所以按狀態*拆開*的計數能給出同樣的分解；不存在的是那種可以單獨丟到磁貼上的預篩度量。
+- **客服（及團隊）** —— `case_metrics` **沒有負責人維度**，所以分析側無法按客服分組、排名或篩選。`owner_id` 是工單上的欄位，沒有任何維度把它暴露出來。這也是服務側各頁都沒有客服排行榜的原因，而「按客服看重開工單」更是兩頭都不成立 —— 也沒有任何東西在記錄「重開」。
+- **客戶（及層級）** —— 這個 dataset 只讀 `crm_case`，從不跨到 `crm_account`。
+- **產品** —— 工單上沒有分析側讀得到的產品關聯，所以「按類別按產品看工單」沒有路徑。
+- **類別** —— 最接近的真實維度是 **Type**（*Question / Problem / Feature Request / Bug*）。
+- **週期** —— **Created** 只按**天**分桶。
+- **CSAT 評分** —— **Customer Satisfaction**（`customer_rating`）是工單上真實的 1–5 星欄位，但沒有任何度量在彙總它。
+
+**這個 dataset 答得出來的範例問題**：
 - *"按優先順序的 SLA 違約率。"*
-- *"按類別按產品的工單——哪些產品產生的支援負荷最大？"*
-- *"按客服的重開工單——品質訊號。"*
+- *"按來源的工單量——負荷是從哪兒進來的？"*
+- *"按類型的平均解決時長。"*
 
-## 📣 Marketing Cube
+## 📣 行銷 —— 沒有 dataset，也就沒有 cube
 
-為行銷活動和潛在客戶來源 ROI 分析提供支援。
+**沒有行銷 dataset，也就沒有任何東西可切。** `src/datasets/` 讀九個物件，`crm_campaign` 不在其中 —— 這讓本節成為全頁唯一一處：缺的不是某個度量，而是資料來源本身。它曾經列出的七個度量與五個維度全都夠不著，而且沒有一個能從報表或 cube 介面上補出來。
 
-**度量**：
-- 加入的成員數
-- 已回應的成員數
-- 轉化數量（成員 → 商機）
-- 來源收入（首次接觸點為該行銷活動的成交贏單）
-- 影響收入（任一接觸點為該行銷活動的成交贏單）
-- 行銷活動支出
-- 每潛在客戶成本、每商機成本、ROI %
+記錄本身是帶著這些數字的。`crm_campaign` 上有 **Budgeted Cost**、**Actual Cost**、**Expected Revenue**、**Actual Revenue**，有 **Num Sent / Responses / Leads / Converted Leads / Opportunities / Won Opportunities** 這一組計數器，還有兩個公式欄位 —— **Response Rate %** 與 **ROI %** —— 它們都擺在行銷活動記錄的 **Performance** 分區裡。`crm_campaign_member` 則逐個成員蓋上 **First Opened**、**First Clicked**、**Response Date** 與 **Responded**。以上每一項都是記錄級的數字，而沒有任何東西在彙總它們。
 
-**維度**：
-- 行銷活動（及類型）
-- 通路（email、網路研討會、活動等）
-- 週期
-- 潛在客戶來源
-- 人物誌（職位角色）
+逐條來看：
 
-**範例問題**：
-- *"按行銷活動類型的 ROI。"*
-- *"按通路的每商機成本。"*
-- *"按人物誌的轉化率。"*
+- **加入的成員數 / 已回應的成員數**、**轉化數量** —— 都是記錄上的單活動計數器；沒有度量，也就沒有跨活動的合計與排名。
+- **來源收入與影響收入** —— 從交易這一側同樣夠不著：`crm_opportunity.crm_campaign` 是真實的 lookup，但 `opportunity_metrics` 沒有宣告行銷活動維度，所以分析側任何地方都無法把收入歸因到某個行銷活動。
+- **行銷活動支出**、**每潛在客戶成本**、**每商機成本**、**ROI %** —— ROI 百分比作為公式在每筆記錄上是有的；但沒有任何東西在彙總支出、也沒有任何東西在比較活動之間的高低。
+- **行銷活動（及類型）**、**通路**、**週期** —— 都是 `crm_campaign` 上真實的欄位，而在任何地方都不是維度。
+- **潛在客戶來源** —— 它是 **Lead Metrics** 與 **Opportunity Metrics** 上的維度，所以「哪些來源帶來了交易」答得出來；來源背後的那個*行銷活動*則答不出來。
+- **人物誌（職位角色）** —— 完全沒有路徑：**Title** 在聯絡人和潛在客戶上都是自由文字，而 **Contact Metrics** 一個維度都沒有宣告。
 
-## 使用者如何與多維資料集互動
+所以本節給出的那三個問題 —— 「按行銷活動類型的 ROI」「按通路的每商機成本」「按人物誌的轉化率」 —— 今天在這裡一個都答不出來。要補上這個缺口，得新增 `src/datasets/campaign.dataset.ts`：那是改原始碼加重新部署，不是一個設定項。行銷活動記錄今天能看到什麼，見 [行銷活動](/zh-Hant/docs/marketing/campaigns)。
 
-多維資料集 UI 讓任何人都可以：
+## 使用者如何與 dataset 打交道
 
-1. **選擇**一個多維資料集。
-2. **拖動**維度到列和欄。
-3. **選擇**要顯示的度量。
-4. **篩選**以縮小檢視範圍。
-5. 即時**樞紐分析**，以不同方式檢視資料。
-6. 將結果以長條圖、折線圖、面積圖、熱力圖或表格形式**繪圖**。
-7. 將檢視**儲存**為報表。
-8. 將檢視**釘選**到儀表板。
+應用能保證的是這層繫結：報表或儀表板磁貼按名字點出一個 dataset，並按名字選它的度量與維度，而 `test/analytics-integrity.test.ts` 會在其中任何一個名字解析不到時讓建構失敗。正是這一點讓兩個磁貼顯示同一個數字。
 
-無需 SQL，無需公式——只需拖放。
+本節曾經描述的那套拖放樞紐體驗 —— 選一個 cube、把維度拖到列和欄、篩選、樞紐、出圖、把檢視存成報表、釘到儀表板 —— 是**平台**側的介面，而不是 HotCRM 宣告出來的東西。本應用的中繼資料裡沒有任何東西組態這樣一塊螢幕，本倉也沒有任何測試涵蓋它，所以本頁對它不做任何方向上的斷言。如果你的工作流依賴自助樞紐分析，請對著你自己的部署去驗證，而不是對著本頁。
 
 ## 多維資料集如何保持新鮮
 
-- **增量重新整理** — 熱資料（當天活動）每隔幾分鐘重新整理一次。
-- **全量重新整理** — 每晚一次。
-- **快照** — 用於時間序列分析（例如為趨勢圖表提供支援的每日管道快照）。
+重新整理是分析服務的事，不是本應用的事。HotCRM 在 `src/` 裡沒有宣告任何重新整理計畫、沒有增量與全量重新整理策略、也沒有快照作業 —— 它宣告的定時工作只有自己的流程（`src/flows/`）。本節曾經引用的那些數字 —— 每幾分鐘增量重新整理、每晚全量重新整理、每日快照、管理主控台裡可見的重新整理狀態 —— 在這裡既沒有被組態，也沒有被實測；請把它們當作面向你自己部署的問題。
 
-重新整理狀態可在管理主控台中檢視。
+其中有一半確實握在應用手裡，而且正是今天不成立的那一半：趨勢圖需要一個快照維度作為比較對象，而沒有任何 dataset 宣告快照維度。時間序列問題只能沿著 dataset 已經帶著的日期維度來問 —— **Close Date**（按月）、**Close Quarter**、**Created**（按天）、**Activity Week**、**Last Contacted**（按月）。
 
 ## AI Copilot 與多維資料集
 
-AI Copilot 直接從多維資料集讀取資料——當你問 *"我們按地區的贏單率是多少？"* 時，是 Sales Cube 在回應。這意味著：
+**在本應用這一側，沒有任何東西把 Copilot 連到某個 dataset 上。** `src/skills/` 下的六個技能，沒有一個點名任何 dataset、cube 或度量。其中負責回答資料問題的那個 —— **Live Data Access** —— 接的是平台的物件工具：`describe_object`、`list_objects`、`query_records`、`get_record`、`aggregate_data`，而它的指令要求 agent 先重新讀一遍物件的 schema，再在記錄上做彙總。所以關於贏單率的 Copilot 回答是從物件上算出來的，而不是從編譯好的 cube 上讀出來的；本應用也沒有宣告任何能讓兩者天然一致的東西。
 
-- **AI 答案與儀表板和報表一致**（同一可信來源）。
-- **AI 能夠解釋**答案，引用多維資料集的度量和維度。
-- **管理員可以稽核** AI 查詢，透過多維資料集存取記錄檔。
+平台自帶的 agent 是否另外也讀編譯後的 cube、cube 存取是否為管理員留下稽核，都是關於執行時而不是關於本應用的問題 —— 所以本頁對它們不做任何方向上的斷言。如果你要求 Copilot 的回答與儀表板小數點後都對得上，請對著你自己的部署去核。
 
 ## 自訂多維資料集
 
-管理員和開發人員可以為特定領域的分析建構新的多維資料集：
+在 HotCRM 裡，一個新 cube 的起點是**原始碼裡的一個新 dataset**：在 `src/datasets/<object>.dataset.ts` 寫一個 `defineDataset(...)`，從 `src/datasets/index.ts` 匯出，由 `objectstack.config.ts` 註冊，然後部署。上面那九個走的都是這條路，這也正是行銷側的缺口是一次程式碼改動、而不是一次組態改動的原因。
 
-- 用於 SaaS 收入的 **Subscriptions Cube**（ARR、NRR、流失率）。
-- 用於續約管道可見性的 **Renewal Cube**。
-- 如果你透過通路銷售，可使用 **Partner Cube**。
-
-有關如何定義新的多維資料集、維度和度量，請參閱 [自訂 › 擴充物件](/zh-Hant/docs/customization/extending-objects)。
+本節曾經給出的三個例子 —— *Subscriptions Cube*、*Renewal Cube*、*Partner Cube* —— 以任何形式都不存在；本應用裡既沒有訂閱物件，也沒有合作夥伴物件可以拿來建。至於主控台是否另外提供面向管理員的 cube 建構器，同樣是本頁不作答的平台問題。
 
 ## 給分析師的提示
 
-- ✅ 每個新分析都從多維資料集開始——不要在原始查詢上建構儀表板。
-- ✅ 對趨勢類問題使用**快照維度**（"這個指標如何變化？"）。
-- ✅ 儲存團隊可訂閱的**共享檢視**。
+- ✅ 從 dataset 與它宣告的度量出發 —— 磁貼顯示的數字就是它點名的那個度量，所以把度量名一起報出來，回答才可核對。
+- ✅ 用 **Forecast Metrics** 時務必把週期釘死：它的度量都是普通求和，而表裡同時存著好幾個週期，不加限定的查詢會把一個季度的配額加到一個月的配額上。
+- ✅ 把 **Win Rate** 與 **Won Deals**、**Lost Deals** 放在一起讀 —— 空白的贏單率意味著「沒有已結的交易」，不是「沒有贏單」。
 
 ## 給管理員的提示
 
-- ✅ 當某個度量在各報表間計算不一致時，**將其提升為多維資料集度量**——單一可信來源。
-- ✅ 監控多維資料集重新整理時間——如果變慢，請刪減未使用的維度。
-- ✅ 為終端使用者記錄每個多維資料集的度量和維度——可發現性是頭號採用障礙。
+- ✅ 當同一個度量在不同報表裡演算法不一致時，**把它提升進 dataset** —— 宣告一次，各處按名字取用。
+- ✅ 補一個維度，是用來關掉上面那些「夠不著」的缺口的；補一個 dataset，則是用來關掉「連資料來源都沒有」的缺口。兩者都是原始碼改動，因此和其他中繼資料一樣要走評審。
+- ✅ 把每個 dataset 能答什麼、不能答什麼寫下來 —— 本頁裡的這些缺口，恰恰就是使用者一直在問的那些問題。

--- a/content/docs/analytics/reports.mdx
+++ b/content/docs/analytics/reports.mdx
@@ -1,6 +1,6 @@
 ---
 title: Reports
-description: The standard report library — pipeline, win/loss, forecast, case volume, SLA performance and more.
+description: The standard report library — the ten reports HotCRM publishes across deals, leads, cases and accounts, and what the missing ones would need.
 ---
 
 # Reports
@@ -9,20 +9,34 @@ Reports are filterable, exportable lists with grouping and summary totals. Where
 
 ## Standard reports
 
-HotCRM ships with these reports out of the box:
+HotCRM ships **ten** reports out of the box — the barrel in `src/reports/index.ts` is the whole library. Each section below lists the ones it publishes, then names what this page used to promise and says whether the semantic layer could answer it:
 
 ### 📈 Sales reports
 
+`src/reports/opportunity.report.ts` publishes **four** opportunity reports:
+
 | Report | What it shows |
 | --- | --- |
-| **Pipeline by Stage** | All open deals grouped by stage with $ totals |
-| **Forecast vs Actual** | Closed Won vs forecast, by period |
-| **Win/Loss Analysis** | Closed deals grouped by win/loss with reason breakdown |
-| **Sales Cycle Length** | Days from creation to close, by owner and product |
-| **Top Performing Reps** | Bookings leaderboard |
-| **Stale Opportunities** | Deals with no activity in 14+ days |
-| **Big Deals Won** | Closed-won opportunities ≥ $100K |
-| **Discount Approval Activity** | All approval requests by status and approver |
+| **Opportunities by Stage** | Pipeline amount and average probability by stage, over deals closing this year and excluding closed-lost — with a bar chart of amount by stage |
+| **Won Opportunities by Owner** | Closed-won amount per rep, charted as *Revenue by Sales Rep* |
+| **Pipeline Coverage by Forecast × Quarter** | A matrix of open pipeline: forecast category down the rows, close quarter across the columns, with amount and deal count in each cell |
+| **Opportunity Funnel by Owner → Stage** | A two-level funnel — each rep's book of business broken down stage by stage, with amount, deal count and average probability |
+
+All four bind `opportunity_metrics` (`src/datasets/opportunity.dataset.ts`), which is what makes *pipeline* mean the same number here as on the dashboards.
+
+The eight names this section used to list are published nowhere. Two of them are real names that belong to something other than a report:
+
+- **Pipeline by Stage** is a dashboard **tile** and a chart title, not a report. The tile is the open-pipeline funnel that **CRM Overview**, **Sales Performance** and **Executive Overview** all share (`src/dashboards/shared-widgets.ts`); the chart is the bar chart on **Opportunities by Stage** above, whose title reads *Pipeline by Stage*. Searching the report library for the name finds nothing; the report you want is **Opportunities by Stage**.
+- **Stale Opportunities** is a **list view** on the opportunity — *⚠️ Stale Opportunities · Longest in Stage First*, the **Stale** tab (`src/views/opportunity.view.ts`) — and it does not apply the 14-day cut this table claimed. It lists **every** open deal, ordered by **Stage Entry Date** ascending, so the longest-parked sit on top; the 14 days belongs to the `opportunity_stagnation` flow that nudges owners, not to the view. Analytics cannot rebuild it either: **Days in Current Stage** is a formula evaluated after the query, so nothing can group, filter or sort on it, and no dataset exposes it.
+- **Top Performing Reps** exists, under its real name: **Won Opportunities by Owner** is the bookings leaderboard, and **Opportunity Funnel by Owner → Stage** is the same ranking with each rep's stages underneath it. `opportunity_metrics` declares an **Owner** dimension — unlike `case_metrics`, which is why the service side has no agent ranking.
+
+Of the five that are simply absent, three are a custom report away and two are not:
+
+- **Forecast vs Actual** — buildable, but not from the pipeline dataset: quota lives in `forecast_metrics` (`src/datasets/forecast.dataset.ts`), one row per owner per period, with **Quota**, **Closed**, **Pipeline**, **Commit** and a derived **Attainment**. Any report over it has to pin the period — group by **Period**, or filter to a single **Period Type** + **Period Start** — because the measures are plain sums and the table holds several periods at once.
+- **Win/Loss Analysis** — buildable: **Win Reason** and **Loss Reason** are dimensions, and **Won Deals**, **Lost Deals**, **Settled Deals**, **Won Revenue**, **Lost Revenue** and **Win Rate** are declared measures on `opportunity_metrics`.
+- **Big Deals Won** — buildable: closed-won amount is **Won Revenue**, and a threshold on the deal amount is an ordinary report filter.
+- **Sales Cycle Length** — not buildable. Nothing stores a cycle duration: the opportunity carries **Stage Entry Date** and **Close Date** but no elapsed-days column, and the one duration it does carry, **Days in Current Stage**, is the post-query formula above. *By product* has no landing place either — no dataset reads `crm_opportunity_line_item`.
+- **Discount Approval Activity** — not buildable. The approvals themselves are real (`src/flows/opportunity-approval.flow.ts`, and **Approval Status** on the opportunity), but no dimension exposes that field, and the discount is a percent on the line item (`crm_opportunity_line_item.discount`) that no dataset reads.
 
 ### 🎯 Lead reports
 
@@ -59,20 +73,31 @@ The five other reports this section used to list are published nowhere, and most
 
 **SLA Performance Report carries no first-response figure either**, and its SLA number is a violation *rate* — the average of the **SLA Violated** flag — rather than an on-time percentage. Nothing in this app measures first response at all: **First Response Date** is stamped on a case the first time a call or meeting that already took place is logged on it, and it is then never compared against a target; `case_metrics` declares no first-response measure, so no report and no dashboard tile can report one. See [SLA & Escalation](/docs/service/sla-and-escalation).
 
-### 💰 Revenue reports
+### 💰 Customer and revenue reports
+
+`src/reports/account.report.ts` and `src/reports/churn.report.ts` publish **two** reports, and this is the section they belong in — neither has ever appeared on this page:
 
 | Report | What it shows |
 | --- | --- |
-| **Contracts Expiring** | Active contracts ending in next 30/60/90 days |
-| **Active Contracts by Product** | Recurring revenue rollup |
-| **Renewal Pipeline** | Opportunities tied to renewing contracts |
+| **Accounts by Industry and Type** | A matrix of active accounts — industry down the rows, account type across the columns — with the account count and the **Annual Revenue** sum in each cell |
+| **Customer Churn Signals** | Three stacked panels for proactive retention: **At-Risk Accounts** (active, no activity in 60+ days, by industry), **Silent High-Value Accounts** (strategic and enterprise tiers quiet for 90+ days, by type) and **Recently Lost Opportunities** (closed-lost in the last 30 days, by owner) |
+
+The three contract reports this section used to list are published nowhere, and none of them can be built as written, for one shared reason: **there is no contract dataset**. `src/datasets/` covers nine objects — account, case, contact, event, forecast, lead, opportunity, product and task — and `crm_contract` is not among them, so nothing in analytics counts, sums or groups contracts.
+
+- **Contracts Expiring** — the question is real and it is answered by a **view**, not a report: **Renewal Calendar** (the *Renewals* tab on Contracts) plots every contract on its **End Date**, and **Contract Terms** shows the same terms as a Gantt (`src/views/contract.view.ts`). Both list records; neither totals them, because there is no dataset behind them to total.
+- **Active Contracts by Product** — unreachable twice over: no contract dataset, and `product_metrics` is a catalog rollup — **Category**, the product count and the list-price sum — that never crosses to contracts or to line items.
+- **Renewal Pipeline** — as written, *opportunities tied to renewing contracts*, it cannot be built: the link runs the other way (`crm_contract.crm_opportunity`) and no dimension exposes it. The renewal pipeline itself is buildable, though: **Deal Type** is a dimension on `opportunity_metrics`, and *Existing Customer - Renewal* is one of its values.
 
 ### 📣 Marketing reports
 
-| Report | What it shows |
-| --- | --- |
-| **Campaign ROI** | Spend vs sourced/influenced pipeline and revenue |
-| **Campaign Engagement** | Open / click / response / conversion by campaign |
+**`src/reports/` publishes no marketing report, and no custom one can be built** — this is the one section of the page where the gap is not a missing report but a missing data source. `src/datasets/` has no campaign dataset, so no report and no dashboard tile can aggregate campaign numbers at all.
+
+The records do carry the numbers. `crm_campaign` has **Budgeted Cost**, **Actual Cost**, **Expected Revenue**, **Actual Revenue**, the **Num Sent / Responses / Leads / Converted Leads / Opportunities / Won Opportunities** counters and two formula fields — **Response Rate %** and **ROI %** — all of which the campaign record shows in its **Performance** section (`src/views/campaign.view.ts`). `crm_campaign_member` stamps **First Opened**, **First Clicked**, **Response Date** and **Responded** per member.
+
+- **Campaign ROI** — the per-campaign figure exists on the record, as the **ROI %** formula above. What does not exist is any way to aggregate or rank it: no campaign dataset means no measure, no dimension and no grouping. Attribution from the deal side is missing too — `crm_opportunity.crm_campaign` is a real lookup, but `opportunity_metrics` declares no campaign dimension, so *sourced* and *influenced* revenue cannot be attributed in analytics either.
+- **Campaign Engagement** — same reason, one layer down: the opens, clicks and responses are stamped on each member record, and nothing rolls them up. *Conversion by campaign* has the extra problem that `lead_metrics` never crosses to campaigns.
+
+Closing the gap means adding `src/datasets/campaign.dataset.ts` — a source change and a redeploy, not something a report builder can reach. See [Campaigns](/docs/marketing/campaigns) for what the campaign record does show today.
 
 ## Working with reports
 
@@ -92,7 +117,7 @@ Every report has the same basic controls:
 
 ## Permissions
 
-- A user only sees records they have access to — a rep running *Pipeline by Stage* sees their own deals; a manager sees the team's.
+- A user only sees records they have access to — a rep running *Opportunities by Stage* sees their own deals; a manager sees the team's.
 - Admins can lock down which fields appear in reports via **Field-Level Security**.
 - Sensitive reports can be restricted to specific [profiles](/docs/administration/profiles).
 
@@ -120,7 +145,7 @@ The most common way to consume reports is by **email subscription**:
 
 A common pattern:
 
-- *Pipeline by Stage* → Mondays 8 AM to the sales team.
+- *Opportunities by Stage* → Mondays 8 AM to the sales team.
 - *SLA Performance Report* → daily 6 PM to the service manager.
 - *Cases Opened by Priority × Day* → Fridays 4 PM to the customer success team.
 
@@ -132,8 +157,8 @@ A common pattern:
 
 ## Tips for managers
 
-- ✅ Schedule **Stale Opportunities** weekly to your team — it forces follow-up discipline.
-- ✅ Use **Win/Loss Analysis** monthly with sales coaches — it's the single best coaching tool.
+- ✅ Schedule **Opportunity Funnel by Owner → Stage** weekly to your team — it forces follow-up discipline, rep by rep. For the stalled deals themselves, send people to the **Stale** tab on Opportunities: it is a list view, so it cannot be scheduled, but it is where the parked deals are ranked.
+- ✅ There is no win/loss report to schedule, but the analysis is a custom report away — group `opportunity_metrics` by **Loss Reason** and read **Lost Deals** next to **Win Rate**. Run it monthly with sales coaches; it is the single best coaching tool.
 
 ## Tips for admins
 

--- a/content/docs/analytics/reports.zh-Hans.mdx
+++ b/content/docs/analytics/reports.zh-Hans.mdx
@@ -1,6 +1,6 @@
 ---
 title: 报表
-description: 标准报表库——管道、赢单/丢单、预测、工单量、SLA 绩效等。
+description: 标准报表库——HotCRM 就商机、线索、工单与客户发布的十份报表，以及缺席的那些各自还缺什么。
 ---
 
 # 报表
@@ -9,20 +9,34 @@ description: 标准报表库——管道、赢单/丢单、预测、工单量、
 
 ## 标准报表
 
-HotCRM 开箱即用地提供以下报表：
+HotCRM 开箱即用地发布 **十份** 报表 —— `src/reports/index.ts` 这个 barrel 就是整个报表库。下面每一节先列出它发布的那几份，再逐条点名本页曾经承诺过的名字，并说明语义层能不能回答它：
 
 ### 📈 销售报表
 
+`src/reports/opportunity.report.ts` 发布的商机报表共 **四份**：
+
 | 报表 | 显示内容 |
 | --- | --- |
-| **Pipeline by Stage** | 所有未结交易按阶段分组，带 $ 合计 |
-| **Forecast vs Actual** | 成交赢单对比预测，按周期 |
-| **Win/Loss Analysis** | 已结交易按赢单/丢单分组，带原因分解 |
-| **Sales Cycle Length** | 从创建到成交的天数，按所有者和产品 |
-| **Top Performing Reps** | 成交排行榜 |
-| **Stale Opportunities** | 14 天以上无活动的交易 |
-| **Big Deals Won** | ≥ $100K 的成交赢单商机 |
-| **Discount Approval Activity** | 所有审批请求，按状态和审批人 |
+| **Opportunities by Stage** | 按阶段的管道金额与平均赢单概率，只算今年内成交的、并排除已丢单的交易 —— 附一张按阶段的金额柱状图 |
+| **Won Opportunities by Owner** | 每位销售代表的赢单金额，图表标题是 *Revenue by Sales Rep* |
+| **Pipeline Coverage by Forecast × Quarter** | 未结管道的矩阵：行是预测类别，列是预计成交季度，每格给出金额与商机数 |
+| **Opportunity Funnel by Owner → Stage** | 两级漏斗 —— 每位代表的商机盘子再按阶段拆开，带金额、商机数与平均概率 |
+
+四份都绑定 `opportunity_metrics`（`src/datasets/opportunity.dataset.ts`），这也正是「管道」在这里和在仪表盘上是同一个数字的原因。
+
+本节曾经列出的八个名字哪儿都没有发布。其中两个是真名，但它们属于报表以外的东西：
+
+- **Pipeline by Stage** 是仪表盘**磁贴**标题和图表标题，不是报表。磁贴是 **CRM Overview**、**Sales Performance** 与 **Executive Overview** 三个仪表盘共用的未结管道漏斗（`src/dashboards/shared-widgets.ts`）；图表则是上面 **Opportunities by Stage** 那张柱状图，它的标题就写作 *Pipeline by Stage*。在报表库里按这个名字搜，一份都搜不到；你要的那份叫 **Opportunities by Stage**。
+- **Stale Opportunities** 是商机上的**列表视图** —— *⚠️ Stale Opportunities · Longest in Stage First*，也就是 **Stale** 标签页（`src/views/opportunity.view.ts`）—— 而且它并不施加本表所说的 14 天筛选。它列出**所有**未结交易，按 **Stage Entry Date** 升序排，停留最久的排在最上面；那 14 天属于负责催办的 `opportunity_stagnation` 流程，不属于这个视图。分析侧也重建不出来：**Days in Current Stage** 是查询之后才求值的公式，任何东西都无法按它分组、筛选或排序，也没有任何数据集把它暴露出来。
+- **Top Performing Reps** 是存在的，只是真名不同：**Won Opportunities by Owner** 就是赢单排行榜，**Opportunity Funnel by Owner → Stage** 则是同一份排名再把每人的各阶段摊开。`opportunity_metrics` 声明了 **Owner** 维度 —— 这一点和 `case_metrics` 不同，也正是服务侧没有客服排行的原因。
+
+剩下五个只是单纯不存在，其中三个自己建得出来、两个建不出来：
+
+- **Forecast vs Actual** —— 建得出来，但不是从管道数据集：配额在 `forecast_metrics`（`src/datasets/forecast.dataset.ts`）里，一位负责人一个周期一行，带 **Quota**、**Closed**、**Pipeline**、**Commit** 以及派生的 **Attainment**。基于它的任何报表都必须把周期钉死 —— 要么按 **Period** 分组，要么筛到单个 **Period Type** + **Period Start** —— 因为这些度量都是普通求和，而表里同时存着好几个周期。
+- **Win/Loss Analysis** —— 建得出来：**Win Reason** 与 **Loss Reason** 是维度，**Won Deals**、**Lost Deals**、**Settled Deals**、**Won Revenue**、**Lost Revenue** 与 **Win Rate** 都是 `opportunity_metrics` 上已声明的度量。
+- **Big Deals Won** —— 建得出来：赢单金额就是 **Won Revenue**，而按金额卡一个阈值是普通的报表筛选条件。
+- **Sales Cycle Length** —— 建不出来。没有任何地方存着销售周期时长：商机上有 **Stage Entry Date** 和 **Close Date**，但没有「已过天数」这样的列，而它唯一带的时长 **Days in Current Stage** 就是上面那个查询后公式。*按产品* 也没有落点 —— 没有任何数据集读 `crm_opportunity_line_item`。
+- **Discount Approval Activity** —— 建不出来。审批本身是真的（`src/flows/opportunity-approval.flow.ts`，以及商机上的 **Approval Status**），但没有任何维度把那个字段暴露出来；折扣则是行项目上的百分比（`crm_opportunity_line_item.discount`），而没有任何数据集读行项目。
 
 ### 🎯 线索报表
 
@@ -59,20 +73,31 @@ HotCRM 开箱即用地提供以下报表：
 
 **SLA Performance Report 里同样没有任何首次响应数字**，而且它那个 SLA 数字是 **SLA Violated** 标志的平均值，也就是违约 *率*，不是准时率。本应用根本不度量首次响应：**First Response Date** 只在工单上第一次记录 *已经发生过* 的通话或会议时被盖上，此后从不与任何目标比较；`case_metrics` 没有声明任何首次响应度量，所以没有报表、也没有仪表盘磁贴能报出一个来。参见 [SLA 与升级](/zh-Hans/docs/service/sla-and-escalation)。
 
-### 💰 收入报表
+### 💰 客户与收入报表
+
+`src/reports/account.report.ts` 与 `src/reports/churn.report.ts` 发布了 **两份** 报表，而这一节正是它们该待的地方 —— 它们从未在本页出现过：
 
 | 报表 | 显示内容 |
 | --- | --- |
-| **Contracts Expiring** | 在未来 30/60/90 天内结束的有效合同 |
-| **Active Contracts by Product** | 经常性收入汇总 |
-| **Renewal Pipeline** | 与续约合同关联的商机 |
+| **Accounts by Industry and Type** | 有效客户的矩阵 —— 行是行业，列是客户类型，每格给出客户数与 **Annual Revenue** 合计 |
+| **Customer Churn Signals** | 面向主动挽留的三块面板：**At-Risk Accounts**（有效但 60 天以上无活动，按行业）、**Silent High-Value Accounts**（战略级与企业级客户沉默 90 天以上，按类型）与 **Recently Lost Opportunities**（最近 30 天丢单，按负责人） |
+
+本节曾经列出的三份合同报表哪儿都没有发布，而且按它们写的口径一份都建不出来，原因是同一个：**没有合同数据集**。`src/datasets/` 覆盖九个对象 —— 客户、工单、联系人、活动、预测、线索、商机、产品、任务 —— `crm_contract` 不在其中，所以分析侧根本无法对合同计数、求和或分组。
+
+- **Contracts Expiring** —— 问题本身是真实的，回答它的是**视图**而不是报表：**Renewal Calendar**（合同的 *Renewals* 标签页）把每份合同按 **End Date** 摆在日历上，**Contract Terms** 则把同样的合同期画成甘特图（`src/views/contract.view.ts`）。两者都在列记录，都不做合计 —— 因为它们背后没有可供合计的数据集。
+- **Active Contracts by Product** —— 两头都够不着：既没有合同数据集，`product_metrics` 又只是产品目录的汇总（**Category**、产品数与目录价合计），它从不跨到合同，也不跨到行项目。
+- **Renewal Pipeline** —— 按它写的口径（*与续约合同关联的商机*）建不出来：这条关联是反着走的（`crm_contract.crm_opportunity`），而且没有任何维度把它暴露出来。不过续约管道本身建得出来：**Deal Type** 是 `opportunity_metrics` 上的维度，*Existing Customer - Renewal* 正是它的取值之一。
 
 ### 📣 市场营销报表
 
-| 报表 | 显示内容 |
-| --- | --- |
-| **Campaign ROI** | 支出对比来源/影响管道和收入 |
-| **Campaign Engagement** | 按营销活动的打开 / 点击 / 响应 / 转化 |
+**`src/reports/` 没有发布任何营销报表，而且自建也建不出来** —— 全页只有这一节缺的不是报表，而是数据源。`src/datasets/` 里没有营销活动数据集，所以没有任何报表、也没有任何仪表盘磁贴能对营销活动的数字做聚合。
+
+记录本身是带着这些数字的。`crm_campaign` 上有 **Budgeted Cost**、**Actual Cost**、**Expected Revenue**、**Actual Revenue**，有 **Num Sent / Responses / Leads / Converted Leads / Opportunities / Won Opportunities** 这一组计数器，还有两个公式字段 —— **Response Rate %** 与 **ROI %** —— 它们都摆在营销活动记录的 **Performance** 分区里（`src/views/campaign.view.ts`）。`crm_campaign_member` 则逐个成员盖上 **First Opened**、**First Clicked**、**Response Date** 与 **Responded**。
+
+- **Campaign ROI** —— 单个营销活动的数字在记录上是有的，就是上面那个 **ROI %** 公式。没有的是任何聚合或排名的办法：没有营销活动数据集，就没有度量、没有维度、也没有分组。从商机那一侧做归因同样缺一块 —— `crm_opportunity.crm_campaign` 是真实的 lookup，但 `opportunity_metrics` 没有声明营销活动维度，所以*来源*收入与*影响*收入在分析侧也归不了因。
+- **Campaign Engagement** —— 同样的原因，只是低一层：打开、点击与响应都盖在各个成员记录上，而没有任何东西把它们汇总起来。「按营销活动的转化」还多一个问题：`lead_metrics` 从不跨到营销活动。
+
+要补上这个缺口，得新增 `src/datasets/campaign.dataset.ts` —— 那是改源码加重新部署，不是报表构建器够得着的事。营销活动记录今天能看到什么，见 [营销活动](/zh-Hans/docs/marketing/campaigns)。
 
 ## 使用报表
 
@@ -92,7 +117,7 @@ HotCRM 开箱即用地提供以下报表：
 
 ## 权限
 
-- 用户只能看到他们有权访问的记录——运行 *Pipeline by Stage* 的销售代表看到自己的交易；经理看到团队的。
+- 用户只能看到他们有权访问的记录——运行 *Opportunities by Stage* 的销售代表看到自己的交易；经理看到团队的。
 - 管理员可以通过**字段级安全**锁定哪些字段出现在报表中。
 - 敏感报表可以限制给特定的 [配置文件](/zh-Hans/docs/administration/profiles)。
 
@@ -120,7 +145,7 @@ HotCRM 开箱即用地提供以下报表：
 
 一种常见模式：
 
-- *Pipeline by Stage* → 周一早上 8 点发给销售团队。
+- *Opportunities by Stage* → 周一早上 8 点发给销售团队。
 - *SLA Performance Report* → 每日下午 6 点发给服务经理。
 - *Cases Opened by Priority × Day* → 周五下午 4 点发给客户成功团队。
 
@@ -132,8 +157,8 @@ HotCRM 开箱即用地提供以下报表：
 
 ## 给经理的提示
 
-- ✅ 每周向你的团队安排 **Stale Opportunities**——它能强制跟进纪律。
-- ✅ 每月与销售教练一起使用 **Win/Loss Analysis**——它是最好的单一辅导工具。
+- ✅ 每周向你的团队安排 **Opportunity Funnel by Owner → Stage**——它能逐人强制跟进纪律。至于停滞的交易本身，请把人指到商机的 **Stale** 标签页：它是列表视图，定时推送不了，但停摆最久的交易就排在那儿。
+- ✅ 没有赢单/丢单报表可以安排，但这份分析只差一份自建报表——把 `opportunity_metrics` 按 **Loss Reason** 分组，并把 **Lost Deals** 与 **Win Rate** 并排看。每月与销售教练一起跑，它是最好的单一辅导工具。
 
 ## 给管理员的提示
 

--- a/content/docs/analytics/reports.zh-Hant.mdx
+++ b/content/docs/analytics/reports.zh-Hant.mdx
@@ -1,6 +1,6 @@
 ---
 title: 報表
-description: 標準報表庫——管道、贏單/丟單、預測、工單量、SLA 績效等。
+description: 標準報表庫——HotCRM 就商機、潛在客戶、工單與客戶發布的十份報表，以及缺席的那些各自還缺什麼。
 ---
 
 # 報表
@@ -9,20 +9,34 @@ description: 標準報表庫——管道、贏單/丟單、預測、工單量、
 
 ## 標準報表
 
-HotCRM 開箱即用地提供以下報表：
+HotCRM 開箱即用地發布 **十份** 報表 —— `src/reports/index.ts` 這個 barrel 就是整個報表庫。下面每一節先列出它發布的那幾份，再逐條點名本頁曾經承諾過的名字，並說明語義層能不能回答它：
 
 ### 📈 銷售報表
 
+`src/reports/opportunity.report.ts` 發布的商機報表共 **四份**：
+
 | 報表 | 顯示內容 |
 | --- | --- |
-| **Pipeline by Stage** | 所有未結交易按階段分組，帶 $ 合計 |
-| **Forecast vs Actual** | 成交贏單對比預測，按週期 |
-| **Win/Loss Analysis** | 已結交易按贏單/丟單分組，帶原因分解 |
-| **Sales Cycle Length** | 從建立到成交的天數，按擁有者和產品 |
-| **Top Performing Reps** | 成交排行榜 |
-| **Stale Opportunities** | 14 天以上無活動的交易 |
-| **Big Deals Won** | ≥ $100K 的成交贏單商機 |
-| **Discount Approval Activity** | 所有審批請求，按狀態和審批人 |
+| **Opportunities by Stage** | 按階段的管道金額與平均贏單機率，只算今年內成交的、並排除已丟單的交易 —— 附一張按階段的金額長條圖 |
+| **Won Opportunities by Owner** | 每位銷售代表的贏單金額，圖表標題是 *Revenue by Sales Rep* |
+| **Pipeline Coverage by Forecast × Quarter** | 未結管道的矩陣：列是預測類別，欄是預計成交季度，每格給出金額與商機數 |
+| **Opportunity Funnel by Owner → Stage** | 兩級漏斗 —— 每位代表的商機盤子再按階段拆開，帶金額、商機數與平均機率 |
+
+四份都繫結 `opportunity_metrics`（`src/datasets/opportunity.dataset.ts`），這也正是「管道」在這裡和在儀表板上是同一個數字的原因。
+
+本節曾經列出的八個名字哪兒都沒有發布。其中兩個是真名，但它們屬於報表以外的東西：
+
+- **Pipeline by Stage** 是儀表板**磁貼**標題和圖表標題，不是報表。磁貼是 **CRM Overview**、**Sales Performance** 與 **Executive Overview** 三個儀表板共用的未結管道漏斗（`src/dashboards/shared-widgets.ts`）；圖表則是上面 **Opportunities by Stage** 那張長條圖，它的標題就寫作 *Pipeline by Stage*。在報表庫裡按這個名字搜，一份都搜不到；你要的那份叫 **Opportunities by Stage**。
+- **Stale Opportunities** 是商機上的**清單檢視** —— *⚠️ Stale Opportunities · Longest in Stage First*，也就是 **Stale** 標籤頁（`src/views/opportunity.view.ts`）—— 而且它並不施加本表所說的 14 天篩選。它列出**所有**未結交易，按 **Stage Entry Date** 升冪排，停留最久的排在最上面；那 14 天屬於負責催辦的 `opportunity_stagnation` 流程，不屬於這個檢視。分析側也重建不出來：**Days in Current Stage** 是查詢之後才求值的公式，任何東西都無法按它分組、篩選或排序，也沒有任何資料集把它暴露出來。
+- **Top Performing Reps** 是存在的，只是真名不同：**Won Opportunities by Owner** 就是贏單排行榜，**Opportunity Funnel by Owner → Stage** 則是同一份排名再把每人的各階段攤開。`opportunity_metrics` 宣告了 **Owner** 維度 —— 這一點和 `case_metrics` 不同，也正是服務側沒有客服排行的原因。
+
+剩下五個只是單純不存在，其中三個自己建得出來、兩個建不出來：
+
+- **Forecast vs Actual** —— 建得出來，但不是從管道資料集：配額在 `forecast_metrics`（`src/datasets/forecast.dataset.ts`）裡，一位負責人一個週期一列，帶 **Quota**、**Closed**、**Pipeline**、**Commit** 以及衍生的 **Attainment**。基於它的任何報表都必須把週期釘死 —— 要麼按 **Period** 分組，要麼篩到單個 **Period Type** + **Period Start** —— 因為這些度量都是普通求和，而表裡同時存著好幾個週期。
+- **Win/Loss Analysis** —— 建得出來：**Win Reason** 與 **Loss Reason** 是維度，**Won Deals**、**Lost Deals**、**Settled Deals**、**Won Revenue**、**Lost Revenue** 與 **Win Rate** 都是 `opportunity_metrics` 上已宣告的度量。
+- **Big Deals Won** —— 建得出來：贏單金額就是 **Won Revenue**，而按金額卡一個閾值是普通的報表篩選條件。
+- **Sales Cycle Length** —— 建不出來。沒有任何地方存著銷售週期時長：商機上有 **Stage Entry Date** 和 **Close Date**，但沒有「已過天數」這樣的欄，而它唯一帶的時長 **Days in Current Stage** 就是上面那個查詢後公式。*按產品* 也沒有落點 —— 沒有任何資料集讀 `crm_opportunity_line_item`。
+- **Discount Approval Activity** —— 建不出來。審批本身是真的（`src/flows/opportunity-approval.flow.ts`，以及商機上的 **Approval Status**），但沒有任何維度把那個欄位暴露出來；折扣則是行項目上的百分比（`crm_opportunity_line_item.discount`），而沒有任何資料集讀行項目。
 
 ### 🎯 潛在客戶報表
 
@@ -59,20 +73,31 @@ HotCRM 開箱即用地提供以下報表：
 
 **SLA Performance Report 裡同樣沒有任何首次回應數字**，而且它那個 SLA 數字是 **SLA Violated** 標誌的平均值，也就是違約 *率*，不是準時率。本應用根本不度量首次回應：**First Response Date** 只在工單上第一次記錄 *已經發生過* 的通話或會議時被蓋上，此後從不與任何目標比較；`case_metrics` 沒有宣告任何首次回應度量，所以沒有報表、也沒有儀表板磁貼能報出一個來。參見 [SLA 與升級](/zh-Hant/docs/service/sla-and-escalation)。
 
-### 💰 收入報表
+### 💰 客戶與收入報表
+
+`src/reports/account.report.ts` 與 `src/reports/churn.report.ts` 發布了 **兩份** 報表，而這一節正是它們該待的地方 —— 它們從未在本頁出現過：
 
 | 報表 | 顯示內容 |
 | --- | --- |
-| **Contracts Expiring** | 在未來 30/60/90 天內結束的有效合約 |
-| **Active Contracts by Product** | 經常性收入彙總 |
-| **Renewal Pipeline** | 與續約合約關聯的商機 |
+| **Accounts by Industry and Type** | 有效客戶的矩陣 —— 列是產業，欄是客戶類型，每格給出客戶數與 **Annual Revenue** 合計 |
+| **Customer Churn Signals** | 面向主動挽留的三塊面板：**At-Risk Accounts**（有效但 60 天以上無活動，按產業）、**Silent High-Value Accounts**（策略級與企業級客戶沉默 90 天以上，按類型）與 **Recently Lost Opportunities**（最近 30 天丟單，按負責人） |
+
+本節曾經列出的三份合約報表哪兒都沒有發布，而且按它們寫的口徑一份都建不出來，原因是同一個：**沒有合約資料集**。`src/datasets/` 涵蓋九個物件 —— 客戶、工單、聯絡人、活動、預測、潛在客戶、商機、產品、任務 —— `crm_contract` 不在其中，所以分析側根本無法對合約計數、求和或分組。
+
+- **Contracts Expiring** —— 問題本身是真實的，回答它的是**檢視**而不是報表：**Renewal Calendar**（合約的 *Renewals* 標籤頁）把每份合約按 **End Date** 擺在日曆上，**Contract Terms** 則把同樣的合約期畫成甘特圖（`src/views/contract.view.ts`）。兩者都在列記錄，都不做合計 —— 因為它們背後沒有可供合計的資料集。
+- **Active Contracts by Product** —— 兩頭都夠不著：既沒有合約資料集，`product_metrics` 又只是產品目錄的彙總（**Category**、產品數與目錄價合計），它從不跨到合約，也不跨到行項目。
+- **Renewal Pipeline** —— 按它寫的口徑（*與續約合約關聯的商機*）建不出來：這條關聯是反著走的（`crm_contract.crm_opportunity`），而且沒有任何維度把它暴露出來。不過續約管道本身建得出來：**Deal Type** 是 `opportunity_metrics` 上的維度，*Existing Customer - Renewal* 正是它的取值之一。
 
 ### 📣 行銷報表
 
-| 報表 | 顯示內容 |
-| --- | --- |
-| **Campaign ROI** | 支出對比來源/影響管道和收入 |
-| **Campaign Engagement** | 按行銷活動的開啟 / 點擊 / 回應 / 轉化 |
+**`src/reports/` 沒有發布任何行銷報表，而且自建也建不出來** —— 全頁只有這一節缺的不是報表，而是資料來源。`src/datasets/` 裡沒有行銷活動資料集，所以沒有任何報表、也沒有任何儀表板磁貼能對行銷活動的數字做彙總。
+
+記錄本身是帶著這些數字的。`crm_campaign` 上有 **Budgeted Cost**、**Actual Cost**、**Expected Revenue**、**Actual Revenue**，有 **Num Sent / Responses / Leads / Converted Leads / Opportunities / Won Opportunities** 這一組計數器，還有兩個公式欄位 —— **Response Rate %** 與 **ROI %** —— 它們都擺在行銷活動記錄的 **Performance** 分區裡（`src/views/campaign.view.ts`）。`crm_campaign_member` 則逐個成員蓋上 **First Opened**、**First Clicked**、**Response Date** 與 **Responded**。
+
+- **Campaign ROI** —— 單個行銷活動的數字在記錄上是有的，就是上面那個 **ROI %** 公式。沒有的是任何彙總或排名的辦法：沒有行銷活動資料集，就沒有度量、沒有維度、也沒有分組。從商機那一側做歸因同樣缺一塊 —— `crm_opportunity.crm_campaign` 是真實的 lookup，但 `opportunity_metrics` 沒有宣告行銷活動維度，所以*來源*收入與*影響*收入在分析側也歸不了因。
+- **Campaign Engagement** —— 同樣的原因，只是低一層：開啟、點擊與回應都蓋在各個成員記錄上，而沒有任何東西把它們彙總起來。「按行銷活動的轉化」還多一個問題：`lead_metrics` 從不跨到行銷活動。
+
+要補上這個缺口，得新增 `src/datasets/campaign.dataset.ts` —— 那是改原始碼加重新部署，不是報表建構器夠得著的事。行銷活動記錄今天能看到什麼，見 [行銷活動](/zh-Hant/docs/marketing/campaigns)。
 
 ## 使用報表
 
@@ -92,7 +117,7 @@ HotCRM 開箱即用地提供以下報表：
 
 ## 權限
 
-- 使用者只能看到他們有權存取的記錄——執行 *Pipeline by Stage* 的業務代表看到自己的交易；經理看到團隊的。
+- 使用者只能看到他們有權存取的記錄——執行 *Opportunities by Stage* 的業務代表看到自己的交易；經理看到團隊的。
 - 管理員可以透過**欄位級安全**鎖定哪些欄位出現在報表中。
 - 敏感報表可以限制給特定的 [設定檔](/zh-Hant/docs/administration/profiles)。
 
@@ -120,7 +145,7 @@ HotCRM 開箱即用地提供以下報表：
 
 一種常見模式：
 
-- *Pipeline by Stage* → 週一早上 8 點發給銷售團隊。
+- *Opportunities by Stage* → 週一早上 8 點發給銷售團隊。
 - *SLA Performance Report* → 每日下午 6 點發給服務經理。
 - *Cases Opened by Priority × Day* → 週五下午 4 點發給客戶成功團隊。
 
@@ -132,8 +157,8 @@ HotCRM 開箱即用地提供以下報表：
 
 ## 給經理的提示
 
-- ✅ 每週向你的團隊安排 **Stale Opportunities**——它能強制跟進紀律。
-- ✅ 每月與銷售教練一起使用 **Win/Loss Analysis**——它是最好的單一輔導工具。
+- ✅ 每週向你的團隊安排 **Opportunity Funnel by Owner → Stage**——它能逐人強制跟進紀律。至於停滯的交易本身，請把人指到商機的 **Stale** 標籤頁：它是清單檢視，定時推送不了，但停擺最久的交易就排在那兒。
+- ✅ 沒有贏單/丟單報表可以安排，但這份分析只差一份自建報表——把 `opportunity_metrics` 按 **Loss Reason** 分組，並把 **Lost Deals** 與 **Win Rate** 並排看。每月與銷售教練一起跑，它是最好的單一輔導工具。
 
 ## 給管理員的提示
 


### PR DESCRIPTION
Fixes #962
Fixes #965

两单并单实施。仅文档，三语同步，`src/` 零改动，`@objectstack/*` 版本未动，`content/docs/releases/` 未动。

## #962 — `analytics/reports` 的 Sales / Revenue / Marketing 三节

`src/reports/` 一共发布 **10 份**报表（build 输出确认 `10 Reports`）。PR #954 之后页面上 4 份是真的（Lead 1 + Service 3），剩下三节的 13 个名字在 `src/` 里零命中，而真实的 6 份从未在本页出现过。

**真名错位两处**（沿 #924 先例点名说清真身与所在）：

- **Pipeline by Stage** 有两个真身，都不是报表：`src/dashboards/shared-widgets.ts` 的未结管道漏斗**磁贴**（CRM Overview / Sales Performance / Executive Overview 三个仪表盘共用），以及真实报表 **Opportunities by Stage** 的**图表标题**（`src/reports/opportunity.report.ts:15`）。
- **Stale Opportunities** 是 `src/views/opportunity.view.ts` 的**列表视图** label（Stale 标签页），而且原表「14 天以上无活动」也是错的：该视图不施加任何 14 天筛选，它列出全部未结交易按 `stage_entry_date` 升序排；14 天属于 `opportunity_stagnation` 流程。

**六份真实报表就位**：Sales 节写四份 opportunity 报表；新的「💰 客户与收入报表」节收下 **Accounts by Industry and Type** 与 **Customer Churn Signals**（含三个块的逐块说明）。

**逐条区分「可自建」与「连自建都不可能」**（沿 #954 已落地的 Lead/Service 口径）：

| 名字 | 判定 |
| --- | --- |
| Forecast vs Actual | 可自建 —— 但要用 `forecast_metrics`，且必须钉死周期 |
| Win/Loss Analysis | 可自建 —— win/loss reason 是维度，win_rate 等是已声明度量 |
| Big Deals Won | 可自建 —— Won Revenue + 金额阈值筛选 |
| Renewal Pipeline | 按原口径不可 —— 关联反向；但按 Deal Type = Existing Customer - Renewal 可自建 |
| Sales Cycle Length | 不可 —— 无时长列，`days_in_stage` 是查询后公式 |
| Discount Approval Activity | 不可 —— approval_status 无维度，折扣在行项目，无 dataset 读行项目 |
| Contracts Expiring / Active Contracts by Product | 不可 —— 无合同 dataset（真身是 Renewal Calendar 等视图） |
| Campaign ROI / Campaign Engagement | 不可 —— 无 campaign dataset |

同页《订阅与定时推送》第一条示例、《权限》一条、《给经理的提示》两条原本都点名幻影报表，一并收口。

## #965 — `analytics/cubes` 整页

页面骨架是「四个内置 cube」，而本仓**一个 cube 都没有声明**：每个语义定义都是 `src/datasets/` 下的 `defineDataset(...)`，由分析服务内部编译成 cube（ADR-0021；`objectstack.config.ts` 明确不注册 `analyticsCubes`，`test/analytics-integrity.test.ts` 也把这一点写死）。整页改写为九个真实 dataset 的表 + 逐节核对：

- **Sales / Pipeline 两个 cube 合成一节** —— 两者描述的都是 `opportunity_metrics`。
- **不可达项逐条给出原因**：weighted pipeline（`expected_revenue` 是记录字段，无度量）、average discount（行项目百分比）、product/family、account tier/size、team/region（是岗位与 Billing Country，属共享机件）、日/周/年粒度、snapshot date（无快照；最近的是 `forecast_metrics` 的按周期行）。
- **Service 节**保留 PR #954 已落地的 SLA 违约率与「无首次响应度量」两段原文不动，并按 #948/#954 已立措辞写「没有负责人维度」。
- **Marketing 节**：无数据源。记录侧确实带着数字（`crm_campaign` 的成本/收入/计数器与 **ROI %**、**Response Rate %** 公式字段，`crm_campaign_member` 的打开/点击/响应时间戳），缺的是 dataset —— 而且 `opportunity_metrics` 没有 campaign 维度，从交易侧也归不了因。

**平台侧主张不预判为假**（沿 #950 Copilot 节先例）：cube 拖放 UI、刷新模型与刷新状态屏、cube 访问审计，都写成「本仓无从判定，请对着自己的部署验证」，不做任何方向上的断言。可实测的应用侧另写：`src/skills/` 六个技能没有一个点名 dataset/cube，**Live Data Access** 走的是平台对象工具（`describe_object` / `aggregate_data` …）；新增 cube 在本仓等价于新增 `src/datasets/*.dataset.ts`（改源码 + 重新部署）。

## 前提复核（rule 6）

两单正文的主张基本成立，但 **#965 有一处点名错误**：它把 **Win rate** 列进「页面列的 measure 有相当一部分不在其中」的清单，而 `opportunity_metrics` 第 92 行确实声明了 `win_rate`（连同 `won_count` / `lost_count` / `decided_count` 三个分母半边）。本 PR 按源码把 Win rate 写在「今天够得着」的一侧。其余 stale-premise 逐条复核未发现问题。

## 验证

六道门全绿（`flock` 内串行，heap 4096）：`validate` / `typecheck` / `lint` / `hygiene` / `build` / `test` 退出码均为 0；`Test Files 71 passed, Tests 1631 passed | 1 skipped`；build 输出 `10 Reports  5 Dashboards`。

守卫单跑：`test/docs-conversion-rate-spelling.test.ts` **4 passed**（#923 的两条 carrier 断言均绿 —— reports 页 carrier 在 #954 的 Lead 节，未触；cubes 页 carrier 落在改写后的 Marketing 节里，保留了「转化率 / 轉化率」的自然表述）。`test/docs-service-index-analytics.test.ts`、`test/docs-drift.test.ts`、`test/analytics-integrity.test.ts` 同跑 67 passed，均不触。

**反向验证（方向先判后跑）**:

1. 预判 RED：把 cubes.zh-Hans 的「转化率」换成别的词 → 实测 `1 failed | 3 passed`，红在 carrier 断言。符合预判。
2. 预判 GREEN（守卫盲区）：把一行幻影报表名 **Campaign ROI** 表格行加回 reports.mdx → 实测四个套件 67 passed 全绿。符合预判 —— **两页在报表名/cube 名这一层没有任何守卫**，唯一钉住的只有 `转化率` carrier。本 PR 如实报告这一盲区，未新增守卫（会跨出两单范围）。

两次实验后均已还原，最终树与提交一致。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_