### PR TITLE
fix(i18n): fill 25 missing ja-JP page-component translation keys

### DIFF
--- a/.changeset/ja-jp-page-component-keys.md
+++ b/.changeset/ja-jp-page-component-keys.md
@@ -1,0 +1,27 @@
+---
+'hotcrm': patch
+---
+
+Filled the last 25 missing `ja-JP` page-component translation keys, closing out the i18n coverage gate that #1060 opened.
+
+`objectstack lint` (run without `--skip-i18n` since #1080) reported 25
+`i18n/missing-page` warnings, all `ja-JP`: page-component `label`/`title`/
+`description` strings on `app_launcher_page`, `case_detail_page`,
+`lead_detail_page`, `opportunity_detail_page`, `sales_home_page` and
+`utility_bar_page` that were defined in `src/pages/*.page.ts` and never
+mirrored into `src/translations/ja-JP.ts`. #1080 filled the same 25 keys for
+`es-ES`/`zh-CN` but deliberately left `ja-JP.ts` untouched — it was claimed by
+#858 (a verb-terminology pass) in the same batch. That claim is now merged, so
+this PR fills the remaining third.
+
+Translated each string against its English source in `src/pages/*.page.ts`,
+matching the nesting shape and register #1080 already established for
+`es-ES`/`zh-CN` (`pages.<page>.components.<component>.<label|title|description>`).
+Only additions — no existing `ja-JP.ts` lines were reordered or reformatted, to
+avoid manufacturing a conflict for #1061, which is queued behind this file for
+the `crm_opportunity` competitors options.
+
+Result: `objectstack lint` now reports **zero** `i18n/missing-page` warnings
+(down from 25; total warning count 178 → 153), across all three locales this
+card and #1080 together completed. `es-ES` and `zh-CN` were already clean and
+are untouched by this PR.

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -1377,34 +1377,69 @@ export const jaJP: TranslationData = {
       label: 'アプリランチャー',
       description: 'すべてのアプリケーションにアクセスするための統合ハブ',
       subtitle: '開始するアプリを選択してください',
+      components: {
+        app_search: { label: 'アプリを検索' },
+        app_grid: { label: 'アプリグリッド' },
+      },
     },
     case_detail_page: {
       label: 'ケース詳細',
       description: 'サービス担当者向けのケースレコードページ：ハイライト、SLA パス、詳細、活動タイムライン。',
       title: '{case_number} · {subject}',
       subtitle: '{crm_account}',
+      components: {
+        case_highlights: { label: '重要情報' },
+        case_status_path: { label: 'ケースステータスの進捗' },
+      },
     },
     lead_detail_page: {
       label: 'リード詳細',
       description: 'ハイライト・詳細・関連情報を備えたリードの総合詳細ページ。',
       title: '{first_name} {last_name}',
       subtitle: '{company}',
+      components: {
+        lead_highlights: { label: '重要情報' },
+        lead_path: { label: 'リードステータスの進捗' },
+        main_tabs: { label: 'リード情報タブ' },
+      },
     },
     opportunity_detail_page: {
       label: '商談詳細',
       description: 'ステージパス・ハイライト・詳細・関連リストを備えた商談の総合詳細ページ。',
       title: '{name}',
       subtitle: '{crm_account}',
+      components: {
+        opp_highlights: { label: '重要情報' },
+        opp_stage_path: { label: '商談ステージの進捗' },
+      },
     },
     sales_home_page: {
       label: '営業ホーム',
       description: '主要指標とクイックアクションをまとめた営業チームのホームページ',
       title: '営業ダッシュボード',
       subtitle: 'おかえりなさい、{current_user.first_name} さん',
+      components: {
+        quick_create: { title: 'クイック作成', label: 'クイック作成' },
+        my_recent_items: { title: '最近使用したアイテム', label: '最近使用したアイテム' },
+        key_metrics: { title: '主要業績評価指標', label: '主要指標' },
+        home_tabs: { label: 'ホームタブ' },
+        ai_briefing: {
+          title: 'AI アシスタントに質問',
+          description:
+            'ページ右端からアシスタントパネルを開き、「今日は何に集中すべきか？」と尋ねてください — リアルタイムのパイプライン、スキーマ、取引先情報を把握しています。',
+          label: '今日の AI アシスタント',
+        },
+        upcoming_events: { title: '今日の予定', label: 'カレンダー' },
+      },
     },
     utility_bar_page: {
       label: 'ユーティリティバー',
       description: 'フローティングツールへのクイックアクセスバー',
+      components: {
+        notifications_panel: { label: '通知' },
+        quick_notes: { title: 'クイックメモ', label: 'クイックメモ' },
+        quick_search: { label: 'クイック検索' },
+      },
     },
   },
 };


### PR DESCRIPTION
Fixes #1060

## What

Fills the remaining third of #1060's debt: the 25 `ja-JP` page-component
translation keys that #1080 deliberately left out (that file was claimed by
#858 in the same batch). #858's PR #1079 merged (`83a8dbdb`), and this branch
is cut from current `origin/main` (`f71b5350`, which already carries both
#1079 and #1080), so the cross-claim boundary is clear.

## Premise re-verified at HEAD, not copied from the issue

Ran `npx objectstack lint` fresh on this branch before touching anything. It
reported exactly **25** `i18n/missing-page` warnings, **all `ja-JP`**, and the
key paths matched the PM's enumerated list exactly:

- `app_launcher_page.components.{app_search,app_grid}.label`
- `case_detail_page.components.{case_highlights,case_status_path}.label`
- `lead_detail_page.components.{lead_highlights,lead_path,main_tabs}.label`
- `opportunity_detail_page.components.{opp_highlights,opp_stage_path}.label`
- `sales_home_page.components.{quick_create,my_recent_items,key_metrics,home_tabs,ai_briefing,upcoming_events}.{title|label|description}`
- `utility_bar_page.components.{notifications_panel,quick_notes,quick_search}.{title|label}`

`es-ES` and `zh-CN` reported zero `i18n/missing-page` warnings — confirming
#1080's fill is intact and untouched by this change.

## Implementation

Translated each string against its English source in `src/pages/*.page.ts`
(`app_launcher.page.ts`, `case_detail.page.ts`, `lead_detail.page.ts`,
`opportunity_detail.page.ts`, `home.page.ts`, `utility_bar.page.ts`), matching
the nesting shape and register #1080 already established for `es-ES`/`zh-CN`
(`pages.<page>.components.<component>.<label|title|description>`).

**File surface: `src/translations/ja-JP.ts` only** — additions, no existing
lines reordered or reformatted, per the card's instruction not to create a
needless conflict for #1061, which is queued behind this file for the
`crm_opportunity` competitors options (a disjoint region — `crm_opportunity`
field block vs. this PR's `pages` block).

## Acceptance evidence

`objectstack lint` `i18n/missing-page` count:

| | before | after |
|---|---|---|
| `i18n/missing-page` warnings | 25 (all `ja-JP`) | **0** |
| total warnings | 178 | 153 |

(`lint`'s exit code is 0 either way — it does not fail on warnings, per
#1083 — so the rule-hit count above, not the exit code, is the evidence.)

## Tests run

- `npx objectstack lint` (no flag): 0 `i18n/missing-page` hits, 153 total
  warnings (down from 178), exit 0.
- `pnpm typecheck` (`tsc --noEmit`): clean, no errors.
- `pnpm validate` (`objectstack validate`): exit 0; remaining warnings are
  pre-existing, unrelated author-time issues (missing `name` on form
  sections, deprecated component props, `colSpan` usage) — none i18n, none
  touching `ja-JP.ts`.
- `pnpm build` (`objectstack build`): exit 0, `dist/objectstack.json` produced
  (1890.1 KB), 157 pre-existing author-time warnings (none i18n).
- `npx vitest run test/i18n-references.test.ts --maxWorkers=2`: 20/20 passed.
- `npx vitest run --maxWorkers=2` (full scoped suite): 86 files, 2086 passed /
  1 skipped, exit 0.
- `node scripts/check-source-hygiene.mjs`: clean.
- Control-byte self-scan (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) on
  the edited file: clean.

## Changeset

Added (`skip-changeset` not applicable — this is a user-visible translation
fill; the `ja-JP` UI previously fell back to English source strings on these
25 component keys).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NM6o28jmBgsyTRQHutn7LC)_