### PR TITLE
fix(quote): carry an accepted quote's payment_terms onto the drafted contract

### DIFF
--- a/.changeset/quote-accepted-carries-payment-terms.md
+++ b/.changeset/quote-accepted-carries-payment-terms.md
@@ -1,0 +1,26 @@
+---
+'hotcrm': patch
+---
+
+An accepted quote's payment terms now reach the contract it drafts. Until now
+they did not: `quote_on_accepted` built the draft contract from the quote's
+account, contact, opportunity, owner, value, term months and dates — but never
+its `payment_terms` — so every auto-drafted contract took
+`crm_contract.payment_terms`'s own option default of **Net 30**, whatever the
+customer had negotiated. A deal closed on Due on Receipt, Net 15, Net 60 or
+Net 90 produced a contract quietly saying 30 days, with nothing on the record
+marking the value as a default rather than a decision.
+
+The value does not stay on the contract, either: the billing hand-off sends the
+contract's `payment_terms` to the billing system when the contract is activated,
+so the wrong term became the invoicing term. And the rep who negotiated it could
+not correct it — Sales Reps have no edit right on contracts, so every occurrence
+needed a manager or an administrator.
+
+Quote and Contract have shared one payment-terms vocabulary since #490,
+including `due_on_receipt`, specifically so that an accepted quote's terms could
+be carried over intact. That was the stated reason for sharing it; the copy that
+justified it had never been written.
+
+Nothing changes for a quote that never chose a term: the field stays absent on
+the draft and the contract's own Net 30 default applies, exactly as before.

--- a/src/objects/_picklists.ts
+++ b/src/objects/_picklists.ts
@@ -79,6 +79,13 @@ export const LEAD_SOURCE_OPTIONS: SelectOption[] = [
  * Payment Terms — Quote + Contract. Superset (incl. `due_on_receipt`,
  * formerly Quote-only): an accepted quote's terms carry over to the contract,
  * so the contract vocabulary must cover every quote value.
+ *
+ * The carry-over is `quote_on_accepted` in `src/objects/quote.hook.ts`, named
+ * here because this rationale spent its first months unenforced (#873): the
+ * hook drafted the contract without `payment_terms`, so every accepted quote
+ * produced a contract on the `net_30` option default below regardless of what
+ * was negotiated — a shared vocabulary justified by a copy that did not exist.
+ * A comment that names its enforcer can be checked; this one could not be.
  */
 export const PAYMENT_TERMS_OPTIONS: SelectOption[] = [
   { label: 'Net 15', value: 'net_15' },

--- a/src/objects/contract.object.ts
+++ b/src/objects/contract.object.ts
@@ -143,7 +143,11 @@ export const Contract = ObjectSchema.create({
       label: 'Payment Terms',
       group: 'value',
       // Canonical set shared with Quote (#490): an accepted quote's terms
-      // (incl. due_on_receipt) must survive the copy onto the contract.
+      // (incl. due_on_receipt) must survive the copy onto the contract. That
+      // copy is `quote_on_accepted` (src/objects/quote.hook.ts), which did not
+      // make it until #873 — until then this field took the `net_30` option
+      // default on every auto-drafted contract. It still does when the quote
+      // itself carried no term, which is the intended fall-through, not a gap.
       options: [...PAYMENT_TERMS_OPTIONS],
     }),
     

--- a/src/objects/quote.hook.ts
+++ b/src/objects/quote.hook.ts
@@ -9,7 +9,9 @@ import type { HookApi } from './_hook-api';
  * - Defaults `expiration_date` to `quote_date + 30 days` when missing.
  * - Freezes quotes once `accepted` or `expired` — against USER edits only: a
  *   write that is purely the engine clearing a link is let through (#720).
- * - On `accepted`, drafts a contract and pushes the linked opportunity to `closed_won`.
+ * - On `accepted`, drafts a contract — carrying the quote's negotiated
+ *   `payment_terms` onto it (#873) — and pushes the linked opportunity to
+ *   `closed_won`.
  */
 
 // NB: helpers used by handlers are declared INSIDE each handler — L2 hook
@@ -178,6 +180,32 @@ const quoteAccepted: Hook = {
           ? (previous.total_price as number)
           : 0;
 
+    /**
+     * The payment terms the customer actually negotiated (#873).
+     *
+     * `_picklists.ts` justifies Quote and Contract sharing one `payment_terms`
+     * vocabulary with "an accepted quote's terms carry over to the contract",
+     * and `contract.object.ts` repeats it — but nothing carried them: the
+     * drafted contract took `crm_contract.payment_terms`'s own option default
+     * `net_30` on every accepted quote, including one negotiated at
+     * `due_on_receipt`. The value is not cosmetic downstream either — the
+     * contract's `payment_terms` is one of the fields
+     * `src/flows/billing-handoff.flow.ts` POSTs to billing when the contract
+     * activates, so a defaulted term becomes an invoicing term.
+     *
+     * Read like `totalPrice` above: the patch's value when the accepting write
+     * carried one, else the value already on the quote. A quote that never
+     * chose a term yields `undefined`, which drops the key (see `pickId`) and
+     * lets the contract's own default apply — exactly today's behaviour for
+     * that case, so this copy is strictly additive.
+     */
+    const paymentTerms =
+      typeof input.payment_terms === 'string' && input.payment_terms
+        ? input.payment_terms
+        : typeof previous?.payment_terms === 'string' && previous.payment_terms
+          ? (previous.payment_terms as string)
+          : undefined;
+
     const today = new Date().toISOString().slice(0, 10);
     const months = 12;
 
@@ -198,6 +226,10 @@ const quoteAccepted: Hook = {
     if (contactId) contract.crm_contact = contactId;
     if (opportunityId) contract.crm_opportunity = opportunityId;
     if (ownerId) contract.owner_id = ownerId;
+    // Same idiom for the same reason: written only when the quote HAS a term,
+    // so "the quote chose nothing" stays an absent key rather than becoming a
+    // value the contract's default would otherwise have supplied.
+    if (paymentTerms) contract.payment_terms = paymentTerms;
 
     // The two legs are INDEPENDENT, and this is the other half of #714: they
     // used to be one straight-line sequence, so anything that made the contract

--- a/test/quote-accepted-payment-terms.test.ts
+++ b/test/quote-accepted-payment-terms.test.ts
@@ -1,0 +1,264 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import quoteHooks from '../src/objects/quote.hook';
+import { Contract } from '../src/objects/contract.object';
+import { Quote } from '../src/objects/quote.object';
+import { PAYMENT_TERMS_OPTIONS } from '../src/objects/_picklists';
+import type { HookApi } from '../src/objects/_hook-api';
+import { makeHarness, makeCtx, hookNamed, type Rec } from './helpers/hook-harness';
+import { makeSandboxEngine, runHookBody } from './helpers/action-sandbox';
+
+/**
+ * An accepted quote's payment terms reach the contract it drafts (#873).
+ *
+ * ### What was wrong
+ *
+ * `_picklists.ts` declares `PAYMENT_TERMS_OPTIONS` a set shared by Quote and
+ * Contract, and justifies the sharing in so many words: *"an accepted quote's
+ * terms carry over to the contract, so the contract vocabulary must cover every
+ * quote value."* `crm_contract.payment_terms` repeats the same rationale. No
+ * such carry-over existed. `quote_on_accepted` drafted the contract from
+ * `status`, the term months, the dates, the value, the type, the description
+ * and the four lookups — and never `payment_terms` — so the contract took
+ * `crm_contract.payment_terms`'s own option default `net_30`, on every accepted
+ * quote, whatever the customer had negotiated.
+ *
+ * That is a rationale the code did not honour, and it was expensive in one
+ * direction only: a quote negotiated at `due_on_receipt` (or net_15 / net_60 /
+ * net_90) produced a contract silently saying 30 days, with nothing marking the
+ * value as defaulted. The rep who closed the deal cannot fix it either —
+ * `sales-rep.profile.ts` gives them `allowEdit: false` on `crm_contract` — and
+ * the value does not stay put: `src/flows/billing-handoff.flow.ts` POSTs the
+ * contract's `payment_terms` to the billing system when the contract activates,
+ * so the defaulted term becomes an invoicing term.
+ *
+ * ### What is asserted here
+ *
+ * 1. the negotiated term is carried — the case the card is about;
+ * 2. a quote that chose NO term still lands on the contract's own default, so
+ *    the change is strictly additive (the maintainer's Q2 ruling: pass through,
+ *    do not invent a way to distinguish "chose net_30" from "chose nothing");
+ * 3. the vocabulary really is a superset — every quote value is accepted by
+ *    `crm_contract`, measured against a real ObjectQL rather than read off the
+ *    two `options:` arrays;
+ * 4. the shipped body does the same inside QuickJS, where `undefined` does not
+ *    survive the JSON hop.
+ *
+ * Cases 1 and 2 are asserted twice: once on the document the hook hands the
+ * engine (a harness cannot tell an omitted key from a defaulted one) and once
+ * on the row a real `crm_contract` insert produces (a document cannot tell you
+ * what the engine's default actually is). Neither layer alone can state the
+ * claim.
+ *
+ * ⚠️ Not this file's subject: #714 — the same hook once passed boolean `false`
+ * into a lookup and the whole chain died. That is the chain not running; this
+ * is the chain running and dropping a value. The fixtures below always give the
+ * quote a contact so #714's refusal path (`crm_contract.crm_contact` is
+ * required while `crm_quote.crm_contact` is not) never masks what is measured.
+ */
+
+type AnyRec = Record<string, any>;
+
+const hook = hookNamed(quoteHooks, 'quote_on_accepted');
+const USER = { id: 'user_1' };
+
+/** Every value a quote can hold, straight from the shared vocabulary. */
+const QUOTE_TERMS = PAYMENT_TERMS_OPTIONS.map((o) => o.value);
+
+/** The value `crm_contract.payment_terms` falls to when nothing is written. */
+const CONTRACT_DEFAULT = 'net_30';
+
+/**
+ * Accept a quote and return the contract document the hook handed the engine.
+ *
+ * `quote` is the accepting write's payload, `stored` the row it updates — the
+ * hook reads a field from the patch first and the previous row second, and a
+ * real acceptance is usually a `{ status }` patch over a quote whose terms were
+ * set long before, so both sides have to be exercised.
+ */
+const draftFor = async (quote: Rec, stored: Rec = {}): Promise<Rec> => {
+  const h = makeHarness({ crm_contract: [], crm_opportunity: [] });
+  await hook.handler(makeCtx({
+    event: 'afterUpdate',
+    input: { id: 'q1', status: 'accepted', total_price: 1_000, crm_account: 'acc1', crm_contact: 'con1', ...quote },
+    previous: { id: 'q1', status: 'presented', ...stored },
+    user: USER,
+    api: h.api as HookApi,
+  }));
+  const [call] = h.callsFor('crm_contract', 'insert');
+  expect(call, 'the hook drafted no contract at all').toBeTruthy();
+  return call!.args[0] as Rec;
+};
+
+describe('the negotiated payment terms reach the drafted contract', () => {
+  it('carries `due_on_receipt` — the case the shared vocabulary was created for', async () => {
+    // The whole point of `due_on_receipt` being in the CONTRACT's options.
+    const doc = await draftFor({}, { payment_terms: 'due_on_receipt' });
+    expect(
+      doc.payment_terms,
+      'a quote negotiated at due_on_receipt drafted a contract on the net_30 default',
+    ).toBe('due_on_receipt');
+  });
+
+  it.each(QUOTE_TERMS)('carries `%s` off the quote it was already stored on', async (term) => {
+    expect((await draftFor({}, { payment_terms: term })).payment_terms).toBe(term);
+  });
+
+  it('prefers the accepting write’s own value when it carries one', async () => {
+    // A rep who re-terms the quote in the same write that accepts it.
+    const doc = await draftFor({ payment_terms: 'net_90' }, { payment_terms: 'net_15' });
+    expect(doc.payment_terms).toBe('net_90');
+  });
+});
+
+describe('a quote that chose no terms is left exactly as it is today', () => {
+  it('writes NO payment_terms key at all', async () => {
+    const doc = await draftFor({}, {});
+    expect(
+      Object.prototype.hasOwnProperty.call(doc, 'payment_terms'),
+      'payment_terms must be OMITTED so the contract’s own default applies',
+    ).toBe(false);
+  });
+
+  it.each([
+    ['an empty string', ''],
+    ['null', null],
+    ['a non-string', 42],
+  ])('writes no key for %s either — never a junk value', async (_label, value) => {
+    const doc = await draftFor({}, { payment_terms: value });
+    expect(Object.prototype.hasOwnProperty.call(doc, 'payment_terms')).toBe(false);
+  });
+});
+
+// ─────────────────────────── the engine's own verdict, not the harness's ──
+
+describe('what a real crm_contract does with those documents', () => {
+  /**
+   * The harness stores whatever it is handed, so it can say the key is absent
+   * but never what absence RESOLVES to — and the claim under test is about a
+   * default. These four verdicts are measured against a real ObjectQL carrying
+   * the app's real `crm_contract` metadata, the same way #714's are.
+   */
+  const stub = (name: string) => ({
+    name,
+    fields: { id: { type: 'text' }, name: { type: 'text' }, stage: { type: 'text' } },
+  });
+
+  let ql: AnyRec;
+  let api: AnyRec;
+
+  beforeAll(async () => {
+    ql = await ObjectQL.create({
+      datasources: { default: new InMemoryDriver({ persistence: false }) },
+      objects: {
+        crm_contract: Contract as never,
+        crm_account: stub('crm_account'),
+        crm_contact: stub('crm_contact'),
+        crm_opportunity: stub('crm_opportunity'),
+        sys_user: stub('sys_user'),
+      } as never,
+    });
+    api = ql.createContext({ isSystem: true });
+  }, 60_000);
+
+  afterAll(async () => { await ql?.close(); });
+
+  const insertDraftFor = async (stored: Rec): Promise<Rec> =>
+    api.object('crm_contract').insert(await draftFor({}, stored));
+
+  it('stores the negotiated term instead of the default', async () => {
+    const row = await insertDraftFor({ payment_terms: 'due_on_receipt' });
+    expect(row.payment_terms).toBe('due_on_receipt');
+    // Read back rather than trusting the insert's echo — a default applied on
+    // read would look identical on the returned row alone.
+    const read = await api.object('crm_contract').findOne({ where: { id: row.id } });
+    expect(read?.payment_terms).toBe('due_on_receipt');
+  });
+
+  it('falls to net_30 when the quote carried nothing — the unchanged case', async () => {
+    // This is what EVERY accepted quote used to produce, and it is still what a
+    // term-less one produces. Pinned so the "strictly additive" claim is a
+    // measurement rather than an argument.
+    const row = await insertDraftFor({});
+    expect(row.payment_terms).toBe(CONTRACT_DEFAULT);
+  });
+
+  it.each(QUOTE_TERMS)('accepts `%s` — the superset claim, measured', async (term) => {
+    const row = await insertDraftFor({ payment_terms: term });
+    expect(row.payment_terms).toBe(term);
+  });
+
+  it('rejects a value outside the vocabulary, so the case above is not vacuous', async () => {
+    // If the select were unenforced, "the contract accepts every quote value"
+    // would be true of any string and would prove nothing about the superset.
+    const doc = { ...(await draftFor({}, {})), payment_terms: 'net_45' };
+    await expect(api.object('crm_contract').insert(doc)).rejects.toThrow(
+      /Payment Terms must be one of: net_15, net_30, net_60, net_90, due_on_receipt/,
+    );
+  });
+});
+
+// ───────────────────────────────── the same body, inside the real sandbox ──
+
+describe('the SHIPPED body behaves the same inside QuickJS', () => {
+  /**
+   * `hook.handler(ctx)` above keeps its closure; the runtime ships a lowered,
+   * body-only source across a JSON boundary — where `undefined` does not
+   * survive at all. Both halves of this change depend on that boundary: the
+   * carried value must cross it, and the absent one must drop the key.
+   */
+  const acceptInSandbox = async (previous: Rec): Promise<Rec> => {
+    const sandbox = makeSandboxEngine({ crm_contract: [], crm_opportunity: [] });
+    await runHookBody(hook, {
+      event: 'afterUpdate',
+      input: { id: 'q_1', status: 'accepted', crm_account: 'acc_1', crm_contact: 'con_1', total_price: 1_000 },
+      previous: { id: 'q_1', status: 'presented', ...previous },
+      user: USER,
+      engine: sandbox,
+    });
+    const [doc] = sandbox.inserted('crm_contract');
+    expect(doc, 'the body never reached the contract insert').toBeTruthy();
+    return doc!;
+  };
+
+  it('carries due_on_receipt across the VM boundary', async () => {
+    expect((await acceptInSandbox({ payment_terms: 'due_on_receipt' })).payment_terms)
+      .toBe('due_on_receipt');
+  });
+
+  it('sends no payment_terms key when the quote has none', async () => {
+    const doc = await acceptInSandbox({});
+    expect(Object.prototype.hasOwnProperty.call(doc, 'payment_terms')).toBe(false);
+  });
+});
+
+// ─────────────────────────────────── the claim the comments make, pinned ──
+
+describe('the rationale the shared vocabulary is justified by', () => {
+  /**
+   * #873 was filed against a COMMENT: two files justified sharing the
+   * vocabulary with a copy that did not exist. Reinstating the copy without
+   * pinning it leaves the next reader in the same position — a stated invariant
+   * with nothing holding it up.
+   */
+  it('both objects really do declare the same vocabulary', () => {
+    const values = (o: AnyRec): string[] => o.fields.payment_terms.options.map((x: AnyRec) => x.value);
+    expect(values(Contract as AnyRec)).toEqual(QUOTE_TERMS);
+    expect(values(Quote as AnyRec)).toEqual(QUOTE_TERMS);
+  });
+
+  it('names the hook that performs the carry-over, in both places that claim it', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const dir = join(process.cwd(), 'src', 'objects');
+    for (const file of ['_picklists.ts', 'contract.object.ts']) {
+      expect(
+        readFileSync(join(dir, file), 'utf8'),
+        `${file} claims an accepted quote's terms carry over but does not say what performs it`,
+      ).toContain('quote_on_accepted');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #873

`_picklists.ts` justifies Quote and Contract sharing one `PAYMENT_TERMS_OPTIONS` vocabulary — `due_on_receipt` included — with a stated reason: *"an accepted quote's terms carry over to the contract, so the contract vocabulary must cover every quote value."* `crm_contract.payment_terms` repeats it. **No such carry-over existed.** `quote_on_accepted` drafted the contract from the quote's account, contact, opportunity, owner, value, term months, dates, type and description, and never its `payment_terms` — so every auto-drafted contract took the field's own `net_30` option default, whatever the customer had negotiated.

This PR adds the copy the comments were already claiming.

## The premise, re-measured against `origin/main`

The card was filed 2026-08-06 and its line numbers had moved, so each of its claims was checked rather than assumed:

| claim | verdict |
| --- | --- |
| the draft happens in `quote_on_accepted` and omits `payment_terms` | **holds** — the field list is now at `quote.hook.ts:188-200` (card said 137-152); `payment_terms` absent |
| `crm_contract.payment_terms` defaults to `net_30` | **holds**, with a nuance: there is no `defaultValue:` on the field — the default comes from `{ value: 'net_30', default: true }` inside the shared option list, and the engine applies it. Measured: a contract inserted with no `payment_terms` stores `net_30`, and re-reads as `net_30` |
| the contract vocabulary is a superset of the quote's | **holds** — both fields spread the same `PAYMENT_TERMS_OPTIONS` array, and all five values were inserted into a real `crm_contract` successfully. A sixth value (`net_45`) is refused, so that result is not vacuous |
| the two comments become true once the copy exists | **holds**, and both were amended anyway — see below |

One extra fact found while measuring, which raises the stakes: the contract's `payment_terms` is one of the fields `src/flows/billing-handoff.flow.ts` POSTs to the billing system when a contract activates. The defaulted term did not just sit on a record; it became the invoicing term.

## The change

**`src/objects/quote.hook.ts`** — the drafted contract carries the quote's term. Read the way the file already reads its other non-id value (`totalPrice`): the accepting write's value first, the stored one second, `undefined` if neither.

```ts
if (paymentTerms) contract.payment_terms = paymentTerms;
```

Per the maintainer's **Q2 ruling**, a quote with no term writes **no key** — the contract's own default applies, exactly as today. The change is strictly additive, and nothing distinguishes "the quote chose net_30" from "the quote chose nothing" (⛔ explicitly out of scope).

**`src/objects/_picklists.ts`, `src/objects/contract.object.ts`** — comment corrections only. Both now name `quote_on_accepted` as the thing that performs the carry-over. That is the actual lesson of this card: the claims were unfalsifiable because they named no enforcer. A test pins that both files keep naming it.

## Proving it can fail

`git checkout origin/main -- src/objects/quote.hook.ts`, same tests, verbatim:

```
 × carries `due_on_receipt` — the case the shared vocabulary was created for
 × carries `net_15` off the quote it was already stored on
 × carries `net_30` off the quote it was already stored on
 × carries `net_60` off the quote it was already stored on
 × carries `net_90` off the quote it was already stored on
 × carries `due_on_receipt` off the quote it was already stored on
 × prefers the accepting write's own value when it carries one
 ✓ writes NO payment_terms key at all
 ✓ writes no key for an empty string either — never a junk value
 ✓ writes no key for null either — never a junk value
 ✓ writes no key for a non-string either — never a junk value
 × stores the negotiated term instead of the default
 ✓ falls to net_30 when the quote carried nothing — the unchanged case
 × accepts `net_15` — the superset claim, measured
 ✓ accepts `net_30` — the superset claim, measured
 × accepts `net_60` — the superset claim, measured
 × accepts `net_90` — the superset claim, measured
 × accepts `due_on_receipt` — the superset claim, measured
 ✓ rejects a value outside the vocabulary, so the case above is not vacuous
 × carries due_on_receipt across the VM boundary
 ✓ sends no payment_terms key when the quote has none

 Tests  13 failed | 10 passed (23)
```

The card's headline case, in full:

```
FAIL > the negotiated payment terms reach the drafted contract >
     carries `due_on_receipt` — the case the shared vocabulary was created for
AssertionError: a quote negotiated at due_on_receipt drafted a contract on the
net_30 default: expected undefined to be 'due_on_receipt'
```

Three things about that colour map are worth reading rather than skimming:

- the **control cases stay green in both directions** — a term-less quote produced `net_30` before and produces `net_30` now. That is the "strictly additive" claim as a measurement instead of an argument.
- `accepts net_30` is green **before** the fix, because `net_30` is the value the default supplies anyway. The defect was invisible for exactly one of the five vocabulary values, which is a fair guess at why it survived this long.
- the comment pin fails too when the comments are reverted (`expected '// Copyright (c) 2025 ObjectStack. Li…' to contain 'quote_on_accepted'`), so it is not a tautology.

After the fix: **23 passed (23)**.

## Verification

```
pnpm typecheck   ✓  (tsc --noEmit, clean)
pnpm validate    ✓  Validation passed (1261ms), exit 0
pnpm build       ✓  Build complete (1457ms), exit 0 — 87 pre-existing author-time warnings, unchanged
pnpm hygiene     ✓  source hygiene clean (no raw control bytes, no console.log, no TODO)
vitest run       ✓  100 files, 2462 passed | 1 skipped
vitest --coverage ✓ quote.hook.ts 98.64 / 92.77 / 100 / 100 — all thresholds green
```

## Out of scope, filed separately

**#1129** — *what should a drafted contract inherit from its accepted quote?* `contract_term_months` hardcoded to 12, `start_date` = today, `contract_type` hardcoded `subscription`, plus the quote fields (`shipping_terms`, the two addresses) that reach nothing. Per the Q1 ruling those are unexamined defaults rather than falsified claims — a product question, not this card.

⚠️ Adjacent but untouched: **#714** — the same hook passing boolean `false` into a lookup so the chain fails silently. That is the chain not running; this is the chain running and dropping one value. Its shape did not obstruct the fixtures here (they always give the quote a contact, so #714's refusal path never masks what is measured).

Also deliberately untouched in `contract.object.ts`: the import sitting above the copyright header, which is **#1094**'s deliverable.

---
_Generated by [Claude Code](https://claude.ai/code/session_012caozke9UaxYdVLaudxJvv)_