### PR TITLE
fix(objects): move license header back above F,P import in three files

### DIFF
--- a/.changeset/reorder-license-header-above-import.md
+++ b/.changeset/reorder-license-header-above-import.md
@@ -1,0 +1,14 @@
+---
+'hotcrm': patch
+---
+
+Move the copyright header back to line 1 in `src/objects/case.object.ts`,
+`src/objects/product.object.ts` and `src/objects/opportunity.object.ts`,
+where the `import { F, P } from '@objectstack/spec'` line had ended up
+above it.
+
+No behavioral change: `F` and `P` (the `cel`-tagged-template aliases for
+formula/predicate expressions) are used productively in all three files —
+`` F`...` `` for computed-field formulas, `` P`...` `` for validation
+conditions and `visible`/`requiredWhen` predicates — so the import itself
+is untouched, only its position relative to the header moves.

--- a/src/objects/case.object.ts
+++ b/src/objects/case.object.ts
@@ -1,7 +1,7 @@
-import { F, P } from '@objectstack/spec';
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { ObjectSchema, Field } from '@objectstack/spec/data';
+import { F, P } from '@objectstack/spec';
 
 export const Case = ObjectSchema.create({
   name: 'crm_case',

--- a/src/objects/opportunity.object.ts
+++ b/src/objects/opportunity.object.ts
@@ -1,7 +1,7 @@
-import { F, P } from '@objectstack/spec';
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { ObjectSchema, Field } from '@objectstack/spec/data';
+import { F, P } from '@objectstack/spec';
 import { LEAD_SOURCE_OPTIONS, OPPORTUNITY_STAGE_OPTIONS } from './_picklists';
 
 export const Opportunity = ObjectSchema.create({

--- a/src/objects/product.object.ts
+++ b/src/objects/product.object.ts
@@ -1,7 +1,7 @@
-import { F, P } from '@objectstack/spec';
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { ObjectSchema, Field } from '@objectstack/spec/data';
+import { F, P } from '@objectstack/spec';
 
 /**
  * Product Object


### PR DESCRIPTION
Fixes #1091

## The issue's premise does not hold — `F`/`P` are used, not dead

#1091's own reproduce command:

```bash
for f in $(grep -rln "^import { F, P } from '@objectstack/spec';" src/); do
  echo "$f: $(grep -cE '\b[FP]\.' $f) uses"
done
```

measures **dot-notation property access** (`F.something`). But `@objectstack/spec` exports `F` and `P` as **tagged-template functions**, per the package's own JSDoc:

```ts
/** Formula alias of {@link cel} — semantic shorthand for computed-field formulas. */
declare const F: typeof cel;
/** Predicate alias of {@link cel} — semantic shorthand for boolean conditions. */
declare const P: typeof cel;
```

They're invoked as `` F`...` `` / `` P`...` `` — never with a `.` after the identifier — so the issue's own repro command was structurally unable to see real usage. Re-measured with the actual call syntax, all nine files use both:

```text
src/objects/opportunity_line_item.object.ts: F`=1 P`=1
src/objects/lead.object.ts:                  F`=2 P`=5
src/objects/case.object.ts:                  F`=1 P`=2
src/objects/product.object.ts:               F`=1 P`=2
src/objects/quote_line_item.object.ts:       F`=2 P`=1
src/objects/knowledge_article.object.ts:     F`=1 P`=2
src/objects/opportunity.object.ts:           F`=1 P`=4
src/objects/forecast.object.ts:              F`=4 P`=4
src/objects/campaign.object.ts:              F`=3 P`=2
```

`` F`...` `` builds computed-field `expression`s; `` P`...` `` builds `condition`/`requiredWhen`/`visible` predicates. This is also the established idiom well beyond these nine files — `` P` `` alone appears in `src/actions/*`, `src/views/lead.view.ts`, every `src/flows/*.flow.ts` that branches on a condition, and all four `src/sharing/*.sharing.ts` files.

Checked git history on `case.object.ts` per the dispatch's blocking precondition: the `F, P` import and its first `` F`...` ``/`` P`...` `` call site landed in the **same commit**, at file creation (`60dc7ed7`) — this was never a partial/mid-migration; it's the file's original, complete form. So neither branch of the precondition applies (not dead, not an in-progress migration) — the premise itself was wrong, per a bug in the issue's measurement, not in the code.

**Nothing was deleted.**

## What was real and got fixed

Three of the nine files did have the import sitting on line 1, above the copyright header (`case.object.ts`, `product.object.ts`, `opportunity.object.ts` — matching the PM's correction that "three", not the body's "four", is right). That part of the issue was accurate and independent of the unused-import claim. Fixed by moving the header back to line 1, matching the layout the other six files already use (header, blank line, then imports):

```diff
-import { F, P } from '@objectstack/spec';
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.

 import { ObjectSchema, Field } from '@objectstack/spec/data';
+import { F, P } from '@objectstack/spec';
```

## Gates not added

The issue suggested two optional gates; neither is included here:

- **`noUnusedLocals` in `tsconfig.json`** — its entire justification for this card was the (false) unused-`F`/`P` premise. I test-enabled it locally anyway to see the actual blast radius: it flags 2 genuinely unused locals elsewhere in the repo (`src/objects/contract.hook.ts:99`, `test/hook-query-predicate.test.ts:52`), both outside this issue's file surface. Per the card's own overflow rule, that's a separate card, not something to fix or force through here.
- **Header-position check in `scripts/check-source-hygiene.mjs`** — while investigating, a full `src/` sweep found the same import-above-header drift in **8 more files** outside this issue's named list (`contract.object.ts`, `task.object.ts`, `quote.object.ts`, `account.object.ts`, and all four `src/sharing/*.sharing.ts`). Filed as #1094 rather than folded in here, since fixing them is out of this card's file surface and a gate should cover all 11 instances, not just #1091's original 3.

## Verification

- `pnpm typecheck` — clean, 0 errors.
- `pnpm hygiene` — clean (4/4 checks pass).
- `pnpm lint` — exit 0, 153 warning(s)/10 suggestion(s), all pre-existing and unrelated (checked: none reference `F, P`, import order, or the copyright header).
- `pnpm build` — succeeds, `dist/objectstack.json` written; warnings pre-existing.
- `pnpm test -- --maxWorkers=2` — **91/91 test files passed, 2194 passed / 1 skipped, 0 failed.**

## Out of scope

- #1094 — 8 more files with the same import-above-header drift (unassigned, `finding`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NM6o28jmBgsyTRQHutn7LC)_