### PR TITLE
chore(lint): drop --skip-i18n from lint script; fill es-ES/zh-CN page-component i18n keys

### DIFF
--- a/.changeset/lint-drop-skip-i18n-gate.md
+++ b/.changeset/lint-drop-skip-i18n-gate.md
@@ -1,0 +1,22 @@
+---
+'hotcrm': patch
+---
+
+Drop `--skip-i18n` from the `lint` script so translation coverage is enforced
+continuously instead of being silently skipped.
+
+Running `objectstack lint` without the flag at the current `17.0.0-rc.6` pin
+surfaced 75 real `i18n/missing-page` warnings — three page-scoped translation
+keys per locale, times 25 UI-component labels/titles that were never added to
+the `es-ES`, `ja-JP` and `zh-CN` bundles for `app_launcher_page`,
+`case_detail_page`, `lead_detail_page`, `opportunity_detail_page`,
+`sales_home_page` and `utility_bar_page`. Filled in the 50 keys for `es-ES`
+and `zh-CN` here (labels/titles for components like `key_metrics`,
+`ai_briefing`, `quick_create`, `notifications_panel`, etc., matching the
+English source in `src/pages/*.page.ts`). Previously these fell back to the
+raw English source string in the Spanish and Chinese UI.
+
+The 25 `ja-JP` keys are intentionally left out of this change: `ja-JP.ts` is
+being edited by a concurrent PR (#858) in the same batch, so touching it here
+would race that work. Those keys are enumerated in the linked issue for a
+follow-up.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "objectstack build",
     "typecheck": "tsc --noEmit",
     "validate": "objectstack validate",
-    "lint": "objectstack lint --skip-i18n",
+    "lint": "objectstack lint",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -1429,34 +1429,69 @@ export const esES: TranslationData = {
       label: 'Lanzador de Aplicaciones',
       description: 'Punto de acceso central a todas las aplicaciones',
       subtitle: 'Seleccione una aplicación para empezar',
+      components: {
+        app_search: { label: 'Buscar Aplicaciones' },
+        app_grid: { label: 'Cuadrícula de Aplicaciones' },
+      },
     },
     case_detail_page: {
       label: 'Detalle de Caso',
       description: 'Página de caso para el agente de servicio: datos destacados, progreso del SLA, detalles y cronología de actividad.',
       title: '{case_number} · {subject}',
       subtitle: '{crm_account}',
+      components: {
+        case_highlights: { label: 'Información Clave' },
+        case_status_path: { label: 'Progreso del Estado del Caso' },
+      },
     },
     lead_detail_page: {
       label: 'Detalle de Prospecto',
       description: 'Página completa de detalle del prospecto, con datos destacados, detalles e información relacionada',
       title: '{first_name} {last_name}',
       subtitle: '{company}',
+      components: {
+        lead_highlights: { label: 'Información Clave' },
+        lead_path: { label: 'Progreso del Estado del Prospecto' },
+        main_tabs: { label: 'Pestañas de Información del Prospecto' },
+      },
     },
     opportunity_detail_page: {
       label: 'Detalle de Oportunidad',
       description: 'Página completa de detalle de la oportunidad, con recorrido de etapas, datos destacados, detalles y listas relacionadas',
       title: '{name}',
       subtitle: '{crm_account}',
+      components: {
+        opp_highlights: { label: 'Información Clave' },
+        opp_stage_path: { label: 'Progreso de Etapa de la Oportunidad' },
+      },
     },
     sales_home_page: {
       label: 'Inicio de Ventas',
       description: 'Página de inicio del equipo comercial con métricas clave y acciones rápidas',
       title: 'Panel de Ventas',
       subtitle: 'Bienvenido de nuevo, {current_user.first_name}',
+      components: {
+        quick_create: { title: 'Creación Rápida', label: 'Creación Rápida' },
+        my_recent_items: { title: 'Elementos Recientes', label: 'Elementos Recientes' },
+        key_metrics: { title: 'Indicadores Clave de Rendimiento', label: 'Métricas Clave' },
+        home_tabs: { label: 'Pestañas de Inicio' },
+        ai_briefing: {
+          title: 'Pregúntale al Asistente de IA',
+          description:
+            'Abra el panel del asistente desde el borde derecho de la página y pregunte "¿en qué debería concentrarme hoy?" — ve su flujo de ventas, esquema y cuentas en tiempo real.',
+          label: 'Hoy con el Asistente de IA',
+        },
+        upcoming_events: { title: 'Agenda de Hoy', label: 'Calendario' },
+      },
     },
     utility_bar_page: {
       label: 'Barra de Utilidades',
       description: 'Barra de acceso rápido con herramientas flotantes',
+      components: {
+        notifications_panel: { label: 'Notificaciones' },
+        quick_notes: { title: 'Notas Rápidas', label: 'Notas Rápidas' },
+        quick_search: { label: 'Búsqueda Rápida' },
+      },
     },
   },
 };

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -1363,34 +1363,69 @@ export const zhCN: TranslationData = {
       label: '应用中心',
       description: '访问全部应用的统一入口',
       subtitle: '选择一个应用开始使用',
+      components: {
+        app_search: { label: '搜索应用' },
+        app_grid: { label: '应用网格' },
+      },
     },
     case_detail_page: {
       label: '工单详情',
       description: '客服工单记录页：关键信息、SLA 进度、明细与活动时间线。',
       title: '{case_number} · {subject}',
       subtitle: '{crm_account}',
+      components: {
+        case_highlights: { label: '关键信息' },
+        case_status_path: { label: '工单状态进度' },
+      },
     },
     lead_detail_page: {
       label: '线索详情',
       description: '完整的线索详情页，包含关键信息、明细与相关记录。',
       title: '{first_name} {last_name}',
       subtitle: '{company}',
+      components: {
+        lead_highlights: { label: '关键信息' },
+        lead_path: { label: '线索状态进度' },
+        main_tabs: { label: '线索信息标签页' },
+      },
     },
     opportunity_detail_page: {
       label: '商机详情',
       description: '完整的商机详情页，包含阶段进度、关键信息、明细与相关列表。',
       title: '{name}',
       subtitle: '{crm_account}',
+      components: {
+        opp_highlights: { label: '关键信息' },
+        opp_stage_path: { label: '商机阶段进度' },
+      },
     },
     sales_home_page: {
       label: '销售主页',
       description: '销售团队主页，汇总关键指标与快捷操作',
       title: '销售看板',
       subtitle: '欢迎回来，{current_user.first_name}',
+      components: {
+        quick_create: { title: '快速创建', label: '快速创建' },
+        my_recent_items: { title: '最近使用', label: '最近使用' },
+        key_metrics: { title: '关键绩效指标', label: '关键指标' },
+        home_tabs: { label: '主页标签页' },
+        ai_briefing: {
+          title: '询问 AI 助手',
+          description:
+            '从页面右侧打开助手面板，询问"我今天应该关注什么？"——它可以实时查看您的销售管道、架构与客户信息。',
+          label: 'AI 助手今日速览',
+        },
+        upcoming_events: { title: '今日日程', label: '日历' },
+      },
     },
     utility_bar_page: {
       label: '工具栏',
       description: '悬浮工具的快捷访问栏',
+      components: {
+        notifications_panel: { label: '通知' },
+        quick_notes: { title: '快速笔记', label: '快速笔记' },
+        quick_search: { label: '快速搜索' },
+      },
     },
   },
 };


### PR DESCRIPTION
Part of #1060

## Premise check at rc.6 (measured, not inherited)

The issue's stated premise ("app-side i18n warnings are 0 on `main`") was measured at `0899b4f` on rc.5/rc.2. This card's own reason to exist is that rc.6 might move that number — so per the PM's instruction, I re-measured on `origin/main` at the current `17.0.0-rc.6` pin **before** deciding whether to drop the flag:

```
$ npx objectstack lint            # no --skip-i18n
  Warnings (228)
$ npx objectstack lint --skip-i18n
  Warnings (153)
```

The 75-warning delta is exactly the `i18n/missing-page` rule (confirmed by rule-id count), spread evenly across three locales: **25 keys × es-ES / ja-JP / zh-CN**, all identical key paths — page-component `label`/`title`/`description` strings on `app_launcher_page`, `case_detail_page`, `lead_detail_page`, `opportunity_detail_page`, `sales_home_page`, `utility_bar_page` that were declared inline in `src/pages/*.page.ts` but never mirrored into the locale bundles' `pages.<page>.components.<id>` block (that block didn't exist at all in any locale file — `en` doesn't need it, since English is the source and resolves through the inline literal). So: **the premise does not hold at rc.6 — debt is not zero.**

## What this PR does

- Fills the 50 `es-ES` + `zh-CN` keys (all 25 keys × 2 locales) with translations matching each page's existing English source string. Previously these fell back to raw English in the Spanish/Chinese UI.
- Drops `--skip-i18n` from `package.json`'s `lint` script so the i18n coverage checker runs on every `pnpm lint` going forward, instead of being silently skipped.

## What this PR deliberately leaves out — the ja-JP boundary

`src/translations/ja-JP.ts` is claimed by **#858** in this same batch (a verb-terminology unification pass), in flight concurrently. Per the dispatch boundary for this card, I did **not** touch it. The 25 missing ja-JP keys (same key paths as es-ES/zh-CN above) are:

```
pages.app_launcher_page.components.app_search.label
pages.app_launcher_page.components.app_grid.label
pages.case_detail_page.components.case_highlights.label
pages.case_detail_page.components.case_status_path.label
pages.lead_detail_page.components.lead_highlights.label
pages.lead_detail_page.components.lead_path.label
pages.lead_detail_page.components.main_tabs.label
pages.opportunity_detail_page.components.opp_highlights.label
pages.opportunity_detail_page.components.opp_stage_path.label
pages.sales_home_page.components.quick_create.title
pages.sales_home_page.components.quick_create.label
pages.sales_home_page.components.my_recent_items.title
pages.sales_home_page.components.my_recent_items.label
pages.sales_home_page.components.key_metrics.title
pages.sales_home_page.components.key_metrics.label
pages.sales_home_page.components.home_tabs.label
pages.sales_home_page.components.ai_briefing.title
pages.sales_home_page.components.ai_briefing.description
pages.sales_home_page.components.ai_briefing.label
pages.sales_home_page.components.upcoming_events.title
pages.sales_home_page.components.upcoming_events.label
pages.utility_bar_page.components.notifications_panel.label
pages.utility_bar_page.components.quick_notes.title
pages.utility_bar_page.components.quick_notes.label
pages.utility_bar_page.components.quick_search.label
```

Because of this, `pnpm lint` on this branch still reports **25 residual `i18n/missing-page` warnings** (all `ja-JP`) — not the fully-green run that would prove debt is zero. `objectstack lint` does not fail the process on warnings alone (exit code 0 both before and after this change), so dropping the flag is mechanically safe; it makes this remaining debt **visible** in the gate output instead of hiding it, which is the actual point of the card ("coverage should enter the gate"). First line is `Part of #1060` rather than `Fixes #1060` for exactly this reason — merging this alone does not fully close the card; the ja-JP portion needs a follow-up once #858 lands.

## Verification

- `pnpm typecheck` — pass
- `pnpm validate` — pass (pre-existing, unrelated author-time warnings only — none of them i18n)
- `pnpm build` — pass, `dist/objectstack.json` produced
- `npx vitest run test/i18n-references.test.ts` — 20/20 pass
- `npx vitest run` (full scoped suite, `--maxWorkers=2`) — 86 files, 2086 passed / 1 skipped
- `node scripts/check-source-hygiene.mjs` — clean
- Self-scan for stray control bytes in both edited translation files — clean

## Changeset

Added `.changeset/lint-drop-skip-i18n-gate.md` as a `patch` — the es-ES/zh-CN translation additions are user-visible (previously-untranslated UI strings), so this is not tooling-only and doesn't qualify for `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NM6o28jmBgsyTRQHutn7LC)_