### PR TITLE
docs(sales): 把 pipeline-management 剩余的仪表盘/报表指称写实 (#989)

### DIFF
--- a/.changeset/pipeline-management-dashboard-and-report-names.md
+++ b/.changeset/pipeline-management-dashboard-and-report-names.md
@@ -1,0 +1,57 @@
+---
+'hotcrm': patch
+---
+
+Write the sales pipeline page's remaining dashboard and report references to what
+the app actually ships — one phantom capability, four wrong report names, and a
+tile that cannot exist.
+
+`content/docs/sales/pipeline-management.mdx` (and both zh pages) carried three
+separate drifts, all of which sent a reader looking for something that is not
+there.
+
+**The weighted forecast is a list-view total, not a dashboard number.** The page
+told a sales manager that a *Sales Dashboard* "sums Expected Revenue across the
+open pipeline". Neither half held. There is no dashboard by that name — the real
+one is `sales_dashboard`, labelled **Sales Performance**, the same phantom #985
+removed from the roll-up list one section further down. And no dashboard widget
+can sum expected revenue at all: the `opportunity_metrics` dataset in
+`src/datasets/opportunity.dataset.ts` declares no measure over
+`expected_revenue`, and every amount measure it does expose (**Total Amount**,
+**Avg Deal Size**, **Won Revenue**, **Lost Revenue**) reads the raw `amount`
+field. The **Total Pipeline** tile is therefore the *unweighted* open pipeline,
+and a reader who took the page at its word was reading a number short of a
+probability coefficient while being told it was the weighted forecast. Where the
+weighted sum genuinely lives is the opportunity list views: **Open Deals** and
+**All Opportunities** each declare
+`{ field: 'expected_revenue', summary: 'sum' }` in
+`src/views/opportunity.view.ts`, which is how
+`content/docs/sales/opportunities.mdx` already describes them. The page now says
+that, and says plainly why the dashboard cannot match it.
+
+**The reports table named a sidebar group that does not exist and four reports
+by names nothing carries.** The group is **Insights**
+(`src/apps/crm.app.ts`), not *Reports*, and it pins three reports — Pipeline
+Coverage, Lead Inflow, SLA Performance — beside the CRM Overview dashboard and
+Forecasts, so only the first row of the table is reachable from the nav at all;
+the rest open from the reports screen. The four drifted rows now carry the
+labels `src/reports/opportunity.report.ts` declares — **Pipeline Coverage by
+Forecast × Quarter**, **Opportunity Funnel by Owner → Stage**, **Won
+Opportunities by Owner** — and the coverage row's axes are stated the way #985
+just landed them one section below (forecast category down the rows, close
+quarter across the columns) instead of the transposed *quarter × stage*. The
+same truncated names in the cadence table and the manager tips were completed to
+match, including the zh pages' invented Chinese report names, which no
+translation file backs.
+
+**There is no *top deals* tile, and there cannot be one.** The roll-up list
+named three Sales Performance widgets; two are real (**Pipeline by Stage**,
+**Win Rate (12M)**) and the third was removed on purpose. A dashboard `table`
+binds to an analytics dataset and can only aggregate — it cannot list raw
+records (ADR-0021) — so the old **Top Open Opportunities** table produced one
+summary row rather than a deal ranking and was replaced by **Open Pipeline by
+Owner**. The Row 5 comment in `src/dashboards/sales.dashboard.ts` records the
+swap; the page now states it and points a reader wanting a deal-by-deal ranking
+at an opportunity list view.
+
+Docs only — no `src/` change.

--- a/content/docs/sales/pipeline-management.mdx
+++ b/content/docs/sales/pipeline-management.mdx
@@ -31,7 +31,9 @@ You can override the probability manually on an individual deal if you have a sp
 
 This number is the heart of the weighted forecast. It's recalculated automatically every time the amount or probability changes (including the auto-updates from stage changes).
 
-The **Sales Dashboard** sums *Expected Revenue* across the open pipeline to give you the weighted forecast for the quarter.
+The weighted forecast is a **list-view total, not a dashboard number**. The **Open Deals** and **All Opportunities** views on Opportunities each carry an *Expected Revenue* column with a column sum (`src/views/opportunity.view.ts`), and that sum over the open pipeline is the weighted forecast.
+
+No dashboard can give you the same figure. The **Sales Performance** dashboard (`sales_dashboard`) reads the `opportunity_metrics` dataset, and that dataset declares **no measure over `expected_revenue`** — every amount measure it exposes (*Total Amount*, *Avg Deal Size*, *Won Revenue*, *Lost Revenue*) reads the raw `amount` field. So its *Total Pipeline* tile is the **unweighted** open pipeline; the two numbers differ by the probability weighting, which is the whole point of the calculation above.
 
 ## The pipeline kanban view
 
@@ -65,14 +67,14 @@ The Sales Copilot surfaces at-risk deals when you ask *"what's slipping?"* or *"
 
 ## Pipeline reports worth bookmarking
 
-You'll find these in the **Reports** section of the sidebar:
+Only the first of these is on the sidebar. There is no *Reports* group: the reports group is called **Insights** (`src/apps/crm.app.ts`), and it pins three reports — **Pipeline Coverage**, **Lead Inflow** and **SLA Performance** — alongside the **CRM Overview** dashboard and **Forecasts**. The other four below are opened from the reports screen. Names here are the labels the report library lists, which is not always the shorter name on the nav entry.
 
 | Report | What it shows |
 | --- | --- |
-| **Pipeline Coverage (Quarter)** | Are we covering 3x the quota for the upcoming quarter? Matrix of quarter × stage. |
-| **Funnel by Owner → Stage** | Per-rep funnel health — spot leaky stages. |
+| **Pipeline Coverage by Forecast × Quarter** | Are we covering 3x the quota for the upcoming quarter? A matrix of open pipeline: forecast category down the rows, close quarter across the columns. The sidebar entry for it reads **Pipeline Coverage**. |
+| **Opportunity Funnel by Owner → Stage** | Per-rep funnel health — spot leaky stages. |
 | **Opportunities by Stage** | Bar chart of pipeline by stage. |
-| **Won by Owner** | Leaderboard for quarter-end recognition. |
+| **Won Opportunities by Owner** | Leaderboard for quarter-end recognition. |
 | **Customer Churn Signals** | Open cases + low NPS on existing customers = churn risk. |
 
 See [Analytics › Reports](/docs/analytics/reports) for details.
@@ -83,18 +85,20 @@ See [Analytics › Reports](/docs/analytics/reports) for details.
 | --- | --- |
 | **Daily** | Open Pipeline Kanban. Find stalled cards (in-stage > 14 days). Push or close. |
 | **Weekly** | Run *Pipeline Coverage*. Ask the Sales Copilot: *"what's at risk?"* |
-| **Monthly** | Run *Funnel by Owner → Stage*. Coach reps with leaky stages 1:1. |
-| **Quarter-end** | Run *Won by Owner* for commissions. Archive lost deals with a *loss reason*. |
+| **Monthly** | Run *Opportunity Funnel by Owner → Stage*. Coach reps with leaky stages 1:1. |
+| **Quarter-end** | Run *Won Opportunities by Owner* for commissions. Archive lost deals with a *loss reason*. |
 
 ## Forecasting roll-up
 
 The Sales Manager / Director view of the forecast is built from:
 
 - The **Opportunity Metrics** dataset (`opportunity_metrics`) — measure **Total Amount** (sum of amount), dimension **Stage**
-- The **Sales Performance** dashboard (`sales_dashboard`) — widgets for pipeline by stage, win rate, top deals
+- The **Sales Performance** dashboard (`sales_dashboard`) — widgets for pipeline by stage, win rate, and open pipeline by owner
 - The **Pipeline Coverage** report (`pipeline_coverage_by_quarter`, whose own label reads **Pipeline Coverage by Forecast × Quarter**) — a matrix of open pipeline: forecast category down the rows, close quarter across the columns
 
 Together they answer: *"do we have enough pipeline to make the quarter, and where are the risks?"*
+
+What that dashboard will not give you is a *top deals* ranking, and no renaming would fix it: a dashboard table binds to an analytics dataset and can only aggregate — it cannot list raw records (ADR-0021). The **Top Open Opportunities** table that once held that slot was replaced by **Open Pipeline by Owner**, a per-rep ranking, for exactly that reason; the Row 5 comment in `src/dashboards/sales.dashboard.ts` records the swap. For a deal-by-deal ranking, open an opportunity list view.
 
 ## Tips for sales reps
 
@@ -104,8 +108,8 @@ Together they answer: *"do we have enough pipeline to make the quarter, and wher
 
 ## Tips for sales managers
 
-- ✅ Run *Funnel by Owner → Stage* monthly to catch reps with leaky funnels.
-- ✅ Use *Pipeline Coverage by Quarter* in QBRs to set the next quarter's targets.
+- ✅ Run *Opportunity Funnel by Owner → Stage* monthly to catch reps with leaky funnels.
+- ✅ Use *Pipeline Coverage* in QBRs to set the next quarter's targets.
 - ✅ Coach reps to fill in *Competitors* — it dramatically improves Copilot quality.
 
 ## Tips for admins

--- a/content/docs/sales/pipeline-management.zh-Hans.mdx
+++ b/content/docs/sales/pipeline-management.zh-Hans.mdx
@@ -31,7 +31,9 @@ description: 销售管道的日常运作方式——推进交易、自动概率�
 
 这个数字是加权预测的核心。每当金额或概率变化时（包括来自阶段变化的自动更新），它都会自动重新计算。
 
-**销售仪表盘**会在开放销售管道上对*预期营收*求和，从而给你本季度的加权预测。
+加权预测是**列表视图上的合计，不是仪表盘上的数字**。商机的**进行中商机**与**全部商机**两个视图各带一列*预期营收*并对该列求和（`src/views/opportunity.view.ts`），这个在开放管道上的合计就是加权预测。
+
+仪表盘给不出同一个数。**Sales Performance** 仪表盘（`sales_dashboard`）读的是 `opportunity_metrics` dataset，而该 dataset **没有任何度量读 `expected_revenue`** —— 它暴露的金额类度量（*Total Amount*、*Avg Deal Size*、*Won Revenue*、*Lost Revenue*）一律读原始的 `amount` 字段。所以它的 *Total Pipeline* 磁贴是**未加权**的在飞管道；两个数字之间差的正是上面这层概率加权。
 
 ## 销售管道看板视图
 
@@ -65,15 +67,15 @@ description: 销售管道的日常运作方式——推进交易、自动概率�
 
 ## 值得收藏的销售管道报告
 
-你会在侧边栏的**报告**部分找到这些：
+这五张里只有第一张在侧边栏上。侧边栏没有*报告*分组：报表所在的分组叫 **Insights**（`src/apps/crm.app.ts`），它钉了三张报表 —— **Pipeline Coverage**、**Lead Inflow**、**SLA Performance** —— 外加 **CRM Overview** 仪表盘与 **Forecasts**。下面其余四张要从报表界面进。这里用的是报表库列出的 label，它未必等于导航项上那个更短的名字。
 
 | 报告 | 它显示什么 |
 | --- | --- |
-| **销售管道覆盖率（季度）** | 我们对即将到来的季度是否覆盖了 3 倍配额？季度 × 阶段矩阵。 |
-| **按负责人 → 阶段的漏斗** | 每位销售代表的漏斗健康——发现漏水的阶段。 |
-| **按阶段的商机** | 按阶段的销售管道柱状图。 |
-| **按负责人的赢单** | 用于季末表彰的排行榜。 |
-| **客户流失信号** | 现有客户的开放案例 + 低 NPS = 流失风险。 |
+| **Pipeline Coverage by Forecast × Quarter** | 我们对即将到来的季度是否覆盖了 3 倍配额？未结管道的矩阵：行是预测类别，列是预计成交季度。它在侧边栏上的导航项写作 **Pipeline Coverage**。 |
+| **Opportunity Funnel by Owner → Stage** | 每位销售代表的漏斗健康——发现漏水的阶段。 |
+| **Opportunities by Stage** | 按阶段的销售管道柱状图。 |
+| **Won Opportunities by Owner** | 用于季末表彰的排行榜。 |
+| **Customer Churn Signals** | 现有客户的开放案例 + 低 NPS = 流失风险。 |
 
 详情参见 [Analytics › Reports](/zh-Hans/docs/analytics/reports)。
 
@@ -82,19 +84,21 @@ description: 销售管道的日常运作方式——推进交易、自动概率�
 | 节奏 | 该做什么 |
 | --- | --- |
 | **每日** | 打开销售管道看板。找出停滞的卡片（阶段内 > 14 天）。推进或关闭。 |
-| **每周** | 运行*销售管道覆盖率*。向 Sales Copilot 提问：*"what's at risk?"* |
-| **每月** | 运行*按负责人 → 阶段的漏斗*。对漏斗漏水的销售代表进行一对一辅导。 |
-| **季末** | 运行*按负责人的赢单*以计算提成。归档*失败*的交易并附上*丢单原因*。 |
+| **每周** | 运行 *Pipeline Coverage*。向 Sales Copilot 提问：*"what's at risk?"* |
+| **每月** | 运行 *Opportunity Funnel by Owner → Stage*。对漏斗漏水的销售代表进行一对一辅导。 |
+| **季末** | 运行 *Won Opportunities by Owner* 以计算提成。归档*失败*的交易并附上*丢单原因*。 |
 
 ## 预测汇总
 
 销售经理 / 总监的预测视图由以下部分构建：
 
 - **Opportunity Metrics** dataset（`opportunity_metrics`）—— 度量 **Total Amount**（金额之和），维度 **Stage**
-- **Sales Performance** 仪表盘（`sales_dashboard`）—— 小部件包括按阶段的销售管道、赢单率、顶级交易
+- **Sales Performance** 仪表盘（`sales_dashboard`）—— 小部件包括按阶段的销售管道、赢单率、按负责人的在飞管道
 - **Pipeline Coverage** 报告（`pipeline_coverage_by_quarter`，报表自身的 label 写作 **Pipeline Coverage by Forecast × Quarter**）—— 未结管道的矩阵：行是预测类别，列是预计成交季度
 
 它们共同回答：*"我们是否有足够的销售管道来完成本季度，以及风险在哪里？"*
+
+这块仪表盘给不了的是*顶级交易*那种逐笔排行，改个名字也解决不了：仪表盘的 table 绑定的是分析 dataset，只能做聚合，列不出原始记录（ADR-0021）。原先占着这个位置的 **Top Open Opportunities** 表正是因此被换成了按负责人聚合的 **Open Pipeline by Owner** —— `src/dashboards/sales.dashboard.ts` 里 Row 5 的注释记下了这次替换。要逐笔的交易排行，请改用商机列表视图。
 
 ## 给销售代表的提示
 
@@ -104,8 +108,8 @@ description: 销售管道的日常运作方式——推进交易、自动概率�
 
 ## 给销售经理的提示
 
-- ✅ 每月运行*按负责人 → 阶段的漏斗*，以发现漏斗漏水的销售代表。
-- ✅ 在 QBR 中使用*按季度的销售管道覆盖率*来设定下一季度的目标。
+- ✅ 每月运行 *Opportunity Funnel by Owner → Stage*，以发现漏斗漏水的销售代表。
+- ✅ 在 QBR 中使用 *Pipeline Coverage* 来设定下一季度的目标。
 - ✅ 辅导销售代表填写*竞争对手*——它能显著提升 Copilot 的质量。
 
 ## 给管理员的提示

--- a/content/docs/sales/pipeline-management.zh-Hant.mdx
+++ b/content/docs/sales/pipeline-management.zh-Hant.mdx
@@ -31,7 +31,9 @@ description: 銷售管道的日常運作方式——推進交易、自動機率�
 
 這個數字是加權預測的核心。每當金額或機率變化時（包括來自階段變化的自動更新），它都會自動重新計算。
 
-**銷售儀表板**會在開放銷售管道上對*預期營收*求和，從而給你本季度的加權預測。
+加權預測是**清單檢視上的合計，不是儀表板上的數字**。商機的**進行中商機**與**全部商機**兩個檢視各帶一欄*預期營收*並對該欄求和（`src/views/opportunity.view.ts`），這個在開放管道上的合計就是加權預測。
+
+儀表板給不出同一個數。**Sales Performance** 儀表板（`sales_dashboard`）讀的是 `opportunity_metrics` dataset，而該 dataset **沒有任何度量讀 `expected_revenue`** —— 它暴露的金額類度量（*Total Amount*、*Avg Deal Size*、*Won Revenue*、*Lost Revenue*）一律讀原始的 `amount` 欄位。所以它的 *Total Pipeline* 磁貼是**未加權**的在飛管道；兩個數字之間差的正是上面這層機率加權。
 
 ## 銷售管道看板視圖
 
@@ -65,15 +67,15 @@ description: 銷售管道的日常運作方式——推進交易、自動機率�
 
 ## 值得收藏的銷售管道報告
 
-你會在側邊欄的**報告**部分找到這些：
+這五張裡只有第一張在側邊欄上。側邊欄沒有*報告*分組：報表所在的分組叫 **Insights**（`src/apps/crm.app.ts`），它釘了三張報表 —— **Pipeline Coverage**、**Lead Inflow**、**SLA Performance** —— 外加 **CRM Overview** 儀表板與 **Forecasts**。下面其餘四張要從報表介面進。這裡用的是報表庫列出的 label，它未必等於導航項上那個更短的名字。
 
 | 報告 | 它顯示什麼 |
 | --- | --- |
-| **銷售管道覆蓋率（季度）** | 我們對即將到來的季度是否覆蓋了 3 倍配額？季度 × 階段矩陣。 |
-| **按負責人 → 階段的漏斗** | 每位銷售代表的漏斗健康——發現漏水的階段。 |
-| **按階段的商機** | 按階段的銷售管道柱狀圖。 |
-| **按負責人的贏單** | 用於季末表彰的排行榜。 |
-| **客戶流失訊號** | 現有客戶的開放案例 + 低 NPS = 流失風險。 |
+| **Pipeline Coverage by Forecast × Quarter** | 我們對即將到來的季度是否覆蓋了 3 倍配額？未結管道的矩陣：列是預測類別，欄是預計成交季度。它在側邊欄上的導航項寫作 **Pipeline Coverage**。 |
+| **Opportunity Funnel by Owner → Stage** | 每位銷售代表的漏斗健康——發現漏水的階段。 |
+| **Opportunities by Stage** | 按階段的銷售管道柱狀圖。 |
+| **Won Opportunities by Owner** | 用於季末表彰的排行榜。 |
+| **Customer Churn Signals** | 現有客戶的開放案例 + 低 NPS = 流失風險。 |
 
 詳情參見 [Analytics › Reports](/zh-Hant/docs/analytics/reports)。
 
@@ -82,19 +84,21 @@ description: 銷售管道的日常運作方式——推進交易、自動機率�
 | 節奏 | 該做什麼 |
 | --- | --- |
 | **每日** | 打開銷售管道看板。找出停滯的卡片（階段內 > 14 天）。推進或關閉。 |
-| **每週** | 執行*銷售管道覆蓋率*。向 Sales Copilot 提問：*"what's at risk?"* |
-| **每月** | 執行*按負責人 → 階段的漏斗*。對漏斗漏水的銷售代表進行一對一輔導。 |
-| **季末** | 執行*按負責人的贏單*以計算提成。歸檔*失敗*的交易並附上*丟單原因*。 |
+| **每週** | 執行 *Pipeline Coverage*。向 Sales Copilot 提問：*"what's at risk?"* |
+| **每月** | 執行 *Opportunity Funnel by Owner → Stage*。對漏斗漏水的銷售代表進行一對一輔導。 |
+| **季末** | 執行 *Won Opportunities by Owner* 以計算提成。歸檔*失敗*的交易並附上*丟單原因*。 |
 
 ## 預測彙總
 
 銷售經理 / 總監的預測視圖由以下部分構建：
 
 - **Opportunity Metrics** dataset（`opportunity_metrics`）—— 度量 **Total Amount**（金額之和），維度 **Stage**
-- **Sales Performance** 儀表板（`sales_dashboard`）—— 小工具包括按階段的銷售管道、贏單率、頂級交易
+- **Sales Performance** 儀表板（`sales_dashboard`）—— 小工具包括按階段的銷售管道、贏單率、按負責人的在飛管道
 - **Pipeline Coverage** 報告（`pipeline_coverage_by_quarter`，報表自身的 label 寫作 **Pipeline Coverage by Forecast × Quarter**）—— 未結管道的矩陣：列是預測類別，欄是預計成交季度
 
 它們共同回答：*"我們是否有足夠的銷售管道來完成本季度，以及風險在哪裡？"*
+
+這塊儀表板給不了的是*頂級交易*那種逐筆排行，改個名字也解決不了：儀表板的 table 綁定的是分析 dataset，只能做聚合，列不出原始記錄（ADR-0021）。原先占著這個位置的 **Top Open Opportunities** 表正是因此被換成了按負責人聚合的 **Open Pipeline by Owner** —— `src/dashboards/sales.dashboard.ts` 裡 Row 5 的註釋記下了這次替換。要逐筆的交易排行，請改用商機清單檢視。
 
 ## 給銷售代表的提示
 
@@ -104,8 +108,8 @@ description: 銷售管道的日常運作方式——推進交易、自動機率�
 
 ## 給銷售經理的提示
 
-- ✅ 每月執行*按負責人 → 階段的漏斗*，以發現漏斗漏水的銷售代表。
-- ✅ 在 QBR 中使用*按季度的銷售管道覆蓋率*來設定下一季度的目標。
+- ✅ 每月執行 *Opportunity Funnel by Owner → Stage*，以發現漏斗漏水的銷售代表。
+- ✅ 在 QBR 中使用 *Pipeline Coverage* 來設定下一季度的目標。
 - ✅ 輔導銷售代表填寫*競爭對手*——它能顯著提升 Copilot 的品質。
 
 ## 給管理員的提示


### PR DESCRIPTION
Fixes #989

同一页上的三族指称漂移，读者按现文在产品里都找不到东西。三语同址同步（en 行号，zh-Hans / zh-Hant 同行），`src/` 零改动，不触 `content/docs/releases/`，不动 `@objectstack/*` 版本。

与 PR #990（刚合并，改本页 :94 / :95）和 #987（:93）行集互斥，两者落地的写法在本 PR 中零回退 —— coverage 报表的轴、`sales_dashboard` 的真名与标识符都按 #990 刚落地的措辞抄平。

## 一、`:34` —— 幻名 + 一条源码里给不出的能力

原文：**Sales Dashboard** sums *Expected Revenue* across the open pipeline …

两半都不成立：

- **幻名**：没有叫 *Sales Dashboard* 的仪表盘。真身 `sales_dashboard`，label 与 Sales 组导航项都是 **Sales Performance**（`src/dashboards/sales.dashboard.ts:22`、`src/apps/crm.app.ts:61`）。这正是 #985 / PR #990 从同页 :94 修掉的那个幻名，:34 还留着一份 —— 现按「一名到底」归位。
- **假能力**：`opportunity_metrics` **没有任何 measure 读 `expected_revenue`**（`grep expected_revenue src/datasets/` 零命中）。它暴露的金额类度量 `total_amount` / `avg_amount` / `won_amount` / `lost_amount` 一律绑 `amount` 字段（`src/datasets/opportunity.dataset.ts:44-91`），所以 **Total Pipeline** 磁贴给的是**未加权**的管道总额，任何仪表盘 widget 都求不出加权预测 —— 语义层没暴露它。

加权预测这件事在产品里是存在的，落点是**表格视图的列合计**：`open_opportunities`（label **Open Deals**）与 `all_opportunities`（label **All Opportunities**）各声明了对 `expected_revenue` 的 `summary: sum`（`src/views/opportunity.view.ts:37`、`:138`）。`content/docs/sales/opportunities.mdx:120` 已经这样写了（Amount and Expected Revenue carry column totals），本 PR 与它对齐，并写明仪表盘为什么给不出同一个数。

### ⚠️ 裁定与实况有一处出入，未按裁定执行

issue 正文与派发裁定都把本页 `:51`（看板列顶的「加权合计」）当作「已写对」的参照系，要求 :34 与之对齐。复核**不成立**：kanban 的列顶合计由 `summarizeField` **一个单数可选字符串**决定 —— `@objectstack/spec` 的 `src/ui/view.zod.ts` 里 `KanbanConfigSchema` 写的是 `summarizeField: z.string().optional()`，describe 为 Field to sum at top of column —— 而 `pipeline_kanban` 设的是 `summarizeField: amount`（`src/views/opportunity.view.ts:147-157`）。看板每列只有**一个**数字，且求的是 amount，`:48`-`:51` 的「两个数字」本身就是同一类假能力。

本 PR 因此**没有引用 :51**，改为按上述源码证据把落点写成两张表格视图；`:48`-`:51` 属本单面外，已另立 #992，本 PR 不动它。

## 二、`:68` + `:72`-`:76` 报表表格（含 `:86` / `:87` / `:107` / `:108` 截断名）

`:68`「You will find these in the **Reports** section of the sidebar」：侧边栏没有 *Reports* 分组。分组叫 **Insights**（`src/apps/crm.app.ts:143-156`），且只钉了三张报表 —— Pipeline Coverage、Lead Inflow、SLA Performance —— 外加 CRM Overview 与 Forecasts。本表五行里只有第一行在导航上，其余四张从报表界面进。改写后与 `content/docs/analytics/index.mdx:54` 的口径（#987 落地）一致，两页不再矛盾。

四行报表名逐字对 `src/reports/opportunity.report.ts`：

| 原文 | 真实 label | 出处 |
| --- | --- | --- |
| Pipeline Coverage (Quarter)，轴写作 quarter × stage | **Pipeline Coverage by Forecast × Quarter**；轴为 forecast_category（行）× close_quarter（列） | `:36`-`:39` |
| Funnel by Owner → Stage | **Opportunity Funnel by Owner → Stage** | `:50`-`:51` |
| Opportunities by Stage | 逐字正确，未动 | `:6`-`:7` |
| Won by Owner | **Won Opportunities by Owner** | `:19`-`:20` |
| Customer Churn Signals | 逐字正确，未动 | `churn.report.ts:28`-`:29` |

coverage 行的轴按 PR #990 刚在 :95 落地的措辞抄平（未结管道的矩阵：行是预测类别，列是预计成交季度），不再写反的 quarter × stage；同时点明导航项上的短名是 **Pipeline Coverage**。`:72` 的「3x the quota」是描述业务问题的修辞（没有任何 coverage-ratio 度量），按原样保留，未当事实句处理。

截断名逐处补全：`:86` 与 `:107` → *Opportunity Funnel by Owner → Stage*，`:87` → *Won Opportunities by Owner*，`:108` 原来的 *Pipeline Coverage by Quarter* 两边都不是，归到导航名 *Pipeline Coverage*，与已写对的 `:85` 一致。

zh 两页里这些报表名原本被意译成中文（销售管道覆盖率 / 按负责人的赢单 …），没有任何翻译文件为它们背书（`src/translations/zh-CN.ts` 不含报表 label），一并归位为真 label —— 与 `content/docs/analytics/reports.zh-Hans.mdx:23` 的既有写法一致，不另造名。这一条也覆盖 zh 的 `:85`：en 的 *Pipeline Coverage* 本就正确无需动，zh 同址的意译名则需要归位，三语才真正同步。

## 三、`:94` 括号里的 *top deals*

- *pipeline by stage* → 真磁贴 **Pipeline by Stage**（`src/dashboards/shared-widgets.ts:32-36`）✓ 逐字未动
- *win rate* → 真磁贴 **Win Rate (12M)**（`src/dashboards/sales.dashboard.ts:143`）✓ 逐字未动
- *top deals* → **不存在，且结构性不可能**

仪表盘 `table` 绑定的是分析 dataset，只能聚合、列不出原始记录（ADR-0021）。`src/dashboards/sales.dashboard.ts` 第 5 行区（`:243`-`:249`）的注释记着这次替换：

```
// A dashboard `table` binds to an analytics cube and aggregates; it cannot
// list raw deals (ADR-0021). The previous "Top Open Opportunities" table
// selected only `opp_count` with no dimension — one summary row, not a deal
// ranking. Grouping open pipeline by owner yields a rep leaderboard (one
// row per rep). For a per-deal list, surface an object-bound ListView
// through app navigation (ADR-0017).
```

所以不是「改个名就行」。列表项改为真磁贴 **Open Pipeline by Owner**，并在列表后新增一段点名说清「为什么不可能有 top deals 磁贴」，把逐笔排行指向商机列表视图 —— 出处（Row 5 注释 + ADR-0021）一并写进正文。

## 验证

六道门全部 `exit=0`（在共享 `flock -w 7200 /tmp/os-heavy-verify.lock` 内串行，`NODE_OPTIONS=--max-old-space-size=4096`）：

| 门 | 结果 |
| --- | --- |
| `pnpm validate` | ✓ Validation passed (1177ms)，exit 0 |
| `pnpm typecheck` | exit 0，无输出 |
| `pnpm lint` | 13 warning(s), 14 suggestion(s)，均为既有项，exit 0 |
| `pnpm hygiene` | ✓ source hygiene clean，exit 0 |
| `pnpm build` | ✓ Build complete (1155ms)，exit 0 |
| `pnpm test -- --maxWorkers=2` | Test Files 75 passed (75)／Tests 1757 passed, 1 skipped (1758)，exit 0 |

**控制字节自扫**：对三个 mdx 跑 `grep -naP` 扫 0x00-0x08 / 0x0b / 0x0c / 0x0e-0x1f 零命中；`pnpm hygiene` 的扫描面本身覆盖 `content` 与 `.changeset`（"255 files under src, test, e2e, scripts; the control-byte scan adds 448 under content, .changeset" → "✓ no raw control bytes in first-party files"）。

**守卫盲区，如实报 predicted GREEN 并已实测**：本页没有任何 guard 覆盖这两族词汇 —— `test/docs-drift.test.ts` 的磁贴/仪表盘规则只扫 `content/docs/analytics/dashboards*.mdx`（`DOC_PAGES`），`test/docs-analytics-vocabulary.test.ts` 虽 `walk(DOCS_ROOT)` 全树，但对全树只查 `cubes/` 字样一条。两个套件单跑：

- 带缺陷（`git stash` 回到 origin/main 的三页）：`Test Files 2 passed (2)｜Tests 73 passed (73)`
- 已修：`Test Files 2 passed (2)｜Tests 73 passed (73)`

即**两种状态同为绿**。这不是「修好了所以绿」，而是这两族词汇根本不在任何门的扫描面上；同理，本次修好之后再漂回去也没有门会红。没有为本页新增 guard —— 那是独立的能力扩张，不在本单面内。

**与刚合并的 #991 的兼容**：#991 给 docs-drift 加了「产品文档里 `src/<dir>/` 必须存在」的新规则，而本 PR 新增了三处这类引用（`src/views/`、`src/apps/`、`src/dashboards/`）。把 #991 版本的 `docs-drift.test.ts` 取到本分支上单跑：本页相关断言全过，6 条失败全部落在 `for-developers.mdx` 上 —— 那是本分支还没有 #991 同 PR 的页面修正所致，合并后即消失。

未起任何 dev server；worktree 已 `git worktree remove`。

## 面外发现（Prime Directive #10，均已另立且未指派）

- **#992** —— 本页 `:48`-`:51`「看板列顶两个数字（未加权 + 加权）」是假能力：kanban 的 `summarizeField` 是单数可选字符串且绑 `amount`，看板每列只有一个数、且未加权。**该条同时否证了 #989 正文里「:51 已写对」这一支撑判断**（见上文第一族的说明），本 PR 据此调整了 :34 的写法，但按面限未动 `:48`-`:51`。
- **#993** —— Sales 组两个非对象导航项被按侧边栏上没有的名字指称：`content/docs/sales/index.mdx:64` / `:65` 的 *Sales Pipeline* / *Sales Dashboard*（后者是同一幻名的第三处），以及本页 `:38` 的「sidebar shortcut **Sales Pipeline**」—— 导航项真名分别是 **Pipeline** 与 **Sales Performance**；`content/docs/sales/opportunities.mdx:122` 已有正确口径可抄。

两条在开单前均已按关键词 + 文件路径检索过 open issues，无重复。
