### PR TITLE
Name all 66 form section headings and gate the blind spot

### DIFF
--- a/.changeset/section-heading-name-gate.md
+++ b/.changeset/section-heading-name-gate.md
@@ -1,0 +1,14 @@
+---
+'hotcrm': patch
+---
+
+Name and translate the 66 form/detail section headings that declared only a
+`label`, so they resolve through `objects.*._sections.<name>.label` instead of
+rendering their raw English text in every locale (13 objects: account, case,
+contact, contract, event, event_attendee, forecast, knowledge_article, lead,
+opportunity, product, quote, task). Adds a structural test —
+`test/i18n-references.test.ts`: "every section with a label carries a name" —
+that walks the page/view tree directly and fails on any `sections[]` entry that
+declares a `label` with no `name`, independent of the existing translation-
+completeness assertions, which cannot see this class at all (a section with no
+`name` has no key for them to check). Refs #1100, #1018.

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -137,6 +137,11 @@ export const en: TranslationData = {
         ownership: { label: 'Ownership & Status' },
         branding: { label: 'Branding' },
         system: { label: 'System' },
+        // Form section names on account.view.ts (#1100)
+        profile: { label: 'Profile' },
+        customer_success: { label: 'Customer Success' },
+        locations: { label: 'Locations' },
+        description: { label: 'Description' },
       },
       _actions: { ...activityActions },
     },
@@ -201,6 +206,11 @@ export const en: TranslationData = {
         mailing_address: { label: 'Mailing Address' },
         additional: { label: 'Additional Info' },
         preferences: { label: 'Communication Preferences' },
+        // Form section names on contact.view.ts (#1100). `contact_details` /
+        // `comm_preferences`, not `contact_info` / `preferences` — those are
+        // already fieldGroup keys with their own (longer) wording above.
+        contact_details: { label: 'Contact Info' },
+        comm_preferences: { label: 'Preferences' },
       },
       _actions: {
         ...activityActions,
@@ -284,6 +294,8 @@ export const en: TranslationData = {
         taxonomy: { label: 'Categorization' },
         metrics: { label: 'Engagement' },
         engagement: { label: 'Engagement' },
+        // Form section name on knowledge_article.view.ts (#1100)
+        article: { label: 'Article' },
       },
       _actions: {
         mark_article_helpful: {
@@ -363,6 +375,11 @@ export const en: TranslationData = {
         basic: { label: 'Snapshot' },
         amounts: { label: 'Amounts' },
         meta: { label: 'Source' },
+        // Form section names on forecast.view.ts (#1100). `basic`'s label
+        // matches "Snapshot" but its key does not, so this form section
+        // needs its own entry; `notes` has no fieldGroup counterpart at all.
+        snapshot: { label: 'Snapshot' },
+        notes: { label: 'Notes' },
       },
     },
 
@@ -487,6 +504,31 @@ export const en: TranslationData = {
         crm_contact: { label: 'Contact' },
         detail: { label: 'Lead Detail' },
         description: { label: 'Description' },
+        // Form section names on lead.view.ts (#1100) — the default form and
+        // its six named formViews. `address` / `qualification` above are
+        // reused (identical fieldGroup wording); every other name here is new.
+        contact_information: { label: 'Contact Information' },
+        lead_classification: { label: 'Lead Classification' },
+        company_information: { label: 'Company Information' },
+        additional_information: { label: 'Additional Information' },
+        privacy: { label: 'Privacy' },
+        lead_details: { label: 'Lead Details' },
+        general: { label: 'General' },
+        details: { label: 'Details' },
+        step_1_contact_details: { label: 'Step 1: Contact Details' },
+        step_2_company_information: { label: 'Step 2: Company Information' },
+        step_3_qualification: { label: 'Step 3: Qualification' },
+        step_4_review_and_convert: { label: 'Step 4: Review & Convert' },
+        primary_information: { label: 'Primary Information' },
+        extended_details: { label: 'Extended Details' },
+        quick_edit: { label: 'Quick Edit' },
+        update_lead_status: { label: 'Update Lead Status' },
+        tell_us_about_yourself: { label: 'Tell us about yourself' },
+        about_your_company: { label: 'About your company' },
+        how_can_we_help: { label: 'How can we help?' },
+        lead_information: { label: 'Lead Information' },
+        address_information: { label: 'Address Information' },
+        privacy_preferences: { label: 'Privacy Preferences' },
       },
       _actions: {
         ...activityActions,
@@ -618,6 +660,11 @@ export const en: TranslationData = {
         // Detail-page sections (src/pages/opportunity_detail.page.ts)
         info: { label: 'Opportunity Information' },
         description: { label: 'Description' },
+        // Form section names on opportunity.view.ts (#1100)
+        overview: { label: 'Overview' },
+        forecast: { label: 'Forecast' },
+        sales_strategy: { label: 'Sales Strategy' },
+        win_loss: { label: 'Win / Loss' },
       },
       _actions: {
         ...activityActions,
@@ -725,6 +772,11 @@ export const en: TranslationData = {
         info: { label: 'Case Information' },
         status: { label: 'Status & SLA' },
         description: { label: 'Description' },
+        // Form section names on case.view.ts (#1100). `sla_overview`, not
+        // `sla` — `sla` is already the fieldGroup key for "SLA & Priority".
+        case: { label: 'Case' },
+        sla_overview: { label: 'SLA' },
+        how_can_we_help: { label: 'How can we help?' },
       },
       _actions: {
         ...activityActions,
@@ -804,6 +856,11 @@ export const en: TranslationData = {
         value: { label: 'Contract Value' },
         status: { label: 'Status & Approval' },
         renewal: { label: 'Renewal' },
+        // Form section names on contract.view.ts (#1100). `contract_terms`,
+        // not `terms` — `terms` is already the fieldGroup key for "Terms & Dates".
+        contract_terms: { label: 'Terms' },
+        signing_and_documents: { label: 'Signing & Documents' },
+        notes: { label: 'Notes' },
       },
     },
 
@@ -864,6 +921,10 @@ export const en: TranslationData = {
         basic: { label: 'Product Information' },
         pricing: { label: 'Pricing & Billing' },
         metadata: { label: 'Resources' },
+        // Form section names on product.view.ts (#1100)
+        product_info: { label: 'Product Info' },
+        pricing_and_inventory: { label: 'Pricing & Inventory' },
+        media: { label: 'Media' },
       },
     },
 
@@ -920,6 +981,12 @@ export const en: TranslationData = {
         terms: { label: 'Terms & Validity' },
         address: { label: 'Addresses' },
         system: { label: 'System' },
+        // Form section names on quote.view.ts (#1100). `quote_terms`, not
+        // `terms` — `terms` is already the fieldGroup key for "Terms & Validity".
+        quote: { label: 'Quote' },
+        totals: { label: 'Totals' },
+        quote_terms: { label: 'Terms' },
+        addresses_and_notes: { label: 'Addresses & Notes' },
       },
     },
 
@@ -995,6 +1062,10 @@ export const en: TranslationData = {
         recurrence: { label: 'Recurrence' },
         effort: { label: 'Progress & Effort' },
         system: { label: 'System' },
+        // Form section names on task.view.ts (#1100)
+        task: { label: 'Task' },
+        related_records: { label: 'Related Records' },
+        recurrence_and_effort: { label: 'Recurrence & Effort' },
       },
     },
 
@@ -1123,6 +1194,10 @@ export const en: TranslationData = {
         schedule: { label: 'Schedule' },
         related: { label: 'Related Records' },
         outcome: { label: 'Outcome' },
+        // Form section names on event.view.ts (#1100). `related_records`,
+        // not `related` — `related` is already the fieldGroup key above.
+        event: { label: 'Event' },
+        related_records: { label: 'Related Records' },
       },
     },
 
@@ -1160,6 +1235,11 @@ export const en: TranslationData = {
       _sections: {
         basic: { label: 'Attendee' },
         response: { label: 'Invitation' },
+        // Form section names on event_attendee.view.ts (#1100) — same English
+        // text as the fieldGroups above, but a distinct key: `attendee` /
+        // `invitation` are not `basic` / `response`.
+        attendee: { label: 'Attendee' },
+        invitation: { label: 'Invitation' },
       },
     },
 

--- a/src/translations/es-ES.ts
+++ b/src/translations/es-ES.ts
@@ -148,6 +148,11 @@ export const esES: TranslationData = {
         ownership: { label: 'Propiedad y Estado' },
         branding: { label: 'Identidad de Marca' },
         system: { label: 'Sistema' },
+        // Nombres de sección del formulario en account.view.ts (#1100)
+        profile: { label: 'Perfil' },
+        customer_success: { label: 'Éxito del Cliente' },
+        locations: { label: 'Ubicaciones' },
+        description: { label: 'Descripción' },
       },
       _actions: { ...activityActions },
     },
@@ -218,6 +223,9 @@ export const esES: TranslationData = {
         mailing_address: { label: 'Dirección de Correo' },
         additional: { label: 'Información Adicional' },
         preferences: { label: 'Preferencias de Comunicación' },
+        // Nombres de sección del formulario en contact.view.ts (#1100)
+        contact_details: { label: 'Información de Contacto' },
+        comm_preferences: { label: 'Preferencias' },
       },
       _actions: {
         ...activityActions,
@@ -301,6 +309,8 @@ export const esES: TranslationData = {
         taxonomy: { label: 'Categorización' },
         metrics: { label: 'Interacción' },
         engagement: { label: 'Interacción' },
+        // Nombre de sección del formulario en knowledge_article.view.ts (#1100)
+        article: { label: 'Artículo' },
       },
       _actions: {
         mark_article_helpful: {
@@ -365,6 +375,9 @@ export const esES: TranslationData = {
         basic: { label: 'Instantánea' },
         amounts: { label: 'Importes' },
         meta: { label: 'Origen' },
+        // Nombres de sección del formulario en forecast.view.ts (#1100)
+        snapshot: { label: 'Instantánea' },
+        notes: { label: 'Notas' },
       },
     },
 
@@ -496,6 +509,30 @@ export const esES: TranslationData = {
         additional: { label: 'Información Adicional' },
         preferences: { label: 'Preferencias de Comunicación' },
         duplicates: { label: 'Gestión de Duplicados' },
+        // Nombres de sección del formulario en lead.view.ts (#1100) — el
+        // formulario por defecto y sus seis formViews con nombre.
+        contact_information: { label: 'Información de Contacto' },
+        lead_classification: { label: 'Clasificación del Lead' },
+        company_information: { label: 'Información de la Empresa' },
+        additional_information: { label: 'Información Adicional' },
+        privacy: { label: 'Privacidad' },
+        lead_details: { label: 'Detalles del Lead' },
+        general: { label: 'General' },
+        details: { label: 'Detalles' },
+        step_1_contact_details: { label: 'Paso 1: Datos de Contacto' },
+        step_2_company_information: { label: 'Paso 2: Información de la Empresa' },
+        step_3_qualification: { label: 'Paso 3: Calificación' },
+        step_4_review_and_convert: { label: 'Paso 4: Revisar y Convertir' },
+        primary_information: { label: 'Información Principal' },
+        extended_details: { label: 'Detalles Ampliados' },
+        quick_edit: { label: 'Edición Rápida' },
+        update_lead_status: { label: 'Actualizar Estado del Lead' },
+        tell_us_about_yourself: { label: 'Cuéntanos sobre ti' },
+        about_your_company: { label: 'Sobre tu empresa' },
+        how_can_we_help: { label: '¿Cómo podemos ayudarte?' },
+        lead_information: { label: 'Información del Lead' },
+        address_information: { label: 'Información de Dirección' },
+        privacy_preferences: { label: 'Preferencias de Privacidad' },
       },
       _actions: {
         ...activityActions,
@@ -640,6 +677,11 @@ export const esES: TranslationData = {
         classification: { label: 'Clasificación' },
         campaign: { label: 'Campañas' },
         notes: { label: 'Notas y Próximos Pasos' },
+        // Nombres de sección del formulario en opportunity.view.ts (#1100)
+        overview: { label: 'Resumen' },
+        forecast: { label: 'Previsión' },
+        sales_strategy: { label: 'Estrategia de Ventas' },
+        win_loss: { label: 'Ganada / Perdida' },
       },
       _actions: {
         ...activityActions,
@@ -747,6 +789,12 @@ export const esES: TranslationData = {
         info: { label: 'Información del Caso' },
         status: { label: 'Estado y SLA' },
         description: { label: 'Descripción' },
+        // Nombres de sección del formulario en case.view.ts (#1100).
+        // `sla_overview`, no `sla` — `sla` ya es la clave del fieldGroup
+        // «SLA & Priority».
+        case: { label: 'Caso' },
+        sla_overview: { label: 'SLA' },
+        how_can_we_help: { label: '¿Cómo podemos ayudarte?' },
         // Claves de sección del objeto (case.object.ts) que usan los
         // formularios de registro. `basic` repite el inglés de `info`
         // («Case Information»), así que comparte traducción.
@@ -835,6 +883,10 @@ export const esES: TranslationData = {
         value: { label: 'Valor del Contrato' },
         status: { label: 'Estado y Aprobación' },
         renewal: { label: 'Renovación' },
+        // Nombres de sección del formulario en contract.view.ts (#1100)
+        contract_terms: { label: 'Términos' },
+        signing_and_documents: { label: 'Firma y Documentos' },
+        notes: { label: 'Notas' },
       },
     },
 
@@ -896,6 +948,10 @@ export const esES: TranslationData = {
         basic: { label: 'Información del Producto' },
         pricing: { label: 'Precios y Facturación' },
         metadata: { label: 'Recursos' },
+        // Nombres de sección del formulario en product.view.ts (#1100)
+        product_info: { label: 'Información del Producto' },
+        pricing_and_inventory: { label: 'Precios e Inventario' },
+        media: { label: 'Multimedia' },
       },
     },
 
@@ -954,6 +1010,11 @@ export const esES: TranslationData = {
         terms: { label: 'Términos y Vigencia' },
         address: { label: 'Direcciones' },
         system: { label: 'Sistema' },
+        // Nombres de sección del formulario en quote.view.ts (#1100)
+        quote: { label: 'Cotización' },
+        totals: { label: 'Totales' },
+        quote_terms: { label: 'Términos' },
+        addresses_and_notes: { label: 'Direcciones y Notas' },
       },
     },
 
@@ -1033,6 +1094,10 @@ export const esES: TranslationData = {
         recurrence: { label: 'Recurrencia' },
         effort: { label: 'Progreso y Esfuerzo' },
         system: { label: 'Sistema' },
+        // Nombres de sección del formulario en task.view.ts (#1100)
+        task: { label: 'Tarea' },
+        related_records: { label: 'Registros Relacionados' },
+        recurrence_and_effort: { label: 'Recurrencia y Esfuerzo' },
       },
     },
 
@@ -1164,6 +1229,9 @@ export const esES: TranslationData = {
         schedule: { label: 'Programación' },
         related: { label: 'Registros Relacionados' },
         outcome: { label: 'Resultado' },
+        // Nombres de sección del formulario en event.view.ts (#1100)
+        event: { label: 'Evento' },
+        related_records: { label: 'Registros Relacionados' },
       },
     },
 
@@ -1200,6 +1268,9 @@ export const esES: TranslationData = {
         // «Basic Information» / «Response Tracking» de crm_campaign_member.
         basic: { label: 'Asistente' },
         response: { label: 'Invitación' },
+        // Nombres de sección del formulario en event_attendee.view.ts (#1100)
+        attendee: { label: 'Asistente' },
+        invitation: { label: 'Invitación' },
       },
     },
 

--- a/src/translations/ja-JP.ts
+++ b/src/translations/ja-JP.ts
@@ -172,6 +172,11 @@ export const jaJP: TranslationData = {
         ownership: { label: '所有者・ステータス' },
         branding: { label: 'ブランディング' },
         system: { label: 'システム' },
+        // account.view.ts のフォームセクション名 (#1100)
+        profile: { label: 'プロフィール' },
+        customer_success: { label: 'カスタマーサクセス' },
+        locations: { label: '所在地' },
+        description: { label: '説明' },
       },
       _actions: { ...activityActions },
     },
@@ -226,6 +231,9 @@ export const jaJP: TranslationData = {
         mailing_address: { label: '郵送先住所' },
         additional: { label: 'その他の情報' },
         preferences: { label: 'コミュニケーション設定' },
+        // contact.view.ts のフォームセクション名 (#1100)
+        contact_details: { label: '連絡先情報' },
+        comm_preferences: { label: '設定' },
       },
       _actions: {
         ...activityActions,
@@ -309,6 +317,8 @@ export const jaJP: TranslationData = {
         taxonomy: { label: '分類' },
         metrics: { label: '利用状況' },
         engagement: { label: '利用状況' },
+        // knowledge_article.view.ts のフォームセクション名 (#1100)
+        article: { label: '記事' },
       },
       _actions: {
         mark_article_helpful: {
@@ -394,6 +404,9 @@ export const jaJP: TranslationData = {
         basic: { label: 'スナップショット' },
         amounts: { label: '金額' },
         meta: { label: 'ソース' },
+        // forecast.view.ts のフォームセクション名 (#1100)
+        snapshot: { label: 'スナップショット' },
+        notes: { label: 'メモ' },
       },
     },
 
@@ -503,6 +516,30 @@ export const jaJP: TranslationData = {
         preferences: { label: 'コミュニケーション設定' },
         conversion: { label: '変換' },
         duplicates: { label: '重複管理' },
+        // lead.view.ts のフォームセクション名 (#1100) — デフォルトフォームと
+        // 名前付き formView 6 種。
+        contact_information: { label: '連絡先情報' },
+        lead_classification: { label: 'リード分類' },
+        company_information: { label: '会社情報' },
+        additional_information: { label: '追加情報' },
+        privacy: { label: 'プライバシー' },
+        lead_details: { label: 'リード詳細' },
+        general: { label: '一般' },
+        details: { label: '詳細' },
+        step_1_contact_details: { label: 'ステップ1：連絡先情報' },
+        step_2_company_information: { label: 'ステップ2：会社情報' },
+        step_3_qualification: { label: 'ステップ3：資格評価' },
+        step_4_review_and_convert: { label: 'ステップ4：確認と変換' },
+        primary_information: { label: '主要情報' },
+        extended_details: { label: '詳細情報' },
+        quick_edit: { label: 'クイック編集' },
+        update_lead_status: { label: 'リードステータスを更新' },
+        tell_us_about_yourself: { label: 'あなたについて教えてください' },
+        about_your_company: { label: '貴社について' },
+        how_can_we_help: { label: 'どのようなご用件でしょうか？' },
+        lead_information: { label: 'リード情報' },
+        address_information: { label: '住所情報' },
+        privacy_preferences: { label: 'プライバシー設定' },
       },
       _actions: {
         ...activityActions,
@@ -622,6 +659,11 @@ export const jaJP: TranslationData = {
         classification: { label: '分類' },
         campaign: { label: 'キャンペーン' },
         notes: { label: 'メモ・次のステップ' },
+        // opportunity.view.ts のフォームセクション名 (#1100)
+        overview: { label: '概要' },
+        forecast: { label: '予測' },
+        sales_strategy: { label: '営業戦略' },
+        win_loss: { label: '受注／失注' },
       },
       _actions: {
         ...activityActions,
@@ -721,6 +763,12 @@ export const jaJP: TranslationData = {
         info: { label: 'ケース情報' },
         status: { label: 'ステータス・SLA' },
         description: { label: '説明' },
+        // case.view.ts のフォームセクション名 (#1100)。sla ではなく
+        // sla_overview — sla は「SLA・優先度」フィールドグループのキーとして
+        // 既に使われている。
+        case: { label: 'ケース' },
+        sla_overview: { label: 'SLA' },
+        how_can_we_help: { label: 'どのようなご用件でしょうか？' },
         // オブジェクト定義のセクションキー（case.object.ts）— 入力フォームで使用
         basic: { label: 'ケース情報' },
         origin: { label: '発生元・振り分け' },
@@ -800,6 +848,10 @@ export const jaJP: TranslationData = {
         value: { label: '契約金額' },
         status: { label: 'ステータス・承認' },
         renewal: { label: '更新' },
+        // contract.view.ts のフォームセクション名 (#1100)
+        contract_terms: { label: '契約条件' },
+        signing_and_documents: { label: '署名と書類' },
+        notes: { label: '備考' },
       },
     },
 
@@ -861,6 +913,10 @@ export const jaJP: TranslationData = {
         basic: { label: '製品情報' },
         pricing: { label: '価格・請求' },
         metadata: { label: '関連資料' },
+        // product.view.ts のフォームセクション名 (#1100)
+        product_info: { label: '製品情報' },
+        pricing_and_inventory: { label: '価格と在庫' },
+        media: { label: 'メディア' },
       },
     },
 
@@ -912,6 +968,11 @@ export const jaJP: TranslationData = {
         terms: { label: '条件・有効期限' },
         address: { label: '住所' },
         system: { label: 'システム' },
+        // quote.view.ts のフォームセクション名 (#1100)
+        quote: { label: '見積書' },
+        totals: { label: '合計' },
+        quote_terms: { label: '契約条件' },
+        addresses_and_notes: { label: '住所と備考' },
       },
     },
 
@@ -985,6 +1046,10 @@ export const jaJP: TranslationData = {
         recurrence: { label: '繰り返し' },
         effort: { label: '進捗・工数' },
         system: { label: 'システム' },
+        // task.view.ts のフォームセクション名 (#1100)
+        task: { label: 'タスク' },
+        related_records: { label: '関連レコード' },
+        recurrence_and_effort: { label: '繰り返しと工数' },
       },
     },
 
@@ -1112,6 +1177,9 @@ export const jaJP: TranslationData = {
         schedule: { label: 'スケジュール' },
         related: { label: '関連レコード' },
         outcome: { label: '実施結果' },
+        // event.view.ts のフォームセクション名 (#1100)
+        event: { label: 'イベント' },
+        related_records: { label: '関連レコード' },
       },
     },
 
@@ -1146,6 +1214,9 @@ export const jaJP: TranslationData = {
       _sections: {
         basic: { label: '参加者' },
         response: { label: '招待' },
+        // event_attendee.view.ts のフォームセクション名 (#1100)
+        attendee: { label: '参加者' },
+        invitation: { label: '招待' },
       },
     },
 

--- a/src/translations/zh-CN.ts
+++ b/src/translations/zh-CN.ts
@@ -131,6 +131,11 @@ export const zhCN: TranslationData = {
         ownership: { label: '归属与状态' },
         branding: { label: '品牌' },
         system: { label: '系统' },
+        // account.view.ts 表单区块名称 (#1100)
+        profile: { label: '资料' },
+        customer_success: { label: '客户成功' },
+        locations: { label: '地址信息' },
+        description: { label: '描述' },
       },
       _actions: { ...activityActions },
     },
@@ -218,6 +223,9 @@ export const zhCN: TranslationData = {
         mailing_address: { label: '邮寄地址' },
         additional: { label: '附加信息' },
         preferences: { label: '沟通偏好' },
+        // contact.view.ts 表单区块名称 (#1100)
+        contact_details: { label: '联系信息' },
+        comm_preferences: { label: '偏好设置' },
       },
     },
 
@@ -275,6 +283,8 @@ export const zhCN: TranslationData = {
         taxonomy: { label: '分类' },
         metrics: { label: '互动数据' },
         engagement: { label: '互动数据' },
+        // knowledge_article.view.ts 表单区块名称 (#1100)
+        article: { label: '文章' },
       },
       _actions: {
         mark_article_helpful: {
@@ -336,6 +346,9 @@ export const zhCN: TranslationData = {
         basic: { label: '快照' },
         amounts: { label: '金额' },
         meta: { label: '来源' },
+        // forecast.view.ts 表单区块名称 (#1100)
+        snapshot: { label: '快照' },
+        notes: { label: '备注' },
       },
     },
 
@@ -462,6 +475,29 @@ export const zhCN: TranslationData = {
         preferences: { label: '沟通偏好' },
         conversion: { label: '转化' },
         duplicates: { label: '重复线索管理' },
+        // lead.view.ts 表单区块名称 (#1100) —— 默认表单及六个具名 formView。
+        contact_information: { label: '联系信息' },
+        lead_classification: { label: '线索分类' },
+        company_information: { label: '公司信息' },
+        additional_information: { label: '附加信息' },
+        privacy: { label: '隐私' },
+        lead_details: { label: '线索详情' },
+        general: { label: '常规信息' },
+        details: { label: '详情' },
+        step_1_contact_details: { label: '第一步：联系方式' },
+        step_2_company_information: { label: '第二步：公司信息' },
+        step_3_qualification: { label: '第三步：资质审核' },
+        step_4_review_and_convert: { label: '第四步：审核并转化' },
+        primary_information: { label: '主要信息' },
+        extended_details: { label: '扩展信息' },
+        quick_edit: { label: '快速编辑' },
+        update_lead_status: { label: '更新线索状态' },
+        tell_us_about_yourself: { label: '请介绍一下您自己' },
+        about_your_company: { label: '您的公司信息' },
+        how_can_we_help: { label: '我们能帮您什么？' },
+        lead_information: { label: '线索信息' },
+        address_information: { label: '地址信息' },
+        privacy_preferences: { label: '隐私偏好' },
       },
       _actions: {
         ...activityActions,
@@ -538,6 +574,11 @@ export const zhCN: TranslationData = {
         terms: { label: '条款与有效期' },
         address: { label: '地址' },
         system: { label: '系统' },
+        // quote.view.ts 表单区块名称 (#1100)
+        quote: { label: '报价单' },
+        totals: { label: '合计' },
+        quote_terms: { label: '条款' },
+        addresses_and_notes: { label: '地址与备注' },
       },
     },
 
@@ -602,6 +643,10 @@ export const zhCN: TranslationData = {
         value: { label: '合同金额' },
         status: { label: '状态与审批' },
         renewal: { label: '续约' },
+        // contract.view.ts 表单区块名称 (#1100)
+        contract_terms: { label: '条款' },
+        signing_and_documents: { label: '签署与文件' },
+        notes: { label: '备注' },
       },
     },
 
@@ -692,6 +737,11 @@ export const zhCN: TranslationData = {
         info: { label: '工单信息' },
         status: { label: '状态与 SLA' },
         description: { label: '描述' },
+        // case.view.ts 表单区块名称 (#1100)。使用 sla_overview 而非 sla ——
+        // sla 已是「SLA 与优先级」字段分组的键。
+        case: { label: '工单' },
+        sla_overview: { label: 'SLA' },
+        how_can_we_help: { label: '我们能帮您什么？' },
         // Object-level section keys (case.object.ts) used by record forms
         basic: { label: '工单信息' },
         origin: { label: '来源与路由' },
@@ -765,6 +815,10 @@ export const zhCN: TranslationData = {
         recurrence: { label: '重复规则' },
         system: { label: '系统' },
         effort: { label: '进度与工时' },
+        // task.view.ts 表单区块名称 (#1100)
+        task: { label: '任务' },
+        related_records: { label: '关联记录' },
+        recurrence_and_effort: { label: '重复与工时' },
       },
       _views: {
         all_tasks: { label: '全部任务' },
@@ -906,6 +960,10 @@ export const zhCN: TranslationData = {
         basic: { label: '产品信息' },
         pricing: { label: '价格与计费' },
         metadata: { label: '资源' },
+        // product.view.ts 表单区块名称 (#1100)
+        product_info: { label: '产品信息' },
+        pricing_and_inventory: { label: '定价与库存' },
+        media: { label: '媒体' },
       },
     },
 
@@ -1014,6 +1072,11 @@ export const zhCN: TranslationData = {
         classification: { label: '分类' },
         campaign: { label: '营销活动' },
         notes: { label: '备注与下一步' },
+        // opportunity.view.ts 表单区块名称 (#1100)
+        overview: { label: '概览' },
+        forecast: { label: '预测' },
+        sales_strategy: { label: '销售策略' },
+        win_loss: { label: '赢单/输单' },
       },
       _actions: {
         ...activityActions,
@@ -1087,6 +1150,9 @@ export const zhCN: TranslationData = {
         schedule: { label: '日程安排' },
         related: { label: '关联记录' },
         outcome: { label: '结果' },
+        // event.view.ts 表单区块名称 (#1100)
+        event: { label: '活动' },
+        related_records: { label: '关联记录' },
       },
       _views: {
         all_events: { label: '全部活动' },
@@ -1126,6 +1192,9 @@ export const zhCN: TranslationData = {
       _sections: {
         basic: { label: '参与者' },
         response: { label: '邀请' },
+        // event_attendee.view.ts 表单区块名称 (#1100)
+        attendee: { label: '参与者' },
+        invitation: { label: '邀请' },
       },
       _views: {
         all_event_attendees: { label: '活动参与者' },

--- a/src/views/account.view.ts
+++ b/src/views/account.view.ts
@@ -196,6 +196,7 @@ export const AccountViews = defineView({
     type: 'tabbed',
     sections: [
       {
+        name: 'profile',
         label: 'Profile',
         columns: 2,
         fields: [
@@ -215,6 +216,7 @@ export const AccountViews = defineView({
         ],
       },
       {
+        name: 'financials',
         label: 'Financials',
         columns: 2,
         fields: ['annual_revenue', 'number_of_employees'],
@@ -223,11 +225,13 @@ export const AccountViews = defineView({
         // The customer-success fields the renewals_due / at_risk_accounts
         // views list and filter on. They existed on the object but no form
         // offered them, so the CS working queues stayed permanently empty.
+        name: 'customer_success',
         label: 'Customer Success',
         columns: 2,
         fields: ['tier', 'segment', 'health_score', 'renewal_owner', 'next_renewal_date'],
       },
       {
+        name: 'locations',
         label: 'Locations',
         columns: 1,
         // `billing_country` and `territory` are readonly and derived, but both
@@ -242,6 +246,7 @@ export const AccountViews = defineView({
         fields: ['billing_address', 'billing_country', 'territory', 'office_location'],
       },
       {
+        name: 'description',
         label: 'Description',
         columns: 1,
         fields: ['description'],

--- a/src/views/case.view.ts
+++ b/src/views/case.view.ts
@@ -256,6 +256,7 @@ export const CaseViews = defineView({
     type: 'tabbed',
     sections: [
       {
+        name: 'case',
         label: 'Case',
         columns: 2,
         fields: [
@@ -273,6 +274,11 @@ export const CaseViews = defineView({
         ],
       },
       {
+        // Named `sla_overview`, not `sla` — `sla` is already a distinct
+        // fieldGroup key on `crm_case` ("SLA & Priority"), and reusing it here
+        // would make this section's translated heading follow that group's
+        // wording instead of its own "SLA".
+        name: 'sla_overview',
         label: 'SLA',
         columns: 2,
         fields: [
@@ -287,6 +293,7 @@ export const CaseViews = defineView({
         ],
       },
       {
+        name: 'resolution',
         label: 'Resolution',
         columns: 1,
         fields: ['resolution', 'internal_notes', 'customer_rating', 'customer_feedback', 'customer_signature', 'closed_date', 'is_closed'],
@@ -310,6 +317,7 @@ export const CaseViews = defineView({
       data: { provider: 'object', object: 'crm_case' },
       sections: [
         {
+          name: 'how_can_we_help',
           label: 'How can we help?',
           columns: 1,
           fields: [

--- a/src/views/contact.view.ts
+++ b/src/views/contact.view.ts
@@ -79,6 +79,7 @@ export const ContactViews = defineView({
     type: 'tabbed',
     sections: [
       {
+        name: 'identity',
         label: 'Identity',
         columns: 2,
         fields: [
@@ -93,11 +94,23 @@ export const ContactViews = defineView({
         ],
       },
       {
+        // Named `contact_details`, not `contact_info` — `contact_info` is
+        // already a distinct fieldGroup key on `crm_contact` ("Contact
+        // Information"), and reusing it here would make this section's
+        // translated heading follow that group's wording instead of its own
+        // "Contact Info".
+        name: 'contact_details',
         label: 'Contact Info',
         columns: 2,
         fields: ['email', 'phone', 'mobile', 'birthdate', 'avatar'],
       },
       {
+        // Named `comm_preferences`, not `preferences` — `preferences` is
+        // already a distinct fieldGroup key on `crm_contact` ("Communication
+        // Preferences"), and reusing it here would make this section's
+        // translated heading follow that group's wording instead of its own
+        // "Preferences".
+        name: 'comm_preferences',
         label: 'Preferences',
         columns: 2,
         fields: ['lead_source', 'is_primary', 'do_not_call', 'email_opt_out'],

--- a/src/views/contract.view.ts
+++ b/src/views/contract.view.ts
@@ -93,11 +93,17 @@ export const ContractViews = defineView({
     type: 'tabbed',
     sections: [
       {
+        name: 'parties',
         label: 'Parties',
         columns: 2,
         fields: ['contract_number', 'crm_account', 'crm_contact', 'crm_opportunity', 'owner_id', 'status'],
       },
       {
+        // Named `contract_terms`, not `terms` — `terms` is already a distinct
+        // fieldGroup key on `crm_contract` ("Terms & Dates"), and reusing it
+        // here would make this section's translated heading follow that
+        // group's wording instead of its own "Terms".
+        name: 'contract_terms',
         label: 'Terms',
         columns: 2,
         fields: [
@@ -112,11 +118,13 @@ export const ContractViews = defineView({
         ],
       },
       {
+        name: 'signing_and_documents',
         label: 'Signing & Documents',
         columns: 2,
         fields: ['signed_date', 'signed_by', 'document_url'],
       },
       {
+        name: 'notes',
         label: 'Notes',
         columns: 1,
         fields: ['special_terms', 'billing_address'],

--- a/src/views/event.view.ts
+++ b/src/views/event.view.ts
@@ -136,6 +136,7 @@ export const EventViews = defineView({
     type: 'simple',
     sections: [
       {
+        name: 'event',
         label: 'Event',
         columns: 2,
         fields: [
@@ -148,6 +149,7 @@ export const EventViews = defineView({
         ],
       },
       {
+        name: 'schedule',
         label: 'Schedule',
         columns: 2,
         fields: [
@@ -158,6 +160,7 @@ export const EventViews = defineView({
         ],
       },
       {
+        name: 'related_records',
         label: 'Related Records',
         collapsible: true,
         columns: 2,
@@ -170,6 +173,7 @@ export const EventViews = defineView({
         ],
       },
       {
+        name: 'outcome',
         label: 'Outcome',
         collapsible: true,
         collapsed: true,

--- a/src/views/event_attendee.view.ts
+++ b/src/views/event_attendee.view.ts
@@ -78,6 +78,7 @@ export const EventAttendeeViews = defineView({
     type: 'simple',
     sections: [
       {
+        name: 'attendee',
         label: 'Attendee',
         columns: 2,
         fields: [
@@ -90,6 +91,7 @@ export const EventAttendeeViews = defineView({
         ],
       },
       {
+        name: 'invitation',
         label: 'Invitation',
         columns: 2,
         fields: ['response', 'is_organizer', 'invited_date'],

--- a/src/views/forecast.view.ts
+++ b/src/views/forecast.view.ts
@@ -122,16 +122,19 @@ export const ForecastViews = defineView({
     type: 'simple',
     sections: [
       {
+        name: 'snapshot',
         label: 'Snapshot',
         columns: 2,
         fields: ['owner_id', 'period', 'period_start', 'period_end', 'period_label', 'snapshot_date', 'source'],
       },
       {
+        name: 'amounts',
         label: 'Amounts',
         columns: 2,
         fields: ['quota', 'closed_amount', 'commit_amount', 'best_case_amount', 'pipeline_amount', 'expected_amount', 'attainment_pct', 'coverage_ratio'],
       },
       {
+        name: 'notes',
         label: 'Notes',
         columns: 1,
         fields: ['notes'],

--- a/src/views/knowledge_article.view.ts
+++ b/src/views/knowledge_article.view.ts
@@ -149,6 +149,7 @@ export const KnowledgeArticleViews = defineView({
     type: 'simple',
     sections: [
       {
+        name: 'article',
         label: 'Article',
         columns: 2,
         fields: [
@@ -164,6 +165,7 @@ export const KnowledgeArticleViews = defineView({
         ],
       },
       {
+        name: 'content',
         label: 'Content',
         columns: 1,
         fields: ['body'],

--- a/src/views/lead.view.ts
+++ b/src/views/lead.view.ts
@@ -199,6 +199,7 @@ export const LeadViews = defineView({
     
     sections: [
       {
+        name: 'contact_information',
         label: 'Contact Information',
         collapsible: true,
         collapsed: false,
@@ -227,6 +228,7 @@ export const LeadViews = defineView({
         ],
       },
       {
+        name: 'lead_classification',
         label: 'Lead Classification',
         collapsible: true,
         collapsed: false,
@@ -260,6 +262,7 @@ export const LeadViews = defineView({
         ],
       },
       {
+        name: 'company_information',
         label: 'Company Information',
         collapsible: true,
         collapsed: true, // Collapsed by default
@@ -270,6 +273,7 @@ export const LeadViews = defineView({
         ],
       },
       {
+        name: 'address',
         label: 'Address',
         collapsible: true,
         collapsed: true,
@@ -286,6 +290,7 @@ export const LeadViews = defineView({
         ],
       },
       {
+        name: 'additional_information',
         label: 'Additional Information',
         collapsible: true,
         collapsed: true,
@@ -296,6 +301,7 @@ export const LeadViews = defineView({
         ],
       },
       {
+        name: 'privacy',
         label: 'Privacy',
         collapsible: true,
         collapsed: true,
@@ -524,6 +530,7 @@ export const LeadViews = defineView({
         {
           // Neutral label — this form backs BOTH the create and edit dialogs,
           // so "Quick Lead Creation" read wrong when editing.
+          name: 'lead_details',
           label: 'Lead Details',
           columns: 2,
           fields: [
@@ -558,6 +565,7 @@ export const LeadViews = defineView({
       type: 'tabbed',
       sections: [
         {
+          name: 'general',
           label: 'General',
           columns: 2,
           fields: [
@@ -572,6 +580,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'qualification',
           label: 'Qualification',
           columns: 2,
           fields: [
@@ -591,6 +600,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'address',
           label: 'Address',
           columns: 2,
           // Single composite `Field.address` — see the note on the default
@@ -600,6 +610,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'details',
           label: 'Details',
           columns: 1,
           fields: [
@@ -624,6 +635,7 @@ export const LeadViews = defineView({
       },
       sections: [
         {
+          name: 'step_1_contact_details',
           label: 'Step 1: Contact Details',
           columns: 2,
           fields: [
@@ -635,6 +647,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'step_2_company_information',
           label: 'Step 2: Company Information',
           columns: 2,
           fields: [
@@ -647,6 +660,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'step_3_qualification',
           label: 'Step 3: Qualification',
           columns: 2,
           fields: [
@@ -670,6 +684,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'step_4_review_and_convert',
           label: 'Step 4: Review & Convert',
           columns: 1,
           fields: [
@@ -694,6 +709,7 @@ export const LeadViews = defineView({
       },
       sections: [
         {
+          name: 'primary_information',
           label: 'Primary Information',
           columns: 1,
           fields: [
@@ -713,6 +729,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'extended_details',
           label: 'Extended Details',
           columns: 2,
           fields: [
@@ -741,6 +758,7 @@ export const LeadViews = defineView({
       },
       sections: [
         {
+          name: 'quick_edit',
           label: 'Quick Edit',
           columns: 1, // Drawers typically use single column
           fields: [
@@ -783,6 +801,7 @@ export const LeadViews = defineView({
       },
       sections: [
         {
+          name: 'update_lead_status',
           label: 'Update Lead Status',
           columns: 1,
           fields: [
@@ -838,6 +857,7 @@ export const LeadViews = defineView({
       },
       sections: [
         {
+          name: 'tell_us_about_yourself',
           label: 'Tell us about yourself',
           columns: 2,
           fields: [
@@ -849,6 +869,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'about_your_company',
           label: 'About your company',
           columns: 2,
           fields: [
@@ -860,6 +881,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'how_can_we_help',
           label: 'How can we help?',
           columns: 1,
           fields: [
@@ -890,6 +912,7 @@ export const LeadViews = defineView({
       },
       sections: [
         {
+          name: 'lead_information',
           label: 'Lead Information',
           columns: 2,
           fields: [
@@ -941,6 +964,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'address_information',
           label: 'Address Information',
           collapsible: true,
           collapsed: true,
@@ -952,6 +976,7 @@ export const LeadViews = defineView({
           ],
         },
         {
+          name: 'privacy_preferences',
           label: 'Privacy Preferences',
           collapsible: true,
           collapsed: true,

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -341,6 +341,7 @@ export const OpportunityViews = defineView({
     type: 'tabbed',
     sections: [
       {
+        name: 'overview',
         label: 'Overview',
         columns: 2,
         fields: [
@@ -355,6 +356,7 @@ export const OpportunityViews = defineView({
         ],
       },
       {
+        name: 'forecast',
         label: 'Forecast',
         columns: 2,
         fields: [
@@ -369,6 +371,7 @@ export const OpportunityViews = defineView({
         ],
       },
       {
+        name: 'sales_strategy',
         label: 'Sales Strategy',
         columns: 1,
         // `competitors` sat here until #1061 retired it — this form section was
@@ -379,6 +382,7 @@ export const OpportunityViews = defineView({
         // Win/loss capture at close time. The fields existed on the object for
         // reporting but no form offered them, so every closed deal lost its
         // why-we-won / why-we-lost data.
+        name: 'win_loss',
         label: 'Win / Loss',
         collapsible: true,
         collapsed: true,

--- a/src/views/product.view.ts
+++ b/src/views/product.view.ts
@@ -74,6 +74,7 @@ export const ProductViews = defineView({
     type: 'simple',
     sections: [
       {
+        name: 'product_info',
         label: 'Product Info',
         columns: 2,
         fields: [
@@ -88,11 +89,13 @@ export const ProductViews = defineView({
         ],
       },
       {
+        name: 'pricing_and_inventory',
         label: 'Pricing & Inventory',
         columns: 2,
         fields: ['list_price', 'cost', 'quantity_on_hand', 'reorder_point'],
       },
       {
+        name: 'media',
         label: 'Media',
         columns: 1,
         fields: ['image', 'datasheet', 'description'],

--- a/src/views/quote.view.ts
+++ b/src/views/quote.view.ts
@@ -76,6 +76,7 @@ export const QuoteViews = defineView({
     type: 'tabbed',
     sections: [
       {
+        name: 'quote',
         label: 'Quote',
         columns: 2,
         // `name` is required on crm_quote with no default — omitting it made
@@ -83,16 +84,23 @@ export const QuoteViews = defineView({
         fields: [{ field: 'name', required: true, colSpan: 2 }, 'quote_number', 'crm_account', 'crm_contact', 'crm_opportunity', 'owner_id', 'status', 'quote_date', 'expiration_date'],
       },
       {
+        name: 'totals',
         label: 'Totals',
         columns: 2,
         fields: ['subtotal', 'discount', 'discount_amount', 'tax', 'shipping_handling', 'total_price'],
       },
       {
+        // Named `quote_terms`, not `terms` — `terms` is already a distinct
+        // fieldGroup key on `crm_quote` ("Terms & Validity"), and reusing it
+        // here would make this section's translated heading follow that
+        // group's wording instead of its own "Terms".
+        name: 'quote_terms',
         label: 'Terms',
         columns: 2,
         fields: ['payment_terms', 'shipping_terms'],
       },
       {
+        name: 'addresses_and_notes',
         label: 'Addresses & Notes',
         columns: 1,
         fields: ['billing_address', 'shipping_address', 'internal_notes'],

--- a/src/views/task.view.ts
+++ b/src/views/task.view.ts
@@ -245,6 +245,7 @@ export const TaskViews = defineView({
     type: 'simple',
     sections: [
       {
+        name: 'task',
         label: 'Task',
         columns: 2,
         // `type` (call / email / meeting / demo) is what makes an activity
@@ -265,6 +266,7 @@ export const TaskViews = defineView({
         ],
       },
       {
+        name: 'related_records',
         label: 'Related Records',
         collapsible: true,
         columns: 2,
@@ -277,6 +279,7 @@ export const TaskViews = defineView({
         ],
       },
       {
+        name: 'recurrence_and_effort',
         label: 'Recurrence & Effort',
         collapsible: true,
         collapsed: true,

--- a/test/i18n-references.test.ts
+++ b/test/i18n-references.test.ts
@@ -713,4 +713,49 @@ describe('every locale is complete on every authored surface', () => {
     }
     expect(bad, `section headings with no translation:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
+
+  /**
+   * The blind spot itself (#1100), asserted directly.
+   *
+   * `sectionsByObject`'s `add()` above requires a `name` before it records
+   * anything, so a `sections[]` entry that declares only a `label` is not an
+   * "untranslated section" to either test above it — it is a section neither
+   * of them can see at all. 67 of exactly that shape sat on `main` reporting
+   * zero i18n failures, because nothing walked the tree asking the question
+   * this test asks: does every section that HAS a heading also have a KEY a
+   * translation bundle could address it by?
+   *
+   * This walks the page/view tree itself (independently of `sectionsByObject`,
+   * which cannot see the failure mode being guarded against here) and fails on
+   * any `sections[]` entry carrying a `label` with no `name` alongside it —
+   * structural, not translation-completeness, so it needs no locale loop.
+   */
+  it('every section with a label carries a name — otherwise it is invisible to the i18n gate (#1100)', () => {
+    const bad: string[] = [];
+    const walk = (node: AnyRec | AnyRec[] | undefined, path: string): void => {
+      if (!node || typeof node !== 'object') return;
+      if (Array.isArray(node)) {
+        node.forEach((x, i) => walk(x, `${path}[${i}]`));
+        return;
+      }
+      for (const key of ['sections', 'properties'] as const) {
+        const arr = key === 'sections' ? node.sections : node.properties?.sections;
+        if (Array.isArray(arr)) {
+          arr.forEach((s: AnyRec, i: number) => {
+            if (s && typeof s === 'object' && s.label && !s.name) {
+              bad.push(`${path}.sections[${i}] label=${JSON.stringify(s.label)}`);
+            }
+          });
+        }
+      }
+      // `fields` is skipped for the same reason `sectionsByObject` skips it:
+      // it is a map of field definitions, not layout.
+      for (const [key, value] of Object.entries(node)) {
+        if (key !== 'fields' && value && typeof value === 'object') walk(value as AnyRec, `${path}.${key}`);
+      }
+    };
+    for (const page of pages) walk(page, `page:${page.name}`);
+    for (const view of views) walk(view, `view:${view.list?.data?.object ?? view.object ?? '?'}`);
+    expect(bad, `sections with a label but no name — invisible to every i18n gate:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes #1100

## What

67 form/detail section headings across 13 objects declared a `label` with no
`name`, so the heading resolved through nothing and rendered raw English in
every locale. `objectstack lint`'s `translation-section-name-missing` count
on this branch's base (`083e7d23`, current `origin/main` at dispatch) is
**66**, not 67 — the issue's original count predates PRs #1099 and #1103,
each of which incidentally fixed part of it (`crm_campaign`'s four,
`crm_knowledge_article`'s Engagement section) before this card was
dispatched. Measured, not assumed — see gate counts below.

This PR:

1. Adds a `name` string (a slug matching the section's semantic role) to all
   66 remaining `sections[]` entries (13 objects: account, case, contact,
   contract, event, event_attendee, forecast, knowledge_article, lead,
   opportunity, product, quote, task) and adds the matching `_sections` entry
   for that name in all four locale packs (`en`, `zh-CN`, `es-ES`, `ja-JP`).
   - Where a section's chosen name would collide with an existing
     *different-meaning* fieldGroup key on the same object (`sla`,
     `contact_info`, `preferences`, `terms` ×2), it gets a distinct name
     instead (`sla_overview`, `contact_details`, `comm_preferences`,
     `contract_terms` / `quote_terms`) — each is commented at the call site
     explaining why. Where the section's label is an exact match for an
     existing fieldGroup's label (`financials`, `resolution`, `identity`,
     `parties`, `schedule`, `outcome`, `amounts`, `content`, `address`,
     `qualification`), the section reuses that key rather than duplicating
     an identical translation under a second name.

2. **Closes the gate blind spot** — the actual deliverable per the PM's
   triage comment. `test/i18n-references.test.ts` gains a new assertion,
   *"every section with a label carries a name"*, that walks the page/view
   tree directly (independent of the existing `sectionsByObject` derivation,
   which requires a `name` before it records anything — that is precisely
   why a nameless section was invisible to every existing check, including
   today's #1098 zero-tolerance i18n gate, which never sees these because
   they never become an `i18n/missing-*` finding).

3. **Verified the gate actually goes red**: temporarily deleted the `name`
   from `crm_account`'s `profile` section, re-ran the suite, confirmed only
   the new assertion failed (20/21 other tests in the file stayed green),
   then restored it. Output:

   ```
   FAIL  test/i18n-references.test.ts > every locale is complete on every authored surface
     > every section with a label carries a name — otherwise it is invisible to the i18n gate (#1100)
   AssertionError: sections with a label but no name — invisible to every i18n gate:
     view:crm_account.form.sections[0] label="Profile": expected [ Array(1) ] to deeply equal []
   Test Files  1 failed (1)
        Tests  1 failed | 20 passed (21)
   ```

   Restored, reran — 21/21 green again.

4. Fixed the issue's own truncated body (it was cut mid-sentence at "Section
   headings resolve through `objects." on filing) using the PM's own
   reconstruction from its second triage comment, so the card no longer
   depends on a comment to be readable.

## Rule hit counts (before / after)

`translation-section-name-missing`, `pnpm exec objectstack lint`:

```
before: 66
after:   0
```

Total lint warnings: 149 -> 83 (exactly the 66 fixed; no other rule family
touched — `absolute-colspan-discouraged` / `component-props-*` warnings are
pre-existing and out of this card's scope, left untouched).

`pnpm lint:i18n-gate` (the #1098 zero-tolerance gate): green before and
after — as expected, since these findings never reached it either way. Per
the card's mechanism assumption, naming a section makes it *visible* to this
gate for the first time; if any of the 66 new/renamed names had a missing
translation, this gate would now catch it. It stayed green because every one
was translated in this PR.

## Out of scope

Pre-existing `absolute-colspan-discouraged` and `component-props-*` lint
warnings are untouched, per the card's explicit instruction not to widen
this into a general cleanup.

## Tests

- `pnpm typecheck` — clean.
- `pnpm exec vitest run test/i18n-references.test.ts` — 21/21 passed
  (20 pre-existing + 1 new).
- `pnpm exec vitest run` (full suite, `--maxWorkers=2`, capped heap) —
  96 files, 2356 passed, 1 skipped, 0 failed.
- `pnpm validate` — exit 0, zero `translation-section-name-missing`
  warnings remaining.
- `pnpm hygiene` — clean (no raw control bytes, no oversized files).
- `pnpm lint:i18n-gate` — green (`0 i18n/missing-* issues`).

## Changeset

`skip-changeset` does **not** apply — this is user-visible (non-English
locale users previously saw English section headings). Added
`.changeset/section-heading-name-gate.md`.

---

_Generated by [Claude Code](https://claude.ai/code/session_01NM6o28jmBgsyTRQHutn7LC)_