### PR TITLE
fix(home): 首页 AI 卡片改称平台助手，并按文档口径指向右缘助手面板 (#1002)

### DIFF
--- a/.changeset/home-card-ai-assistant-copy.md
+++ b/.changeset/home-card-ai-assistant-copy.md
@@ -1,0 +1,50 @@
+---
+'hotcrm': patch
+---
+
+The home page's AI card no longer names a retired assistant persona, and it now
+sends you to the entry point the product documentation describes.
+
+The right-hand card on the Sales Home page read:
+
+```
+Today with Copilot
+Ask the Sales Copilot
+Open the floating Copilot (bottom-right) and ask "what should I focus on
+today?" — it sees your live pipeline, schema, and accounts.
+```
+
+Two things were wrong with that, and both were visible to a user today — this is
+interface copy, not documentation. **The persona does not exist**: the app's own
+`sales_copilot` agent was retired long ago, and AI capability is implemented by
+agents on the platform side while HotCRM contributes domain skills, so a card
+inviting you to "ask the Sales Copilot" names an entity this app does not
+contain. **The entry point was wrong too**: the card described a floating widget
+in the bottom-right corner, while the assistant is the chat panel the platform
+opens from the right edge of every page — the wording the `AI Copilot` docs
+section already uses. Whichever of the two was accurate, users were being given
+two different places to look.
+
+The card now reads:
+
+```
+Today with the AI Assistant
+Ask the AI Assistant
+Open the assistant panel from the right edge of the page and ask "what should I
+focus on today?" — it sees your live pipeline, schema, and accounts.
+```
+
+What the card *does* is unchanged — same card, same position on the page, same
+suggested question, same statement about what the assistant can see. Only the
+name and the directions changed.
+
+This was the last live persona mention outside the documentation. The prose
+sweep shipped separately and its guard is scoped to the documentation tree, so
+this string sat outside every check: `os validate` and `pnpm lint` walk metadata
+shape and treat a card's `title` and `description` as free text. A pin in
+`test/metadata-references.test.ts` now holds this card to the platform-assistant
+wording. Note that card-level copy has no locale keys — the translation contract
+carries page `label` / `description` / `title` / `subtitle` only — so this card
+renders the English string in every locale, exactly as it did before (#1004).
+
+Fixes #1002.

--- a/src/pages/home.page.ts
+++ b/src/pages/home.page.ts
@@ -231,11 +231,18 @@ export const SalesHomePage: Page = {
         {
           type: 'page:card',
           id: 'ai_briefing',
-          label: 'Today with Copilot',
+          // The assistant is the PLATFORM's (`ask`), not an app-owned persona:
+          // HotCRM contributes skills, the agent lives in the cloud side
+          // (maintainer ruling on #612, 2026-08-04). The retired `sales_copilot`
+          // agent (#512, ADR-0063 §2) must not be named in live UI copy — and
+          // the entry point is the assistant panel the platform opens from the
+          // right edge of every page, which is the wording
+          // `content/docs/ai-copilot/index.mdx` landed in #611/PR #1001.
+          label: 'Today with the AI Assistant',
           properties: {
-            title: 'Ask the Sales Copilot',
+            title: 'Ask the AI Assistant',
             description:
-              'Open the floating Copilot (bottom-right) and ask "what should I focus on today?" — it sees your live pipeline, schema, and accounts.',
+              'Open the assistant panel from the right edge of the page and ask "what should I focus on today?" — it sees your live pipeline, schema, and accounts.',
             bordered: true,
           },
         },

--- a/test/metadata-references.test.ts
+++ b/test/metadata-references.test.ts
@@ -746,3 +746,83 @@ describe('app AI bindings resolve to a platform agent', () => {
     expect(((stack as any).skills ?? []).length, 'no skills registered').toBeGreaterThan(0);
   });
 });
+
+/**
+ * The home page's AI card does not name a retired persona (#1002).
+ *
+ * The two guards above check agent BINDINGS — `defaultAgent`, `stack.agents` —
+ * because those are keys a schema can be pointed at. This one checks a
+ * paragraph, and that is the whole point: the card below said
+ * "Ask the Sales Copilot" for months while every gate stayed green. `os
+ * validate` and `pnpm lint` walk authored metadata and treat a card's `title` /
+ * `description` as free text; PR #1001's persona rule is deliberately scoped to
+ * `content/docs/**` (the range the maintainer drew for #612), so it never
+ * opened a `.page.ts`. A retired persona in `src/` had no guard at all — and
+ * this one was live UI copy, visible to a user today, not documentation.
+ *
+ * Two drifts were fixed here, both from the maintainer's 2026-08-04 ruling on
+ * #612 (Option A) and the architecture note that followed it:
+ *
+ * - **The persona.** `sales_copilot` was retired in #512 and ADR-0063 §2 made
+ *   the surface skills-only. AI capability is implemented by agents in
+ *   `objectstack-ai/cloud`; HotCRM contributes domain skills. So the copy names
+ *   the platform's assistant, never an app-owned one.
+ * - **The entry point.** The card sent users to "the floating Copilot
+ *   (bottom-right)"; `content/docs/ai-copilot/index.mdx` documents "the chat
+ *   panel the platform opens from the right edge of every page" (#611 / PR
+ *   #1001). Two descriptions of one entry point is drift whichever is right, so
+ *   the card now uses the documented one.
+ *
+ * SCOPE — read before extending. This pins the ONE card this PR rewrote. It is
+ * not the general rule, and it cannot catch the same persona reappearing in a
+ * different card, view, or skill description: that is a scan-surface question
+ * over every user-visible string in `src/` (`title` / `label` / `description` /
+ * `help`), which touches the public wording surface and needs its own ruling.
+ * Filed as #1003 for that reason — do not quietly grow this into it.
+ *
+ * Reverse verification: predicted red-before / green-after, the ordinary
+ * direction for a forbidden-string pin over copy that plainly contained the
+ * string. Measured by restoring the old three lines: 2 of 3 assertions fail
+ * ("Ask the Sales Copilot" on `title`, "Today with Copilot" on `label`, and the
+ * floating/bottom-right entry point), then green once rewritten.
+ */
+describe('live UI copy does not name a retired copilot persona (#1002)', () => {
+  const homePage = pages.find((p) => p.name === 'sales_home_page');
+
+  /** The card carries the app's only AI-facing home-page copy. */
+  const card = [...walk(homePage?.regions), ...walk(homePage?.slots)].find(
+    (c: AnyRec) => c.id === 'ai_briefing',
+  );
+
+  it('the card this rule reads is still on the home page', () => {
+    // Guard the guard: renamed away, every assertion below would pass by
+    // reading `undefined` — the empty-pass failure mode a copy rule dies of.
+    expect(homePage, 'sales_home_page is no longer registered in the stack').toBeDefined();
+    expect(card, 'no component with id "ai_briefing" on sales_home_page').toBeDefined();
+    expect(typeof card?.properties?.title).toBe('string');
+    expect(typeof card?.properties?.description).toBe('string');
+  });
+
+  it('no retired persona name in the card copy', () => {
+    const copy = [card?.label, card?.properties?.title, card?.properties?.description]
+      .filter((s): s is string => typeof s === 'string')
+      .join('\n');
+    // The bare word is included on purpose: "Copilot" alone reads as an
+    // app-owned assistant in UI copy, even though the DOCS keep *AI Copilot* as
+    // a section name (#611's line, which applies to a docs nav, not to a card).
+    const found = ['Sales Copilot', 'Service Copilot', 'Copilot'].filter((name) =>
+      copy.includes(name),
+    );
+    expect(found, `retired persona named in home-page card copy: ${found.join(', ')}`).toEqual([]);
+  });
+
+  it('the card points at the documented assistant entry point', () => {
+    const description: string = card?.properties?.description ?? '';
+    // The stale spelling, not a paraphrase of the new one: pinning the exact
+    // sentence would fail on any harmless rewording, while "floating" /
+    // "bottom-right" is precisely the claim that contradicts the docs.
+    expect(description.toLowerCase()).not.toContain('floating');
+    expect(description.toLowerCase()).not.toContain('bottom-right');
+    expect(description).toContain('right edge');
+  });
+});


### PR DESCRIPTION
Fixes #1002

`src/pages/home.page.ts` 的 `ai_briefing` 卡片是 PR #1001 全站去人格化之后、`src/`
与维护者文档中**仅存的最后一处退役人格**，而且它不是文档，是用户今天就能看到的界面文案。

## 改了什么

```diff
-          label: 'Today with Copilot',
+          label: 'Today with the AI Assistant',
           properties: {
-            title: 'Ask the Sales Copilot',
+            title: 'Ask the AI Assistant',
             description:
-              'Open the floating Copilot (bottom-right) and ask "what should I focus on today?" — it sees your live pipeline, schema, and accounts.',
+              'Open the assistant panel from the right edge of the page and ask "what should I focus on today?" — it sees your live pipeline, schema, and accounts.',
```

两处漂移，都按 #612 评论区维护者 2026-08-04 的方案 A 拍板与随后的架构定调处理：

1. **人格**：`sales_copilot` 已由 #512 退役，ADR-0063 §2 把应用面收敛为 skills-only；
   AI 能力由 objectstack-ai/cloud 侧的 agent 承载，应用只定义领域 skills。卡片因此
   不能再指向一个本应用不包含的实体。裸 "Copilot"（`label` 与 description 里各一处）
   一并中性化——文档侧 #611 保留 *AI Copilot* 作为**文档区名**，那条界线不适用于界面卡片。
2. **入口**：卡片写「the floating Copilot (bottom-right)」，而
   `content/docs/ai-copilot/index.mdx` 的现行口径是「the chat panel the platform opens
   from the **right edge** of every page」（#611 / PR #1001 落地）。两种说法指向同一个
   入口却互相矛盾，按文档口径统一。

卡片的功能语义原样保留：同一张卡、同一个位置、同一个建议问句、同一句「它能看到你的实时
管道、schema 与客户」。

## 语言包

**没有对应键，取值链是字面量直通产物。** 翻译契约里 `pages` 是 `.strict()` 的四个键
`label / description / title / subtitle`，其中 `title` / `subtitle` 按
`test/i18n-references.test.ts` 的注释对应的是 **`page:header`**（header 实例无稳定 id，
页面名是唯一能够到它的键）。卡片 `title` / `description` 没有任何翻译位——语言包写不进去
（strict 会拒），运行时也无处可读。四个语言包 `pages.sales_home_page` 现有的
`label/description/title/subtitle` 与本次改动无关，故未动。

这个缺口本身另立 #1004 记录（实测 12 处，首页占 10 处；对照组是 `dashboards.widgets`
——同样按 id 定位的组件，那边**有**翻译面）。

## 验证

六道门在共享锁内串行，全绿：

| 门 | 结果 |
| --- | --- |
| `pnpm validate` | exit 0（5 条既有 author-time 警告，与本改动无关） |
| `pnpm typecheck` | exit 0 |
| `pnpm lint` | exit 0（13 warning / 14 suggestion，均既有） |
| `pnpm hygiene` | exit 0，`✓ no raw control bytes`（257 + 454 文件） |
| `pnpm build` | exit 0，`Artifact: dist/objectstack.json` |
| `pnpm test` | exit 0，**77 files / 1822 passed / 1 skipped** |

**dist 产物核对**（新串进产物、旧串归零）：

```
"Ask the Sales Copilot"  => 0      "Ask the AI Assistant"                => 1
"Sales Copilot"          => 0      "Today with the AI Assistant"         => 1
"Today with Copilot"     => 0      "Open the assistant panel from the …" => 1
"floating Copilot"       => 0
"bottom-right"           => 0
产物中任何 "Copilot" 残留 => 0
```

**既有守卫零回退**：`docs-drift` / `i18n-references` / `metadata-references` /
`skills-integrity` / `source-hygiene-scan-surface` 五个文件 120 断言全绿。

**反向验证**（方向先定后跑：红→绿，普通禁字规则的常规方向）：把三行旧文案原样放回，
新 pin 的 3 条断言里 **2 条转红**——`["Sales Copilot", "Copilot"]` 被 title/label 命中，
以及 `expected 'open the floating copilot (bottom-rig…' not to contain 'floating'`；
第 3 条「卡片仍在页面上」的防空转断言保持绿（它本来就该绿）。改回后 30/30 全绿。

## 新增的 pin 与它**不**覆盖的东西

`test/metadata-references.test.ts` 新增 `live UI copy does not name a retired copilot
persona (#1002)`，与既有的两条退役 agent 守卫同族。三条断言：卡片仍可达（防空转）、
文案不含人格名、入口不再写 floating/bottom-right 且写了 right edge。

**这条 pin 只钉这一张卡片，是刻意的**：换一张卡片、换一个视图的 emptyState、换一条
skill 的 description，同样的人格照样进得来。把扫描面扩到 `src/` 全部用户可见字符串
（`title`/`label`/`description`/`help`）会碰公共措辞面、需要单独裁定（裸 Copilot 算不算
违规、豁免机制怎么设），按本单裁定不在此做——已立 #1003 记录。

## 边界

- ⛔ `content/docs/`、`releases/`、`@objectstack/*` 版本、语言包内容均未触碰；
- 与 #734（同页 Component Placeholder 渲染问题）互不触碰：那是渲染，这是文案内容；
- #595 不预判；未起 dev server。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_