### PR TITLE
fix(freeze-guards): yield to the engine's reference cleanup so a frozen record cannot make people undeletable (#720)

### DIFF
--- a/.changeset/freeze-guards-yield-to-reference-cleanup.md
+++ b/.changeset/freeze-guards-yield-to-reference-cleanup.md
@@ -1,0 +1,48 @@
+---
+'hotcrm': patch
+---
+
+A frozen record no longer makes the people it references undeletable. The three
+freeze/lock guards — the converted-lead lock, the closed-opportunity freeze and
+the accepted/expired quote freeze — now yield to the engine's reference-cleanup
+write, so a delete that has to clear a link on a settled record completes
+instead of being refused:
+
+```
+DELETE /api/v1/data/crm_contact/<id>
+→ was 400 "Opportunity … is closed (closed_won) and frozen, so its link(s)
+           primary_contact cannot be cleared — which also blocks deleting the
+           record(s) they point at."
+→ now 200, with the closed deal's primary_contact cleared and nothing else
+      about the deal touched.
+```
+
+The engine implements `deleteBehavior: 'set_null'` by UPDATING the row that
+holds the lookup, so "delete this contact" reaches the holder's `beforeUpdate`
+looking exactly like a user editing a settled record — which is what these
+guards exist to refuse. The consequence was not cosmetic: a contact whose only
+referent was a **closed** opportunity could never be deleted, and because
+`crm_contact.crm_account` is a master-detail with `deleteBehavior: 'cascade'`,
+that contact's **account** could not be deleted either. The only ways out were
+destroying sales history or asking an admin for a system write. The same shape
+blocked deleting anything a **converted lead** or an **accepted quote** pointed
+at.
+
+The yield is deliberately narrow. A write passes only when **every** one of its
+non-system changes is a declared reference field going from a value to `null` —
+the shape measured from the engine on 17.0.0-rc.6, which is
+`{ id, <link>: null, updated_at, updated_by }`. Anything else is still refused,
+verbatim as before:
+
+* a business field changed alongside the cleared link;
+* a link repointed to a different record;
+* an ordinary edit to a frozen record's business fields;
+* a `null` written over a field that is not a declared link.
+
+What changes for a reader of the data: a settled record can now lose a link
+without anyone having edited it, because the record it pointed at was deleted.
+That is the accepted cost of being able to carry out a "delete this person"
+request. The refusal messages for cleared links are gone — nothing produces
+them any more — while every other refusal these guards raise is unchanged.
+
+Refs #720, #693.

--- a/src/objects/lead.hook.ts
+++ b/src/objects/lead.hook.ts
@@ -7,7 +7,8 @@ import type { HookApi } from './_hook-api';
  * Lead automation hook.
  *
  * - Auto-scores incoming leads into `rating` (1-5) using industry/title/email/phone weights.
- * - Refuses edits to a converted lead.
+ * - Refuses edits to a converted lead — but not the engine's reference cleanup,
+ *   so a converted lead never makes its conversion products undeletable (#720).
  * - When status flips to `qualified`, schedules a follow-up `crm_task` for the current user.
  * - Normalizes `email` and flags a re-captured address as a suspected duplicate.
  */
@@ -192,8 +193,8 @@ const leadHook: Hook = {
     // `cannot_edit_converted` script validation over the four identity fields,
     // documented as the friendlier half of a two-layer design; #575 B1 removed
     // it because this throw always won the race, so the second layer was a
-    // second implementation that could only drift. The messages below therefore
-    // have to carry the whole story — hence the attempted-field list.
+    // second implementation that could only drift. The message below therefore
+    // has to carry the whole story — hence the attempted-field list.
     if (event === 'beforeUpdate' && ctx.user?.id) {
       const previous = ctx.previous;
       const wasConverted = previous?.is_converted === true || previous?.status === 'converted';
@@ -208,21 +209,44 @@ const leadHook: Hook = {
           (k) => !ALLOWED.has(k) && input[k] !== previous?.[k],
         );
         if (violating.length > 0) {
-          // Every lookup on `crm_lead` a referential clear can attack. The
-          // engine's `cascadeDeleteRelations` pass clears a `set_null` lookup
-          // by UPDATING the row that holds it, so deleting the account /
-          // contact / opportunity a converted lead points at (or the lead /
-          // contact it was flagged as a duplicate of) arrives here as an
-          // ordinary `beforeUpdate` — and nothing in the hook context says the
-          // write came from a cascade (measured on 17.0.0-rc.2: the ctx carries
-          // no cascade marker, and `session` is the caller's own). So a delete
-          // of an opportunity was reported as an *edit* of a *lead* (#693).
-          // Both messages below therefore describe the LOCK and the LINK rather
-          // than assuming which record the caller addressed.
+          // Every lookup on `crm_lead` a referential clear can attack.
           const REFERENCE_FIELDS = new Set([
             'converted_account', 'converted_contact', 'converted_opportunity',
             'duplicate_of_lead', 'duplicate_of_contact',
           ]);
+          // ───────────────────────────────────── the reference-cleanup yield ──
+          // #720. The engine implements `deleteBehavior: 'set_null'` by UPDATING
+          // the row that HOLDS the lookup, so deleting the account / contact /
+          // opportunity a converted lead points at (or the lead / contact it was
+          // flagged as a duplicate of) arrives here as an ordinary user
+          // `beforeUpdate` — and this lock refused it, which made a converted
+          // lead able to keep all three of its conversion products undeletable
+          // forever (a GDPR erasure that cannot be carried out).
+          //
+          // Measured on 17.0.0-rc.6, not assumed: the payload is exactly
+          // `{ id, <link>: null, updated_at, updated_by }`; `ctx.user` is the
+          // CALLER; `ctx.session` is the caller's own `{ userId, isSystem }`.
+          // The engine DOES stamp a `__referentialFieldClear: true` marker, but
+          // on its internal operation context — `ObjectQL.buildSession` copies a
+          // fixed allow-list of keys into `ctx.session`, and `__`-prefixed
+          // operation-private keys are deliberately not among them (see the
+          // `__` convention note in `@objectstack/core`). So no marker reaches a
+          // hook, and the WRITE SHAPE is the only evidence there is.
+          //
+          // ⛔ Keep this narrow (maintainer's ruling on #720, Option A): a write
+          // yields ONLY when every one of its non-system changes is a DECLARED
+          // link going from a value to `null`. One business field alongside it,
+          // or a link repointed to a NEW value, and the refusal below still
+          // fires. The three freeze guards share this block verbatim — sharing
+          // it as an imported helper is not possible (hook bodies run body-only
+          // in the sandbox and cannot reach module scope), so
+          // `test/freeze-guard-reference-cleanup.test.ts` pins the three copies
+          // as identical text and pins both directions of the narrowness.
+          const isReferenceCleanup = violating.every(
+            (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous?.[k] != null,
+          );
+          if (isReferenceCleanup) return;
+
           const person = [previous?.first_name, previous?.last_name]
             .filter((part) => typeof part === 'string' && part.trim() !== '')
             .join(' ');
@@ -233,17 +257,6 @@ const leadHook: Hook = {
             '';
           const label = [name, leadId ? `(${leadId})` : ''].filter(Boolean).join(' ');
 
-          // A refusal made up ENTIRELY of links being cleared is the shape a
-          // delete of the linked record produces — describe it that way. A
-          // user nulling the same field by hand gets the same (true) sentence.
-          const detached = violating.filter(
-            (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous?.[k] != null,
-          );
-          if (detached.length === violating.length) {
-            throw new Error(
-              `${label ? `Converted lead ${label}` : 'A converted lead'} is locked, so its link(s) ${detached.join(', ')} cannot be cleared — which also blocks deleting the record(s) they point at. Delete the lead first, or have an admin clear the link with a system write.`,
-            );
-          }
           throw new Error(
             `Cannot edit ${label ? `converted lead ${label}` : 'a converted lead'} (attempted: ${violating.join(', ')}). Make changes on the converted records instead.`,
           );

--- a/src/objects/opportunity.hook.ts
+++ b/src/objects/opportunity.hook.ts
@@ -9,7 +9,9 @@ import type { HookApi } from './_hook-api';
  * - Re-derives `expected_revenue` from `amount * stageProbability` when either changes.
  * - Stamps `stage_entry_date` on insert and on every stage change — the stored
  *   clock behind the `days_in_stage` formula and the stagnation sweep (#489).
- * - Freezes most fields after stage is closed (won/lost) — only narrative fields editable.
+ * - Freezes most fields after stage is closed (won/lost) — only narrative fields
+ *   editable. The freeze yields to the engine's reference cleanup, so a closed
+ *   deal never makes the records it points at undeletable (#720).
  * - On `closed_won`: stamps `close_date=today`, promotes the parent account to `customer`,
  *   and asynchronously schedules an "Activate customer" task.
  */
@@ -84,16 +86,41 @@ const opportunityValidationHook: Hook = {
           (k) => !NARRATIVE_FIELDS.has(k) && !SYSTEM_FIELDS.has(k) && !APPROVAL_FIELDS.has(k) && input[k] !== previous[k],
         );
         if (violating.length > 0) {
-          // Same defect class as #693's two reported cases: this freeze also
-          // fires from a write the caller never made. Deleting a contact or a
-          // campaign a CLOSED opportunity references makes the engine clear
-          // that lookup, which arrives here as an ordinary `beforeUpdate` —
-          // measured: `DELETE /crm_contact/<id>` answered
-          // "Opportunity is closed (closed_won); … Attempted: primary_contact."
-          // The hook cannot tell a cascade from a hand edit (no marker in the
-          // context), so the refusal names the frozen record and the link
-          // instead of assuming the caller addressed the opportunity.
+          // Every lookup on `crm_opportunity` a referential clear can attack.
           const REFERENCE_FIELDS = new Set(['crm_account', 'primary_contact', 'crm_campaign']);
+          // ───────────────────────────────────── the reference-cleanup yield ──
+          // #720. The engine implements `deleteBehavior: 'set_null'` by UPDATING
+          // the row that HOLDS the lookup, so deleting a contact or a campaign a
+          // CLOSED opportunity references arrives here as an ordinary user
+          // `beforeUpdate` — and this freeze refused it, which made the frozen
+          // opportunity able to keep a person undeletable forever (and, through
+          // the master-detail cascade, that person's account too — a GDPR
+          // erasure that cannot be carried out).
+          //
+          // Measured on 17.0.0-rc.6, not assumed: the payload is exactly
+          // `{ id, <link>: null, updated_at, updated_by }`; `ctx.user` is the
+          // CALLER; `ctx.session` is the caller's own `{ userId, isSystem }`.
+          // The engine DOES stamp a `__referentialFieldClear: true` marker, but
+          // on its internal operation context — `ObjectQL.buildSession` copies a
+          // fixed allow-list of keys into `ctx.session`, and `__`-prefixed
+          // operation-private keys are deliberately not among them (see the
+          // `__` convention note in `@objectstack/core`). So no marker reaches a
+          // hook, and the WRITE SHAPE is the only evidence there is.
+          //
+          // ⛔ Keep this narrow (maintainer's ruling on #720, Option A): a write
+          // yields ONLY when every one of its non-system changes is a DECLARED
+          // link going from a value to `null`. One business field alongside it,
+          // or a link repointed to a NEW value, and the refusal below still
+          // fires. The three freeze guards share this block verbatim — sharing
+          // it as an imported helper is not possible (hook bodies run body-only
+          // in the sandbox and cannot reach module scope), so
+          // `test/freeze-guard-reference-cleanup.test.ts` pins the three copies
+          // as identical text and pins both directions of the narrowness.
+          const isReferenceCleanup = violating.every(
+            (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous?.[k] != null,
+          );
+          if (isReferenceCleanup) return;
+
           const name = typeof previous.name === 'string' ? previous.name : '';
           const oppId =
             (typeof previous.id === 'string' && previous.id) ||
@@ -101,14 +128,6 @@ const opportunityValidationHook: Hook = {
             '';
           const label = [name, oppId ? `(${oppId})` : ''].filter(Boolean).join(' ');
           const subject = label ? `Opportunity ${label}` : 'Opportunity';
-          const detached = violating.filter(
-            (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous[k] != null,
-          );
-          if (detached.length === violating.length) {
-            throw new Error(
-              `${subject} is closed (${prevStage}) and frozen, so its link(s) ${detached.join(', ')} cannot be cleared — which also blocks deleting the record(s) they point at. Delete the opportunity first, or have an admin clear the link with a system write.`,
-            );
-          }
           throw new Error(
             `${subject} is closed (${prevStage}); only ${[...NARRATIVE_FIELDS].join(', ')} may be edited. Attempted: ${violating.join(', ')}.`,
           );

--- a/src/objects/quote.hook.ts
+++ b/src/objects/quote.hook.ts
@@ -7,7 +7,8 @@ import type { HookApi } from './_hook-api';
  * Quote workflow hook.
  *
  * - Defaults `expiration_date` to `quote_date + 30 days` when missing.
- * - Freezes quotes once `accepted` or `expired`.
+ * - Freezes quotes once `accepted` or `expired` — against USER edits only: a
+ *   write that is purely the engine clearing a link is let through (#720).
  * - On `accepted`, drafts a contract and pushes the linked opportunity to `closed_won`.
  */
 
@@ -55,19 +56,47 @@ const quoteValidation: Hook = {
           'id', 'owner_id', 'created_at', 'updated_at',
           'created_by', 'updated_by', 'space_id', 'organization_id', 'org_id', 'version',
         ]);
-        const changed = Object.keys(input).filter(
+        // `violating` rather than `changed` (#720): the three freeze guards now
+        // share one reference-cleanup predicate verbatim, and a shared block can
+        // only be shared if it reads the same variable in all three.
+        const violating = Object.keys(input).filter(
           (k) => !allowed.has(k) && !SYSTEM_FIELDS.has(k) && input[k] !== previous[k],
         );
-        if (changed.length > 0) {
-          // Same defect class as #693: the freeze also fires from a write the
-          // caller never made. Deleting an opportunity (or a contact) an
-          // ACCEPTED quote references makes the engine clear that lookup, and
-          // the clear arrives here as an ordinary `beforeUpdate` — measured:
-          // `DELETE /crm_opportunity/<id>` answered "Quote is accepted; only
-          // internal_notes may be edited. Attempted: crm_opportunity.", naming
-          // an object the caller never addressed. Nothing in the hook context
-          // marks a cascade, so the refusal names the frozen quote and the link.
+        if (violating.length > 0) {
+          // Every lookup on `crm_quote` a referential clear can attack.
           const REFERENCE_FIELDS = new Set(['crm_account', 'crm_contact', 'crm_opportunity']);
+          // ───────────────────────────────────── the reference-cleanup yield ──
+          // #720. The engine implements `deleteBehavior: 'set_null'` by UPDATING
+          // the row that HOLDS the lookup, so deleting the opportunity (or the
+          // contact) an ACCEPTED quote references arrives here as an ordinary
+          // user `beforeUpdate` — and this freeze refused it, which made a
+          // settled quote able to keep a deal, a person and (through the
+          // master-detail cascade) that person's account undeletable forever.
+          //
+          // Measured on 17.0.0-rc.6, not assumed: the payload is exactly
+          // `{ id, <link>: null, updated_at, updated_by }`; `ctx.user` is the
+          // CALLER; `ctx.session` is the caller's own `{ userId, isSystem }`.
+          // The engine DOES stamp a `__referentialFieldClear: true` marker, but
+          // on its internal operation context — `ObjectQL.buildSession` copies a
+          // fixed allow-list of keys into `ctx.session`, and `__`-prefixed
+          // operation-private keys are deliberately not among them (see the
+          // `__` convention note in `@objectstack/core`). So no marker reaches a
+          // hook, and the WRITE SHAPE is the only evidence there is.
+          //
+          // ⛔ Keep this narrow (maintainer's ruling on #720, Option A): a write
+          // yields ONLY when every one of its non-system changes is a DECLARED
+          // link going from a value to `null`. One business field alongside it,
+          // or a link repointed to a NEW value, and the refusal below still
+          // fires. The three freeze guards share this block verbatim — sharing
+          // it as an imported helper is not possible (hook bodies run body-only
+          // in the sandbox and cannot reach module scope), so
+          // `test/freeze-guard-reference-cleanup.test.ts` pins the three copies
+          // as identical text and pins both directions of the narrowness.
+          const isReferenceCleanup = violating.every(
+            (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous?.[k] != null,
+          );
+          if (isReferenceCleanup) return;
+
           const name = typeof previous.name === 'string' ? previous.name : '';
           const quoteId =
             (typeof previous.id === 'string' && previous.id) ||
@@ -75,16 +104,8 @@ const quoteValidation: Hook = {
             '';
           const label = [name, quoteId ? `(${quoteId})` : ''].filter(Boolean).join(' ');
           const subject = label ? `Quote ${label}` : 'Quote';
-          const detached = changed.filter(
-            (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous[k] != null,
-          );
-          if (detached.length === changed.length) {
-            throw new Error(
-              `${subject} is ${previous.status as string} and frozen, so its link(s) ${detached.join(', ')} cannot be cleared — which also blocks deleting the record(s) they point at. Delete the quote first, or have an admin clear the link with a system write.`,
-            );
-          }
           throw new Error(
-            `${subject} is ${previous.status as string}; only internal_notes may be edited. Attempted: ${changed.join(', ')}.`,
+            `${subject} is ${previous.status as string}; only internal_notes may be edited. Attempted: ${violating.join(', ')}.`,
           );
         }
       }

--- a/test/cascade-guard-messages.test.ts
+++ b/test/cascade-guard-messages.test.ts
@@ -35,7 +35,7 @@ import stack from '../objectstack.config';
  * - `contact_integrity`'s `beforeDelete` runs on a direct contact delete AND as
  *   a cascade child of an account delete (`crm_contact.crm_account` is a
  *   master-detail with `deleteBehavior: 'cascade'`).
- * - The `beforeUpdate` locks (`lead_automation`, `opportunity_stage_automation`,
+ * - The `beforeUpdate` locks (`lead_automation`, `opportunity_lifecycle`,
  *   `quote_workflow`) run on a hand edit AND on the engine's referential clear:
  *   `cascadeDeleteRelations` implements `set_null` by UPDATING the row that
  *   holds the lookup, so deleting the referenced record arrives at the guard as
@@ -45,8 +45,14 @@ import stack from '../objectstack.config';
  * the cascade case carries no marker at all: the same keys, and a `session`
  * that is the caller's own. So the fix is not to detect the cascade — it is to
  * phrase every refusal from the BLOCKING RELATIONSHIP, which is true in both
- * contexts. The messages name the refusing record, the link or the references
- * that block, and what to do.
+ * contexts. The messages name the refusing record, the references that block,
+ * and what to do.
+ *
+ * ⚠️ Superseded in part by #720. The three `beforeUpdate` locks no longer refuse
+ * the referential clear at all — they yield to it on the write SHAPE, so those
+ * deletes now succeed and their refusal messages have been deleted rather than
+ * re-worded. That half moved to `test/freeze-guard-reference-cleanup.test.ts`.
+ * The `beforeDelete` half below is untouched and still refuses.
  *
  * ### Why this file boots a real kernel
  *
@@ -214,120 +220,25 @@ describe('deleting an account whose contact is still referenced', () => {
 
 // ────────────────────────────────────── symptom 2: the opportunity delete ──
 
-describe('deleting an opportunity a converted lead points at', () => {
-  const build = async () => {
-    const n = uniq();
-    const account = await insert('crm_account', {
-      name: `Globex ${n}`, type: 'customer', industry: 'technology',
-    });
-    const contact = await insert('crm_contact', {
-      first_name: 'Bo', last_name: 'Chen', crm_account: account.id,
-      email: `bo.${n}@cascade-guards.test`,
-    });
-    const opportunity = await insert('crm_opportunity', {
-      name: 'Globex New Business', crm_account: account.id, primary_contact: contact.id,
-      stage: 'negotiation', amount: 5000, close_date: '2026-12-01',
-    });
-    const lead = await insert('crm_lead', {
-      first_name: 'Bo', last_name: 'Chen', company: 'Globex', status: 'new',
-      lead_source: 'web', email: `bo.${n}@cascade-guards.test`,
-    });
-    // The conversion itself is a SYSTEM write (the flow's), which the lock lets
-    // through by design — it is user edits that are refused.
-    await ql.update('crm_lead', {
-      id: lead.id, is_converted: true, status: 'converted',
-      converted_account: account.id, converted_contact: contact.id,
-      converted_opportunity: opportunity.id, converted_date: '2026-02-01',
-    }, { context: SYS });
-    return { lead, opportunity };
-  };
-
-  it('names the lead and the link, not an edit of the lead', async () => {
-    const { lead, opportunity } = await build();
-    const message = await deleteAndCatch('crm_opportunity', opportunity.id);
-
-    expect(message, 'the opportunity delete must still be refused').toBeTruthy();
-    expect(message).toContain(`Converted lead Bo Chen (${lead.id})`);
-    expect(message).toContain('its link(s) converted_opportunity cannot be cleared');
-    expect(message).toContain('blocks deleting the record(s) they point at');
-    // The reported symptom: a DELETE of an OPPORTUNITY reported as an EDIT of a
-    // LEAD, advising the caller to go and change the record they just tried to
-    // delete.
-    expect(message).not.toContain('Cannot edit');
-    expect(message).not.toContain('Make changes on the converted records');
-  });
-
-  it('refuses, and leaves both records in place (semantics unchanged)', async () => {
-    const { lead, opportunity } = await build();
-    await deleteAndCatch('crm_opportunity', opportunity.id);
-    expect(await rowsOf('crm_opportunity', opportunity.id)).toHaveLength(1);
-    expect(await rowsOf('crm_lead', lead.id)).toHaveLength(1);
-    // And the message's own advice works: delete the lead, then the
-    // opportunity — the order the acceptance sweep had to discover by hand.
-    expect(await deleteAndCatch('crm_lead', lead.id)).toBeNull();
-    expect(await deleteAndCatch('crm_opportunity', opportunity.id)).toBeNull();
-  });
-});
-
-// ───────────────────────────── the same defect class on the sibling guards ──
-
 /**
- * Neither of these is in #693's report, and both are reachable with the same
- * two REST calls the sweep made. They are the same construction — a lock whose
- * message assumed the caller had addressed the locked record — so they are
- * fixed here rather than left to be re-found.
+ * #693's second symptom — a `DELETE /crm_opportunity/<id>` answered by the
+ * converted-lead lock — no longer produces a refusal at all, and neither do the
+ * two sibling freeze guards on the same construction.
+ *
+ * #720 ruled (maintainer, 2026-08-11) that a frozen record must not make the
+ * records it points at undeletable: all three guards now YIELD to the engine's
+ * reference-cleanup write shape, so the cascade completes and there is no
+ * sentence left to phrase. The message this file used to pin here —
+ * "…its link(s) X cannot be cleared — which also blocks deleting the record(s)
+ * they point at" — is gone from the three hooks, and with it the whole reason a
+ * caller ever saw it.
+ *
+ * Those cases now live, as successful deletes plus the narrowness that keeps
+ * ordinary edits refused, in `test/freeze-guard-reference-cleanup.test.ts`.
+ * What stays HERE is #693's other half, which #720 did not touch: refusals that
+ * are still correct (`contact_integrity`, `account_protection`) and must still
+ * name the record that is refusing.
  */
-describe('sibling guards reached the same way', () => {
-  it('a closed opportunity blocking a contact delete names the opportunity and the link', async () => {
-    const { contact } = await accountWithContact('Frozen Corp');
-    const elsewhere = await insert('crm_account', {
-      name: `Elsewhere ${uniq()}`, type: 'customer', industry: 'technology',
-    });
-    // CLOSED, so `contact_integrity` does not count it (it counts OPEN work)
-    // and the delete reaches the opportunity's own freeze.
-    const opportunity = await insert('crm_opportunity', {
-      name: 'Closed Deal', crm_account: elsewhere.id, primary_contact: contact.id,
-      stage: 'closed_won', win_reason: 'better_price', amount: 1000, close_date: '2026-01-01',
-    });
-
-    const message = await deleteAndCatch('crm_contact', contact.id);
-    expect(message).toContain(`Opportunity Closed Deal (${opportunity.id})`);
-    expect(message).toContain('its link(s) primary_contact cannot be cleared');
-    expect(message).toContain('blocks deleting the record(s) they point at');
-    expect(message).not.toContain('may be edited');
-  });
-
-  it('an accepted quote blocking an opportunity delete names the quote and the link', async () => {
-    const n = uniq();
-    const account = await insert('crm_account', {
-      name: `Quoted Corp ${n}`, type: 'customer', industry: 'technology',
-    });
-    const opportunity = await insert('crm_opportunity', {
-      name: 'Quoted Deal', crm_account: account.id,
-      stage: 'negotiation', amount: 1000, close_date: '2026-12-01',
-    });
-    // The recipient is not decoration here: since #1017 `crm_quote.crm_contact`
-    // is `requiredWhen` the status is `presented`/`accepted`, so a contact-less
-    // quote cannot reach `accepted` at all and this fixture would never get as
-    // far as the freeze it is measuring.
-    const contact = await insert('crm_contact', {
-      first_name: 'Quinn', last_name: 'Reyes', crm_account: account.id,
-      email: `quinn.${n}@cascade-guards.test`,
-    });
-    const quote = await insert('crm_quote', {
-      name: `Q-${n}`, crm_account: account.id, crm_opportunity: opportunity.id,
-      crm_contact: contact.id,
-      status: 'draft', quote_date: '2026-01-01', expiration_date: '2026-02-01',
-    });
-    await ql.update('crm_quote', { id: quote.id, status: 'accepted' }, { context: SYS });
-
-    const message = await deleteAndCatch('crm_opportunity', opportunity.id);
-    expect(message).toContain(`Quote Q-${n} (${quote.id})`);
-    expect(message).toContain('its link(s) crm_opportunity cannot be cleared');
-    expect(message).toContain('blocks deleting the record(s) they point at');
-    expect(message).not.toContain('may be edited');
-  });
-});
 
 // ───────────────────── the account guard's own sentence, measured (#721) ──
 

--- a/test/converted-lead-guard.test.ts
+++ b/test/converted-lead-guard.test.ts
@@ -116,40 +116,36 @@ describe('the hook is the guard that actually speaks', () => {
   });
 
   /**
-   * #693's second symptom, at the unit level: the engine clears a `set_null`
-   * lookup by UPDATING the row that holds it, so `DELETE /crm_opportunity/<id>`
-   * reaches this guard as `{ converted_opportunity: null }` on the lead. The
-   * old message reported that as "Cannot edit a converted lead … Make changes
-   * on the converted records instead" — a delete of an opportunity described
-   * as an edit of a lead, advising the caller to go and edit the very record
-   * they had asked to delete.
+   * #693's second symptom at the unit level, and #720's ruling on it: the
+   * engine clears a `set_null` lookup by UPDATING the row that holds it, so
+   * `DELETE /crm_opportunity/<id>` reaches this guard as
+   * `{ converted_opportunity: null }` on the lead. The lock used to refuse
+   * that, which meant a converted lead made all three of its conversion
+   * products permanently undeletable — an erasure request with no way to
+   * carry it out.
    *
-   * The guard cannot know it is inside a cascade (measured on 17.0.0-rc.2: the
-   * hook context carries no cascade marker), so the refusal is phrased from the
-   * LINK, which is true whether the null came from the engine or from a hand
-   * edit. The end-to-end proof that this is the message a real cascade produces
-   * lives in `test/cascade-guard-messages.test.ts`.
+   * No marker distinguishes the cleanup (measured on rc.2 when #693 landed, and
+   * again on rc.6 for #720 — the engine's own `__referentialFieldClear` is
+   * stripped before a hook sees it), so the lock yields on the write SHAPE
+   * instead: a write whose every non-system change is a declared link going
+   * value→null. The end-to-end proof that a real cascade produces exactly that
+   * shape, and the narrowness in both directions, live in
+   * `test/freeze-guard-reference-cleanup.test.ts`.
    */
-  describe('a cleared conversion link is described as a link, not as an edit', () => {
+  describe('a cleared conversion link is the engine tidying up, not an edit', () => {
     it.each([
       ['converted_opportunity', 'opp_1'],
       ['converted_account', 'acc_1'],
       ['converted_contact', 'con_1'],
+      ['duplicate_of_lead', 'lead_9'],
+      ['duplicate_of_contact', 'con_9'],
     ])('%s', async (field, previousValue) => {
-      const err = await editConverted({ [field]: null }, { [field]: previousValue }).then(
-        () => null,
-        (e: Error) => e,
-      );
-      expect(err, `clearing ${field} was allowed`).toBeInstanceOf(Error);
-      expect(err!.message).toContain(`its link(s) ${field} cannot be cleared`);
-      expect(err!.message).toContain('blocks deleting the record(s) they point at');
-      // The sentence that sent readers to the wrong record must be gone from
-      // this branch: the caller may never have edited anything.
-      expect(err!.message).not.toContain('Cannot edit');
-      expect(err!.message).not.toContain('Make changes on the converted records');
+      await expect(
+        editConverted({ [field]: null }, { [field]: previousValue }),
+      ).resolves.toBeUndefined();
     });
 
-    it('falls back to the edit wording when the write is not only a link clear', async () => {
+    it('refuses the edit when the write is not only a link clear', async () => {
       // A hand edit that also touches a business field is an edit, and saying
       // so stays correct — the link branch must not swallow it.
       await expect(

--- a/test/freeze-guard-reference-cleanup.test.ts
+++ b/test/freeze-guard-reference-cleanup.test.ts
@@ -1,0 +1,648 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { DefaultDatasourcePlugin, AppPlugin } from '@objectstack/runtime';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { MetadataPlugin } from '@objectstack/metadata';
+import stack from '../objectstack.config';
+import leadHooks from '../src/objects/lead.hook';
+import oppHooks from '../src/objects/opportunity.hook';
+import quoteHooks from '../src/objects/quote.hook';
+import { hookNamed, makeCtx, makeHarness, type Rec } from './helpers/hook-harness';
+import { extractSandboxBody } from './helpers/action-sandbox';
+
+/**
+ * A frozen record must not make the people it references undeletable (#720).
+ *
+ * ### The defect
+ *
+ * The engine implements `deleteBehavior: 'set_null'` by UPDATING the row that
+ * HOLDS the lookup. So "delete the contact" reaches the holder's `beforeUpdate`
+ * as `{ <link>: null }` — and this app's three freeze/lock guards
+ * (`lead_automation`, `opportunity_lifecycle`, `quote_workflow`) refused it,
+ * because they are written to stop USER edits to settled records and a cascade
+ * looks exactly like one. The consequence was not a wording problem:
+ *
+ *   - a contact whose only referent was a CLOSED opportunity could never be
+ *     deleted, and `crm_contact.crm_account` is a master-detail with
+ *     `deleteBehavior: 'cascade'`, so that contact's ACCOUNT could not be
+ *     deleted either — a GDPR erasure request with no way to carry it out;
+ *   - the two escapes on offer were destroying sales history (delete the
+ *     closed deal) or asking an admin for a system write.
+ *
+ * Maintainer's ruling of 2026-08-11 on #720 is Option A: the guards yield to
+ * the engine's reference-cleanup write shape, and the yield must be narrow.
+ *
+ * ### The measurement the yield rests on
+ *
+ * Taken on `@objectstack/*` 17.0.0-rc.6 (the issue was filed against rc.2), by
+ * instrumenting each of the three handlers on the real kernel below:
+ *
+ *     input   = { id, <link>: null, updated_at, updated_by }
+ *     user    = { id: <the caller> }            ← the CALLER, not a system id
+ *     session = { userId: <the caller>, isSystem: true }
+ *     provenance = undefined
+ *
+ * All three objects produce that same shape, which is why one predicate serves
+ * all three and no per-object differentiation was needed.
+ *
+ * A marker DOES exist, and it is deliberately out of reach: the engine tags its
+ * own cleanup write with `__referentialFieldClear: true` on the internal
+ * operation context (`ObjectQL.cascadeDeleteRelations`), but `buildSession`
+ * copies a fixed allow-list of keys into `ctx.session` and the `__`-prefixed
+ * operation-private keys are not among them (that stripping is a rule, not an
+ * oversight — see the `__` convention note in `@objectstack/core`). Preferring a
+ * first-class marker over shape-sniffing was the instruction; the marker is not
+ * offered to hooks, so the WRITE SHAPE is the only evidence there is. If a
+ * future platform release surfaces one, the drift pin at the bottom of this
+ * file is where to start, and switching to it is strictly better.
+ *
+ * ### Why the narrowness is pinned in both directions
+ *
+ * The yield is not "tolerate null". A write passes only when EVERY one of its
+ * non-system changes is a declared link going from a value to `null`. One
+ * business field alongside the null, or a link repointed to a new value, and
+ * the freeze refuses exactly as before. Both directions are asserted here,
+ * because a suite that goes green by dropping the refusals would look identical
+ * to one that goes green by fixing the bug.
+ *
+ * ### On the refusal envelope
+ *
+ * Measured end-to-end on rc.6: every refusal these guards raise arrives at the
+ * caller as a bare `Error` — `code` and `status` are both `undefined`, and so
+ * they are for the platform's own `account_protection` / `contact_integrity`
+ * refusals. This app's hooks have no ADR-0112 envelope to assert, so the
+ * envelope is pinned as the (absent) thing it measurably is, alongside the
+ * message wording, which IS the contract here (PR #719 wrote it). A failure of
+ * the envelope assertion means the platform started wrapping hook errors —
+ * news to act on, not a regression to paper over.
+ */
+
+type AnyRec = Record<string, any>;
+
+process.env.OS_REGISTRY_LOG ??= 'silent';
+
+const SYS = { isSystem: true } as AnyRec;
+
+let kernel: AnyRec;
+let ql: AnyRec;
+/** The context a REST `DELETE` runs under: a real user id. */
+let userCtx: AnyRec;
+
+const insert = (object: string, doc: AnyRec): Promise<AnyRec> =>
+  ql.insert(object, doc, { context: SYS });
+
+/** Delete as the user; `null` when it went through, else the refusal message. */
+const deleteAndCatch = async (object: string, id: string): Promise<string | null> => {
+  try {
+    await ql.delete(object, { where: { id }, context: userCtx });
+    return null;
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+const rowsOf = (object: string, id: string): Promise<AnyRec[]> =>
+  ql.find(object, { where: { id } }, { context: SYS });
+
+const rowOf = async (object: string, id: string): Promise<AnyRec> => {
+  const [row] = await rowsOf(object, id);
+  expect(row, `${object}/${id} is gone`).toBeTruthy();
+  return row;
+};
+
+/** A unique suffix per fixture — `crm_contact.email` is globally unique. */
+let seq = 0;
+const uniq = (): string => `${++seq}`;
+
+beforeAll(async () => {
+  kernel = new ObjectKernel({ logger: { level: 'silent' } } as never);
+  await kernel.use(new DefaultDatasourcePlugin({ driver: 'memory', config: {} } as never));
+  await kernel.use(new MetadataPlugin({ watch: false, artifactWatch: false, environmentId: 'proj_720' } as never));
+  await kernel.use(new ObjectQLPlugin({ environmentId: 'proj_720' } as never));
+  // The app's own metadata is the subject — objects and hooks exactly as
+  // `objectstack.config.ts` declares them (the rig `cascade-guard-messages`
+  // uses, which is the rig #720 was measured with).
+  await kernel.use(new AppPlugin(stack as never, undefined as never, { skipSeedData: true } as never));
+  await kernel.bootstrap();
+  ql = kernel.getService('objectql');
+
+  const user = await insert('sys_user', { name: 'Erasure Rep', email: 'rep@freeze-cleanup.test' });
+  userCtx = { userId: user.id, isSystem: true } as AnyRec;
+}, 180_000);
+
+afterAll(async () => {
+  await kernel?.shutdown?.();
+});
+
+// ───────────────────────────────────────── the reported repro, end to end ──
+
+/**
+ * #720's own repro, both halves of it. A unit test of the predicate cannot show
+ * this: only the engine decides which guard the cascade reaches, and the value
+ * of the change is that these two DELETEs complete.
+ */
+describe('deleting a contact a CLOSED opportunity points at', () => {
+  /** Account A with contact C, plus a closed-won deal elsewhere that points at C. */
+  const build = async (stage: 'closed_won' | 'closed_lost' = 'closed_won') => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Erasure Corp ${n}`, type: 'customer', industry: 'technology',
+    });
+    const contact = await insert('crm_contact', {
+      first_name: 'Ada', last_name: 'Lovelace',
+      crm_account: account.id, email: `ada.${n}@freeze-cleanup.test`,
+    });
+    // The deal sits on ANOTHER account so the account delete is not refused by
+    // `account_protection` first; it is CLOSED so `contact_integrity` (which
+    // counts OPEN work) does not answer either, and the contact's fate is
+    // decided by the opportunity's freeze — the reported case exactly.
+    const elsewhere = await insert('crm_account', {
+      name: `Elsewhere ${n}`, type: 'customer', industry: 'technology',
+    });
+    const opportunity = await insert('crm_opportunity', {
+      name: `Closed Deal ${n}`, crm_account: elsewhere.id, primary_contact: contact.id,
+      stage, ...(stage === 'closed_won' ? { win_reason: 'better_price' } : { loss_reason: 'price' }),
+      amount: 25_000, close_date: '2026-01-01',
+    });
+    return { account, contact, opportunity };
+  };
+
+  it('deletes the contact, and clears the frozen deal’s link instead of refusing', async () => {
+    const { contact, opportunity } = await build();
+
+    expect(await deleteAndCatch('crm_contact', contact.id)).toBeNull();
+    expect(await rowsOf('crm_contact', contact.id)).toHaveLength(0);
+
+    // The deal itself survives, still closed, with only the link gone — the
+    // history change the ruling accepted, and nothing more.
+    const opp = await rowOf('crm_opportunity', opportunity.id);
+    expect(opp.primary_contact ?? null).toBeNull();
+    expect(opp.stage).toBe('closed_won');
+    expect(opp.amount).toBe(25_000);
+    expect(opp.win_reason).toBe('better_price');
+    expect(opp.name).toBe(`Closed Deal ${opportunity.name.split(' ').pop()}`);
+  });
+
+  it('then deletes the account the contact belonged to (the second half of the repro)', async () => {
+    const { account, contact } = await build();
+    expect(await deleteAndCatch('crm_contact', contact.id)).toBeNull();
+    expect(await deleteAndCatch('crm_account', account.id)).toBeNull();
+    expect(await rowsOf('crm_account', account.id)).toHaveLength(0);
+  });
+
+  it('deletes the account directly, cascading through the contact', async () => {
+    // The path a caller actually takes: `DELETE crm_account/{A}` cascades to
+    // its contacts (master-detail), and each of those runs the cleanup that
+    // used to be refused. One call, the whole chain.
+    const { account, contact, opportunity } = await build('closed_lost');
+
+    expect(await deleteAndCatch('crm_account', account.id)).toBeNull();
+    expect(await rowsOf('crm_account', account.id)).toHaveLength(0);
+    expect(await rowsOf('crm_contact', contact.id)).toHaveLength(0);
+
+    const opp = await rowOf('crm_opportunity', opportunity.id);
+    expect(opp.primary_contact ?? null).toBeNull();
+    expect(opp.stage).toBe('closed_lost');
+  });
+
+  it('deletes a campaign a closed opportunity was attributed to', async () => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Campaigned Corp ${n}`, type: 'customer', industry: 'technology',
+    });
+    const campaign = await insert('crm_campaign', {
+      name: `Spring Push ${n}`, type: 'email', status: 'completed',
+      start_date: '2026-01-01', end_date: '2026-02-01',
+    });
+    const opportunity = await insert('crm_opportunity', {
+      name: `Attributed Deal ${n}`, crm_account: account.id, crm_campaign: campaign.id,
+      stage: 'closed_won', win_reason: 'better_price', amount: 1000, close_date: '2026-01-01',
+    });
+
+    expect(await deleteAndCatch('crm_campaign', campaign.id)).toBeNull();
+    expect((await rowOf('crm_opportunity', opportunity.id)).crm_campaign ?? null).toBeNull();
+  });
+});
+
+describe('deleting an opportunity an ACCEPTED quote points at', () => {
+  it('deletes the deal, and leaves the settled quote settled', async () => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Quoted Corp ${n}`, type: 'customer', industry: 'technology',
+    });
+    const opportunity = await insert('crm_opportunity', {
+      name: `Quoted Deal ${n}`, crm_account: account.id,
+      stage: 'negotiation', amount: 1000, close_date: '2026-12-01',
+    });
+    // Since #1017 a quote cannot reach `accepted` without a recipient, so the
+    // contact is load-bearing fixture, not decoration.
+    const contact = await insert('crm_contact', {
+      first_name: 'Quinn', last_name: 'Reyes', crm_account: account.id,
+      email: `quinn.${n}@freeze-cleanup.test`,
+    });
+    const quote = await insert('crm_quote', {
+      name: `Q-${n}`, crm_account: account.id, crm_opportunity: opportunity.id,
+      crm_contact: contact.id, status: 'draft',
+      quote_date: '2026-01-01', expiration_date: '2026-02-01',
+    });
+    await ql.update('crm_quote', { id: quote.id, status: 'accepted' }, { context: SYS });
+
+    expect(await deleteAndCatch('crm_opportunity', opportunity.id)).toBeNull();
+    expect(await rowsOf('crm_opportunity', opportunity.id)).toHaveLength(0);
+
+    const row = await rowOf('crm_quote', quote.id);
+    expect(row.crm_opportunity ?? null).toBeNull();
+    expect(row.status).toBe('accepted');
+    expect(row.crm_contact).toBe(contact.id);
+  });
+});
+
+describe('deleting a record a CONVERTED lead points at', () => {
+  const build = async () => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Globex ${n}`, type: 'customer', industry: 'technology',
+    });
+    const contact = await insert('crm_contact', {
+      first_name: 'Bo', last_name: 'Chen', crm_account: account.id,
+      email: `bo.${n}@freeze-cleanup.test`,
+    });
+    const opportunity = await insert('crm_opportunity', {
+      name: `Globex New Business ${n}`, crm_account: account.id, primary_contact: contact.id,
+      stage: 'negotiation', amount: 5000, close_date: '2026-12-01',
+    });
+    // NB: the lead's email deliberately does NOT match the contact's. An
+    // intake match makes `lead_duplicate_check` stamp `duplicate_of_type` +
+    // `duplicate_of_contact`, and that pairing has its own delete-blocking
+    // defect, which is neither this fix's nor masked by it — see the boundary
+    // test at the end of this describe.
+    const lead = await insert('crm_lead', {
+      first_name: 'Bo', last_name: 'Chen', company: 'Globex', status: 'new',
+      lead_source: 'web', email: `bo.lead.${n}@freeze-cleanup.test`,
+    });
+    // The conversion is a SYSTEM write (the flow's), which the lock always let
+    // through — it is user edits it refuses.
+    await ql.update('crm_lead', {
+      id: lead.id, is_converted: true, status: 'converted',
+      converted_account: account.id, converted_contact: contact.id,
+      converted_opportunity: opportunity.id, converted_date: '2026-02-01',
+    }, { context: SYS });
+    return { lead, account, contact, opportunity };
+  };
+
+  it('deletes the converted opportunity, and the lead stays converted and locked', async () => {
+    const { lead, opportunity } = await build();
+
+    expect(await deleteAndCatch('crm_opportunity', opportunity.id)).toBeNull();
+    expect(await rowsOf('crm_opportunity', opportunity.id)).toHaveLength(0);
+
+    const row = await rowOf('crm_lead', lead.id);
+    expect(row.converted_opportunity ?? null).toBeNull();
+    // Only the one link moved: the conversion itself is still recorded.
+    expect(row.is_converted).toBe(true);
+    expect(row.status).toBe('converted');
+    expect(row.converted_account).toBeTruthy();
+    expect(row.converted_contact).toBeTruthy();
+  });
+
+  it('tears the whole conversion down, and the lead keeps saying it converted', async () => {
+    const { lead, account, contact, opportunity } = await build();
+
+    // `account_protection` counts OPEN opportunities, so the deal goes first —
+    // its own guard, unrelated to this fix and deliberately left alone.
+    expect(await deleteAndCatch('crm_opportunity', opportunity.id)).toBeNull();
+    expect(await deleteAndCatch('crm_account', account.id)).toBeNull();
+    expect(await rowsOf('crm_account', account.id)).toHaveLength(0);
+    expect(await rowsOf('crm_contact', contact.id)).toHaveLength(0);
+
+    const row = await rowOf('crm_lead', lead.id);
+    expect(row.converted_account ?? null).toBeNull();
+    expect(row.converted_contact ?? null).toBeNull();
+    expect(row.converted_opportunity ?? null).toBeNull();
+    expect(row.is_converted).toBe(true);
+    expect(row.status).toBe('converted');
+  });
+
+  /**
+   * The boundary of this fix, pinned so nobody reads it as wider than it is.
+   *
+   * `lead_duplicate_check` stamps `duplicate_of_type: 'crm_contact'` +
+   * `duplicate_of_contact` on any new lead whose email matches an existing
+   * contact — and `duplicate_of_contact` carries
+   * `requiredWhen has(record.duplicate_of_type) && … == "crm_contact"`. So the
+   * engine's cleanup nulls the lookup while the discriminator stays behind, and
+   * the record's own rule refuses the write. That is the #696 / #711
+   * construction (a `set_null` clear that violates the holder's own rule), NOT
+   * the freeze-guard construction this card fixes, and it is fully independent
+   * of it: an OPEN, unconverted lead blocks the same delete the same way, on a
+   * path where no freeze guard runs at all.
+   *
+   * What this test pins forever is that none of the three freeze guards is the
+   * one answering any more. The `Duplicate Of Contact is required` line is
+   * today's truth and is expected to flip to a clean delete when that finding
+   * lands — treat a failure of that assertion as news, and update it here.
+   */
+  it('leaves the duplicate-pairing blocker to its own fix, and stops answering for it', async () => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Dupe Corp ${n}`, type: 'customer', industry: 'technology',
+    });
+    const contact = await insert('crm_contact', {
+      first_name: 'Dee', last_name: 'Dupe', crm_account: account.id,
+      email: `dee.${n}@freeze-cleanup.test`,
+    });
+    // Same email ⇒ the intake dedupe flags the lead against this contact.
+    const lead = await insert('crm_lead', {
+      first_name: 'Dee', last_name: 'Dupe', company: 'Dupe Inc', status: 'new',
+      lead_source: 'web', email: `dee.${n}@freeze-cleanup.test`,
+    });
+    const flagged = await rowOf('crm_lead', lead.id);
+    expect(flagged.duplicate_of_type, 'the intake dedupe did not flag this lead').toBe('crm_contact');
+    expect(flagged.duplicate_of_contact).toBe(contact.id);
+
+    const message = await deleteAndCatch('crm_contact', contact.id);
+
+    // Not one of this card's guards — whatever else happens.
+    expect(message ?? '').not.toContain('is locked');
+    expect(message ?? '').not.toContain('and frozen');
+    expect(message ?? '').not.toContain('Cannot edit converted lead');
+    // Today: the field-pairing rule still refuses, on its own account.
+    expect(message).toContain('Duplicate Of Contact is required');
+  });
+});
+
+// ─────────────────────────── the guarded surface has NOT shrunk, end to end ──
+
+/**
+ * The other direction, through the same kernel: what the freeze exists for is
+ * still refused, with the sentence PR #719 wrote, unchanged.
+ */
+describe('an ordinary user edit to a settled record is still refused', () => {
+  it('refuses a business-field edit on a closed opportunity', async () => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Settled Corp ${n}`, type: 'customer', industry: 'technology',
+    });
+    const opportunity = await insert('crm_opportunity', {
+      name: `Settled Deal ${n}`, crm_account: account.id,
+      stage: 'closed_won', win_reason: 'better_price', amount: 1000, close_date: '2026-01-01',
+    });
+
+    const err = await ql
+      .update('crm_opportunity', { id: opportunity.id, amount: 5 }, { context: userCtx })
+      .then(() => null, (e: Error) => e);
+
+    expect(err, 'a user edit to a frozen deal must still be refused').toBeInstanceOf(Error);
+    expect(err!.message).toContain(`Opportunity Settled Deal ${n} (${opportunity.id}) is closed (closed_won)`);
+    expect(err!.message).toContain('only description, next_step, notes may be edited');
+    expect(err!.message).toContain('Attempted: amount');
+    // Refused for real, not merely announced.
+    expect((await rowOf('crm_opportunity', opportunity.id)).amount).toBe(1000);
+  });
+
+  it('refuses a hand edit that repoints a frozen quote’s link to another record', async () => {
+    const n = uniq();
+    const account = await insert('crm_account', {
+      name: `Repoint Corp ${n}`, type: 'customer', industry: 'technology',
+    });
+    const contact = await insert('crm_contact', {
+      first_name: 'Rae', last_name: 'Point', crm_account: account.id,
+      email: `rae.${n}@freeze-cleanup.test`,
+    });
+    const other = await insert('crm_opportunity', {
+      name: `Other Deal ${n}`, crm_account: account.id,
+      stage: 'negotiation', amount: 1, close_date: '2026-12-01',
+    });
+    const quote = await insert('crm_quote', {
+      name: `QR-${n}`, crm_account: account.id, crm_contact: contact.id,
+      status: 'draft', quote_date: '2026-01-01', expiration_date: '2026-02-01',
+    });
+    await ql.update('crm_quote', { id: quote.id, status: 'accepted' }, { context: SYS });
+
+    const err = await ql
+      .update('crm_quote', { id: quote.id, crm_opportunity: other.id }, { context: userCtx })
+      .then(() => null, (e: Error) => e);
+
+    expect(err, 'repointing a link is an edit, not a cleanup').toBeInstanceOf(Error);
+    expect(err!.message).toContain(`Quote QR-${n} (${quote.id}) is accepted`);
+    expect(err!.message).toContain('only internal_notes may be edited');
+    expect(err!.message).toContain('Attempted: crm_opportunity');
+  });
+});
+
+// ─────────────────────────────────── the predicate, both directions, by unit ──
+
+/**
+ * The same narrowness at handler level, where every neighbouring shape can be
+ * enumerated cheaply. `expectRefusal` carries the envelope floor: the message
+ * wording (the contract PR #719 wrote) plus the `code`/`status` this app's hook
+ * refusals measurably carry — see the note in the file header.
+ */
+const expectRefusal = (err: unknown, wording: RegExp): void => {
+  expect(err, `expected a refusal matching ${wording}`).toBeInstanceOf(Error);
+  const e = err as AnyRec;
+  expect(e.message).toMatch(wording);
+  // Measured on 17.0.0-rc.6: hook refusals reach the caller as bare `Error`s,
+  // with no ADR-0112 envelope on them — this asserts what IS, so that the day
+  // the platform starts wrapping them, this file says so.
+  expect([e.code, e.status]).toEqual([undefined, undefined]);
+};
+
+const runGuard = (hook: AnyRec, input: Rec, previous: Rec): Promise<unknown> =>
+  hook.handler(
+    makeCtx({
+      event: 'beforeUpdate',
+      input,
+      previous,
+      user: { id: 'usr_1' },
+      api: makeHarness().api,
+    }),
+  );
+
+const refusalOf = (hook: AnyRec, input: Rec, previous: Rec): Promise<unknown> =>
+  runGuard(hook, input, previous).then(() => null, (e: Error) => e);
+
+interface GuardCase {
+  label: string;
+  hook: AnyRec;
+  /** A settled record of this object, as `previous`. */
+  previous: Rec;
+  /** A declared link on it, and a second value to repoint it to. */
+  link: string;
+  other: string;
+  /** A business field the freeze protects, and a value that changes it. */
+  businessField: string;
+  businessValue: unknown;
+  /** The refusal the guard raises for a genuine edit. */
+  refusal: RegExp;
+}
+
+const GUARDS: GuardCase[] = [
+  {
+    label: 'opportunity_lifecycle',
+    hook: hookNamed(oppHooks, 'opportunity_lifecycle'),
+    previous: { id: 'o1', name: 'Acme Renewal', stage: 'closed_won', primary_contact: 'c1', amount: 10 },
+    link: 'primary_contact',
+    other: 'c2',
+    businessField: 'amount',
+    businessValue: 1,
+    refusal: /Opportunity Acme Renewal \(o1\) is closed \(closed_won\); only .* may be edited/,
+  },
+  {
+    label: 'quote_workflow',
+    hook: hookNamed(quoteHooks, 'quote_workflow'),
+    previous: { id: 'q1', name: 'Q-1001', status: 'accepted', crm_opportunity: 'o1', total_price: 100 },
+    link: 'crm_opportunity',
+    other: 'o2',
+    businessField: 'total_price',
+    businessValue: 1,
+    refusal: /Quote Q-1001 \(q1\) is accepted; only internal_notes may be edited/,
+  },
+  {
+    label: 'lead_automation',
+    hook: hookNamed(leadHooks, 'lead_automation'),
+    previous: {
+      id: 'lead_1', is_converted: true, status: 'converted', company: 'Acme',
+      first_name: 'Ada', last_name: 'Lovelace', converted_opportunity: 'opp_1', rating: 1,
+    },
+    link: 'converted_opportunity',
+    other: 'opp_2',
+    businessField: 'company',
+    businessValue: 'Globex',
+    refusal: /Cannot edit converted lead Ada Lovelace \(lead_1\)/,
+  },
+];
+
+describe.each(GUARDS)('$label yields to the cleanup shape and nothing else', (guard) => {
+  const { hook, previous, link, other, businessField, businessValue, refusal } = guard;
+
+  it('lets a lone link clear through', async () => {
+    await expect(runGuard(hook, { id: previous.id, [link]: null }, previous)).resolves.toBeUndefined();
+  });
+
+  it('lets a clear carrying the engine’s audit columns through', async () => {
+    // The payload measured on rc.6 — the audit hook stamps these before the
+    // freeze runs, and they must not count as an edit.
+    await expect(
+      runGuard(
+        hook,
+        { id: previous.id, [link]: null, updated_at: '2026-08-11T00:00:00.000Z', updated_by: 'usr_1' },
+        previous,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('still refuses the same clear when a business field rides along', async () => {
+    const err = await refusalOf(
+      hook,
+      { id: previous.id, [link]: null, [businessField]: businessValue },
+      previous,
+    );
+    expectRefusal(err, refusal);
+    expect((err as Error).message).toContain(businessField);
+  });
+
+  it('still refuses a link repointed to another record', async () => {
+    expectRefusal(await refusalOf(hook, { id: previous.id, [link]: other }, previous), refusal);
+  });
+
+  it('still refuses a plain business-field edit', async () => {
+    expectRefusal(await refusalOf(hook, { id: previous.id, [businessField]: businessValue }, previous), refusal);
+  });
+
+  it('does not yield for a null on a field that is not a declared link', async () => {
+    // "Everything in this write is null" is NOT the shape — the shape is
+    // "everything in this write is a declared LINK going value→null".
+    expectRefusal(
+      await refusalOf(hook, { id: previous.id, [businessField]: null }, previous),
+      refusal,
+    );
+  });
+
+  it('does not yield when the link was already empty', async () => {
+    // Nothing to clean up: the engine only clears links that point somewhere,
+    // so a null over an absent value is a hand edit that invented one.
+    const { [link]: _dropped, ...withoutLink } = previous;
+    expectRefusal(await refusalOf(hook, { id: previous.id, [link]: null }, withoutLink), refusal);
+  });
+});
+
+// ──────────────────────────────────────────────── one predicate, three copies ──
+
+/**
+ * The three guards carry the SAME predicate, verbatim, and it has to be that
+ * way: a hook body runs body-only inside QuickJS (see
+ * `test/action-sandbox.test.ts`), so it cannot call an imported helper — a
+ * shared module-scope predicate would be `undefined` at runtime in the shipped
+ * artifact. Sharing by copy is only as good as a guard against drift, so this
+ * pins the copies against each other, the same way the actions' shared
+ * `actor_name` block is pinned.
+ */
+describe('the reference-cleanup predicate is one block in three places', () => {
+  const CANONICAL = [
+    'const isReferenceCleanup = violating.every((k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous?.[k] != null);',
+    'if (isReferenceCleanup) return;',
+  ].join(' ');
+
+  /** A body with comments stripped and whitespace flattened. */
+  const normalise = (source: string): string =>
+    source
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('//'))
+      .join('\n')
+      .replace(/\s+/g, ' ');
+
+  const bodyOf = (hook: AnyRec): string =>
+    normalise(extractSandboxBody(hook.handler, `hook '${hook.name}'`).source);
+
+  it.each(GUARDS.map((g) => g.label))('%s carries the canonical predicate', (label) => {
+    const guard = GUARDS.find((g) => g.label === label)!;
+    expect(
+      bodyOf(guard.hook),
+      `${label} no longer carries the shared #720 predicate verbatim — a second ` +
+        'spelling of "is this write a reference cleanup?" is a second thing to get wrong',
+    ).toContain(CANONICAL);
+  });
+
+  it('is the only spelling anywhere in the app’s hooks', async () => {
+    const { allHooks } = (await import('../src/hooks')) as AnyRec;
+    const divergent = (allHooks as AnyRec[])
+      .filter((h) => {
+        const body = bodyOf(h);
+        return body.includes('isReferenceCleanup') && !body.includes(CANONICAL);
+      })
+      .map((h) => h.name as string);
+    expect(divergent, `these hooks spell the cleanup predicate differently: ${divergent.join(', ')}`)
+      .toEqual([]);
+  });
+
+  /**
+   * The predicate is only as narrow as its field list is complete: a lookup
+   * added to one of these objects and not to `REFERENCE_FIELDS` would go on
+   * blocking deletes exactly as before, silently.
+   */
+  it.each([
+    ['crm_opportunity', 'opportunity_lifecycle'],
+    ['crm_quote', 'quote_workflow'],
+    ['crm_lead', 'lead_automation'],
+  ])('%s: REFERENCE_FIELDS lists every declared lookup', (objectName, hookName) => {
+    const guard = GUARDS.find((g) => g.label === hookName)!;
+    const source = extractSandboxBody(guard.hook.handler, hookName).source;
+    const literal = /const REFERENCE_FIELDS = new Set\(\[([\s\S]*?)\]\)/.exec(source);
+    expect(literal, `${hookName} declares no REFERENCE_FIELDS`).toBeTruthy();
+    const listed = [...literal![1].matchAll(/["']([^"']+)["']/g)].map((m) => m[1]).sort();
+
+    const object = ((stack as AnyRec).objects as AnyRec[]).find((o) => o.name === objectName)!;
+    const declared = Object.entries(object.fields as Record<string, AnyRec>)
+      .filter(([, f]) => f.type === 'lookup' || f.type === 'master_detail')
+      // `owner_id` is framework-managed: every guard already treats it as a
+      // system column, so it never reaches the predicate.
+      .map(([name]) => name)
+      .filter((name) => name !== 'owner_id')
+      .sort();
+
+    expect(listed).toEqual(declared);
+  });
+});

--- a/test/hooks-runtime-sales.test.ts
+++ b/test/hooks-runtime-sales.test.ts
@@ -106,25 +106,22 @@ describe('opportunity_lifecycle', () => {
   });
 
   /**
-   * #693's defect class, on this guard: deleting a contact or a campaign a
-   * CLOSED opportunity references makes the engine clear that lookup, which
-   * arrives here as an ordinary `beforeUpdate`. Measured end-to-end,
-   * `DELETE /crm_contact/<id>` used to answer "Opportunity is closed
-   * (closed_won); … Attempted: primary_contact." — an object the caller never
-   * addressed, described as an edit they never made.
+   * #693's defect class, on this guard, as #720 settled it: deleting a contact
+   * or a campaign a CLOSED opportunity references makes the engine clear that
+   * lookup, which arrives here as an ordinary `beforeUpdate`. It used to be
+   * refused — "Opportunity is closed (closed_won); … Attempted: primary_contact"
+   * — which made the frozen deal able to keep that person undeletable. The
+   * freeze now yields to that write shape and only to it; the full narrowness,
+   * and the end-to-end deletes, live in
+   * `test/freeze-guard-reference-cleanup.test.ts`.
    */
-  it('describes a cleared link as a link, and names the opportunity', async () => {
+  it('lets the engine clear a link on a closed opportunity', async () => {
     const previous: Rec = { id: 'o1', name: 'Acme Renewal', stage: 'closed_won', primary_contact: 'c1' };
-    const err = await hook
-      .handler(makeCtx({
+    await expect(
+      hook.handler(makeCtx({
         event: 'beforeUpdate', input: { primary_contact: null }, previous, user: USER,
-      }))
-      .then(() => null, (e: Error) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect(err!.message).toContain('Opportunity Acme Renewal (o1)');
-    expect(err!.message).toContain('its link(s) primary_contact cannot be cleared');
-    expect(err!.message).toContain('blocks deleting the record(s) they point at');
-    expect(err!.message).not.toContain('may be edited');
+      })),
+    ).resolves.toBeUndefined();
   });
 
   it('still reports a mixed write as the edit it is', async () => {
@@ -256,23 +253,20 @@ describe('quote_workflow', () => {
   });
 
   /**
-   * #693's defect class, on this guard: deleting the opportunity (or contact) a
-   * frozen quote references makes the engine clear that lookup. Measured
-   * end-to-end, `DELETE /crm_opportunity/<id>` used to answer "Quote is
-   * accepted; only internal_notes may be edited. Attempted: crm_opportunity."
+   * #693's defect class on this guard, as #720 settled it: deleting the
+   * opportunity (or contact) a frozen quote references makes the engine clear
+   * that lookup, and the freeze used to answer "Quote is accepted; only
+   * internal_notes may be edited. Attempted: crm_opportunity." — a settled
+   * quote keeping a deal undeletable. It now yields to that write shape and
+   * only to it; see `test/freeze-guard-reference-cleanup.test.ts`.
    */
-  it('describes a cleared link as a link, and names the quote', async () => {
+  it('lets the engine clear a link on a frozen quote', async () => {
     const previous: Rec = { id: 'q1', name: 'Q-1001', status: 'accepted', crm_opportunity: 'o1' };
-    const err = await hook
-      .handler(makeCtx({
+    await expect(
+      hook.handler(makeCtx({
         event: 'beforeUpdate', input: { crm_opportunity: null }, previous, user: USER,
-      }))
-      .then(() => null, (e: Error) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect(err!.message).toContain('Quote Q-1001 (q1)');
-    expect(err!.message).toContain('its link(s) crm_opportunity cannot be cleared');
-    expect(err!.message).toContain('blocks deleting the record(s) they point at');
-    expect(err!.message).not.toContain('may be edited');
+      })),
+    ).resolves.toBeUndefined();
   });
 
   it('still reports a mixed write as the edit it is', async () => {


### PR DESCRIPTION
Fixes #720

Implements the maintainer's ruling of 2026-08-11 (issue comment 5249160023), quoted verbatim and untranslated:

> **Option A — the three freeze/lock guards yield to the engine's reference-cleanup write shape** (a write whose entire payload is reference fields being set to null). A frozen record must not make the people and accounts it references undeletable — GDPR erasure has to be able to proceed. Implementation notes: the dev verifies the exact engine cleanup write shape by measurement before loosening (do not guess the payload form); the yield must be shape-narrow (only the cleanup shape passes; ordinary user edits to frozen records stay refused, pinned by tests); per-object differentiation as the filer suggested is in scope if measurement shows the shapes differ.

## What was measured first

The ruling asks for measurement before loosening, and the dispatch asked whether a first-class marker exists. Both were checked on the current stack (17.0.0-rc.6; the issue was filed against rc.2), by instrumenting each of the three handlers on the real kernel rig:

```
input   = { id, LINK: null, updated_at, updated_by }   // LINK = the cleared lookup
user    = { id: CALLER_ID }                            // the CALLER, not a system id
session = { userId: CALLER_ID, isSystem: true }
provenance = undefined
```

All three objects (`crm_lead`, `crm_opportunity`, `crm_quote`) produce that same shape, so one predicate serves all three and no per-object differentiation was needed.

**A marker does exist, and it is deliberately out of reach.** `ObjectQL.cascadeDeleteRelations` tags its own cleanup write with `__referentialFieldClear: true` — but on the internal operation context:

```js
const referentialCtx = { ...context ?? {}, __referentialFieldClear: true };
await this.update(childName, { id: depId, [fieldName]: null }, { context: referentialCtx });
```

`buildSession` then copies a fixed allow-list of keys into `ctx.session`, and `__`-prefixed operation-private keys are not among them — that stripping is a documented rule in `@objectstack/core`, not an oversight. So no marker reaches a hook, and the write SHAPE is the only evidence available. Measured, not assumed: `ctx.session` in the cleanup is `{ userId, isSystem }`, byte-identical to a hand edit's.

## The change

All three guards gained the same block, verbatim:

```ts
const isReferenceCleanup = violating.every(
  (k) => REFERENCE_FIELDS.has(k) && input[k] === null && previous?.[k] != null,
);
if (isReferenceCleanup) return;
```

`violating` is each guard's existing "changes that are not narrative / system / approval fields" list, so the yield is exactly the PM triage's narrow condition: every violating key is a declared reference field, and every one of them is going value→null. The refusal messages for cleared links are deleted rather than re-worded — nothing produces them any more. Every other refusal is unchanged, verbatim.

A shared exported helper is not possible here: hook bodies run body-only in the QuickJS sandbox and cannot reach module scope (`test/action-sandbox.test.ts` enforces it). So the block is inlined three times and pinned as identical text, the same way the actions' shared `actor_name` block is.

## Tests

New: `test/freeze-guard-reference-cleanup.test.ts` (38 cases).

* **End to end, on the real kernel** (`ObjectKernel` + `ObjectQLPlugin` + `AppPlugin` over this repo's `objectstack.config.ts` — the rig the filer measured with): the issue's own repro now completes. `DELETE crm_contact/{C}` succeeds, then `DELETE crm_account/{A}`; also the account delete taken directly, cascading through the contact; a campaign a closed deal was attributed to; an opportunity an accepted quote references; the three records a converted lead points at. Each asserts the delete succeeded, the link is null, and the settled record is otherwise untouched (stage, amount, win_reason, status).
* **Narrowness, both directions**, per guard: a business field riding along, a link repointed to a new value, a plain business-field edit, a null on a field that is not a declared link, and a null over an already-empty link — all still refused, with the exact message. Two of them are also driven end to end through the kernel.
* **REFERENCE_FIELDS completeness**: each guard's list is compared against the object's declared lookups, so a lookup added later cannot silently keep blocking deletes.
* **Anti-drift**: the three lowered hook bodies carry the canonical predicate verbatim, and no hook anywhere spells it differently.

Updated: `cascade-guard-messages.test.ts`, `hooks-runtime-sales.test.ts`, `converted-lead-guard.test.ts` — the pins on the now-deleted "cannot be cleared" refusals become pins on the successful clear. #693's other half (the `beforeDelete` refusals, which #720 does not touch) stays exactly as it was.

**Reverse verification.** With the three hooks restored to `origin/main` and the new file unchanged: 16 of 38 red — every end-to-end delete, every yield case, and all three drift pins — while all 22 refusal/narrowness assertions stayed green, which is the point of them (they pin a surface that must not shrink, so they cannot be what turns the suite green).

**On the refusal envelope.** The card asks every refusal case to assert `code` and `status`. Measured end to end on rc.6: these guards' refusals — and the platform's own `account_protection` / `contact_integrity` refusals — reach the caller as bare `Error`s with `code` and `status` both `undefined`. There is no ADR-0112 envelope in this app to assert, so the tests pin the message wording (the contract PR #719 wrote) plus the envelope as the absent thing it measurably is, with a note that a failure there is news rather than a regression. Filed as a finding rather than widened into this card.

Gate: `pnpm verify` green (validate, typecheck, lint, hygiene, build, 1975 tests), plus `pnpm test:coverage` — CI's gate — at 96.71% statements / 84.92% branches, above every floor.

## Out of scope, filed separately

Filed as #1072: the intake dedupe (`lead_duplicate_check`) stamps `duplicate_of_type` + `duplicate_of_contact` on any new lead whose email matches an existing contact, and `duplicate_of_contact` is `requiredWhen` that discriminator is set. Deleting the contact nulls the lookup while the discriminator stays, so the record's own rule refuses the write: `Duplicate Of Contact is required`. That is the #696 / #711 construction, not this one, and it is fully independent of this change — an OPEN, unconverted lead blocks the same delete the same way, on a path where no freeze guard runs at all. A boundary test in the new file pins that none of these three guards answers for it any more.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NM6o28jmBgsyTRQHutn7LC)_