### PR TITLE
fix(hotcrm): repoint crm app branding to existing icon.svg (404 on crm-logo.png / crm-favicon.ico)

### DIFF
--- a/.changeset/crm-app-branding-asset-404.md
+++ b/.changeset/crm-app-branding-asset-404.md
@@ -1,0 +1,5 @@
+---
+'hotcrm': patch
+---
+
+Fixed the `crm_enterprise` app's `branding.logo` / `branding.favicon` pointing at `crm-logo.png` / `crm-favicon.ico`, neither of which was ever added to `assets/` — every Console page load hit two 404s. Repointed both to the existing `assets/icon.svg`, served live at `/runtime/assets/icon.svg` (the only mount the runtime actually serves app assets from; a plain `/assets/*` path — what was previously referenced — is not served at all).

--- a/src/apps/crm.app.ts
+++ b/src/apps/crm.app.ts
@@ -22,10 +22,21 @@ export const CrmApp = App.create({
   // which attach to the platform agents by `surface` affinity. The app-authored
   // agents this key used to name were retired in #512.
   defaultAgent: 'ask',
+  // `logo`/`favicon` point at the repo's existing `assets/icon.svg` (#731):
+  // the previously-referenced `crm-logo.png` / `crm-favicon.ico` were never
+  // added to `assets/`, and — separately — the runtime never serves a plain
+  // `/assets/*` path at all; static assets under `assets/` are only mounted
+  // at `/runtime/assets/:filename` (packages/cli's `createRuntimeAssetsPlugin`
+  // in @objectstack/cli). Verified live: GET /runtime/assets/icon.svg → 200,
+  // `content-type: image/svg+xml`. Both console consumers accept an SVG
+  // string here — `logo` renders via a plain `<img src>` (objectui's
+  // `AppSidebar.tsx`) and `favicon` is set via `link.href` (objectui's
+  // `AppShell.tsx`'s `useAppShellBranding`) — so repointing to the existing
+  // icon is correct without adding new binary assets.
   branding: {
     primaryColor: '#4169E1',
-    logo: '/assets/crm-logo.png',
-    favicon: '/assets/crm-favicon.ico',
+    logo: '/runtime/assets/icon.svg',
+    favicon: '/runtime/assets/icon.svg',
   },
 
   navigation: [


### PR DESCRIPTION
Fixes #731

## Description

The `crm_enterprise` app's `branding` block referenced `/assets/crm-logo.png` and `/assets/crm-favicon.ico`, neither of which was ever added to `assets/`. Every Console page load requested the favicon and got a 404.

Verifying this against a live dev server surfaced a second problem beyond what the issue described: the runtime does **not** serve a plain `/assets/*` path at all — repo `assets/` files are only mounted at `/runtime/assets/:filename` (`createRuntimeAssetsPlugin` in `@objectstack/cli`, confirmed by reading `packages/cli/src/utils/console.ts` in the `objectstack` repo and by booting `hotcrm`'s dev server and curling both paths). So simply adding `crm-logo.png` / `crm-favicon.ico` under `/assets/` — the issue's option A — would still have 404'd; only `/runtime/assets/crm-logo.png` would have resolved.

Given that, I took the issue's option B and repointed both `branding.logo` and `branding.favicon` to the repo's existing `assets/icon.svg`, served live at `/runtime/assets/icon.svg`. This is the smaller diff (no new binary assets, no image-generation tooling needed) and both console consumers accept an arbitrary string here:
- `logo` renders via a plain img element, `src` set to `branding.logo` (objectui `packages/app-shell/src/layout/AppSidebar.tsx`)
- `favicon` is applied via `link.href = branding.favicon` (objectui `packages/layout/src/AppShell.tsx`'s `useAppShellBranding`)

Neither has a format/extension restriction in the Zod schema (`AppBrandingSchema` in `@objectstack/spec`, `packages/spec/src/ui/app.zod.ts`) — both `logo` and `favicon` are `z.string().optional()`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
Fixes #731

## Changes Made

- `src/apps/crm.app.ts`: `branding.logo` / `branding.favicon` repointed from the non-existent `/assets/crm-logo.png` / `/assets/crm-favicon.ico` to the existing `/runtime/assets/icon.svg` (same icon for both), with a comment explaining the `/runtime/assets/` mount and why an SVG is safe for both fields.
- `.changeset/crm-app-branding-asset-404.md`: user-visible fix changeset.

## Testing

Verified live by booting the dev server (`node_modules/.bin/objectstack dev -p PORT -d memory:// --database-driver memory`) inside the shared build/test lock and curling the actual routes:

```
GET /assets/crm-logo.png       -> 404   (as before; confirms the issue's repro)
GET /assets/crm-favicon.ico    -> 404   (as before; confirms the issue's repro)
GET /assets/icon.svg           -> 404   (confirms /assets/* is never served — new finding)
GET /runtime/assets/icon.svg   -> 200, content-type: image/svg+xml  (the actual route)
```

After the fix, the compiled artifact (`dist/objectstack.json`) shows:
```json
"branding": {"primaryColor":"#4169E1","logo":"/runtime/assets/icon.svg","favicon":"/runtime/assets/icon.svg"}
```
and `GET /runtime/assets/icon.svg` (the URL now actually referenced) returns `200` with `content-type: image/svg+xml`.

- `pnpm validate` — exit 0 (pre-existing, unrelated warnings only; no new issues from this change)
- `pnpm build` — exit 0, `✓ Build complete`
- `pnpm typecheck` — exit 0
- `pnpm test -- --maxWorkers=2` — exit 0, `Test Files 81 passed (81)`, `Tests 1886 passed | 1 skipped (1887)`

- [x] Unit tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Manual testing completed (live dev-server boot + curl, see above)
- [ ] New tests added — not applicable; this is a static metadata value with no dedicated branding test in the suite, verified instead via live boot (see Testing)

## Checklist

- [x] I have added a changeset (`.changeset/crm-app-branding-asset-404.md`)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

File surface is `src/apps/crm.app.ts` (branding block only) + the changeset, per the dispatch scope for this card.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NM6o28jmBgsyTRQHutn7LC)_
