### PR TITLE
feat(service): round-robin case intake + Unassigned triage view

### DIFF
--- a/.changeset/case-intake-round-robin-and-triage.md
+++ b/.changeset/case-intake-round-robin-and-triage.md
@@ -1,0 +1,55 @@
+---
+'hotcrm': patch
+---
+
+Give inbound cases an owner, and make the case that has none visible.
+
+A web-to-case submission arrived ownerless by design — the guest-sanitisation
+branch of `case_sla_defaults` strips a client-supplied `owner_id`, correctly,
+because a public form must not choose its own owner — and then had nowhere to
+go. ObjectStack has no queue engine (`sys_queue` does not exist; the `queue`
+sharing-recipient and approver enum members are deprecated upstream), and
+HotCRM had no substitute for cases, so an inbound case landed with nobody
+accountable for it and no view that could even list it. Non-portal cases were
+unaffected: those default to their creator.
+
+Two things ship together, because either alone leaves a silent state.
+
+**`case_auto_assign`** assigns an ownerless new case to the service agent with
+the fewest OPEN cases — a load-balanced round-robin needing no rotation
+counter, copied from the `lead_auto_assign` precedent that already does this for
+inbound leads. The pool is whoever holds the `service_agent` position
+(`sys_user_position`). It writes `owner_id`, the one ownership column since
+#548, so the assigned agent really owns the case rather than being named on it.
+Load counts exclude `resolved` and `closed` (not `is_closed`, which only flips
+on `closed` and would keep finished work counting against an agent — the same
+`$nin` predicate `case_sla_monitor` settled on). It runs at priority 250, after
+the guest strip at 200: `lead_auto_assign` shipped below its strip and had every
+web-to-lead assigned and then un-assigned, so the ordering is pinned rather than
+assumed.
+
+**`Unassigned — triage`**, a pinned list view on `crm_case`, is the other half.
+The pool is EMPTY on a fresh install — `sys_user_position` membership is runtime
+data — and assignment also stands down when the read is denied, which is the
+normal anonymous-form case. Both leave the case ownerless, which is the right
+behaviour (intake must never be blocked) and was previously invisible. The view
+filters `owner_id is_null` and excludes closed cases, so its row count is the
+intake backlog. Label and empty state are authored in all four locales.
+
+No permission-model change. Stamping another user's `owner_id` is a transfer,
+denied by the platform's #3004 guard without `allowTransfer`, and whether that
+gate applies is a property of the SEAM rather than of the object — so it was
+measured rather than inherited: against a real ObjectQL with a recorder on the
+same middleware seam the security plugin uses, a `crm_case` insert whose
+`beforeInsert` hook stamped `owner_id` reached the middleware with no `owner_id`
+at all, while the stored row carried the assigned agent. `crm_case.allowTransfer`
+is therefore neither needed nor granted. The measurement is pinned, with a
+negative control, in `test/case-assignment.test.ts`; if a platform release ever
+moves the guard downstream of the hook phase, that test goes red rather than the
+feature failing quietly in production.
+
+⚠️ This is explicitly an **app-level stopgap**. It lives alone in
+`src/objects/_case-assignment.ts` — the single home for "who should own this
+case", so the escalation-reassignment work in #1070 extends it instead of
+authoring a second ownership path — and that module is the code to delete, not
+adapt, when a platform queue or assignment-rule engine lands. Fixes #596.

--- a/.changeset/case-intake-round-robin-and-triage.md
+++ b/.changeset/case-intake-round-robin-and-triage.md
@@ -36,6 +36,15 @@ behaviour (intake must never be blocked) and was previously invisible. The view
 filters `owner_id is_null` and excludes closed cases, so its row count is the
 intake backlog. Label and empty state are authored in all four locales.
 
+⚠️ Who sees rows in that view is decided by record-level access, not by the
+view: `system_admin` and `sales_manager` see the whole backlog, service
+manager/director see the critical open slice through the existing criteria
+rules, and a `service_agent` — `readScope: 'own'` on `crm_case` — sees none,
+because an unowned row is owned by nobody. The empty-pool state is an admin
+problem (only an admin can staff `sys_user_position`), so the admin is the
+right first audience; making an agent able to pull from triage is a
+sharing-model change and is filed as #1096 rather than ridden in here.
+
 No permission-model change. Stamping another user's `owner_id` is a transfer,
 denied by the platform's #3004 guard without `allowTransfer`, and whether that
 gate applies is a property of the SEAM rather than of the object — so it was

--- a/src/objects/_case-assignment.ts
+++ b/src/objects/_case-assignment.ts
@@ -1,0 +1,252 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Hook, HookContext } from '@objectstack/spec/data';
+import type { HookApi } from './_hook-api';
+
+/**
+ * ═══ Case ownership assignment — THE app-level stopgap for a missing queue ══
+ *
+ * # ⛔ This module is a STOPGAP. It is the code to delete.
+ *
+ * Salesforce-shaped case intake routes an ownerless case into a QUEUE and lets
+ * agents pull from it. ObjectStack has no queue engine: `sys_queue` does not
+ * exist, and the `queue` sharing-recipient and approver enum members are
+ * deprecated upstream. So a web-to-case submission — whose `owner_id` is
+ * deliberately stripped by the guest-sanitisation branch of `case_sla_defaults`
+ * — has nowhere to sit, and lands ownerless with nobody accountable for it.
+ *
+ * This module substitutes a load-balanced round-robin for the missing queue, at
+ * the app layer, copying the `lead_auto_assign` precedent (`lead.hook.ts`) that
+ * already does the same thing for inbound leads. **When a platform `sys_queue`
+ * (or an assignment-rule engine) lands, this whole module is the code that gets
+ * reclaimed — not adapted.** Its replacement is declarative queue metadata; a
+ * hook that picks an owner by counting rows is not something to keep alongside
+ * one. Delete the module, delete its hook from `case.hook.ts`, and re-point the
+ * triage view at the queue.
+ *
+ * # Why a MODULE and not a branch inside `case.hook.ts`
+ *
+ * #1070 (route an ESCALATED case to the `service_manager` pool) writes case
+ * ownership too. Two independently-authored ownership paths on `crm_case` is
+ * the "one operation, two implementations" shape that later has to be converged
+ * by deleting one of them. This module is the single home for the question
+ * "who should own this case", so #1070 extends it rather than authoring a
+ * second answer — see "Extending this for #1070" at the bottom.
+ *
+ * # ⚠️ The sandbox constraint, and what "shared" can therefore mean here
+ *
+ * L2 hook bodies run BODY-ONLY inside QuickJS: the handler is lowered to a
+ * source string with no module scope, so a body referencing an import, a
+ * top-level const or a factory PARAMETER is a `ReferenceError` at runtime, not
+ * a closure. `test/action-sandbox.test.ts` lowers every hook in `allHooks` with
+ * the CLI build's own extraction pass and fails the ones that leak.
+ *
+ * So sharing here is the same authoring-time sharing
+ * `_line-item-price-fill.ts` established: the FACTORY composes the hook and
+ * owns the doc, the constants and the contract; the handler body closes over
+ * nothing but its own `ctx` and spells its literals inline. That is not a
+ * stylistic choice and the inline literals are not duplication by accident —
+ * they are the only shape the runtime accepts. What keeps them honest is a
+ * behavioural pin: `test/case-assignment.test.ts` drives the real handler and
+ * asserts the pool it queries is exactly {@link SERVICE_AGENT_POSITION}, so the
+ * exported constant and the literal in the body cannot drift apart quietly.
+ * (Same technique as the `priority_rank` map and the SLA matrix in
+ * `case.hook.ts`, for the same reason.)
+ *
+ * # The transfer gate — MEASURED, not assumed (the #596 precondition)
+ *
+ * Stamping another user's `owner_id` is an ownership TRANSFER, denied by the
+ * platform's #3004 guard unless the caller holds `allowTransfer` on the object
+ * (`@objectstack/spec` `security/permission.zod.ts`). `crm_case.allowTransfer`
+ * is NOT granted to `service_agent`, and granting it would widen what an agent
+ * may do to a case generally — a permission-model change, not a hook change.
+ *
+ * This hook needs no such grant, and that is measured rather than reasoned:
+ * the guard is an operation middleware wrapping the whole call, and the
+ * `beforeInsert` hook phase runs INSIDE it, so by the time this body writes,
+ * the guard has already read and released the payload. Against a real ObjectQL
+ * with a recorder on the same `registerMiddleware` seam the security plugin
+ * uses, a `crm_case` insert of `{subject, status}` whose beforeInsert hook
+ * stamped `owner_id` reached the middleware as:
+ *
+ *   {"object":"crm_case","operation":"insert","data":{"subject":"…","status":"new"}}
+ *
+ * — no `owner_id` at all — while the STORED row carried the stamped agent. The
+ * pin lives in `test/case-assignment.test.ts` ("the transfer gate cannot see
+ * this stamp"), with a negative control proving the recorder is not simply
+ * blind. If a future platform release moves the guard downstream of the hook
+ * phase that test goes red, and the signal is to grant `allowTransfer`
+ * deliberately or to stop assigning in a hook — NOT to widen the permission
+ * model to make a red test green.
+ *
+ * The asymmetry matters, because the sibling seam behaves the opposite way: a
+ * hook's `ctx.api` WRITE is a fresh operation carrying the caller's identity, so
+ * the guard does see it. That is why `case_status_side_effects` opening an
+ * escalation task under the account owner needs
+ * `service_agent.crm_task.allowTransfer`. Both seams are pinned in
+ * `test/ownership-model.test.ts`.
+ */
+
+/** The position whose holders form the case intake pool (`sys_user_position`). */
+export const SERVICE_AGENT_POSITION = 'service_agent';
+
+/**
+ * The position #1070 routes ESCALATED cases to. Exported here so that card
+ * extends this module rather than re-deriving the pool concept elsewhere.
+ */
+export const SERVICE_MANAGER_POSITION = 'service_manager';
+
+/**
+ * Statuses that mean "this case is no longer live work".
+ *
+ * Load balancing counts OPEN cases, and `is_closed` is the wrong predicate for
+ * that: it only flips on `closed`, so a pile of `resolved` cases would keep
+ * counting against an agent who has already finished them. `case_sla_monitor`
+ * settled the same question the same way — see the `$nin` note in
+ * `src/flows/case-sla-monitor.flow.ts`, which also records that comparing the
+ * boolean `is_closed` suffers the SQLite `1 != true` trap.
+ */
+export const CLOSED_CASE_STATUSES = ['resolved', 'closed'] as const;
+
+/** Cap on the pool read — the same bound `lead_auto_assign` uses. */
+export const POOL_QUERY_LIMIT = 1000;
+
+/**
+ * Round-robin assignment for ownerless new cases.
+ *
+ * A case created without an owner — a web-to-case submission, an email-to-case
+ * import, an API capture — is assigned to the service agent with the FEWEST
+ * OPEN cases. Least-loaded is a self-balancing round-robin: it needs no
+ * rotation counter, no stored cursor and no coordination between concurrent
+ * inserts.
+ *
+ * It writes `owner_id`, the platform ownership anchor (#548) — the column OWD,
+ * sharing rules and the "My Open Cases" view all read — so the assigned agent
+ * really owns the case rather than merely being named on it.
+ *
+ * ## Priority 250: it MUST run after `case_sla_defaults` (200)
+ *
+ * Hooks run in ASCENDING priority order, and `case_sla_defaults` is where the
+ * guest-sanitisation branch does `delete input.owner_id` to drop a
+ * client-spoofed owner from an anonymous submission. Assigning first and being
+ * stripped afterwards would land every web-to-case ownerless — the exact case
+ * this hook exists for. `lead_auto_assign` shipped at priority 150 and had to
+ * be moved to 250 for precisely this reason; this one starts where that one
+ * ended up, and `test/case-assignment.test.ts` pins the ordering.
+ *
+ * ## The empty pool is the FIRST-INSTALL NORM, not an edge case
+ *
+ * `sys_user_position` membership is runtime data. On a fresh install — before
+ * anyone has been given the `service_agent` position — the pool is empty and
+ * this hook is a NO-OP: the case is created and stays ownerless. That is the
+ * correct behaviour (never block intake), but silent ownerlessness is how the
+ * original defect hid, so the no-op path has a UI counterpart: the
+ * `unassigned_triage` list view on `crm_case` (`src/views/case.view.ts`), a
+ * pinned tab that shows exactly the cases this hook could not place.
+ *
+ * ## Best-effort, always
+ *
+ * Auto-assignment is an ENHANCEMENT and must never reject the insert. An
+ * anonymous Web-to-Case submission runs under the public-form grant, which
+ * permits create/read-back on `crm_case` and DENIES `find` on
+ * `sys_user_position`; letting that denial propagate would 403 the whole
+ * submission and break the public support form. So every read is wrapped and
+ * ANY failure leaves the case ownerless for the triage view to surface.
+ *
+ * @param hookName registry name for the hook (metadata only — never read by
+ *   the body, which the sandbox would not let it be).
+ */
+export function createCaseRoundRobinAssign(hookName = 'case_auto_assign'): Hook {
+  return {
+    name: hookName,
+    object: 'crm_case',
+    events: ['beforeInsert'],
+    priority: 250,
+    description: 'Assign ownerless new cases to the least-loaded service agent.',
+    handler: async (ctx: HookContext) => {
+      const { input } = ctx;
+      // Respect an explicit / creator-assigned owner. On any write that carries
+      // a user the security middleware has ALREADY stamped `owner_id` to that
+      // user by the time this runs, so this is also what keeps the round-robin
+      // scoped to genuinely ownerless intake rather than firing on every
+      // agent-created case.
+      if (typeof input.owner_id === 'string' && input.owner_id) return;
+      const api = ctx.api as HookApi | undefined;
+      if (!api) return;
+
+      try {
+        // The pool = holders of the `service_agent` position. This literal is
+        // the exported SERVICE_AGENT_POSITION; the sandbox forbids reading the
+        // constant from here, and the parity assertion in
+        // `test/case-assignment.test.ts` is what keeps the two in step.
+        const holders = await api.object('sys_user_position').find({
+          where: { position: 'service_agent' }, fields: ['user_id'], top: 1000,
+        });
+        const agentIds = Array.from(
+          new Set(
+            (holders ?? [])
+              .map((r) => (typeof r.user_id === 'string' ? r.user_id : ''))
+              .filter(Boolean),
+          ),
+        );
+        // No pool → leave the case ownerless (no-op). The `unassigned_triage`
+        // view is what makes this visible instead of silent.
+        if (agentIds.length === 0) return;
+
+        // Fewest OPEN cases wins. `$nin` rather than `is_closed: false`: a
+        // resolved case is finished work and must stop counting against its
+        // agent (same predicate as `case_sla_monitor`).
+        let best: string | undefined;
+        let bestCount = Infinity;
+        for (const agentId of agentIds) {
+          const openCount = await api.object('crm_case').count({
+            where: { owner_id: agentId, status: { $nin: ['resolved', 'closed'] } },
+          });
+          if (openCount < bestCount) {
+            bestCount = openCount;
+            best = agentId;
+          }
+        }
+        if (best) input.owner_id = best;
+      } catch {
+        // Swallow: assignment must never block case creation. The common case
+        // is the anonymous public-form context, which cannot read
+        // `sys_user_position` — the case is still captured, ownerless, and the
+        // triage view surfaces it. (No `console` here — the L2 hook sandbox
+        // does not define one.)
+      }
+    },
+  };
+}
+
+/**
+ * ─── Extending this for #1070 (escalation → `service_manager` pool) ─────────
+ *
+ * #1070 reassigns an ESCALATED case to the least-loaded holder of
+ * {@link SERVICE_MANAGER_POSITION}. It belongs in THIS module, as a second
+ * exported factory beside {@link createCaseRoundRobinAssign} — not as a fresh
+ * ownership path in `case.hook.ts`. Three things that card must account for,
+ * all of which differ from the intake path above and none of which are
+ * cosmetic:
+ *
+ *  1. **Different seam, different verdict.** Escalation reassignment is an
+ *     UPDATE to an existing row, which cannot be done by mutating `input` in a
+ *     `beforeInsert`. Whether it runs as a `beforeUpdate` `input` mutation
+ *     (invisible to the guard, like this hook) or a `ctx.api` update (VISIBLE
+ *     to the guard, and therefore needing `crm_case.allowTransfer` on the
+ *     writing profile — a permission-model widening) decides whether that card
+ *     is a hook change or a security change. ⛔ Do not assume this module's
+ *     measured "no grant needed" answer carries over: it is a property of the
+ *     `beforeInsert` seam, not of `crm_case`. Measure the chosen seam the same
+ *     way `test/case-assignment.test.ts` measures this one.
+ *  2. **Re-entrancy.** `case_status_side_effects` is an `afterUpdate` hook on a
+ *     file that has looped before (the `is_escalated` re-fire that wedged a
+ *     first-boot seed on 2026-07-06, and the `closed_date`-as-`resolved_date`
+ *     write). An ownership write on the escalation transition re-enters the
+ *     record-change trigger surface and must be reasoned about, not assumed.
+ *  3. **The empty pool is still the norm**, and the answer is still a no-op
+ *     that leaves the case where it is — plus a way to SEE it. The
+ *     `unassigned_triage` view covers ownerless cases; an escalated case that
+ *     could not be handed over is not ownerless, so #1070 needs its own
+ *     visibility answer rather than inheriting this one.
+ */

--- a/src/objects/case.hook.ts
+++ b/src/objects/case.hook.ts
@@ -2,6 +2,7 @@
 
 import type { Hook, HookContext } from '@objectstack/spec/data';
 import type { HookApi } from './_hook-api';
+import { createCaseRoundRobinAssign } from './_case-assignment';
 
 /**
  * Case SLA & escalation hook.
@@ -16,6 +17,12 @@ import type { HookApi } from './_hook-api';
  *   since #548, so the person the task names is the person who can work it.
  * - On `resolved`: stamps `closed_date` (proxy for the resolution time — there is
  *   no resolved_date field) and bumps account `last_activity_date`.
+ *
+ * Ownership assignment for ownerless intake is NOT here: it lives in
+ * `_case-assignment.ts`, which is the single home for "who should own this
+ * case" and is explicitly an app-level stopgap for the platform's missing queue
+ * engine (#596). Its hook is composed into this module's default export below,
+ * so the registry still sees one `crm_case` hook set.
  */
 
 const caseValidation: Hook = {
@@ -237,4 +244,14 @@ const caseSideEffects: Hook = {
   },
 };
 
-export default [caseValidation, caseSideEffects];
+/**
+ * Ownerless-intake round-robin (#596), composed from `_case-assignment.ts`.
+ *
+ * It is listed AFTER `case_sla_defaults` here for readability only — ordering
+ * at runtime is decided by `priority` (250 vs 200), not by array position, and
+ * that ordering is load-bearing: `case_sla_defaults` strips a guest-supplied
+ * `owner_id` and this hook must run after the strip, never before it.
+ */
+const caseAutoAssign: Hook = createCaseRoundRobinAssign();
+
+export default [caseValidation, caseAutoAssign, caseSideEffects];

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -685,6 +685,13 @@ export const en: TranslationData = {
         case_workflow: { label: 'Service Workflow' },
         sla_calendar: { label: 'SLA Calendar' },
         case_timeline: { label: 'Case Timeline' },
+        unassigned_triage: {
+          label: 'Unassigned — triage',
+          emptyState: {
+            title: 'Nothing waiting for triage',
+            message: 'Every case has an owner. Cases appear here when they arrive with no owner — typically a web-to-case submission that arrived while nobody held the Service Agent position.',
+          },
+        },
         escalated_cases: { label: 'Escalated Cases' },
         my_open_cases: { label: 'My Open Cases' },
         sla_at_risk: { label: '⏰ SLA at Risk' },

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -712,6 +712,13 @@ export const esES: TranslationData = {
         case_workflow: { label: 'Flujo de Servicio' },
         sla_calendar: { label: 'Calendario SLA' },
         case_timeline: { label: 'Línea de Tiempo de Casos' },
+        unassigned_triage: {
+          label: 'Sin asignar — triaje',
+          emptyState: {
+            title: 'Nada pendiente de triaje',
+            message: 'Todos los casos tienen propietario. Los casos aparecen aquí cuando llegan sin propietario — normalmente un envío web-a-caso recibido mientras nadie ocupaba el puesto de Agente de Servicio.',
+          },
+        },
         escalated_cases: { label: 'Casos Escalados' },
         my_open_cases: { label: 'Mis Casos Abiertos' },
         sla_at_risk: { label: '⏰ SLA en Riesgo' },

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -687,6 +687,13 @@ export const jaJP: TranslationData = {
         case_workflow: { label: 'サービスフロー' },
         sla_calendar: { label: 'SLA カレンダー' },
         case_timeline: { label: 'ケースタイムライン' },
+        unassigned_triage: {
+          label: '未割り当て — トリアージ',
+          emptyState: {
+            title: 'トリアージ待ちはありません',
+            message: 'すべてのケースに所有者がいます。所有者のないケースはここに表示されます — 通常は、サービスエージェントの職位を誰も保持していない間に届いた Web-to-Case の送信です。',
+          },
+        },
         escalated_cases: { label: 'エスカレートしたケース' },
         my_open_cases: { label: '私のオープンケース' },
         sla_at_risk: { label: '⏰ SLA リスクあり' },

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -645,6 +645,13 @@ export const zhCN: TranslationData = {
         case_workflow: { label: '服务流转' },
         sla_calendar: { label: 'SLA 日历' },
         case_timeline: { label: '工单时间线' },
+        unassigned_triage: {
+          label: '未分派 — 待分诊',
+          emptyState: {
+            title: '没有待分诊的工单',
+            message: '所有工单都有负责人。当工单到达时没有负责人，就会出现在这里 —— 通常是在无人担任「客服专员」职位期间提交的网页转工单。',
+          },
+        },
         escalated_cases: { label: '已升级工单' },
         my_open_cases: { label: '我的待处理工单' },
         sla_at_risk: { label: '⏰ SLA 风险预警' },

--- a/src/views/case.view.ts
+++ b/src/views/case.view.ts
@@ -167,6 +167,31 @@ export const CaseViews = defineView({
      * Closed cases are excluded: an ownerless case that has already been closed
      * is history, not backlog, and leaving it here would make the count stop
      * meaning "work waiting for a human".
+     *
+     * ⚠️ WHO ACTUALLY SEES ROWS HERE is decided by record-level access, not by
+     * this view, and the answer today is narrower than the tab suggests. A
+     * view tab carries no role scoping — `ViewTabSchema` has `pinned`,
+     * `isDefault` and a boolean `visible`, and nothing per-profile — so this is
+     * pinned for everyone who can open Cases, while the ROWS resolve per
+     * profile:
+     *
+     *   - `system_admin` — `viewAllRecords`, so the full backlog. This is the
+     *     persona the empty-pool state is FOR: an empty `service_agent` pool is
+     *     fixed by staffing `sys_user_position`, which only an admin can do.
+     *   - `sales_manager` — `viewAllRecords`, read-only.
+     *   - a service manager / director — the critical, open slice only, via the
+     *     existing `case_escalation_sharing` / `case_director_sharing` criteria
+     *     rules (`src/sharing/case.sharing.ts`).
+     *   - `service_agent` — `readScope: 'own'` on `crm_case`, and an unowned
+     *     row is owned by nobody, so **an agent's triage tab is empty**.
+     *
+     * The last line is a real gap for the "agent pulls from the queue" story
+     * and is deliberately NOT closed here: granting service roles sight of
+     * unowned cases is a sharing-model change (a new criteria rule, or a
+     * `readScope` widening), which is outside this card's file surface and is
+     * exactly the kind of quiet permission widening the #596 ruling rules out.
+     * Filed as #1096 for a decision, with the reach table above and the three
+     * options priced.
      */
     unassigned_triage: {
       name: 'unassigned_triage',

--- a/src/views/case.view.ts
+++ b/src/views/case.view.ts
@@ -59,6 +59,10 @@ export const CaseViews = defineView({
       { name: 'workflow', label: 'Workflow', icon: 'columns-3', view: 'case_workflow' },
       { name: 'sla', label: 'SLA', icon: 'calendar', view: 'sla_calendar' },
       { name: 'timeline', label: 'Timeline', icon: 'git-commit-horizontal', view: 'case_timeline' },
+      // Pinned, and second only to All: the triage queue is the first thing a
+      // service role must be able to reach, because a case sitting in it is a
+      // case nobody owns. See `unassigned_triage` below.
+      { name: 'triage', label: 'Unassigned — triage', icon: 'inbox', view: 'unassigned_triage', pinned: true },
       { name: 'escalated', label: 'Escalated', icon: 'triangle-alert', view: 'escalated_cases' },
       { name: 'at_risk', label: 'SLA at Risk', icon: 'clock-alert', view: 'sla_at_risk' },
       { name: 'mine', label: 'My Cases', icon: 'user', view: 'my_open_cases' },
@@ -135,6 +139,65 @@ export const CaseViews = defineView({
         { field: 'priority_rank', order: 'desc' },
         { field: 'sla_due_date', order: 'asc' },
       ],
+    },
+
+    /**
+     * Unassigned — triage (#596). The second half of the queue substitute.
+     *
+     * `case_auto_assign` (`src/objects/_case-assignment.ts`) is a NO-OP whenever
+     * the `service_agent` pool is empty, and an empty pool is the FIRST-INSTALL
+     * NORM rather than an edge case: `sys_user_position` membership is runtime
+     * data, so on a fresh org — and any time every agent has been unassigned
+     * from the position — an inbound web-to-case lands ownerless. Best-effort
+     * assignment also stands down on a permission denial (the anonymous
+     * public-form context cannot read `sys_user_position` at all).
+     *
+     * Those cases used to be invisible: no view filtered on the absence of an
+     * owner, so an unowned case appeared in `All Cases` with a blank Owner
+     * column and nothing distinguished it from the rest. This view is the
+     * standing answer — silence replaced by a pinned tab whose row count IS the
+     * intake backlog.
+     *
+     * `is_null` on `owner_id`, not `equals: null`: the ownerless shape is an
+     * ABSENT column on driver-memory (see the totality note in
+     * `case-escalation.flow.ts`, where `record.escalated_date == null` aborted
+     * with `No such key`) as well as a NULL one on SQL, and only the operator
+     * form answers the same way for both.
+     *
+     * Closed cases are excluded: an ownerless case that has already been closed
+     * is history, not backlog, and leaving it here would make the count stop
+     * meaning "work waiting for a human".
+     */
+    unassigned_triage: {
+      name: 'unassigned_triage',
+      type: 'grid',
+      label: 'Unassigned — triage',
+      data: { provider: 'object', object: 'crm_case' },
+      columns: ['case_number', 'subject', 'crm_account', 'crm_contact', 'priority', 'status', 'origin', 'sla_due_date'],
+      filter: [
+        { field: 'owner_id', operator: 'is_null' },
+        { field: 'is_closed', operator: 'equals', value: false },
+      ],
+      // Same ordering as the main queue: urgency first (on the materialised
+      // ordinal, never the raw select), then soonest deadline.
+      sort: [
+        { field: 'priority_rank', order: 'desc' },
+        { field: 'sla_due_date', order: 'asc' },
+      ],
+      rowColor: {
+        field: 'priority',
+        colors: { critical: '#dc2626', high: '#f97316', medium: '#eab308', low: '#94a3b8' },
+      },
+      // The empty state carries the operational instruction, because "no rows"
+      // here is ambiguous on its own: it means either "the round-robin placed
+      // everything" (good) or "no case has arrived yet" (also fine) — and the
+      // reader most likely to be looking is someone who just found the tab
+      // full and needs to know why.
+      emptyState: {
+        title: 'Nothing waiting for triage',
+        message: 'Every case has an owner. Cases appear here when they arrive with no owner — typically a web-to-case submission that arrived while nobody held the Service Agent position.',
+        icon: 'inbox',
+      },
     },
 
     escalated_cases: {

--- a/test/case-assignment.test.ts
+++ b/test/case-assignment.test.ts
@@ -1,0 +1,397 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import stack from '../objectstack.config';
+import caseHooks from '../src/objects/case.hook';
+import {
+  SERVICE_AGENT_POSITION,
+  CLOSED_CASE_STATUSES,
+  POOL_QUERY_LIMIT,
+} from '../src/objects/_case-assignment';
+import { makeHarness, makeDeniedApi, makeCtx, hookNamed, type Rec } from './helpers/hook-harness';
+import { localePacks } from './helpers/metadata-fixtures';
+
+/**
+ * ═══ Case intake assignment — the app-level queue substitute (#596) ════════
+ *
+ * ObjectStack has no queue engine (`sys_queue` does not exist; the `queue`
+ * sharing-recipient and approver enum members are deprecated upstream), so a
+ * web-to-case submission — whose `owner_id` the guest-sanitisation branch of
+ * `case_sla_defaults` deliberately strips — used to land ownerless with nobody
+ * accountable for it and no view that could even show it.
+ *
+ * `src/objects/_case-assignment.ts` substitutes a load-balanced round-robin,
+ * and `unassigned_triage` on `crm_case` is the second half: the empty pool is
+ * the FIRST-INSTALL NORM, not an edge case, and the whole point of the card is
+ * that the no-op path is VISIBLE rather than silent. Both paths are covered
+ * here, and neither one is the happy path alone.
+ *
+ * The file opens with the precondition the ruling made blocking: whether a
+ * hook-stamped `owner_id` passes the platform's `allowTransfer` write gate.
+ * That question decides whether this feature is a hook change or a
+ * permission-model widening, so it is MEASURED against a real engine rather
+ * than inherited from the `lead_auto_assign` precedent — the guard's verdict is
+ * a property of the SEAM, and `crm_case` had never been measured on it.
+ */
+
+type AnyRec = Record<string, any>;
+
+const assign = hookNamed(caseHooks, 'case_auto_assign');
+const slaDefaults = hookNamed(caseHooks, 'case_sla_defaults');
+
+// ─────────────────────────── the blocking precondition, measured ──
+
+describe('the transfer gate cannot see a beforeInsert owner_id stamp on crm_case', () => {
+  let ql: AnyRec;
+  /** Every operation the middleware seam observed, with the payload as it was THEN. */
+  let seen: { object: string; operation: string; data: AnyRec }[];
+
+  beforeAll(async () => {
+    seen = [];
+    ql = (await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: {
+        crm_case: {
+          name: 'crm_case',
+          fields: {
+            id: { type: 'text' },
+            subject: { type: 'text' },
+            status: { type: 'text' },
+            owner_id: { type: 'lookup', reference: 'sys_user' },
+          },
+        },
+      } as never,
+    })) as never;
+
+    // The SAME seam `@objectstack/plugin-security` registers the #3004 owner_id
+    // write guard on. A RECORDER, not a gate: what is being measured is
+    // VISIBILITY, not the verdict — what this can see, the guard can see, and
+    // what it cannot see, the guard cannot either. (Standing the real plugin up
+    // would test the platform's code rather than ours; same reasoning, and the
+    // same technique, as `test/ownership-model.test.ts`.)
+    ql.registerMiddleware(async (opCtx: AnyRec, next: () => Promise<void>) => {
+      seen.push({
+        object: opCtx.object,
+        operation: opCtx.operation,
+        data: JSON.parse(JSON.stringify(opCtx.data ?? {})) as AnyRec,
+      });
+      return next();
+    });
+
+    ql.registerHook?.('beforeInsert', async (ctx: AnyRec) => {
+      if (ctx.object !== 'crm_case') return;
+      const data = ctx.input?.data ?? ctx.data;
+      if (data && !data.owner_id) data.owner_id = 'agent_round_robin';
+    }, { object: 'crm_case' });
+  });
+
+  afterAll(async () => {
+    await ql?.close();
+  });
+
+  it('the stamp never reaches the middleware, and still reaches storage', async () => {
+    // Predicted direction, stated before running: the middleware sees NO
+    // `owner_id`, and the STORED row carries the hook's agent. Measured
+    // 2026-08-11 on @objectstack/* 17.0.0-rc.6 — the middleware observed
+    //   {"object":"crm_case","operation":"insert","data":{"subject":"…","status":"new"}}
+    // and the stored row came back with `owner_id: "agent_round_robin"`.
+    //
+    // So round-robin intake assignment needs NO `crm_case.allowTransfer` grant,
+    // and this feature is not a permission-model widening. ⛔ If a future
+    // platform release moves the guard downstream of the hook phase, the first
+    // expectation below flips and this test goes red. That is the signal to
+    // grant `allowTransfer` deliberately, or to stop assigning in a hook — NOT
+    // to widen the permission model in order to make a red test green.
+    const api = ql.createContext({ userId: 'usr_guest_form' });
+    const row = await api.object('crm_case').insert({ subject: 'Printer on fire', status: 'new' });
+
+    const observed = seen.filter((s) => s.object === 'crm_case' && s.operation === 'insert').pop();
+    expect(observed, 'the middleware seam never fired for the insert').toBeTruthy();
+    expect(
+      observed!.data.owner_id,
+      'the guard COULD see the hook-assigned owner — case round-robin now needs crm_case.allowTransfer, ' +
+        'which is a permission-model change and not a hook change',
+    ).toBeUndefined();
+
+    const stored = await api.object('crm_case').findOne({ where: { id: row.id } });
+    expect(stored?.owner_id, 'the hook’s assignment did not survive to storage')
+      .toBe('agent_round_robin');
+  });
+
+  it('negative control: the recorder is not simply blind to owner_id', async () => {
+    // Guards the guard. The assertion above is an ABSENCE, and an absence
+    // proves nothing if the recorder could never have seen the key in the first
+    // place. A caller-supplied `owner_id` on the same object, through the same
+    // seam, must be visible — that is what makes "the hook's stamp is invisible"
+    // a statement about the hook phase rather than about this test.
+    const api = ql.createContext({ userId: 'usr_admin' });
+    await api.object('crm_case').insert({
+      subject: 'Manually owned', status: 'new', owner_id: 'agent_explicit',
+    });
+    const observed = seen.filter((s) => s.object === 'crm_case' && s.operation === 'insert').pop();
+    expect(
+      observed!.data.owner_id,
+      'the recorder cannot see owner_id AT ALL — the invisibility measurement above is vacuous',
+    ).toBe('agent_explicit');
+  });
+});
+
+// ───────────────────────────────── the round-robin, both paths ──
+
+describe('case_auto_assign', () => {
+  /** A pool of `service_agent` holders plus a case backlog, in one store. */
+  const storeWith = (agents: string[], cases: Rec[] = []) => ({
+    sys_user_position: [
+      // Deliberately mixed: other positions must NOT be read as service agents.
+      { user_id: 'rep_1', position: 'sales_rep' },
+      { user_id: 'mgr_1', position: 'service_manager' },
+      ...agents.map((user_id) => ({ user_id, position: SERVICE_AGENT_POSITION })),
+    ],
+    crm_case: cases,
+  });
+
+  it('assigns an ownerless case to the least-loaded agent — the assigned path', async () => {
+    const harness = makeHarness(storeWith(['agent_a', 'agent_b'], [
+      { id: 'c1', owner_id: 'agent_a', status: 'new' },
+      { id: 'c2', owner_id: 'agent_a', status: 'in_progress' },
+      { id: 'c3', owner_id: 'agent_b', status: 'new' },
+    ]));
+    const input: Rec = { subject: 'Web submission', status: 'new', origin: 'web' };
+
+    await assign.handler(makeCtx({ event: 'beforeInsert', input, api: harness.api }));
+
+    expect(input.owner_id, 'did not assign the least-loaded service agent').toBe('agent_b');
+    expect('owner' in input, 'wrote a second, unread ownership column (#548)').toBe(false);
+  });
+
+  it('reads the SERVICE_AGENT_POSITION pool, and only that pool', async () => {
+    // The parity pin the module's header promises. The hook body must spell its
+    // position literal inline — L2 bodies run body-only in QuickJS and cannot
+    // reach the exported constant — so this drives the real handler and asserts
+    // the predicate it actually issued. Without it the constant and the literal
+    // could drift apart silently, and the hook would quietly assign from (or to)
+    // the wrong pool.
+    const seenQueries: Rec[] = [];
+    const api: Rec = {
+      object: (name: string) => ({
+        async find(q: Rec = {}) {
+          seenQueries.push({ object: name, ...q });
+          return name === 'sys_user_position' ? [{ user_id: 'agent_a' }] : [];
+        },
+        async count() { return 0; },
+      }),
+    };
+    const input: Rec = { subject: 'Web submission' };
+    await assign.handler(makeCtx({ event: 'beforeInsert', input, api: api as never }));
+
+    const poolQuery = seenQueries.find((q) => q.object === 'sys_user_position');
+    expect(poolQuery, 'the hook never read the position pool').toBeTruthy();
+    expect(
+      poolQuery!.where?.position,
+      'the position literal in the hook body drifted from SERVICE_AGENT_POSITION',
+    ).toBe(SERVICE_AGENT_POSITION);
+    expect(poolQuery!.top, 'the pool read bound drifted from POOL_QUERY_LIMIT').toBe(POOL_QUERY_LIMIT);
+    expect(input.owner_id).toBe('agent_a');
+  });
+
+  it('counts OPEN cases only — a resolved case stops counting against its agent', async () => {
+    // `is_closed` would be the wrong predicate: it only flips on `closed`, so a
+    // pile of resolved cases keeps an agent looking busy forever. Here agent_a
+    // has three cases but all are finished, and agent_b has one live case — so
+    // agent_a must win.
+    const harness = makeHarness(storeWith(['agent_a', 'agent_b'], [
+      { id: 'c1', owner_id: 'agent_a', status: 'resolved' },
+      { id: 'c2', owner_id: 'agent_a', status: 'closed' },
+      { id: 'c3', owner_id: 'agent_a', status: 'resolved' },
+      { id: 'c4', owner_id: 'agent_b', status: 'waiting_customer' },
+    ]));
+    const input: Rec = { subject: 'Web submission' };
+
+    await assign.handler(makeCtx({ event: 'beforeInsert', input, api: harness.api }));
+
+    expect(input.owner_id, 'resolved/closed cases are still counting as load').toBe('agent_a');
+  });
+
+  it('the closed-status vocabulary it counts by is exactly CLOSED_CASE_STATUSES', () => {
+    // Both names are real options on the object, so the predicate cannot be
+    // filtering on a status that no case can ever hold — the way a load count
+    // silently degrades to "count everything".
+    const caseObject = ((stack as AnyRec).objects ?? [])
+      .find((o: AnyRec) => o.name === 'crm_case');
+    const declared = (caseObject?.fields?.status?.options ?? [])
+      .map((o: AnyRec) => o.value);
+    for (const status of CLOSED_CASE_STATUSES) {
+      expect(declared, `"${status}" is not a declared crm_case status`).toContain(status);
+    }
+  });
+
+  it('stands down when the middleware already stamped an owner', async () => {
+    // On any write that carries a user, `owner_id` is already the creator by the
+    // time this hook runs — which is what keeps the round-robin scoped to
+    // genuinely ownerless intake instead of re-routing every agent-created case.
+    const harness = makeHarness(storeWith(['agent_a', 'agent_b']));
+    const input: Rec = { subject: 'Agent-created', owner_id: 'usr_creator' };
+
+    await assign.handler(makeCtx({ event: 'beforeInsert', input, api: harness.api }));
+
+    expect(input.owner_id).toBe('usr_creator');
+    expect(harness.callsFor('crm_case').length, 'it queried anyway — wasted reads on every case insert')
+      .toBe(0);
+  });
+
+  // ── the empty-pool path: a first install, not an edge case ──
+
+  it('is a NO-OP when nobody holds the service_agent position — the pool-empty path', async () => {
+    // `sys_user_position` membership is runtime data, so a fresh org has an
+    // empty pool by construction. The case must still be created, ownerless,
+    // and the `unassigned_triage` view is what makes that visible.
+    const harness = makeHarness(storeWith([], [{ id: 'c1', owner_id: 'someone', status: 'new' }]));
+    const input: Rec = { subject: 'Web submission', status: 'new' };
+
+    await assign.handler(makeCtx({ event: 'beforeInsert', input, api: harness.api }));
+
+    expect('owner_id' in input, 'invented an owner out of an empty pool').toBe(false);
+    // And it did not fall back to some other pool's holders (sales_rep /
+    // service_manager rows are in the store above).
+    expect(harness.callsFor('crm_case').length).toBe(0);
+  });
+
+  it('never rejects the insert when the pool read is DENIED', async () => {
+    // The anonymous Web-to-Case grant permits create/read-back on `crm_case` and
+    // denies `find` on `sys_user_position`. Propagating that denial would 403
+    // the whole submission and break the public support form — so the case is
+    // captured ownerless and lands in triage instead.
+    const input: Rec = { subject: 'Anonymous submission', status: 'new' };
+    await expect(
+      assign.handler(makeCtx({ event: 'beforeInsert', input, api: makeDeniedApi() })),
+    ).resolves.not.toThrow();
+    expect('owner_id' in input).toBe(false);
+  });
+
+  it('does nothing without an api rather than throwing', async () => {
+    const input: Rec = { subject: 'No api' };
+    await assign.handler(makeCtx({ event: 'beforeInsert', input }));
+    expect('owner_id' in input).toBe(false);
+  });
+});
+
+// ─────────────────── ordering: the strip must run BEFORE the assign ──
+
+describe('the guest strip and the assignment are ordered, not merely coexisting', () => {
+  it('case_auto_assign runs after case_sla_defaults', () => {
+    // Hooks run in ASCENDING priority order. `lead_auto_assign` shipped at 150,
+    // BELOW the guest-strip hook, and every web-to-lead landed ownerless because
+    // the strip deleted the owner the round-robin had just assigned — the exact
+    // defect this card is about, on the sibling object. Pinning the relation
+    // rather than the numbers: what matters is which side of the strip this
+    // runs on.
+    expect(assign.priority, 'case_auto_assign must run after the guest strip')
+      .toBeGreaterThan(slaDefaults.priority as number);
+    expect(assign.events).toEqual(['beforeInsert']);
+  });
+
+  it('end to end: a guest submission is stripped, then assigned', async () => {
+    // Both handlers in their real order, on one input — the shape a web-to-case
+    // submission actually takes, including the spoofed owner a public form can
+    // always post.
+    const harness = makeHarness({
+      sys_user_position: [{ user_id: 'agent_a', position: SERVICE_AGENT_POSITION }],
+      crm_case: [],
+    });
+    const input: Rec = { subject: 'Spoofed', description: 'x', owner_id: 'attacker_chosen_user' };
+    const ctx = { event: 'beforeInsert', input, user: undefined, api: harness.api };
+
+    await slaDefaults.handler(ctx as never);
+    expect(input.owner_id, 'the guest strip stopped removing the spoofed owner').toBeUndefined();
+
+    await assign.handler(ctx as never);
+    expect(input.owner_id, 'the assignment did not run after the strip').toBe('agent_a');
+    expect(input.origin, 'guest defaults regressed').toBe('web');
+  });
+
+  it('reverse verification: swap the order and the submission lands ownerless', async () => {
+    // The direction this pin exists for. Running the assignment FIRST and the
+    // strip second reproduces the original `lead_auto_assign` defect exactly —
+    // the owner is assigned and then deleted — which is what makes the priority
+    // relation above load-bearing rather than decorative.
+    const harness = makeHarness({
+      sys_user_position: [{ user_id: 'agent_a', position: SERVICE_AGENT_POSITION }],
+      crm_case: [],
+    });
+    const input: Rec = { subject: 'Spoofed', description: 'x' };
+    const ctx = { event: 'beforeInsert', input, user: undefined, api: harness.api };
+
+    await assign.handler(ctx as never);
+    expect(input.owner_id).toBe('agent_a');
+    await slaDefaults.handler(ctx as never);
+    expect(
+      input.owner_id,
+      'the strip no longer removes owner_id — the priority ordering has stopped mattering, ' +
+        'and so has this pin',
+    ).toBeUndefined();
+  });
+});
+
+// ─────────────────────── the second deliverable: the triage view ──
+
+describe('unassigned_triage makes the empty-pool path visible', () => {
+  const caseViews = ((stack as AnyRec).views ?? [])
+    .find((v: AnyRec) => v.list?.data?.object === 'crm_case');
+  const triage = caseViews?.listViews?.unassigned_triage;
+
+  it('exists on crm_case as a pinned tab', () => {
+    expect(triage, 'the triage view is gone — the pool-empty path is silent again').toBeTruthy();
+    expect(triage.data?.object).toBe('crm_case');
+    const tab = (caseViews?.list?.tabs ?? []).find((t: AnyRec) => t.view === 'unassigned_triage');
+    expect(tab, 'no tab reaches the triage view — an unreachable view is not visibility').toBeTruthy();
+    expect(tab.pinned, 'the triage tab is not pinned').toBe(true);
+  });
+
+  it('filters on the ABSENCE of an owner, and excludes closed cases', () => {
+    const byField = new Map<string, AnyRec>(
+      (triage.filter ?? []).map((f: AnyRec) => [f.field, f]),
+    );
+    const owner = byField.get('owner_id');
+    expect(owner, 'the view does not filter on owner_id at all').toBeTruthy();
+    // `is_null`, not `equals: null`: the ownerless shape is an ABSENT column on
+    // driver-memory as well as a NULL one on SQL, and only the operator form
+    // answers the same way for both.
+    expect(owner!.operator, 'an equals-null filter cannot see an absent column').toBe('is_null');
+    expect(byField.get('is_closed'), 'closed ownerless cases are history, not backlog').toMatchObject({
+      operator: 'equals', value: false,
+    });
+  });
+
+  it('sorts on the materialised ordinal, never the raw priority select', () => {
+    // Sorting on `priority` itself compares raw strings and inverts urgency
+    // (medium > low > high > critical), burying every critical untriaged case at
+    // the bottom of the one queue that exists to be worked top-down.
+    const fields = (triage.sort ?? []).map((s: AnyRec) => s.field);
+    expect(fields).toContain('priority_rank');
+    expect(fields, 'sorting on the raw select inverts urgency').not.toContain('priority');
+  });
+
+  it('carries an empty state in all four locales', () => {
+    // The one string this view shows in the state it exists to explain. The
+    // generic i18n guard covers labels and empty states across the app; this is
+    // the same requirement stated where a reader of THIS feature will see it.
+    expect(triage.emptyState?.title).toBeTruthy();
+    expect(triage.emptyState?.message).toBeTruthy();
+    // `stack.translations` is a LIST of bundles, each keyed by locale — not a
+    // list of per-locale records. Deriving it wrongly is how a guard spends its
+    // life green over an empty collection, so `localePacks` is shared and the
+    // count below is asserted before the contents.
+    const missing: string[] = [];
+    for (const [locale, pack] of localePacks) {
+      const t = pack?.objects?.crm_case?._views?.unassigned_triage;
+      if (!t?.label) missing.push(`${locale}: label`);
+      if (!t?.emptyState?.title) missing.push(`${locale}: emptyState.title`);
+      if (!t?.emptyState?.message) missing.push(`${locale}: emptyState.message`);
+    }
+    expect(localePacks.length, 'no translation packs discovered — this guard checks nothing')
+      .toBeGreaterThanOrEqual(4);
+    expect(missing, `untranslated triage copy:\n  ${missing.join('\n  ')}`).toEqual([]);
+  });
+});

--- a/test/runtime-coverage.test.ts
+++ b/test/runtime-coverage.test.ts
@@ -47,6 +47,12 @@ const RUNTIME_TEST_FILES = [
   // parity check that keeps the duplicated bubble body from drifting, and the
   // readonly-strip regression proof against a real engine.
   'activity-recency.test.ts',
+  // #596 — case intake assignment. Same precedent as the line above: a feature
+  // whose runtime evidence is one story (the transfer-gate measurement, the
+  // assigned and pool-empty paths, the strip-then-assign ordering, and the
+  // triage view that makes the no-op visible) gets its own runtime file rather
+  // than being scattered across the by-domain ones.
+  'case-assignment.test.ts',
 ];
 
 /**


### PR DESCRIPTION
Fixes #596

Web-to-case submissions land ownerless by design — the guest-sanitisation branch of `case_sla_defaults` strips a client-supplied `owner_id`, correctly, because a public form must not choose its own owner — and then had nowhere to go. The platform has no queue engine (`sys_queue` does not exist; the `queue` sharing-recipient and approver enum members are deprecated upstream), and HotCRM had no substitute for cases.

Both deliverables the ruling named, plus the precondition it made blocking.

## The blocking precondition, answered by measurement

The ruling required verifying that a hook-stamped `owner_id` passes the platform's `allowTransfer` write gate **before** building on it, because if it does not, this is a permission-model widening rather than a hook change. It was measured against a real ObjectQL with a recorder on the same `registerMiddleware` seam `@objectstack/plugin-security` registers the #3004 guard on — the technique `test/ownership-model.test.ts` established, applied to `crm_case`, which had never been measured on it. The guard's verdict is a property of the SEAM, not of the object, so the `lead_auto_assign` precedent was not taken as an answer.

A `crm_case` insert of `{subject, status}` whose `beforeInsert` hook stamped `owner_id` reached the middleware as:

```
{"object":"crm_case","operation":"insert","data":{"subject":"…","status":"new"}}
```

— no `owner_id` at all — while the stored row came back with `owner_id: "agent_round_robin"`. The hook phase runs INSIDE the operation the middleware already wrapped, so by the time the body writes, the guard has read and released the payload.

**Conclusion: no `crm_case.allowTransfer` grant is needed, and none is added.** No profile, permission set or sharing rule changes in this PR. The measurement is pinned in `test/case-assignment.test.ts` with a negative control (a caller-supplied `owner_id` on the same object through the same seam IS visible, so the absence above is a statement about the hook phase and not about a blind recorder). If a platform release ever moves the guard downstream of the hook phase, that test goes red — which is the signal to grant `allowTransfer` deliberately or to stop assigning in a hook, never to widen the model to make a red test green.

## 1. `case_auto_assign` — the round-robin

`src/objects/_case-assignment.ts`. An ownerless new case goes to the `service_agent` with the fewest OPEN cases; least-loaded is a self-balancing round-robin needing no rotation counter. It writes `owner_id`, the one ownership column since #548.

- **Priority 250, after the guest strip at 200.** Hooks run in ascending priority order. `lead_auto_assign` shipped at 150, below its strip, and every web-to-lead was assigned and then immediately un-assigned — the exact defect this card is about, on the sibling object. Pinned as a relation rather than as numbers, with a reverse verification that swaps the two handlers and shows the submission landing ownerless again.
- **Open-case load, not `is_closed`.** `status: { $nin: ['resolved','closed'] }` — `is_closed` only flips on `closed`, so a pile of resolved cases would keep counting against an agent who has finished them. Same predicate `case_sla_monitor` settled on, and `$nin` on `count` was verified against a real engine before being relied on.
- **Best-effort, always.** The anonymous public-form grant cannot read `sys_user_position`; propagating that denial would 403 the whole submission and break the public support form. Every read is wrapped, and any failure leaves the case ownerless for triage.

## 2. `unassigned_triage` — the view, because the empty pool is the first-install NORM

`sys_user_position` membership is runtime data, so a fresh org has an empty pool by construction and the hook is a no-op. That is correct (intake must never be blocked) and was previously invisible: no view filtered on the absence of an owner, so an unowned case sat in All Cases with a blank Owner column. A pinned tab now shows exactly the cases the round-robin could not place; its row count is the intake backlog.

`is_null` on `owner_id`, not `equals: null` — the ownerless shape is an ABSENT column on driver-memory as well as a NULL one on SQL, and only the operator form answers the same way for both. Closed cases excluded: history, not backlog. Label and empty state authored in all four locales.

## A reusable module, and the sandbox constraint on what that can mean

#1070 (route an escalated case to the `service_manager` pool) writes case ownership too, and two independently-authored ownership paths on `crm_case` is the shape that later has to be converged by deleting one. So `_case-assignment.ts` is the single home for "who should own this case", carries the constants, the seam analysis and the stopgap notice, and ends with a written-down extension contract for #1070 — including the warning that this PR's measured "no grant needed" answer is a property of the `beforeInsert` seam and must NOT be assumed to carry over to an escalation-time reassignment.

What it cannot be is a shared function the hook body calls. L2 hook bodies run body-only inside QuickJS: a body referencing an import, a top-level const or a factory parameter is a `ReferenceError` at runtime, and `test/action-sandbox.test.ts` lowers every hook in `allHooks` with the CLI build's own extraction pass and fails the ones that leak. So sharing here is the authoring-time sharing `_line-item-price-fill.ts` established — the factory owns the metadata and the doc, the body closes over nothing and spells its literals inline — and a behavioural parity test drives the real handler to assert the pool it queries is exactly the exported `SERVICE_AGENT_POSITION`, so the constant and the literal cannot drift apart quietly.

## Stopgap, stated in the code

Per condition 1 of the ruling, the module header says in as many words that it is an app-level stopgap and **the code to delete, not adapt**, when a platform queue or assignment-rule engine lands.

## One thing deliberately NOT fixed here: #1096

A view tab carries no role scoping, so the triage tab is pinned for everyone who can open Cases — but the rows resolve per profile, and `service_agent` holds `crm_case` with `readScope: 'own'`. An unowned row is owned by nobody, so **an agent's triage tab is empty**; `system_admin` and `sales_manager` see the whole backlog, and service manager/director see the critical open slice via the existing criteria rules.

That is a real gap for the "agent pulls from the queue" story, and closing it is a sharing-model change in `src/sharing/` or `src/profiles/` — outside this card's declared file surface, and exactly the quiet permission widening the ruling rules out. It is documented at the view with the full reach table, noted in the changeset, and filed as #1096 with three options priced. The empty-pool state remains actionable meanwhile, because only an admin can staff `sys_user_position` and the admin sees the whole backlog.

## Verification

Local, on this branch:

- `pnpm test` — **92 files, 2214 passed, 1 skipped, 0 failed** (17 new in `test/case-assignment.test.ts`).
- `pnpm typecheck` — exit 0, no diagnostics.
- `pnpm hygiene` — clean; `no raw control bytes in first-party files` among them, plus a manual scan of every touched file.
- `pnpm validate` — exit 0; 158 warnings, all pre-existing page/form ones, none naming `unassigned_triage`, `case_auto_assign` or `_case-assignment`.
- `pnpm lint` — 153 warning(s), 10 suggestion(s), 0 errors — **byte-identical to the same command on `origin/main`** (measured by checking `src`/`test`/`.changeset` out to `origin/main` in this worktree and re-running). Zero new rule hits, so the exit code is not the evidence.
- `pnpm build` — exit 0, and `Skipping legacy runtime bundle (all 28 callables are body-only)`: the new hook lowers to a metadata-only body. `action-sandbox.test.ts > every registered hook still lowers to a metadata-only body > case_auto_assign` passes.

Changeset: `.changeset/case-intake-round-robin-and-triage.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NM6o28jmBgsyTRQHutn7LC)_