### PR TITLE
fix(forecast): state period_start's calendar-boundary constraint in description + four-locale help

### DIFF
--- a/.changeset/period-start-boundary-help.md
+++ b/.changeset/period-start-boundary-help.md
@@ -1,0 +1,29 @@
+---
+'hotcrm': patch
+---
+
+`crm_forecast.period_start` now states its calendar-boundary constraint on the
+field itself, in the record form's Snapshot section, instead of only surfacing
+it when a bad write is refused.
+
+#1081 (#1008) made a hand-filled `period_start` off a calendar-period boundary
+a rejected write, enforced by two rules that are unchanged by this PR:
+
+- `period_start_first_of_period` — "Period Start must be the first day of the
+  period — e.g. 2026-08-01 for Aug 2026."
+- `quarter_starts_on_quarter_boundary` — "A quarterly forecast must start on a
+  quarter boundary — January 1, April 1, July 1 or October 1."
+
+`period_start` now carries a `description` echoing those same two messages, and
+a matching `help` entry lands in all four locale packs (`en`, `zh-CN`, `es-ES`,
+`ja-JP`), which is what `test/i18n-references.test.ts` requires for any field
+that carries a `description`.
+
+`period_end` is also editable on the Snapshot section (measured — it is not
+readonly, and `forecast.hook.ts` only derives it when a write leaves it unset),
+so it gets its own `description` + four-locale `help` too — but for the rule
+actually bound to it, `period_end_after_start` ("Period End must be after
+Period Start."), not `period_start`'s calendar-boundary rules, which do not
+apply to it.
+
+No validation rule changed.

--- a/src/objects/forecast.object.ts
+++ b/src/objects/forecast.object.ts
@@ -80,15 +80,28 @@ export const Forecast = ObjectSchema.create({
       ],
     }),
 
+    // Wording mirrors the two refusal messages this field is bound by
+    // (`period_start_first_of_period` / `quarter_starts_on_quarter_boundary`,
+    // both below) so the form and the rejection agree on the same rule
+    // instead of describing two different ones (#1085).
     period_start: Field.date({
       label: 'Period Start',
+      description:
+        'Must be the first day of the period — e.g. 2026-08-01 for Aug 2026. A quarterly forecast must additionally start on a quarter boundary: January 1, April 1, July 1 or October 1.',
       required: true,
       storage: { notNull: true },
       group: 'basic',
     }),
 
+    // Not read-only: `forecast.hook.ts` fills it only when the write leaves it
+    // unset, so a caller may still hand-type it. The only rule bound to THIS
+    // field is `period_end_after_start` below — it does not share
+    // `period_start`'s calendar-boundary rules, so the description says only
+    // what is actually enforced on it (#1085).
     period_end: Field.date({
       label: 'Period End',
+      description:
+        'Normally derived automatically from Period and Period Start. If set by hand, it must be after Period Start.',
       required: true,
       storage: { notNull: true },
       group: 'basic',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -287,8 +287,14 @@ export const en: TranslationData = {
       fields: {
         owner_id: { label: 'Owner' },
         period: { label: 'Period', options: { month: 'Month', quarter: 'Quarter' } },
-        period_start: { label: 'Period Start' },
-        period_end: { label: 'Period End' },
+        period_start: {
+          label: 'Period Start',
+          help: 'Must be the first day of the period — e.g. 2026-08-01 for Aug 2026. A quarterly forecast must additionally start on a quarter boundary: January 1, April 1, July 1 or October 1.',
+        },
+        period_end: {
+          label: 'Period End',
+          help: 'Normally derived automatically from Period and Period Start. If set by hand, it must be after Period Start.',
+        },
         period_label: { label: 'Period', help: 'Human-friendly label, e.g. "Q3 2026" or "Aug 2026".' },
         snapshot_date: { label: 'Snapshot Date', help: 'The day this snapshot was captured.' },
         source: {

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -304,8 +304,14 @@ export const esES: TranslationData = {
       fields: {
         owner_id: { label: 'Propietario' },
         period: { label: 'Periodo', options: { month: 'Mes', quarter: 'Trimestre' } },
-        period_start: { label: 'Inicio del periodo' },
-        period_end: { label: 'Fin del periodo' },
+        period_start: {
+          label: 'Inicio del periodo',
+          help: 'Debe ser el primer día del periodo — p. ej. 2026-08-01 para agosto de 2026. Además, una previsión trimestral debe comenzar en un límite de trimestre: 1 de enero, 1 de abril, 1 de julio o 1 de octubre.',
+        },
+        period_end: {
+          label: 'Fin del periodo',
+          help: 'Normalmente se calcula automáticamente a partir de Periodo e Inicio del periodo. Si se introduce a mano, debe ser posterior al Inicio del periodo.',
+        },
         period_label: { label: 'Periodo', help: 'Etiqueta legible, p. ej. «T3 2026» o «Ago 2026».' },
         display_title: { label: 'Título Mostrado' },
         snapshot_date: { label: 'Fecha de instantánea', help: 'El día en que se capturó esta instantánea.' },

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -312,8 +312,14 @@ export const jaJP: TranslationData = {
       fields: {
         owner_id: { label: '担当者' },
         period: { label: '期間', options: { month: '月次', quarter: '四半期' } },
-        period_start: { label: '期間開始' },
-        period_end: { label: '期間終了' },
+        period_start: {
+          label: '期間開始',
+          help: '期間の初日である必要があります — 例: 2026 年 8 月なら 2026-08-01。四半期のフォーキャストはさらに四半期の境界（1 月 1 日・4 月 1 日・7 月 1 日・10 月 1 日）で開始する必要があります。',
+        },
+        period_end: {
+          label: '期間終了',
+          help: '通常は「期間」と「期間開始」から自動的に算出されます。手動で入力する場合は、期間開始より後の日付にする必要があります。',
+        },
         period_label: {
           label: '期間',
           help: '「2026 年第 3 四半期」「2026 年 8 月」のような読みやすい期間ラベル。',

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -278,8 +278,14 @@ export const zhCN: TranslationData = {
       fields: {
         owner_id: { label: '负责人' },
         period: { label: '周期', options: { month: '月度', quarter: '季度' } },
-        period_start: { label: '周期起始' },
-        period_end: { label: '周期截止' },
+        period_start: {
+          label: '周期起始',
+          help: '必须是所在周期的第一天——例如 2026 年 8 月对应 2026-08-01。季度预测还必须落在季度边界上：1 月 1 日、4 月 1 日、7 月 1 日或 10 月 1 日。',
+        },
+        period_end: {
+          label: '周期截止',
+          help: '通常根据"周期"和"周期起始"自动推算。如手动填写，必须晚于周期起始。',
+        },
         period_label: { label: '周期标签', help: '易读的周期标签，例如"2026 年第三季度"或"2026 年 8 月"。' },
         snapshot_date: { label: '快照日期', help: '本次快照的采集日期。' },
         source: {


### PR DESCRIPTION
Fixes #1085

## Description

`crm_forecast.period_start` now states the calendar-boundary constraint on the
field itself (`description` + four-locale `help`), so a manager filling in the
Snapshot section of the record form reads the rule before a save is refused,
not only after. `period_end`, measured to be editable on the same form
section, gets the same treatment for the rule actually bound to it.

**Premise verified against current `origin/main` (`1713fb7e`, after #1090)
before implementing:**

- `crm_forecast.period_start` had no `description` — confirmed by reading
  `src/objects/forecast.object.ts` before editing. Premise held.
- `test/i18n-references.test.ts` requires, for every field carrying a
  `description`, a `help` entry in **every** locale pack — no per-locale
  exemption. Read directly out of the test (`every authored field label and
  help string is translated`, line 366:
  `if (f?.description && !fields[name]?.help) bad.push(...)`, run against
  `localePacks`, which the file states covers all four packs). Premise held.

## Type of Change

- [x] Documentation update (metadata `description` / locale `help` only —
      no behavior change)

## Related Issues

Fixes #1085
Related to #1008, #1081

## Changes Made

- `src/objects/forecast.object.ts`: added `description` to `period_start`,
  wording chosen to match the two live refusal messages verbatim —
  `period_start_first_of_period` ("Period Start must be the first day of the
  period — e.g. 2026-08-01 for Aug 2026.") and
  `quarter_starts_on_quarter_boundary` ("A quarterly forecast must start on a
  quarter boundary — January 1, April 1, July 1 or October 1."). **Neither
  rule's condition or message was touched.**
- `src/objects/forecast.object.ts`: added `description` to `period_end` too —
  see "period_end" below for why the wording differs from `period_start`'s.
- `src/translations/{en,zh-CN,es-ES,ja-JP}.ts`: added matching `help` entries
  for both fields under `crm_forecast.fields`, translating the same rule (not
  free-translated) in each locale.
- `.changeset/period-start-boundary-help.md`: user-visible form-copy change.

## `period_end` — measured, not assumed

The issue's scope item 3 asked to check whether `period_end` "deserves the
same treatment," measuring rather than assuming it is purely derived/hidden.
Measured on this branch:

- **Exposed on the form**: `src/views/forecast.view.ts:127` lists `period_end`
  in the Snapshot section's `fields`, alongside `period_start`. Not hidden.
- **Not read-only**: `Field.date(...)` for `period_end` sets no `readonly`.
- **Hand-fillable**: `src/objects/forecast.hook.ts:93` —
  `if (!input.period_end) input.period_end = isoDate(end);` — the hook only
  derives it when a write leaves it unset. A caller (including the record
  form) can still hand-type it.

So `period_end` is genuinely user-facing and typeable, and it does carry an
enforced-but-undocumented constraint — **but it is not `period_start`'s
calendar-boundary constraint**. `period_start_first_of_period` and
`quarter_starts_on_quarter_boundary` are both conditioned on
`record.period_start` only; neither reads `record.period_end`. The rule
actually bound to `period_end` is `period_end_after_start` ("Period End must
be after Period Start."). Giving `period_end` `period_start`'s exact wording
would describe a rule it isn't subject to — which the issue calls out as
worse than no description at all — so `period_end`'s description instead
says it is normally derived and, if hand-filled, must be after Period Start,
matching the rule it is actually bound by.

## Testing

All commands run from a dedicated worktree (`hotcrm-issue-1085`) off current
`origin/main` (`1713fb7e`), inside the shared verification lock
(`flock /tmp/os-heavy-verify.lock`), `NODE_OPTIONS=--max-old-space-size=4096`.

- [x] `pnpm typecheck` — exit 0, no errors.
- [x] `pnpm validate` — exit 0, `✓ Validation passed`, `Data: 17 Objects  344
      Fields` (unchanged field count — `description`/`help` are not new
      fields).
- [x] `pnpm hygiene` — exit 0, `✓ source hygiene clean` (275 files scanned).
      Self-scanned the 6 changed files for control bytes beyond the gate
      (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) — no matches.
- [x] `pnpm build` — exit 0, `✓ Build complete`, artifact `dist/objectstack.json`
      1900.8 KB.
- [x] `pnpm lint` — exit 0 (not evidence per #1018, so rule hit counts below).
      **`i18n/missing-*`: 0 hits, both before and after.** Per-rule warning
      histogram is **byte-identical** to a pristine `origin/main` worktree —
      153 warnings / 10 suggestions on both sides, `diff` of the sorted
      `rule-name` histograms is empty. This change added zero new lint
      findings of any kind.
- [x] `npx vitest run test/i18n-references.test.ts` — 1 file, **20 passed**.
- [x] `npx vitest run --maxWorkers=2` (full local suite, scoped to this
      single-package repo) — **91 files, 2194 passed, 1 skipped** — same
      totals as the most recent merged PR on this branch of work (#1090).

CI has not been read — reporting at draft-PR time per the dispatch contract
(#6644 L2); the PM reads gate-job conclusions before any ready-flip.

## Checklist

- [x] I have added a changeset (`.changeset/period-start-boundary-help.md`)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (see lint histogram diff above)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective — not applicable:
      this is a `description`/`help` copy change, already covered by the
      existing `test/i18n-references.test.ts` completeness guard, which now
      exercises both new fields.

## Additional Notes

Out of scope, untouched per the card's explicit fence: `period_start_first_of_period`,
`quarter_starts_on_quarter_boundary`, `period_end_after_start` — all three
rules' `condition` and `message` are byte-for-byte what they were on
`origin/main`. `src/objects/opportunity.object.ts` was not touched (kept clear
of #1090, already merged). No other object file under `src/objects/` was
touched (kept clear of #1091, queued after this card per the PM's dispatch
comment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NM6o28jmBgsyTRQHutn7LC)_