### PR TITLE
fix(quote): an absent link on an accepted quote is an absent key, not `false` (#714)

### DIFF
--- a/.changeset/quote-accepted-absent-links.md
+++ b/.changeset/quote-accepted-absent-links.md
@@ -1,0 +1,40 @@
+---
+'hotcrm': patch
+---
+
+Accepting a quote that is missing a link no longer breaks the rest of the
+acceptance chain.
+
+`quote_on_accepted` read the ids it copies onto the drafted contract with
+`(typeof input.x === 'string' && input.x) || (typeof previous?.x === 'string' &&
+previous.x)`. When neither operand held — a quote with no contact, or no
+opportunity, both of which `crm_quote` allows by design — that expression is not
+`undefined`, it is boolean `false`, and `false` went to the engine as the
+*content* of a lookup. A lookup column takes a record id or nothing at all, so
+the write was wrong in every deployment, in one of two ways:
+
+- with strict value shapes on (after `os migrate value-shapes --apply`), the
+  insert was refused — `Primary Contact has an invalid lookup value: Invalid
+  input: expected string, received boolean` — and the refusal aborted the whole
+  handler, so the **close-won step below it never ran either**. A rep accepting a
+  quote that carried its opportunity but no contact got no contract *and* an
+  opportunity still sitting open, while the accepting save answered `200`: the
+  hook is `async` with `onError: 'log'`, so the only evidence was a server log;
+- with the warn-first default, nothing was refused at all — `false` was
+  **stored** in the reference column, which is a row the value-shape migration
+  scan later cannot convert.
+
+An absent link is now an absent key. The contract is drafted with only the
+lookups the quote actually carries, so an opportunity-less quote drafts its
+contract normally instead of being rejected for a link it never had. The two
+consequences of acceptance are also independent now: a contract that will not
+draft no longer decides whether the deal is won, and each leg that fails is
+reported by name (`could not draft the contract for quote …`) so the log says
+what happened instead of nothing.
+
+One behaviour is unchanged and worth restating, because it is the reason this
+looked like a total failure: `crm_contract.crm_contact` is required, so a quote
+accepted with no contact still produces no contract — now refused honestly with
+`Primary Contact is required` rather than as a shape error, and no longer at the
+cost of the opportunity. This is what the Quotes page already tells reps ("put
+both on the quote before you mark it accepted").

--- a/src/objects/quote.hook.ts
+++ b/src/objects/quote.hook.ts
@@ -115,16 +115,41 @@ const quoteAccepted: Hook = {
       return d.toISOString().slice(0, 10);
     }
 
-    const quoteId = (typeof input.id === 'string' && input.id) || previous?.id;
-    const accountId =
-      (typeof input.crm_account === 'string' && input.crm_account) ||
-      (typeof previous?.crm_account === 'string' && previous.crm_account);
-    const contactId =
-      (typeof input.crm_contact === 'string' && input.crm_contact) ||
-      (typeof previous?.crm_contact === 'string' && previous.crm_contact);
-    const opportunityId =
-      (typeof input.crm_opportunity === 'string' && input.crm_opportunity) ||
-      (typeof previous?.crm_opportunity === 'string' && previous.crm_opportunity);
+    /**
+     * First candidate that is a non-empty record id, or `undefined` (#714).
+     *
+     * The id chains here used to be written `(typeof a === 'string' && a) || (typeof
+     * b === 'string' && b)`, whose value when NEITHER operand holds is boolean
+     * `false` — not `undefined`. `false` is a VALUE: it went into the contract
+     * document as the content of a lookup, and a lookup column takes a record id
+     * or nothing at all. What the engine did with it depends on the deployment's
+     * ADR-0104 value-shape posture, and both outcomes are wrong:
+     *
+     *   - warn-first (a deployment that has not run `os migrate value-shapes
+     *     --apply`): the write is ADMITTED with a `[value-shape] … accepted for
+     *     now` warning, and `crm_contact = false` is persisted into a reference
+     *     column — a row the value-shape scan will later refuse to convert;
+     *   - strict (after that gate, or `OS_DATA_VALUE_SHAPE_STRICT_ENABLED=1`):
+     *     `ValidationError: Primary Contact has an invalid lookup value: Invalid
+     *     input: expected string, received boolean`, which aborted this whole
+     *     handler — so no contract, and the close-won leg below never ran.
+     *
+     * `undefined` is the only correct "there is no id here": it does not survive
+     * the JSON hop into the engine, and the writes below drop the key outright,
+     * so an absent optional link is an ABSENT COLUMN rather than a junk value.
+     */
+    function pickId(...candidates: unknown[]): string | undefined {
+      for (const candidate of candidates) {
+        if (typeof candidate === 'string' && candidate) return candidate;
+      }
+      return undefined;
+    }
+
+    const quoteId = pickId(input.id, previous?.id);
+    const accountId = pickId(input.crm_account, previous?.crm_account);
+    const contactId = pickId(input.crm_contact, previous?.crm_contact);
+    const opportunityId = pickId(input.crm_opportunity, previous?.crm_opportunity);
+    const ownerId = pickId(input.owner_id, previous?.owner_id, ctx.user?.id);
     const totalPrice =
       typeof input.total_price === 'number'
         ? input.total_price
@@ -134,14 +159,12 @@ const quoteAccepted: Hook = {
 
     const today = new Date().toISOString().slice(0, 10);
     const months = 12;
-    await api.object('crm_contract').insert({
-      crm_account: accountId,
-      crm_contact: contactId,
-      crm_opportunity: opportunityId,
-      owner_id:
-        (typeof input.owner_id === 'string' && input.owner_id) ||
-        (typeof previous?.owner_id === 'string' && previous.owner_id) ||
-        ctx.user?.id,
+
+    // Only lookups we actually HAVE are written. A missing optional link is an
+    // absent key — never `false` (see `pickId`), and never `null` either: `null`
+    // is a legal shape for the optional `crm_opportunity` but not for the
+    // required `crm_contact`, and one idiom for both is what keeps this honest.
+    const contract: Record<string, unknown> = {
       status: 'draft',
       contract_term_months: months,
       start_date: today,
@@ -149,28 +172,70 @@ const quoteAccepted: Hook = {
       contract_value: totalPrice,
       contract_type: 'subscription',
       description: `Auto-drafted from accepted quote ${quoteId ?? ''}`.trim(),
-    });
+    };
+    if (accountId) contract.crm_account = accountId;
+    if (contactId) contract.crm_contact = contactId;
+    if (opportunityId) contract.crm_opportunity = opportunityId;
+    if (ownerId) contract.owner_id = ownerId;
+
+    // The two legs are INDEPENDENT, and this is the other half of #714: they
+    // used to be one straight-line sequence, so anything that made the contract
+    // insert throw also swallowed the close-won below it — an accepted quote on
+    // a live opportunity left the deal open, with the hook's `onError: 'log'`
+    // making the whole thing invisible to the user. Winning the deal is keyed on
+    // the quote being ACCEPTED, not on the contract being draftable, so a
+    // refusal from `crm_contract` must not decide the opportunity's stage.
+    // Failures are collected and re-thrown together at the end, so the log the
+    // runtime writes still names everything that went wrong.
+    const failures: string[] = [];
+
+    try {
+      await api.object('crm_contract').insert(contract);
+    } catch (err) {
+      // `crm_quote.crm_contact` is deliberately optional while
+      // `crm_contract.crm_contact` is `required + notNull`, so a quote accepted
+      // without a recipient legitimately lands here with "Primary Contact is
+      // required". That refusal is the documented behaviour, not a defect —
+      // `content/docs/sales/quotes.mdx` already tells reps to put the contact on
+      // the quote first, because "what the quote does not carry, acceptance
+      // cannot pass on". What this catch changes is that the refusal is now
+      // truthful (a named missing field, not "received boolean") and that it no
+      // longer takes the close-won leg with it.
+      failures.push(
+        `could not draft the contract for quote ${quoteId ?? '(unknown)'}: ${(err as Error).message}`,
+      );
+    }
 
     if (opportunityId) {
-      const opp = await api.object('crm_opportunity').findOne({ where: { id: opportunityId } });
-      if (opp && opp.stage !== 'closed_won' && opp.stage !== 'closed_lost') {
-        await api.object('crm_opportunity').update(
-          {
-            id: opportunityId,
-            stage: 'closed_won',
-            close_date: today,
-            // `crm_opportunity.win_reason` is `requiredWhen` stage is
-            // closed_won (#593), and this write is the ONE close path with no
-            // human in it to attribute the win — so without a value here the
-            // CPQ leg would be rejected by the engine on every accepted quote.
-            // `quote_accepted` names the automated path rather than guessing a
-            // rep's answer; keep the reason the rep already recorded if there
-            // is one.
-            ...(opp.win_reason ? {} : { win_reason: 'quote_accepted' }),
-          },
-          { where: { id: opportunityId } },
+      try {
+        const opp = await api.object('crm_opportunity').findOne({ where: { id: opportunityId } });
+        if (opp && opp.stage !== 'closed_won' && opp.stage !== 'closed_lost') {
+          await api.object('crm_opportunity').update(
+            {
+              id: opportunityId,
+              stage: 'closed_won',
+              close_date: today,
+              // `crm_opportunity.win_reason` is `requiredWhen` stage is
+              // closed_won (#593), and this write is the ONE close path with no
+              // human in it to attribute the win — so without a value here the
+              // CPQ leg would be rejected by the engine on every accepted quote.
+              // `quote_accepted` names the automated path rather than guessing a
+              // rep's answer; keep the reason the rep already recorded if there
+              // is one.
+              ...(opp.win_reason ? {} : { win_reason: 'quote_accepted' }),
+            },
+            { where: { id: opportunityId } },
+          );
+        }
+      } catch (err) {
+        failures.push(
+          `could not close-won opportunity ${opportunityId}: ${(err as Error).message}`,
         );
       }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(`quote_on_accepted: ${failures.join('; ')}`);
     }
   },
 };

--- a/test/quote-accepted-lookups.test.ts
+++ b/test/quote-accepted-lookups.test.ts
@@ -1,0 +1,337 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import quoteHooks from '../src/objects/quote.hook';
+import { Contract } from '../src/objects/contract.object';
+import type { HookApi } from '../src/objects/_hook-api';
+import { makeHarness, makeCtx, hookNamed, type Rec } from './helpers/hook-harness';
+import { makeSandboxEngine, runHookBody } from './helpers/action-sandbox';
+
+/**
+ * `quote_on_accepted` and the links the quote does not have (#714).
+ *
+ * ### What went wrong
+ *
+ * The hook read its ids with `(typeof input.x === 'string' && input.x) ||
+ * (typeof previous?.x === 'string' && previous.x)`. When NEITHER operand holds
+ * — a quote carrying no contact, or no opportunity — that expression is not
+ * `undefined`, it is boolean **`false`**, and `false` went into the contract
+ * document as the content of a lookup.
+ *
+ * What the engine then did depends on the deployment's ADR-0104 value-shape
+ * posture, and BOTH outcomes are wrong. Measured on 17.0.0-rc.3 (pinned by
+ * `the engine's own verdict on a lookup value` below):
+ *
+ * | posture | what happens to `crm_contact: false` |
+ * | --- | --- |
+ * | warn-first (default; gate not yet run) | admitted, `[value-shape] … accepted for now` warning, `false` PERSISTED into a reference column |
+ * | strict (after `os migrate value-shapes --apply`, or `OS_DATA_VALUE_SHAPE_STRICT_ENABLED=1`) | `ValidationError: Primary Contact has an invalid lookup value: Invalid input: expected string, received boolean` |
+ *
+ * The issue was filed against rc.2, where strict was the only behaviour: the
+ * ValidationError aborted the handler, so no contract was drafted AND the
+ * close-won leg that sits after the insert never ran. `async: true` +
+ * `onError: 'log'` meant the accepting PATCH still answered 200 — the user saw
+ * a won-looking quote, an open opportunity and no contract, with the only
+ * evidence in a server log.
+ *
+ * ### What is asserted here
+ *
+ * 1. no lookup in the drafted contract ever carries a non-string — an absent
+ *    link is an ABSENT KEY;
+ * 2. the two legs are independent: a contract that refuses to draft no longer
+ *    decides whether the opportunity is won;
+ * 3. a leg that fails is still REPORTED (the handler throws), so `onError:
+ *    'log'` has something true to log instead of nothing at all.
+ *
+ * Assertion (1) is written against the document the hook actually hands the
+ * engine, not against the row a stub stored, because the stubs in
+ * `hook-harness.ts` / `action-sandbox.ts` accept values the kernel does not —
+ * `crm_contact: false` stored perfectly well in both of them, which is why the
+ * existing coverage was green throughout. The real verdicts are pinned against
+ * a real ObjectQL in the last describe of this file.
+ */
+
+type AnyRec = Record<string, any>;
+
+const hook = hookNamed(quoteHooks, 'quote_on_accepted');
+const USER = { id: 'user_1' };
+
+/** The lookups on the drafted contract, in the order the schema declares them. */
+const LOOKUPS = ['crm_account', 'crm_contact', 'crm_opportunity', 'owner_id'] as const;
+
+/** Accept a quote whose links are exactly `quote` — nothing is defaulted in. */
+const accept = (api: HookApi, quote: Rec): Promise<unknown> =>
+  hook.handler(makeCtx({
+    event: 'afterUpdate',
+    input: { id: 'q1', status: 'accepted', total_price: 1_000, owner_id: 'rep1', ...quote },
+    previous: { id: 'q1', status: 'presented' },
+    user: USER,
+    api,
+  }));
+
+/** The document the hook handed `crm_contract.insert`. */
+const draftedContract = (h: ReturnType<typeof makeHarness>): Rec => {
+  const [call] = h.callsFor('crm_contract', 'insert');
+  expect(call, 'the hook drafted no contract at all').toBeTruthy();
+  return call!.args[0] as Rec;
+};
+
+describe('an absent link is an absent key, never a boolean', () => {
+  it('drafts a contract for a quote with NO contact — and writes no crm_contact', async () => {
+    const h = makeHarness({
+      crm_contract: [],
+      crm_opportunity: [{ id: 'opp1', stage: 'proposal' }],
+    });
+    // The reproduction from the issue: account + opportunity, no contact.
+    await accept(h.api, { crm_account: 'acc1', crm_opportunity: 'opp1' }).catch(() => {});
+
+    const doc = draftedContract(h);
+    expect(
+      Object.prototype.hasOwnProperty.call(doc, 'crm_contact'),
+      'crm_contact must be OMITTED, not written as false/null',
+    ).toBe(false);
+    expect(doc.crm_opportunity).toBe('opp1');
+  });
+
+  it('drafts a contract for a quote with NO opportunity — and writes no crm_opportunity', async () => {
+    const h = makeHarness({ crm_contract: [], crm_opportunity: [] });
+    await accept(h.api, { crm_account: 'acc1', crm_contact: 'con1' });
+
+    const doc = draftedContract(h);
+    expect(
+      Object.prototype.hasOwnProperty.call(doc, 'crm_opportunity'),
+      'crm_opportunity must be OMITTED, not written as false/null',
+    ).toBe(false);
+    expect(doc.crm_contact).toBe('con1');
+    // Everything the contract needs from the quote is still there.
+    expect(doc.crm_account).toBe('acc1');
+    expect(doc.contract_value).toBe(1_000);
+    expect(doc.status).toBe('draft');
+  });
+
+  it.each([
+    ['no contact', { crm_account: 'acc1', crm_opportunity: 'opp1' }],
+    ['no opportunity', { crm_account: 'acc1', crm_contact: 'con1' }],
+    ['neither', { crm_account: 'acc1' }],
+    ['no owner either', { crm_account: 'acc1', owner_id: undefined }],
+  ])('every lookup it DOES write is a record id — quote with %s', async (_label, quote) => {
+    const h = makeHarness({
+      crm_contract: [],
+      crm_opportunity: [{ id: 'opp1', stage: 'proposal' }],
+    });
+    await accept(h.api, quote).catch(() => {});
+
+    const doc = draftedContract(h);
+    for (const field of LOOKUPS) {
+      if (!Object.prototype.hasOwnProperty.call(doc, field)) continue;
+      expect(
+        typeof doc[field],
+        `${field} reached the engine as ${JSON.stringify(doc[field])}, which is not a record id`,
+      ).toBe('string');
+      expect(doc[field], `${field} reached the engine empty`).not.toBe('');
+    }
+  });
+});
+
+describe('a contract that will not draft does not decide whether the deal is won', () => {
+  /**
+   * A harness whose `crm_contract.insert` refuses the way the kernel refuses a
+   * contact-less contract. This is the shape the CPQ chain meets every time a
+   * quote is accepted without a recipient — `crm_quote.crm_contact` is
+   * deliberately optional while `crm_contract.crm_contact` is `required +
+   * notNull` — and the refusal is pinned against a real ObjectQL below.
+   */
+  const refusingContracts = (h: ReturnType<typeof makeHarness>, message: string): HookApi => ({
+    object: (name: string) => {
+      const repo = h.api.object(name);
+      if (name !== 'crm_contract') return repo;
+      return { ...repo, insert: async () => { throw new Error(message); } };
+    },
+  });
+
+  it('still pushes the linked opportunity to closed_won', async () => {
+    const h = makeHarness({
+      crm_contract: [],
+      crm_opportunity: [{ id: 'opp1', stage: 'proposal' }],
+    });
+    const api = refusingContracts(h, 'Primary Contact is required');
+
+    // The failure is reported — `onError: 'log'` needs something true to log.
+    await expect(accept(api, { crm_account: 'acc1', crm_opportunity: 'opp1' }))
+      .rejects.toThrow(/could not draft the contract for quote q1: Primary Contact is required/);
+
+    // …and the deal the quote won is won. This is the half of #714 that made
+    // the whole chain look dead: the close-won leg used to sit AFTER the insert
+    // in one straight line, so the throw took it with it.
+    const opp = h.rows('crm_opportunity')[0]!;
+    expect(opp.stage, 'the accepted quote left its opportunity open').toBe('closed_won');
+    expect(opp.win_reason).toBe('quote_accepted');
+  });
+
+  it('reports the close-won failure too, without hiding the contract it did draft', async () => {
+    const h = makeHarness({
+      crm_contract: [],
+      crm_opportunity: [{ id: 'opp1', stage: 'proposal' }],
+    });
+    const api: HookApi = {
+      object: (name: string) => {
+        const repo = h.api.object(name);
+        if (name !== 'crm_opportunity') return repo;
+        return { ...repo, update: async () => { throw new Error('write rejected'); } };
+      },
+    };
+
+    await expect(accept(api, { crm_account: 'acc1', crm_contact: 'con1', crm_opportunity: 'opp1' }))
+      .rejects.toThrow(/could not close-won opportunity opp1: write rejected/);
+    expect(h.rows('crm_contract'), 'the contract leg was dragged down with the other').toHaveLength(1);
+  });
+});
+
+describe('the SHIPPED body behaves the same inside QuickJS', () => {
+  /**
+   * `hook.handler(ctx)` above keeps the closure; the runtime runs a lowered
+   * body-only source across a JSON boundary. Two things this change relies on
+   * only exist there: `undefined` must DROP the key on the way to the engine,
+   * and a rejection from the engine facade must be catchable inside the VM.
+   */
+  it('omits the absent lookup and still wins the deal when the contract refuses', async () => {
+    const sandbox = makeSandboxEngine({ crm_opportunity: [{ id: 'opp_1', stage: 'proposal' }] });
+    const passThrough = sandbox.engine.insert as (o: string, d: Rec) => Promise<Rec>;
+    const seen: Rec[] = [];
+    sandbox.engine.insert = async (object: string, data: Rec) => {
+      if (object !== 'crm_contract') return passThrough(object, data);
+      seen.push(data);
+      throw new Error('Primary Contact is required');
+    };
+
+    await expect(runHookBody(hook, {
+      event: 'afterUpdate',
+      // No `crm_contact` — the issue's reproduction, run as the artifact ships it.
+      input: { id: 'q_1', status: 'accepted', crm_account: 'acc_1', crm_opportunity: 'opp_1', total_price: 1_000 },
+      previous: { id: 'q_1', status: 'presented' },
+      user: USER,
+      engine: sandbox,
+    })).rejects.toThrow(/could not draft the contract/);
+
+    const doc = seen[0]!;
+    expect(doc, 'the body never reached the contract insert').toBeTruthy();
+    expect(Object.prototype.hasOwnProperty.call(doc, 'crm_contact')).toBe(false);
+    expect(doc.crm_opportunity).toBe('opp_1');
+    expect(sandbox.rows('crm_opportunity')[0]!.stage).toBe('closed_won');
+  });
+});
+
+// ─────────────────────── the stand-ins' verdicts are the kernel's verdicts ──
+
+describe("the engine's own verdict on a lookup value", () => {
+  /**
+   * Everything above runs against a stub, and a stub that accepts what the
+   * kernel rejects proves nothing — `crm_contact: false` stored happily in both
+   * of this repo's harnesses, which is exactly why #714 shipped. So the four
+   * verdicts the fix depends on are measured here against a real ObjectQL
+   * carrying the app's REAL `crm_contract` metadata.
+   *
+   * Strict value shapes are switched on for this describe. That is not an
+   * artificial setting: it is what `os migrate value-shapes --apply` records on
+   * a real deployment (docs/MAINTENANCE.md §3.2), it is what the rc.2
+   * acceptance run in #714 met, and the warn-first default is a migration
+   * grace period, not the destination. The warn-first outcome is asserted too,
+   * because "admitted" there is not "fine" — it persists `false` into a
+   * reference column.
+   */
+  const STRICT = 'OS_DATA_VALUE_SHAPE_STRICT_ENABLED';
+  const stub = (name: string) => ({
+    name,
+    fields: { id: { type: 'text' }, name: { type: 'text' }, stage: { type: 'text' } },
+  });
+
+  let ql: AnyRec;
+  let api: AnyRec;
+  let previousStrict: string | undefined;
+
+  beforeAll(async () => {
+    previousStrict = process.env[STRICT];
+    process.env[STRICT] = '1';
+    ql = await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: {
+        crm_contract: Contract as never,
+        crm_account: stub('crm_account'),
+        crm_contact: stub('crm_contact'),
+        crm_opportunity: stub('crm_opportunity'),
+        sys_user: stub('sys_user'),
+      } as never,
+    });
+    api = ql.createContext({ isSystem: true });
+  }, 60_000);
+
+  afterAll(async () => {
+    if (previousStrict === undefined) delete process.env[STRICT];
+    else process.env[STRICT] = previousStrict;
+    await ql?.close();
+  });
+
+  /** The contract document the hook builds today, for the given quote links. */
+  const hookDocFor = async (quote: Rec): Promise<Rec> => {
+    const h = makeHarness({ crm_contract: [], crm_opportunity: [] });
+    await accept(h.api, quote).catch(() => {});
+    return draftedContract(h);
+  };
+
+  const insertAndCatch = async (doc: Rec): Promise<string | null> => {
+    try {
+      await api.object('crm_contract').insert(doc);
+      return null;
+    } catch (e) {
+      return (e as Error).message;
+    }
+  };
+
+  it('rejects the boolean the hook used to send — the exact #714 ValidationError', async () => {
+    const doc = await hookDocFor({ crm_account: 'acc_1', crm_contact: 'con_1' });
+    // The pre-fix document, reconstructed: the two `&&` chains that found
+    // nothing evaluated to `false` and the value went in as-is.
+    const message = await insertAndCatch({ ...doc, crm_contact: false, crm_opportunity: false });
+    expect(message).toMatch(
+      /Primary Contact has an invalid lookup value: Invalid input: expected string, received boolean/,
+    );
+    expect(message).toMatch(
+      /Related Opportunity has an invalid lookup value: Invalid input: expected string, received boolean/,
+    );
+  });
+
+  it('accepts the document the hook builds when the quote has no opportunity', async () => {
+    // Straight from the hook — the leg the fix RESTORES. Before it, this same
+    // quote produced `crm_opportunity: false` and was refused outright.
+    const doc = await hookDocFor({ crm_account: 'acc_1', crm_contact: 'con_1' });
+    expect(await insertAndCatch(doc)).toBeNull();
+  });
+
+  it('rejects a contact-less contract by NAME — the schema conflict, not a shape error', async () => {
+    // `crm_quote.crm_contact` is optional by design; `crm_contract.crm_contact`
+    // is `required + notNull`. After the fix the refusal is this truthful one
+    // instead of "received boolean", and it no longer takes close-won with it —
+    // but the CPQ chain still ends here for a contact-less quote, which is what
+    // `content/docs/sales/quotes.mdx` already tells reps ("what the quote does
+    // not carry, acceptance cannot pass on"). Pinned so that a later change to
+    // either schema has to come past this assertion.
+    const doc = await hookDocFor({ crm_account: 'acc_1', crm_opportunity: 'opp_1' });
+    expect(await insertAndCatch(doc)).toMatch(/Primary Contact is required/);
+  });
+
+  it('admits the same boolean under the warn-first default — silently storing it', async () => {
+    // Why the fix matters even where nothing throws: without the strict gate,
+    // `false` is not refused, it is KEPT. `os migrate value-shapes` is what
+    // later finds these rows, and by then they are data.
+    delete process.env[STRICT];
+    try {
+      const doc = await hookDocFor({ crm_account: 'acc_1', crm_contact: 'con_1' });
+      const row = await api.object('crm_contract').insert({ ...doc, crm_opportunity: false });
+      expect(row.crm_opportunity).toBe(false);
+    } finally {
+      process.env[STRICT] = '1';
+    }
+  });
+});


### PR DESCRIPTION
Fixes #714

## 现象

接受一张**没有同时挂 `crm_contact` 和 `crm_opportunity`** 的报价时,`quote_on_accepted` 整条链断掉:合同不起草,即便报价挂着 opportunity(只缺 contact)也不会 close-won。hook 是 `async: true` + `onError: 'log'`,接受写本身照样 200,用户完全无感知。

## 前提复核(fresh origin/main + rc.3):部分成立

代码缺陷**依然在**,但 rc.3 下症状与 issue(rc.2 时代)描述的**不一样**——因为 ADR-0104 的 value-shape 校验在 rc.3 变成了 warn-first。实测两种 posture:

| deployment posture | `crm_contact: false` 的结果 |
| --- | --- |
| warn-first(默认,未跑 `os migrate value-shapes --apply`) | **放行**,只打 `[value-shape] … accepted for now` 警告,`false` 被**写进 reference 列** |
| strict(跑过该 gate,或 `OS_DATA_VALUE_SHAPE_STRICT_ENABLED=1`) | `ValidationError: Primary Contact has an invalid lookup value: Invalid input: expected string, received boolean` —— 与 issue 日志逐字一致 |

也就是说:issue 描述的「合同不起草 + close-won 不执行」在 strict 下**完全复现**(rc.2 的默认行为,也是 `os migrate value-shapes` 之后的归宿);在 rc.3 的 warn-first 默认下,它变形成了**静默写脏数据**——合同起草了,但 `crm_contact = false` 落库,正是 value-shape 扫描日后无法转换的那类行。两种结果都错,根因是同一个。

顺带实测到 issue 未单独点名的一条:**有 contact、缺 opportunity** 的报价在 strict 下同样被拒(`Related Opportunity has an invalid lookup value`),即合同也起草不出来。

## 根因

`src/objects/quote.hook.ts` 的 id 取值写成:

```ts
const contactId =
  (typeof input.crm_contact === 'string' && input.crm_contact) ||
  (typeof previous?.crm_contact === 'string' && previous.crm_contact);
```

两个操作数都不成立时,表达式的值不是 `undefined` 而是 boolean **`false`**,并被原样当作 lookup 的**值**塞进合同 insert。lookup 列只接受 record id 或什么都不填,`false` 两者都不是。

第二处根因是**顺序耦合**:起草合同与 close-won 原本是一条直线,合同 insert 一抛,后面的 close-won 就永远到不了——成交是否推进,取决于合同能不能起草。

## 修法

1. `pickId(...candidates)`:把「这里没有 id」的所有形态(缺键、null、空串、类型不对)统一收敛成 `undefined`;
2. 合同文档**只写真正有的 lookup**——缺失的链接是**缺键**,不是 `false` 也不是 `null`(实测:`null` 对可选的 `crm_opportunity` 合法,对必填的 `crm_contact` 不合法,统一用缺键这一种写法);
3. 两条腿**互相独立**:各自 try/catch,失败按名字收集,最后一起抛出,`onError: 'log'` 因此能记到真实原因(`could not draft the contract for quote …`),而不是什么都记不到。

**没有动**的是 `crm_contract.crm_contact` 的 `required + notNull`:缺 contact 的报价仍然起草不出合同,但现在是诚实的 `Primary Contact is required`,而不是 `received boolean`,并且不再连累 close-won。这与 `content/docs/sales/quotes.mdx` 已经写给销售的口径一致——「what the quote does not carry, acceptance cannot pass on」。

## 验证

新增 `test/quote-accepted-lookups.test.ts`(13 例),分三层:

- **闭包层**:断言的是 hook 交给引擎的**文档**,不是 stub 存下的行——仓内两个 harness 都会照单全收 `crm_contact: false`,这正是既有覆盖一路绿灯的原因;
- **QuickJS 层**:跑 `runHookBody` 下发的 body-only 源码,证明 `undefined` 过 JSON 边界会丢键、引擎 facade 的 rejection 在 VM 内可被 catch;
- **真引擎层**:用 app 真实的 `crm_contract` metadata 起一个 ObjectQL,把上面 stub 的判决钉在内核的判决上(strict 下拒 boolean、接受本次修好的文档、缺 contact 报 `Primary Contact is required`;并单独钉住 warn-first 下 `false` 被存下来这件事)。

**反向验证**(先预判方向再跑):把 hook 还原成 origin/main 版本,13 例中 **11 例转红**,红的方向与预判一致——

```
× drafts a contract for a quote with NO contact — and writes no crm_contact
  → AssertionError: crm_contact must be OMITTED, not written as false/null
× every lookup it DOES write is a record id — quote with no contact
  → AssertionError: crm_contact reached the engine as false, which is not a record id
× still pushes the linked opportunity to closed_won
  → expected [Function] to throw error matching /could not draft the contract…/ but got 'Primary Contact is required'
× accepts the document the hook builds when the quote has no opportunity
  → expected 'Related Opportunity has an invalid lo…' to be null
Tests  11 failed | 2 passed (13)
```

保持绿的 2 例是**只量引擎、不量 hook** 的那两例(strict 下拒 boolean、warn-first 下收下 boolean)——平台行为没变,它们本就该两边都绿,这是正确的方向而不是漏网。

close-won 那条腿另做了一次直接测量(合同 insert 按内核的方式拒绝时):

```
修复前: handler threw: Primary Contact is required
        opportunity stage after accept: proposal      ← 成交没推进
        crm_opportunity update calls: 0
修复后: handler threw: quote_on_accepted: could not draft the contract for quote q1: Primary Contact is required
        opportunity stage after accept: closed_won    ← 推进了,且失败仍被如实上报
        crm_opportunity update calls: 1
```

六门自检(rc.3,未改任何 `@objectstack/*` 版本):

- `pnpm validate` ✅ · `pnpm lint` ✅(13 warning / 14 suggestion,全部既有)· `pnpm typecheck` ✅ · `pnpm hygiene` ✅ · `pnpm build` ✅
- `pnpm test` ✅ `78 files / 1835 passed, 1 skipped`
- `pnpm test:coverage` ✅ 分支 84.51%(阈值 78)· `quote.hook.ts` 行覆盖 100%
- `node scripts/check-stackblitz-lock.mjs` ✅

## 留给维护者的一个问题(未在本 PR 决定)

`crm_quote.crm_contact` 有意可选,而 `crm_contract.crm_contact` 必填,所以缺 contact 的报价被接受后合同仍然起不出来——本 PR 只让它失败得诚实且不再连累成交。但 quote schema 自己的注释写着 "Recipient is nailed down by the time a quote is presented",这个意图**没有任何东西在执行**:没有规则拦住一张没有 contact 的报价走到 `presented` / `accepted`。是否要把它变成强制(例如 `crm_quote.crm_contact` 在 `presented` 起 `requiredWhen`),会改变报价何时可被呈现,并影响存量数据,属于产品决策,留给维护者。


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHrPAGEgFDoHjphqYG4BMa)_