### PR TITLE
fix(metadata): 明细行随父记录级联删除（opportunity / quote）

### DIFF
--- a/.changeset/line-item-cascade-on-parent-delete.md
+++ b/.changeset/line-item-cascade-on-parent-delete.md
@@ -1,0 +1,45 @@
+---
+'hotcrm': patch
+---
+
+Let an opportunity or a quote that carries product lines be deleted again. Once a
+rep itemised a deal — which is the ordinary state of any deal priced from the
+product catalog — the parent record refused to delete, and the refusal handed the
+API caller an internal authoring instruction:
+
+```
+DELETE /api/v1/data/crm_opportunity/<id>
+→ 409 {"error":"Cannot delete crm_opportunity (<id>): 1 dependent
+       crm_opportunity_line_item record(s) reference it via crm_opportunity
+       (crm_opportunity is required, so it cannot be cleared). Delete or reassign
+       them first, or set deleteBehavior:'cascade' on
+       crm_opportunity_line_item.crm_opportunity.","code":"DELETE_RESTRICTED"}
+```
+
+`crm_quote` produced the same sentence with the nouns swapped. The only way
+through was to delete every line by hand first.
+
+The cause was a default nobody wrote down. `crm_opportunity_line_item
+.crm_opportunity` and `crm_quote_line_item.crm_quote` declared no
+`deleteBehavior`, so both took `Field.lookup`'s spec default of `set_null` — and
+the engine's referential pass escalates a `set_null` default on a **required**
+lookup to `restrict`, because a NOT NULL column cannot be cleared. Nothing in
+either object's source said "refuse to delete the parent"; the behaviour came
+entirely from the unwritten default.
+
+Both parent lookups now declare `deleteBehavior: 'cascade'`. A line item is
+subordinate by construction, and both objects already said so: their headers
+state that a line has no meaning apart from its deal, and the rollup hooks derive
+`crm_opportunity.amount` and the quote's subtotal/total **from** the line set. A
+line whose parent is gone denotes nothing and would keep a deleted deal's revenue
+alive in every line-level report.
+
+**What changes for you:** deleting an opportunity or a quote now also removes its
+product lines, so line-level revenue reporting drops accordingly — deliberately,
+since the deal is gone. Nothing else on these objects changed: the `crm_product`
+lookup stays on the restricting default, so retiring a catalog product that
+priced any line is still refused ("Set is_active=false to retire instead"), and
+lines belonging to other deals are never touched. This is deliberately *not* the
+answer taken for campaign members and meeting attendees, whose parent lookups
+keep restricting — a campaign's member list and a meeting's attendee list are
+those records' historical evidence, while a price line is not. Refs #727.

--- a/src/objects/opportunity_line_item.object.ts
+++ b/src/objects/opportunity_line_item.object.ts
@@ -60,12 +60,41 @@ export const OpportunityLineItem = ObjectSchema.create({
   highlightFields: ['crm_product', 'quantity', 'unit_price', 'total_price'],
 
   fields: {
+    // The parent link, and the ONE field on this object that decides whether the
+    // deal it belongs to can be deleted at all (#727).
+    //
+    // Declaring nothing here does not mean "no opinion": `Field.lookup` resolves
+    // `deleteBehavior` to the spec default `set_null`, and the engine's
+    // `cascadeDeleteRelations` escalates a `set_null` default on a REQUIRED
+    // lookup to `restrict` — a NOT NULL column cannot be cleared. So the silent
+    // default made every itemised opportunity undeletable, with a message that
+    // told the API caller to `set deleteBehavior:'cascade'` on this very field:
+    //
+    //     DELETE /api/v1/data/crm_opportunity/<id>
+    //     → 409 DELETE_RESTRICTED "…1 dependent crm_opportunity_line_item
+    //       record(s) reference it via crm_opportunity…"
+    //
+    // `cascade` is the semantics this object already claims twice over: the
+    // header comment says a line has no meaning apart from its deal, and
+    // `opportunity_line_item.hook.ts` derives `crm_opportunity.amount` FROM the
+    // line set. A record whose parent is gone denotes nothing and would keep a
+    // dead deal's revenue in the line-level reports.
+    //
+    // This is deliberately NOT the campaign/event answer (#696, #711 kept
+    // `crm_campaign_member.crm_campaign` and `crm_event_attendee.crm_event` on
+    // the restricting default): a member list is a campaign's historical record
+    // and survives on its own terms. A price line does not.
     crm_opportunity: Field.lookup('crm_opportunity', {
       label: 'Opportunity',
       required: true,
       storage: { notNull: true },
+      deleteBehavior: 'cascade',
     }),
 
+    // Deliberately left on the default, which the same escalation turns into
+    // `restrict`: deleting a catalog product must NOT shred the priced history
+    // of deals that sold it. `product.hook.ts`'s own `beforeDelete` says the
+    // same thing in words ("Set is_active=false to retire instead").
     crm_product: Field.lookup('crm_product', {
       label: 'Product',
       required: true,

--- a/src/objects/quote_line_item.object.ts
+++ b/src/objects/quote_line_item.object.ts
@@ -53,12 +53,22 @@ export const QuoteLineItem = ObjectSchema.create({
   highlightFields: ['crm_product', 'quantity', 'unit_price', 'total_price'],
 
   fields: {
+    // The parent link — same decision, same reasoning, as
+    // `opportunity_line_item.crm_opportunity` (#727); read the long note there.
+    // In short: declaring nothing resolves to the spec default `set_null`, which
+    // the engine escalates to `restrict` on a REQUIRED lookup, so every quote
+    // that had been itemised refused to delete with a 409 quoting this field.
+    // A quote line is subordinate to its quote (`quote_line_item.hook.ts` rolls
+    // the quote's subtotal/total UP from these rows), so it goes with it.
     crm_quote: Field.lookup('crm_quote', {
       label: 'Quote',
       required: true,
       storage: { notNull: true },
+      deleteBehavior: 'cascade',
     }),
 
+    // Left on the restricting default on purpose — see the twin object: a
+    // product's catalog entry must not take priced quote history with it.
     crm_product: Field.lookup('crm_product', {
       label: 'Product',
       required: true,

--- a/test/line-item-cascade.test.ts
+++ b/test/line-item-cascade.test.ts
@@ -1,0 +1,291 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import stack from '../objectstack.config';
+
+/**
+ * Deleting an itemised opportunity or quote must work (#727).
+ *
+ * ### The bug this file exists to keep dead
+ *
+ * Both line-item objects hang off their parent through a REQUIRED lookup that
+ * declared no `deleteBehavior`. Declaring nothing is not "no opinion": the spec
+ * resolves the field to its default `set_null` (measured on 17.0.0-rc.3 — the
+ * resolved field literally reads `"deleteBehavior":"set_null"` with nothing in
+ * source), and `cascadeDeleteRelations` escalates a `set_null` default on a
+ * required lookup to `restrict`, because a NOT NULL column cannot be cleared.
+ *
+ * So every opportunity or quote that had been itemised — which is the normal
+ * state of a deal once a rep configures products on it — refused to delete:
+ *
+ *     DELETE /api/v1/data/crm_opportunity/<id>
+ *     → 409 DELETE_RESTRICTED "Cannot delete crm_opportunity (<id>): 1 dependent
+ *       crm_opportunity_line_item record(s) reference it via crm_opportunity
+ *       (crm_opportunity is required, so it cannot be cleared). Delete or
+ *       reassign them first, or set deleteBehavior:'cascade' on
+ *       crm_opportunity_line_item.crm_opportunity."
+ *
+ * `crm_quote` -> `crm_quote_line_item` was the same sentence with the nouns
+ * swapped. Two things are wrong with that: the caller has to tear the deal down
+ * by hand line by line before the parent will go, and the refusal hands an API
+ * consumer an internal authoring instruction about a metadata key they cannot
+ * reach.
+ *
+ * ### The fix, and why cascade rather than a nicer refusal
+ *
+ * `deleteBehavior: 'cascade'` on the two parent lookups. A line item is
+ * subordinate by construction and both objects already say so: their own
+ * headers state a line "has no meaning apart from its deal", and the rollup
+ * hooks derive `crm_opportunity.amount` and the quote's subtotal/total FROM the
+ * line set — the parent's headline number is a function of the children, not
+ * the other way round. A surviving line whose parent is gone denotes nothing and
+ * would keep a deleted deal's revenue alive in every line-level report.
+ *
+ * ### Why this is NOT the campaign/event answer
+ *
+ * #696 and #711 deliberately left `crm_campaign_member.crm_campaign` and
+ * `crm_event_attendee.crm_event` on the restricting default: a campaign's member
+ * list and a meeting's attendee list are those records' historical evidence, so
+ * they are refused loudly rather than shredded. A price line carries no such
+ * standalone value. The distinction is pinned in both directions — here, and by
+ * the two sibling `*-cascade.test.ts` files — so a copy-paste in either
+ * direction fails.
+ */
+
+type AnyRec = Record<string, any>;
+
+const objects: AnyRec[] = (stack as any).objects ?? [];
+const byName = (n: string) => objects.find((o) => o.name === n) as AnyRec;
+
+const OPP_LINE_ITEM = byName('crm_opportunity_line_item');
+const QUOTE_LINE_ITEM = byName('crm_quote_line_item');
+
+// ───────────────────────────────────────────────── the declaration ──
+
+describe('the line-item objects declare cascade on their parent lookup', () => {
+  /**
+   * A structural pin, deliberately kept next to the end-to-end run below: the
+   * hazard is a MISSING key, and a missing key is invisible in review because
+   * the spec quietly fills in `set_null`. Asserting the RESOLVED value catches
+   * both a deletion of the declaration and a future spec default flip.
+   */
+  it.each([
+    ['crm_opportunity_line_item', () => OPP_LINE_ITEM, 'crm_opportunity'],
+    ['crm_quote_line_item', () => QUOTE_LINE_ITEM, 'crm_quote'],
+  ])('%s.%s cascades from its parent', (_object, schema, field) => {
+    const f = schema().fields[field as string];
+    expect(f.type).toBe('lookup');
+    expect(f.required).toBe(true);
+    expect(f.deleteBehavior).toBe('cascade');
+  });
+
+  /**
+   * The scope boundary, and the reason this fix is two fields and not "every
+   * lookup on a line item". `crm_product` stays on the default, which the same
+   * escalation turns into `restrict`: retiring a catalog product must never
+   * shred the priced history of the deals that sold it. `product.hook.ts` says
+   * the same thing in its own `beforeDelete` ("Set is_active=false to retire
+   * instead"), and the engine-level answer below proves the restrict survives
+   * independently of that hook.
+   */
+  it.each([
+    ['crm_opportunity_line_item', () => OPP_LINE_ITEM],
+    ['crm_quote_line_item', () => QUOTE_LINE_ITEM],
+  ])('%s leaves the product lookup on the restricting default', (_object, schema) => {
+    const f = schema().fields.crm_product;
+    expect(f.required).toBe(true);
+    expect(f.deleteBehavior).toBe('set_null');
+  });
+});
+
+// ─────────────────────────────────────────── on the real engine ──
+
+/**
+ * End-to-end over a real ObjectQL — the only place the interaction is visible.
+ * `cascadeDeleteRelations` is engine behaviour driven by metadata; no
+ * metadata-only assertion can show that a delete now succeeds, and no hook
+ * harness runs the referential pass at all.
+ *
+ * Objects only, no hooks — same as the two sibling cascade files. The rollup
+ * hooks are `async: true` / `onError: 'log'` by design and can neither block nor
+ * unblock a delete, so leaving them out measures the referential pass itself
+ * rather than a hook's opinion of it.
+ */
+describe('deleting an itemised parent', () => {
+  let ql: AnyRec;
+  let api: AnyRec;
+
+  beforeEach(async () => {
+    ql = (await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: {
+        crm_opportunity_line_item: OPP_LINE_ITEM,
+        crm_quote_line_item: QUOTE_LINE_ITEM,
+        crm_opportunity: byName('crm_opportunity'),
+        crm_quote: byName('crm_quote'),
+        crm_account: byName('crm_account'),
+        crm_product: byName('crm_product'),
+      } as never,
+    })) as never;
+    api = ql.createContext({ isSystem: true });
+  });
+  afterEach(async () => {
+    await ql?.close();
+  });
+
+  let seq = 0;
+  const uniq = () => `${++seq}`;
+
+  const newAccount = () =>
+    api.object('crm_account').insert({
+      name: `ACME ${uniq()}`,
+      type: 'customer',
+      industry: 'technology',
+    });
+
+  const newProduct = async () => {
+    const n = uniq();
+    return api.object('crm_product').insert({
+      name: `Widget ${n}`,
+      sku: `WIDGET-${n}`,
+      list_price: 100,
+    });
+  };
+
+  const newOpportunity = async (name = 'Repro Opp') => {
+    const account = await newAccount();
+    return api.object('crm_opportunity').insert({
+      name: `${name} ${uniq()}`,
+      crm_account: account.id,
+      amount: 1000,
+      stage: 'prospecting',
+      close_date: '2026-12-31',
+    });
+  };
+
+  const newQuote = async (name = 'Q') => {
+    const account = await newAccount();
+    return api.object('crm_quote').insert({
+      name: `${name}-${uniq()}`,
+      crm_account: account.id,
+      status: 'draft',
+      quote_date: '2026-01-01',
+      expiration_date: '2026-02-01',
+    });
+  };
+
+  const oppLines = () => api.object('crm_opportunity_line_item').find({ where: {} });
+  const quoteLines = () => api.object('crm_quote_line_item').find({ where: {} });
+
+  it('deletes an opportunity carrying several product lines, and takes the lines with it', async () => {
+    const opportunity = await newOpportunity();
+    const product = await newProduct();
+    for (const quantity of [1, 3]) {
+      await api.object('crm_opportunity_line_item').insert({
+        crm_opportunity: opportunity.id,
+        crm_product: product.id,
+        quantity,
+        unit_price: 50,
+      });
+    }
+    expect(await oppLines()).toHaveLength(2);
+
+    // The assertion that WAS the bug: this used to reject with
+    // "…1 dependent crm_opportunity_line_item record(s) reference it…".
+    await expect(
+      api.object('crm_opportunity').delete({ where: { id: opportunity.id } }),
+    ).resolves.not.toThrow();
+
+    expect(
+      await api.object('crm_opportunity').find({ where: { id: opportunity.id } }),
+    ).toHaveLength(0);
+    expect(await oppLines()).toHaveLength(0);
+  });
+
+  it('deletes an itemised quote the same way', async () => {
+    const quote = await newQuote();
+    const product = await newProduct();
+    await api.object('crm_quote_line_item').insert({
+      crm_quote: quote.id,
+      crm_product: product.id,
+      quantity: 2,
+      unit_price: 75,
+    });
+
+    await expect(
+      api.object('crm_quote').delete({ where: { id: quote.id } }),
+    ).resolves.not.toThrow();
+
+    expect(await api.object('crm_quote').find({ where: { id: quote.id } })).toHaveLength(0);
+    expect(await quoteLines()).toHaveLength(0);
+  });
+
+  /**
+   * The cascade is keyed on the parent ID, not on the object. A cascade that
+   * keyed off the object would empty the whole table on any deal's delete —
+   * silent, total data loss that every assertion above would still pass.
+   */
+  it('leaves every line that belongs to another deal alone', async () => {
+    const doomed = await newOpportunity('Doomed');
+    const bystander = await newOpportunity('Bystander');
+    const product = await newProduct();
+
+    await api.object('crm_opportunity_line_item').insert({
+      crm_opportunity: doomed.id, crm_product: product.id, quantity: 1, unit_price: 50,
+    });
+    const keep = await api.object('crm_opportunity_line_item').insert({
+      crm_opportunity: bystander.id, crm_product: product.id, quantity: 4, unit_price: 25,
+    });
+    // A quote line naming the same product must survive an OPPORTUNITY delete —
+    // the two line-item objects are separate cascade paths.
+    const quote = await newQuote();
+    const keepQuoteLine = await api.object('crm_quote_line_item').insert({
+      crm_quote: quote.id, crm_product: product.id, quantity: 1, unit_price: 90,
+    });
+
+    await api.object('crm_opportunity').delete({ where: { id: doomed.id } });
+
+    expect((await oppLines()).map((r: AnyRec) => r.id)).toEqual([keep.id]);
+    expect((await quoteLines()).map((r: AnyRec) => r.id)).toEqual([keepQuoteLine.id]);
+    expect(
+      await api.object('crm_opportunity').find({ where: { id: bystander.id } }),
+    ).toHaveLength(1);
+  });
+
+  it('still deletes a deal that was never itemised (nothing regressed for the plain case)', async () => {
+    const opportunity = await newOpportunity('Bare');
+    await expect(
+      api.object('crm_opportunity').delete({ where: { id: opportunity.id } }),
+    ).resolves.not.toThrow();
+    expect(
+      await api.object('crm_opportunity').find({ where: { id: opportunity.id } }),
+    ).toHaveLength(0);
+  });
+
+  /**
+   * The scope boundary, end-to-end. The product lookup was NOT touched, so the
+   * engine still refuses to delete a product any line prices — and the refusal
+   * names the real obstacle. This is the assertion that fails if someone later
+   * "finishes the job" by cascading every lookup on these objects.
+   */
+  it('still refuses to delete a product that priced lines reference, naming the obstacle', async () => {
+    const opportunity = await newOpportunity('Priced');
+    const product = await newProduct();
+    const line = await api.object('crm_opportunity_line_item').insert({
+      crm_opportunity: opportunity.id, crm_product: product.id, quantity: 1, unit_price: 50,
+    });
+
+    await expect(
+      api.object('crm_product').delete({ where: { id: product.id } }),
+    ).rejects.toThrow(
+      /dependent crm_opportunity_line_item record\(s\) reference it via crm_product/i,
+    );
+    expect(await api.object('crm_product').find({ where: { id: product.id } })).toHaveLength(1);
+    expect(await oppLines()).toHaveLength(1);
+
+    // And the line is still reachable the ordinary way — nothing was half-deleted.
+    expect((await oppLines())[0].id).toBe(line.id);
+  });
+});


### PR DESCRIPTION
Fixes #727

## 现象

在 fresh `origin/main` + `@objectstack/* 17.0.0-rc.3` 上复验，issue 前提**依然成立**：只要商机/报价挂过明细行（即用产品目录配过价的正常状态），父记录就删不掉，且拒绝文案把一条调用方根本够不着的元数据键甩给了 API 使用者：

```
DELETE /api/v1/data/crm_opportunity/{id}
→ 409 DELETE_RESTRICTED "Cannot delete crm_opportunity ({id}): 1 dependent
   crm_opportunity_line_item record(s) reference it via crm_opportunity
   (crm_opportunity is required, so it cannot be cleared). Delete or reassign
   them first, or set deleteBehavior:'cascade' on
   crm_opportunity_line_item.crm_opportunity."
```

`crm_quote` → `crm_quote_line_item` 是同一句话换名词。唯一的绕行是先手工把明细行一条条删干净。

## 根因

不是引擎缺陷，是**一个没人写下来的默认值**。

`crm_opportunity_line_item.crm_opportunity` 与 `crm_quote_line_item.crm_quote` 都没声明 `deleteBehavior`。「不声明」不等于「没意见」：spec 把该字段落到默认值 `set_null`（rc.3 实测，解析后的字段字面量就是 `"deleteBehavior":"set_null"`，而源码里一个字都没写），而引擎的 `cascadeDeleteRelations` 会把 **required** lookup 上的 `set_null` 默认升级成 `restrict` —— NOT NULL 列没法置空。所以两个对象的源码里没有任何一处表达过「禁止删除父记录」，这个行为完全来自那条隐式默认。

## 契约核验（改之前的硬前置）

在动手前先确认 rc.3 契约支持这个键，而不是写平台 workaround：

- `node_modules/@objectstack/spec/src/data/field.zod.ts:463`
  `deleteBehavior: z.enum(['set_null', 'cascade', 'restrict']).optional().default('set_null')`
  —— 键存在，取值面含 `'cascade'`。
- `node_modules/@objectstack/objectql/dist/core.js:6541`
  `behavior = fdef.type === "master_detail" ? … : fdef.deleteBehavior || "set_null"`，随后
  `if (behavior === "set_null" && fdef.required === true) behavior = "restrict"`；
  `behavior === "cascade"` 分支逐条 `this.delete(childName, …)`。
  —— 引擎确实消费它，且级联发生在父记录 `driver.delete` **之前**（`core.js:6626`）。

契约支持，故按 issue 的方案一实施。

## 修法

两个父 lookup 各加一行 `deleteBehavior: 'cascade'`，并把「为什么是 cascade、为什么不是 restrict」写进对象源码。明细行在构造上就是从属记录，这一点两个对象本来就说了两遍：对象头注释写着 line item 离开它的 deal 就没有意义，而 rollup hook 把 `crm_opportunity.amount` 和报价的 subtotal/total 都是**从**明细行集合派生出来的。父记录没了还留着的明细行什么都不指代，只会让一个已删除商机的收入继续活在所有行级报表里。

**范围严格限定在这两个字段**，并且把边界也一并钉住：

- 两个对象的 `crm_product` lookup **保持**在会升级成 restrict 的默认上 —— 下架一个产品目录项不能连带铲掉卖过它的成交历史（`product.hook.ts` 的 `beforeDelete` 也是同一句话：`Set is_active=false to retire instead`）。
- 这**不是** #696 / #711 的答案：`crm_campaign_member.crm_campaign` 和 `crm_event_attendee.crm_event` 继续 restrict，因为活动的成员名单、会议的参与者名单是那条记录本身的历史证据，而一条价格行不是。两个方向都有断言兜着，任一边的复制粘贴都会红。

## 验证

新增 `test/line-item-cascade.test.ts`，沿用仓内已有的 `*-cascade.test.ts` 家族形态（结构断言 + 真引擎端到端放在同一个文件，理由见 `campaign-member-cascade.test.ts` 的说明）：结构上钉住两个父 lookup 解析值为 `cascade`、两个 product lookup 仍为 `set_null`；行为上在 `ObjectQL` + `InMemoryDriver` 上跑真删除 —— 挂明细的商机/报价删得掉且明细随删、别的 deal 的行和同产品的报价行都不受影响、没挂明细的商机照常删、引用中的产品仍被 restrict 拦住并报出真正的阻塞方。

反向验证（**先定方向再跑**）：预期把两行声明摘掉后 2 条结构断言 + 2 条端到端删除转红，实测 `5 failed | 4 passed` —— 多红的一条是跨 deal 隔离用例（它同样依赖级联真的发生），4 条绿的正是不依赖级联的边界断言。方向与预期一致，非空转通过。

六门：

```
pnpm validate   ✓ Validation passed (1520ms)
pnpm typecheck  ✓ tsc --noEmit 无输出
pnpm lint       ✓ 13 warning(s), 14 suggestion(s)（均为既有信息级项）
pnpm hygiene    ✓ source hygiene clean（含控制字节扫描）
pnpm build      ✓ Build complete，17 Objects 344 Fields
pnpm test       ✓ Test Files 78 passed，Tests 1831 passed | 1 skipped
```

changeset：`.changeset/line-item-cascade-on-parent-delete.md`（patch），正文按发布说明读者写清了「删商机/报价会连带删掉产品行、行级收入报表相应下降」这个用户可见后果。

## 未做的事

没有改 `content/docs/` —— 同族的 #712（campaign_member 级联）也没有配套文档改动，本次行为变更的用户可见说明走 changeset。若维护者认为应当在 `sales/opportunities.mdx` / `sales/quotes.mdx` 三个语言版本各补一条删除语义说明，可另开单，我不在本单里顺手加。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_