### PR TITLE
Converge every large-deal site on `>=`: a deal at exactly $100,000 is now governed as well as visible

### DIFF
--- a/.changeset/large-deal-boundary-inclusive.md
+++ b/.changeset/large-deal-boundary-inclusive.md
@@ -1,0 +1,30 @@
+---
+'hotcrm': minor
+---
+
+Large-deal governance now starts **at** $100,000, not above it
+
+A deal priced at exactly $100,000 used to be shared with the sales director and
+the executive as a large open deal, while requiring **no** manager approval and
+firing **no** large-deal-won alert: the two sharing rules cut at `>= $100,000`
+and the approval entry gate and won-deal alert cut at `> $100,000`. Leadership
+could see the deal; nobody had to sign it. A threshold set at a round number
+attracts deals priced at exactly that number, so this was not a rounding edge —
+"a hundred K" is how deals get quoted.
+
+All four large-deal sites now cut the same way, inclusively:
+
+- `opportunity_approval` entry gate, and its `opportunity_approval_on_create`
+  insert twin — `amount >= $100,000`
+- `opportunity_won_alert` — `amount >= $100,000`
+- both opportunity sharing rules — unchanged, already `>= $100,000`
+
+**What changes for users:** an opportunity at exactly $100,000 now locks and
+routes for Sales Manager review, and fires the won-deal alert when it closes.
+Nothing that was previously visible to leadership stops being visible, and no
+deal that previously needed approval stops needing it — the change only widens
+governance by the boundary case. The $500,000 director tier is untouched, and
+so is the threshold value itself.
+
+The published tables in the Sales and Admin package docs now read
+"$100,000 or more" instead of "> $100,000".

--- a/src/docs/crm_admin.md
+++ b/src/docs/crm_admin.md
@@ -110,12 +110,12 @@ revisits:
 
 | Behavior | Current setting | Defined in |
 |---|---|---|
-| Large-deal approval (manager) | amount **> $100,000** | `opportunity-approval.flow.ts` |
+| Large-deal approval (manager) | amount **$100,000 or more** | `opportunity-approval.flow.ts` |
 | Large-deal approval (+ director) | amount **> $500,000** | `opportunity-approval.flow.ts` |
 | Hot-lead follow-up SLA | **1 day** (Lead Score ≥ 4★) | `lead-assignment.flow.ts` |
 | Standard-lead follow-up SLA | **3 days** | `lead-assignment.flow.ts` |
 | Stalled-deal nudge | **> 14 days** in stage, swept daily **07:30** | `opportunity-stagnation.flow.ts` |
-| Won-deal alert | **Closed Won** over **$100,000** | `opportunity-won-alert.flow.ts` |
+| Won-deal alert | **Closed Won** at **$100,000** or more | `opportunity-won-alert.flow.ts` |
 | Quote default validity | **30 days** | `quote-generation.flow.ts` |
 | Quote auto-expiration sweep | daily **01:00** | `quote-expiration.flow.ts` |
 | Case SLA breach sweep | **hourly** | `case-sla-monitor.flow.ts` |

--- a/src/docs/crm_sales.md
+++ b/src/docs/crm_sales.md
@@ -75,19 +75,20 @@ their manager — and a **high-priority follow-up task** is created. Advance the
 stage or re-qualify the deal to clear it.
 
 ### Won-deal alert (automatic)
-When a deal over **$100,000** is marked **Closed Won**, the owner is notified
-automatically — the owner alone, not their manager.
+When a deal of **$100,000** or more is marked **Closed Won**, the owner is
+notified automatically — the owner alone, not their manager. A deal at exactly
+$100,000 counts: the large-deal line is inclusive everywhere.
 
 ## 4. Large-deal approval — when a deal pauses for sign-off
 
 Deals above a threshold **lock and wait** for approval. There is no "submit"
-step — the moment a deal's **amount** crosses $100K, it routes for approval
+step — the moment a deal's **amount** reaches $100K, it routes for approval
 automatically, and you can't move it forward until each required approver signs
 off.
 
 | Deal amount | Required approval |
 |---|---|
-| **> $100,000** | Sales Manager review |
+| **$100,000 or more** | Sales Manager review |
 | **> $500,000** | Sales Manager **and** Sales Director sign-off |
 
 While an approval is pending, the opportunity is **locked** and its

--- a/src/flows/opportunity-approval.flow.ts
+++ b/src/flows/opportunity-approval.flow.ts
@@ -24,8 +24,17 @@ type Flow = Automation.Flow;
  * instead of the no-op `script` + `actionType:'email'` shape.
  *
  * Tiered policy (single source of truth — no double-firing):
- *   - amount > $100K          → Sales Manager review
+ *   - amount >= $100K         → Sales Manager review
  *   - amount > $500K          → additionally Sales Director sign-off
+ *
+ * The entry gate is INCLUSIVE at the line (`>=`, #1087) and the director tier is
+ * exclusive (`>`): those are not the same kind of number. `LARGE_DEAL_AMOUNT` is
+ * the one line this app draws around "large deal", and every consumer of it —
+ * this gate, its insert twin, the won-deal alert and both sharing rules — now
+ * cuts the same way, so a deal at exactly $100,000 is large everywhere or
+ * nowhere. `HIGH_VALUE_DEAL_AMOUNT` below is a matched PAIR (`> 500000` /
+ * `<= 500000`) whose two halves must partition, which is a different property
+ * and is left alone.
  * On full approval the deal is stamped `approval_status = approved` (+ date);
  * any rejection stamps `approval_status = rejected`. The record is locked while
  * a step is pending and `approval_status` mirrors the live request status.
@@ -33,7 +42,7 @@ type Flow = Automation.Flow;
 export const OpportunityApprovalFlow: Flow = {
   name: 'opportunity_approval',
   label: 'Large Deal Approval',
-  description: 'Tiered approval for opportunities: manager review > $100K, director sign-off > $500K.',
+  description: 'Tiered approval for opportunities: manager review at $100K or more, director sign-off > $500K.',
   type: 'record_change',
   status: 'active',
   // Same user-less exposure as every record-change flow (ADR-0049, #1888,
@@ -79,14 +88,14 @@ export const OpportunityApprovalFlow: Flow = {
         // could never resolve (lockRecord held the closed record hostage).
         // TOTALITY (#633): `has(...)` on every read, plus `!= null` on the
         // ordering comparison — `has()` passes an explicit null and
-        // `record.amount > 100000` then aborts with
-        // `no such overload: dyn<null> > int`. Measured total as authored
+        // `record.amount >= 100000` then aborts with
+        // `no such overload: dyn<null> >= int`. Measured total as authored
         // today (amount/stage are required, approval_status is defaulted), but
         // that is `crm_opportunity`'s schema doing the work, not the
         // predicate. An absent `approval_status` reads the same as the null
         // this condition already tolerates; an absent `stage` is not a settled
         // stage, so it must not block approval.
-        condition: P`has(record.amount) && record.amount != null && record.amount > ${LARGE_DEAL_AMOUNT}
+        condition: P`has(record.amount) && record.amount != null && record.amount >= ${LARGE_DEAL_AMOUNT}
           && (!has(record.approval_status) || record.approval_status == "not_required" || record.approval_status == null)
           && (!has(record.stage) || (record.stage != "closed_won" && record.stage != "closed_lost"))`,
       },
@@ -98,7 +107,7 @@ export const OpportunityApprovalFlow: Flow = {
       config: { objectName: 'crm_opportunity', filter: { id: '{record.id}' }, outputVariable: 'oppRecord' },
     },
 
-    // ── Tier 1: Sales Manager review (all deals > $100K) ────────────
+    // ── Tier 1: Sales Manager review (all deals at $100K or more) ───
     {
       id: 'manager_review',
       type: 'approval',

--- a/src/flows/opportunity-won-alert.flow.ts
+++ b/src/flows/opportunity-won-alert.flow.ts
@@ -9,18 +9,24 @@ type Flow = Automation.Flow;
  * Large-deal-won alert — record-change flow on opportunity update.
  *
  * Migrated from the removed `notify_on_large_deal_won` object workflow (7.7
- * dropped `workflows[]`). When a deal > $100K is marked closed_won, notify the
- * owner — the owner alone, not their manager (see the notify node for why the
- * manager cannot be reached).
+ * dropped `workflows[]`). When a deal of $100K or more is marked closed_won,
+ * notify the owner — the owner alone, not their manager (see the notify node
+ * for why the manager cannot be reached).
  *
- * NB: `record.amount > 100000` is authored as bare CEL against the (string-
+ * The cut is INCLUSIVE (`>=`, #1087): `LARGE_DEAL_AMOUNT` means one thing across
+ * this alert, the approval entry gate and both sharing rules, so a deal at
+ * exactly $100,000 is announced on win for the same reason it is shared with
+ * leadership. Before #1087 this site cut at `>` and the sharing rules at `>=`,
+ * which made that deal visible to leadership and invisible to governance.
+ *
+ * NB: `record.amount >= 100000` is authored as bare CEL against the (string-
  * serialized) currency field — this relies on the 7.7 numeric-hydration fix
  * (framework #1534); pre-7.7 it would have needed `double(record.amount)`.
  */
 export const OpportunityWonAlertFlow: Flow = {
   name: 'opportunity_won_alert',
   label: 'Large Deal Won Alert',
-  description: 'On closed_won opportunities over $100K: notify the owner — the owner alone, not their manager.',
+  description: 'On closed_won opportunities of $100K or more: notify the owner — the owner alone, not their manager.',
   type: 'record_change',
   status: 'active',
   // A record-change flow fired by a SYSTEM write carries no trigger user
@@ -49,8 +55,8 @@ export const OpportunityWonAlertFlow: Flow = {
         // condition scope (cf. the engine's record-change context).
         // TOTALITY (#633): `has(...)` on every read, plus `!= null` on the
         // ordering comparison (`has()` passes an explicit null and
-        // `record.amount > 100000` then aborts with
-        // `no such overload: dyn<null> > int`).
+        // `record.amount >= 100000` then aborts with
+        // `no such overload: dyn<null> >= int`).
         //
         // `previous.stage` is guarded FAIL-CLOSED — `has(previous.stage) &&`,
         // not `!has(previous.stage) ||` — which is the opposite of how
@@ -66,7 +72,7 @@ export const OpportunityWonAlertFlow: Flow = {
         // exactly what nobody wants.
         condition: P`has(record.stage) && record.stage == "closed_won"
           && has(previous.stage) && previous.stage != "closed_won"
-          && has(record.amount) && record.amount != null && record.amount > ${LARGE_DEAL_AMOUNT}`,
+          && has(record.amount) && record.amount != null && record.amount >= ${LARGE_DEAL_AMOUNT}`,
       },
     },
     {

--- a/src/objects/_thresholds.ts
+++ b/src/objects/_thresholds.ts
@@ -7,14 +7,15 @@
  * ### What this replaces
  *
  * "What counts as a large deal" was answered by four independent numeric
- * literals sitting in three files, with nothing joining them:
+ * literals sitting in three files, with nothing joining them. What each site
+ * wrote then, and what it interpolates today:
  *
- * | site | literal |
- * | --- | --- |
- * | `flows/opportunity-approval.flow.ts` start condition (both the update and the insert twin share it) | `record.amount > 100000` |
- * | `flows/opportunity-won-alert.flow.ts` start condition | `record.amount > 100000` |
- * | `sharing/opportunity.sharing.ts` — sales-director rule | `record.amount >= 100000` |
- * | `sharing/opportunity.sharing.ts` — executive rule | `record.amount >= 100000` |
+ * | site | was | ships now |
+ * | --- | --- | --- |
+ * | `flows/opportunity-approval.flow.ts` start condition (both the update and the insert twin share it) | `record.amount > 100000` | `record.amount >= LARGE_DEAL_AMOUNT` |
+ * | `flows/opportunity-won-alert.flow.ts` start condition | `record.amount > 100000` | `record.amount >= LARGE_DEAL_AMOUNT` |
+ * | `sharing/opportunity.sharing.ts` — sales-director rule | `record.amount >= 100000` | `record.amount >= LARGE_DEAL_AMOUNT` |
+ * | `sharing/opportunity.sharing.ts` — executive rule | `record.amount >= 100000` | `record.amount >= LARGE_DEAL_AMOUNT` |
  *
  * plus a second tier stated twice, in complementary polarity, for the director
  * step: `vars.oppRecord.amount > 500000` / `<= 500000`.
@@ -28,20 +29,40 @@
  * `test/deal-threshold-parity.test.ts` reads the shipped metadata back and
  * fails if any of them stops agreeing.
  *
- * ### ⚠️ The operators are deliberately NOT unified here — the value is
+ * ### The operator was converged after the value, and it took a ruling (#1087)
  *
- * The approval and won-alert sites cut at `> LARGE_DEAL_AMOUNT`; the two
- * sharing rules cut at `>= LARGE_DEAL_AMOUNT`. Converging the *value* leaves
- * that boundary disagreement exactly where it was, and it is real: an
- * opportunity at **exactly $100,000.00** — the single likeliest amount in a
- * CRM — is shared with the sales director and the executive, and is neither
- * routed for approval nor announced when it is won.
+ * #599 converged the *number* and deliberately left the comparisons alone: the
+ * approval and won-alert sites still cut at `> LARGE_DEAL_AMOUNT` while the two
+ * sharing rules cut at `>=`. That residue was real, not a rounding edge. An
+ * opportunity at **exactly $100,000.00** was shared with the sales director and
+ * the executive as a large open deal, and was neither routed for approval nor
+ * announced when it was won — visible to leadership, invisible to governance.
+ * A threshold set at a round number *attracts* deals priced at exactly that
+ * number ("a hundred K" is how deals get quoted), so the boundary case was
+ * plausibly the modal large deal rather than a measure-zero one.
  *
- * That is a product decision (does a $100K deal need manager approval?), not a
- * refactor, and #599's ruling scoped this card to the constant. So the drift is
- * not silently "fixed" by picking an operator here: it is pinned as a recorded
- * fact in the parity test and filed for triage. What this module guarantees is
- * that both operators now cut at the SAME NUMBER, and cannot drift apart again.
+ * Which way to converge was a product decision — it changes who signs what — so
+ * it was escalated rather than guessed, and #1087 ruled: **a deal at the line is
+ * a large deal.** Every site now cuts at `>=`. The decisive argument was not the
+ * boundary population but the mental model: governance narrower than visibility
+ * is the counter-intuitive direction, and the next author extending this system
+ * will assume the reverse (*if leadership can see it, someone signs it*). One
+ * line, and at or above it everything applies.
+ *
+ * So this module now guarantees two things about "large deal", not one: every
+ * consumer cuts at the same NUMBER, and every consumer cuts the same WAY.
+ * `test/deal-threshold-parity.test.ts` reads both back out of the shipped
+ * metadata — the compiled CEL of every flow condition and sharing rule — and
+ * fails if any site stops agreeing on either.
+ *
+ * If a reason ever appears for leadership to see a deal that needs no approval,
+ * that reason belongs **here**, next to the constant, and the split becomes a
+ * design instead of the drift it was. It is not written here because nothing in
+ * this repo makes that argument.
+ *
+ * `HIGH_VALUE_DEAL_AMOUNT` below is deliberately NOT part of this: its `> ` and
+ * `<= ` halves are one branch stated in complementary polarity, which must
+ * PARTITION rather than agree. Two operators there are the design.
  */
 
 /**

--- a/test/deal-threshold-parity.test.ts
+++ b/test/deal-threshold-parity.test.ts
@@ -28,15 +28,19 @@ import { HIGH_VALUE_DEAL_AMOUNT, LARGE_DEAL_AMOUNT } from '../src/objects/_thres
  * The companion guard is `test/docs-drift.test.ts`, which pins the published
  * prose in `src/docs/*.md` to the same compiled conditions.
  *
- * ### ⚠️ Scope, stated honestly: the VALUE is converged, the OPERATORS are not
+ * ### The VALUE and the OPERATOR are both converged (#599, then #1087)
  *
- * Two sites cut at `> LARGE_DEAL_AMOUNT` (approval entry, won alert) and two at
- * `>= LARGE_DEAL_AMOUNT` (both sharing rules). #599's ruling scoped this card to
- * the constant, and closing that boundary is a product decision — does a deal at
- * exactly $100,000.00 need manager approval? — not a refactor. So the
- * disagreement is not papered over here: it is asserted, with the population it
- * affects named, so that it is a recorded fact rather than a silent one. When
- * the product question is answered, the `BOUNDARY` block below is what changes.
+ * #599 converged the value and deliberately left the operators alone: approval
+ * entry and the won alert cut at `> LARGE_DEAL_AMOUNT`, both sharing rules at
+ * `>=`, so a deal at exactly $100,000.00 was shared with the sales director and
+ * the executive and was neither routed for approval nor announced when it was
+ * won — visible to leadership, invisible to governance.
+ *
+ * #1087 answered the product question that left open (**does a deal at exactly
+ * the threshold count as large? — yes**) and converged every site on `>=`. The
+ * `BOUNDARY` block below is what states that: one line, and above it — at it,
+ * inclusive — everything applies. It is the assertion that fails if a future
+ * author flips one site back, which is the same drift by another name.
  */
 
 type AnyRec = Record<string, any>;
@@ -57,7 +61,7 @@ const flowNamed = (name: string): AnyRec | undefined => flows.find((f) => f?.nam
  *
  * Both source sweeps below are about what the app EXECUTES. Prose is not only
  * allowed to quote the old literals, it should: the totality notes in both
- * flows explain why `record.amount > 100000` aborts on a null, and
+ * flows explain why `record.amount >= 100000` aborts on a null, and
  * `_thresholds.ts` records the whole four-way history. A sweep that could not
  * tell code from commentary would force those explanations to be deleted,
  * which trades a real drift guard for a worse-documented repo.
@@ -234,45 +238,99 @@ describe('one definition of the director tier', () => {
   });
 });
 
-// ── the boundary that is NOT converged, recorded rather than hidden ─────────
+// ── the boundary, converged and pinned ──────────────────────────────────────
 
-describe('BOUNDARY: the operators still disagree, and this is what it costs', () => {
+describe('BOUNDARY: every large-deal site cuts inclusively at the line (#1087)', () => {
   /**
-   * Converging the value leaves the operators where they were. This block is
-   * the honest statement of the residue: at EXACTLY `LARGE_DEAL_AMOUNT` a deal
-   * is visible to leadership and invisible to governance.
+   * The ruling on #1087: a deal at exactly `LARGE_DEAL_AMOUNT` **is** a large
+   * deal, so all five sites cut at `>=`. Before it, governance (approval entry,
+   * its insert twin, the won alert) cut at `>` while visibility (both sharing
+   * rules) cut at `>=`, and the $100,000.00 deal — plausibly the single
+   * commonest amount in a CRM, because a round threshold attracts deals priced
+   * at exactly that number — was shared with the sales director and the
+   * executive, not routed for approval, and not announced when it was won.
    *
-   * It is asserted, not merely commented, for two reasons. It makes the
-   * disagreement fail loudly if someone changes one operator and not the
-   * others — the same drift by another name — and it is the test that goes red
-   * when the product question is answered, which is exactly when someone should
-   * be reading this file.
+   * The operator is asserted per site rather than inferred from one of them: a
+   * single site flipped back is the same drift #599 closed on the value, and it
+   * is exactly as invisible. The truth table underneath then states what the
+   * operators MEAN, in the three rows that separate the two readings — the
+   * middle row is the whole card.
    */
   const opFor = (label: string): string => {
     const site = LARGE_DEAL_SITES.find((s) => s.label === label)!;
     return amountCuts(site.source() ?? '').find((c) => c.scope === site.scope)!.op;
   };
 
-  it('governance cuts strictly above the line; visibility cuts at it', () => {
-    expect(opFor('approval entry gate (afterUpdate)')).toBe('>');
-    expect(opFor('approval entry gate (afterInsert twin)')).toBe('>');
-    expect(opFor('won-deal alert')).toBe('>');
-    expect(opFor('sharing: sales director')).toBe('>=');
-    expect(opFor('sharing: executive')).toBe('>=');
-  });
+  it.each(LARGE_DEAL_SITES.map((s) => [s.label] as const))(
+    '%s cuts at `>=`, not `>`',
+    (label) => {
+      expect(
+        opFor(label),
+        `${label} cuts at "${opFor(label)}" — every large-deal site must cut at ">=" (#1087). ` +
+          'One site on ">" puts a deal at exactly the threshold on the wrong side of that ' +
+          'site alone, which is how "visible to leadership, invisible to governance" happened.',
+      ).toBe('>=');
+    },
+  );
 
-  it('names the population that falls in the gap', () => {
-    // A deal at exactly $100,000.00 — plausibly the single commonest amount in
-    // a CRM — is shared with the director and the executive, is NOT routed for
-    // approval, and is NOT announced when it is won. Recorded as a truth table
-    // so the gap is a row someone can read, not a sentence someone can skip.
-    const shared = (amount: number) => amount >= LARGE_DEAL_AMOUNT;
-    const governed = (amount: number) => amount > LARGE_DEAL_AMOUNT;
+  it('a deal AT the line is both shared and governed; below it, neither', () => {
+    // Derived from the SHIPPED operators, not restated: `shared` / `governed`
+    // are built out of what the metadata cuts at, so the table cannot stay
+    // green while a flow flips back — which is what makes it a truth table
+    // about this app rather than about JavaScript's `>=`.
+    const cutAt = (label: string) => {
+      const op = opFor(label);
+      return (amount: number) => (op === '>=' ? amount >= LARGE_DEAL_AMOUNT : amount > LARGE_DEAL_AMOUNT);
+    };
+    const shared = (amount: number) =>
+      cutAt('sharing: sales director')(amount) && cutAt('sharing: executive')(amount);
+    const governed = (amount: number) =>
+      cutAt('approval entry gate (afterUpdate)')(amount) &&
+      cutAt('approval entry gate (afterInsert twin)')(amount) &&
+      cutAt('won-deal alert')(amount);
     const at = LARGE_DEAL_AMOUNT;
 
-    expect({ shared: shared(at), governed: governed(at) }).toEqual({ shared: true, governed: false });
-    expect({ shared: shared(at + 1), governed: governed(at + 1) }).toEqual({ shared: true, governed: true });
-    expect({ shared: shared(at - 1), governed: governed(at - 1) }).toEqual({ shared: false, governed: false });
+    // The row the card exists for: $100,000 is large for BOTH, or the fix did
+    // not land. Accepted and intended consequence — a deal at exactly the
+    // threshold now requires manager approval and fires the won-deal alert.
+    expect({ amount: at, shared: shared(at), governed: governed(at) }).toEqual({
+      amount: at, shared: true, governed: true,
+    });
+    expect({ amount: at + 1, shared: shared(at + 1), governed: governed(at + 1) }).toEqual({
+      amount: at + 1, shared: true, governed: true,
+    });
+    expect({ amount: at - 1, shared: shared(at - 1), governed: governed(at - 1) }).toEqual({
+      amount: at - 1, shared: false, governed: false,
+    });
+  });
+
+  it('visibility and governance answer the same at every amount around the line', () => {
+    // The property behind the table, stated once so it survives the next
+    // threshold change: "large deal" is ONE predicate. Sweeping a window rather
+    // than the three rows above catches an operator pair that agrees at the
+    // boundary and disagrees elsewhere (e.g. a `>` paired with a value one
+    // lower), which the three-row table alone would pass.
+    const disagreements: string[] = [];
+    for (const amount of [
+      LARGE_DEAL_AMOUNT - 2, LARGE_DEAL_AMOUNT - 1, LARGE_DEAL_AMOUNT,
+      LARGE_DEAL_AMOUNT + 1, LARGE_DEAL_AMOUNT + 2,
+    ]) {
+      const verdicts = LARGE_DEAL_SITES.map((site) => {
+        const cut = amountCuts(site.source() ?? '').find((c) => c.scope === site.scope)!;
+        const large = cut.op === '>=' ? amount >= cut.value : amount > cut.value;
+        return { label: site.label, large };
+      });
+      if (new Set(verdicts.map((v) => v.large)).size > 1) {
+        disagreements.push(
+          `${amount}: ${verdicts.map((v) => `${v.label}=${v.large ? 'large' : 'not large'}`).join(', ')}`,
+        );
+      }
+    }
+    expect(
+      disagreements,
+      'these amounts are a large deal to some sites and not to others:\n  ' +
+        disagreements.join('\n  '),
+    ).toEqual([]);
   });
 });
 

--- a/test/docs-drift.test.ts
+++ b/test/docs-drift.test.ts
@@ -65,7 +65,7 @@ const cap = (file: string, re: RegExp): string => {
  *
  * The approval and won-alert amounts stopped being source literals in #599 —
  * they are interpolated from `src/objects/_thresholds.ts`, so the file now
- * reads `record.amount > ${LARGE_DEAL_AMOUNT}` and a regex over the text finds
+ * reads `record.amount >= ${LARGE_DEAL_AMOUNT}` and a regex over the text finds
  * no digits to capture. Reading the compiled condition is not a workaround for
  * that, it is strictly better: `P` interpolates at build time, so this sees the
  * number the deployed flow actually cuts at, whatever spelling produced it —
@@ -117,7 +117,14 @@ const RULES: Rule[] = [
     // broke the moment #633 inserted the `has(...)` / `!= null` totality
     // guards between the two — a drift detector should key on the value's own
     // scope, not on whatever happens to sit next to it.
-    extract: () => capCel('opportunity_approval', /record\.amount > (\d+)/),
+    //
+    // The OPERATOR is spelled out (`>=` since #1087) rather than made optional.
+    // A `>=?` would keep matching through an operator flip and quietly publish
+    // the same number under a changed meaning; as written, flipping the gate
+    // fails here as "pattern not found in the conditions of …", which is the
+    // right kind of loud — the published table in `crm_sales.md` / `crm_admin.md`
+    // states the operator as well as the value, and both have to move together.
+    extract: () => capCel('opportunity_approval', /record\.amount >= (\d+)/),
     display: money,
     docs: ['crm_sales.md', 'crm_admin.md'],
   },
@@ -129,7 +136,8 @@ const RULES: Rule[] = [
   },
   {
     label: 'won-deal alert threshold',
-    extract: () => capCel('opportunity_won_alert', /record\.amount > (\d+)/),
+    // `>=` since #1087, for the reason spelled out on the manager rule above.
+    extract: () => capCel('opportunity_won_alert', /record\.amount >= (\d+)/),
     display: money,
     docs: ['crm_sales.md', 'crm_admin.md'],
   },

--- a/test/flow-record-change.test.ts
+++ b/test/flow-record-change.test.ts
@@ -312,11 +312,14 @@ describe('opportunity_approval — start condition', () => {
       ['afterInsert twin', OpportunityApprovalOnCreateFlow],
     ] as const;
 
-    it.each(GATES)('%s routes a deal at EXACTLY $100,000 for approval', (_label, flow) => {
+    // No `$` in these titles: vitest reads `$name` in an `it.each` template as
+    // an object-property interpolation, so `$100,000` renders as
+    // "undefined,000" and the failure names an amount nobody wrote.
+    it.each(GATES)('%s routes a deal at EXACTLY 100,000 for approval', (_label, flow) => {
       expect(startConditionHolds(flow as unknown as Rec, openDeal(100_000))).toBe(true);
     });
 
-    it.each(GATES)('%s leaves $99,999 alone', (_label, flow) => {
+    it.each(GATES)('%s leaves 99,999 alone', (_label, flow) => {
       expect(startConditionHolds(flow as unknown as Rec, openDeal(99_999))).toBe(false);
     });
   });

--- a/test/flow-record-change.test.ts
+++ b/test/flow-record-change.test.ts
@@ -45,7 +45,7 @@ describe('opportunity_won_alert — start condition', () => {
     id: 'o1', name: 'Big Deal', stage: 'closed_won', amount: 250_000, owner_id: 'rep1', ...over,
   });
 
-  it('fires on the TRANSITION into closed_won above $100K', () => {
+  it('fires on the TRANSITION into closed_won at or above $100K', () => {
     expect(startConditionHolds(OpportunityWonAlertFlow, {
       record: opp(), previous: { stage: 'negotiation' },
     })).toBe(true);
@@ -59,8 +59,19 @@ describe('opportunity_won_alert — start condition', () => {
     })).toBe(false);
   });
 
-  it('ignores deals at or below the $100K threshold', () => {
-    for (const amount of [100_000, 50_000]) {
+  it('fires at EXACTLY the $100K threshold (#1087)', () => {
+    // The boundary case this flow used to miss. It cut at `>` while both
+    // sharing rules cut at `>=`, so a deal at exactly $100,000 was shared with
+    // leadership as a large deal and then closed without the large-deal alert.
+    // Asserted against the engine, not against the condition string, because
+    // the string is what the parity test reads — this is the behaviour.
+    expect(startConditionHolds(OpportunityWonAlertFlow, {
+      record: opp({ amount: 100_000 }), previous: { stage: 'negotiation' },
+    }), 'a deal at exactly $100,000 must alert on win').toBe(true);
+  });
+
+  it('ignores deals below the $100K threshold', () => {
+    for (const amount of [99_999, 50_000]) {
       expect(startConditionHolds(OpportunityWonAlertFlow, {
         record: opp({ amount }), previous: { stage: 'negotiation' },
       }), `amount ${amount} should not alert`).toBe(false);
@@ -283,6 +294,31 @@ describe('opportunity_approval — start condition', () => {
       previous: { id: 'o1', amount: 750_000, approval_status: 'pending', stage: 'negotiation' },
     };
     expect(startConditionHolds(OpportunityApprovalFlow, pending)).toBe(false);
+  });
+
+  describe('the large-deal line is inclusive (#1087)', () => {
+    // The governance half of the card's truth table, measured through the
+    // engine. The parity test reads the operator out of the shipped condition
+    // string; this asserts what that operator DOES, on both the update gate and
+    // its insert twin — a deal born at exactly $100,000 has to enter approval
+    // for the same reason one edited up to it does.
+    const openDeal = (amount: number): Record<string, unknown> => ({
+      record: { id: 'o1', amount, approval_status: 'not_required', stage: 'negotiation' },
+      previous: { id: 'o1', amount, approval_status: 'not_required', stage: 'negotiation' },
+    });
+
+    const GATES = [
+      ['afterUpdate gate', OpportunityApprovalFlow],
+      ['afterInsert twin', OpportunityApprovalOnCreateFlow],
+    ] as const;
+
+    it.each(GATES)('%s routes a deal at EXACTLY $100,000 for approval', (_label, flow) => {
+      expect(startConditionHolds(flow as unknown as Rec, openDeal(100_000))).toBe(true);
+    });
+
+    it.each(GATES)('%s leaves $99,999 alone', (_label, flow) => {
+      expect(startConditionHolds(flow as unknown as Rec, openDeal(99_999))).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #1087
Fixes #1126

Implements the ruling on #1087 — **Option A, converge on `>=`** — verbatim as scoped there. The value is untouched and `HIGH_VALUE_DEAL_AMOUNT`'s two-polarity pair is untouched.

## What changed

| site | before | after |
| --- | --- | --- |
| `opportunity_approval` entry gate | `record.amount > LARGE_DEAL_AMOUNT` | `>=` |
| `opportunity_approval_on_create` (insert twin) | inherited `>` | inherited `>=` |
| `opportunity_won_alert` | `record.amount > LARGE_DEAL_AMOUNT` | `>=` |
| both opportunity sharing rules | `>=` | unchanged |

**Accepted and intended consequence:** a deal at exactly $100,000 now requires manager approval and fires the won-deal alert. That is the point of the card.

### PM measurement corrected — one condition string, not two

The dispatch expected the approval flow's `_on_create` twin to carry its own copy of the condition. It does not. `OpportunityApprovalOnCreateFlow` is built by spreading the parent and re-binding only the start node's `triggerType`:

```ts
nodes: OpportunityApprovalFlow.nodes.map((n) =>
  n.id === 'start' ? { ...n, config: { ...n.config, triggerType: 'record-after-create' } } : n,
)
```

so `config.condition` is the same object and there is exactly **one** literal to edit — `git grep -n LARGE_DEAL_AMOUNT origin/main -- src/` returns one hit in that file, not two. The twin is nonetheless verified independently: the parity test reads it out of the compiled stack under its own name, and this PR adds engine-level boundary assertions against both flows.

## Two sites the dispatch did not name, found by measurement

Both would have gone red in CI:

1. **`test/docs-drift.test.ts`** extracts the published amounts with `capCel('opportunity_approval', /record\.amount > (\d+)/)`. That pattern does not match `>=`, and a miss **throws** `drift test out of date: pattern ... not found` rather than failing an assertion. Both affected rules now spell `>=`. The operator is written out rather than made optional (`>=?`): an operator flip should fail loudly here too, because the published tables state the operator as well as the value.
2. **`test/flow-record-change.test.ts`** asserted `ignores deals at or below the $100K threshold` over `[100_000, 50_000]` — a direct pin of the defect. Split into a boundary case that must now fire and a below-the-line case over `[99_999, 50_000]`.

## The new assertion — the deliverable

`test/deal-threshold-parity.test.ts`'s `BOUNDARY` block is rewritten from "the operators still disagree, and this is what it costs" to the converged truth table:

- every one of the five sites is asserted to cut at `>=`, per site, so a single site flipped back names itself
- the truth table's three rows, with `shared` / `governed` **derived from the shipped operators** rather than restated in JavaScript — so the table cannot stay green while a flow drifts
- a window sweep (`LARGE_DEAL_AMOUNT ± 2`) asserting all five sites agree at every amount around the line, which catches an operator/value pair that agrees at the boundary and disagrees elsewhere

Engine-level coverage was added alongside the string-level parity: `test/flow-record-change.test.ts` now runs the real CEL through the flow harness for both approval gates and the won alert at exactly 100,000 and at 99,999.

## Reverse verification — predicted red, measured red

Predicted direction: the new assertions fail against `origin/main`'s operators and pass after. Taken out with `git checkout origin/main -- src/flows/opportunity-approval.flow.ts src/flows/opportunity-won-alert.flow.ts` (never `git stash` — shared stack), then restored from HEAD.

**With `origin/main`'s operators, the new tests only:**

```
 Test Files  3 failed (3)
      Tests  10 failed | 134 passed (144)

 FAIL test/deal-threshold-parity.test.ts > BOUNDARY: every large-deal site cuts inclusively at the line (#1087)
   > approval entry gate (afterUpdate) cuts at `>=`, not `>`
 AssertionError: approval entry gate (afterUpdate) cuts at ">" — every large-deal site
 must cut at ">=" (#1087). One site on ">" puts a deal at exactly the threshold on the
 wrong side of that site alone, which is how "visible to leadership, invisible to
 governance" happened.: expected '>' to be '>='
   > approval entry gate (afterInsert twin) cuts at `>=`, not `>`      (same)
   > won-deal alert cuts at `>=`, not `>`                              (same)
   > a deal AT the line is both shared and governed; below it, neither
   > visibility and governance answer the same at every amount around the line
 AssertionError: these amounts are a large deal to some sites and not to others

 FAIL test/docs-drift.test.ts > manager approval threshold: docs match the flow source
 Error: drift test out of date: pattern /record\.amount >= (\d+)/ not found in the
 conditions of "opportunity_approval"
 FAIL test/docs-drift.test.ts > won-deal alert threshold: docs match the flow source   (same)

 FAIL test/flow-record-change.test.ts > fires at EXACTLY the $100K threshold (#1087)
 AssertionError: a deal at exactly $100,000 must alert on win: expected false to be true
 FAIL ... > afterUpdate gate routes a deal at EXACTLY 100,000 for approval
 FAIL ... > afterInsert twin routes a deal at EXACTLY 100,000 for approval
```

Ten failures, every one of them a new or updated assertion, nothing else. **With the fix restored:**

```
 Test Files  99 passed (99)
      Tests  2449 passed | 1 skipped (2450)
```

## Docs

`src/docs/crm_sales.md` and `src/docs/crm_admin.md` now read "$100,000 or more" where they read "> $100,000", and the sales page says a deal's amount "reaches" rather than "crosses" the line. Both still contain the literal `$100,000` that `docs-drift.test.ts` requires.

`src/objects/_thresholds.ts` is rewritten too (**Fixes #1126**, folded in on the PM's ruling after this PR was opened). The module documented the operator split as a deliberate, still-open product question and listed the two flow rows as `record.amount > 100000` — both abolished by this change. Left as-is it would be the file an author opens before adding a sixth consumer of the constant, telling them governance deliberately cuts narrower than visibility, with no gate able to go red on it. It now states the converged rule and keeps the drift as history: #599 converged the value, #1087 converged the operator, and `HIGH_VALUE_DEAL_AMOUNT`'s complementary pair is explicitly excluded from the "one operator" rule, because there two operators are the design. The constant itself is unchanged.

## Out of scope, filed

- **#1127** — 21 product pages in `content/docs/**` (three locales) plus `docs/feature-inventory.md` and `scripts/demo-staff.ts` state "> $100K", two of them quoting the CEL verbatim. No gate reads the threshold cell on those pages. That surface belongs to another card this round and is sequenced separately by the PM; deliberately untouched here.

## Local gates

Re-run after the `_thresholds.ts` patch: `pnpm validate` ✓ · `pnpm typecheck` ✓ · `pnpm build` ✓ · `pnpm hygiene` ✓ · `pnpm lint` ✓ (0 errors) · `pnpm lint:i18n-gate` ✓ · `pnpm test` ✓ 2449 passed / 1 skipped. Changeset: `.changeset/large-deal-boundary-inclusive.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012caozke9UaxYdVLaudxJvv)_