### PR TITLE
fix(forecast): a manual forecast suppresses the nightly sweep for that period

### DIFF
--- a/.changeset/forecast-sweep-defers-to-manual-override.md
+++ b/.changeset/forecast-sweep-defers-to-manual-override.md
@@ -1,0 +1,39 @@
+---
+'hotcrm': patch
+---
+
+Stop the nightly Forecast Snapshot from overwriting a forecast someone entered
+by hand. A manual forecast for a period now **suppresses** the automated
+snapshot for that period.
+
+Before, the 3 AM sweep picked "this owner's current-quarter row" purely by
+window containment — and a manager's hand-entered row (**Source: Manual entry**,
+typed into the Snapshot block of the forecast form) sits in exactly that window.
+Since the period boundaries were pinned to the calendar quarter, the manager's
+row and the sweep's row became indistinguishable by construction, so the sweep
+adopted the manual one: all four amounts replaced with its computed totals,
+**Snapshot Date** restamped to today, **Source** flipped from Manual entry to
+Scheduled snapshot. **Quota** survived — the sweep never writes it — which is
+what made the loss easy to miss: attainment and coverage silently re-based onto
+the swept numbers while the row still looked plausible, and nothing recorded
+that the typed numbers had ever existed.
+
+What changes, per period and per owner:
+
+- **A manual (or AI-written) forecast exists** → the sweep stands down for that
+  owner and period. It writes nothing and, just as importantly, opens no second
+  row beside it, so *This Quarter* and the Sales dashboard's *Quota Attainment
+  by Rep* still see exactly one row.
+- **A scheduled row exists** → refreshed in place, exactly as before.
+- **Nothing exists** → the sweep opens its own row, exactly as before.
+
+Deleting the manual row hands the period back to automation: the next sweep
+opens its own row again. That is the only way out, and it is an ordinary edit —
+no schema change, no second object, no view-precedence rule.
+
+Mechanically, the sweep now reads through two filters instead of one: the
+idempotency gate still asks "has this period been handled?" of *any* row in the
+window, while the write target asks "which row do I own?" and matches only rows
+with `source: 'scheduled'`. Narrowing the single shared filter instead would
+have made the gate stop seeing the manual row and open a duplicate in the same
+window. Refs #1082, #702, #1008, #1093.

--- a/src/flows/forecast-snapshot.flow.ts
+++ b/src/flows/forecast-snapshot.flow.ts
@@ -63,6 +63,40 @@ type Flow = Automation.Flow;
  * `opportunity_stagnation`. Re-running is how a snapshot stays current, and it
  * is the only way an amount ever decreases.
  *
+ * ## Two questions, two scopes — a manual forecast SUPPRESSES the sweep (#1082)
+ *
+ * The window above answers "has this period been handled?". It does NOT answer
+ * "which row do I own?", and using it for both is what destroyed a manager's
+ * typed numbers: `source: 'manual'` is one of three documented origins, and a
+ * hand-entered current-quarter row satisfies the window filter exactly as the
+ * sweep's own row does — by construction, since #1008/#1093 pinned both ends of
+ * the window to the calendar quarter. At 03:00 the sweep adopted it, overwrote
+ * the four amounts, restamped `snapshot_date` and flipped `source` to
+ * `scheduled`. `quota` survived (it is never written), so attainment silently
+ * re-based onto swept numbers and the row still looked plausible.
+ *
+ * So the two jobs read through two filters:
+ *
+ *   gate  (`find_forecast`)   → CURRENT_PERIOD_FILTER — ANY row in the window,
+ *                               manual included. "Handled" is about the period,
+ *                               not about who handled it.
+ *   write (`reload_forecast`) → OWNED_PERIOD_FILTER  — only rows the sweep
+ *                               wrote (`source: 'scheduled'`).
+ *
+ * and `check_owned` turns "the window is handled, but not by a row I own" into
+ * a stand-down: no write, and — this is the half option 1 of #1082 got wrong —
+ * no second row either. A sweep that merely excluded non-`scheduled` rows from
+ * one shared filter would stop finding the manual row, decide the period was
+ * unhandled and OPEN a duplicate in the same window, which is #702 again:
+ * `this_quarter_forecasts` and the quota-attainment widget pin `period_start`
+ * by equality and would match two rows.
+ *
+ * The way out stays open: delete the manual row and the next sweep opens its
+ * own again (path 3). Automation an override cannot silence is not an override.
+ *
+ * Note the scope is `source == 'scheduled'`, not `source != 'manual'`: an `ai`
+ * row is equally not the sweep's to overwrite, and gets the same deference.
+ *
  * Scope: an "active opportunity owner" is a user owning at least one
  * opportunity that is not `closed_lost`. Users with none are skipped entirely,
  * so a fresh install does not litter a zero row per employee.
@@ -79,13 +113,32 @@ const SNAPSHOT_PERIOD = 'quarter';
 /** Open = not yet resolved either way. Both closed stages leave the pipeline. */
 const OPEN_STAGES = { $nin: ['closed_won', 'closed_lost'] };
 
-/** Window the current-period row: `period_start <= today <= period_end`. */
+/**
+ * Window the current-period row: `period_start <= today <= period_end`.
+ *
+ * The IDEMPOTENCY scope — deliberately source-blind. "Has this period been
+ * handled?" is a question about the window, so a manual row answers it just as
+ * a scheduled one does, and the sweep opens nothing beside it (#1082/#702).
+ */
 const CURRENT_PERIOD_FILTER = {
   owner_id: '{currentOwner.id}',
   period: SNAPSHOT_PERIOD,
   period_start: { $lte: '{TODAY()}' },
   period_end: { $gte: '{TODAY()}' },
 };
+
+/**
+ * The same window narrowed to the rows this sweep OWNS — its WRITE scope.
+ *
+ * `source` is what separates the two jobs (#1082). Anything else in the window
+ * belongs to a human (`manual`) or an agent (`ai`) and is theirs to keep; a
+ * miss here is the stand-down signal `check_owned` reads, not a reason to
+ * create a second row. Narrowing the write scope also makes the target
+ * DETERMINISTIC when a manager adds a manual row beside an existing scheduled
+ * one: `findOne` over the shared window would hand back whichever row the
+ * driver happened to order first.
+ */
+const OWNED_PERIOD_FILTER = { ...CURRENT_PERIOD_FILTER, source: 'scheduled' };
 
 /** Opportunities of the owner in flight during the snapshot window. */
 const inPeriod = (extra: Record<string, unknown>) => ({
@@ -157,11 +210,14 @@ const BUCKETS = [
 ];
 
 /**
- * The per-owner body runs as one straight line once the two gates pass:
- * reload → reset → (find/sum) × 4 → write.
+ * The per-owner body runs as one straight line once the THREE gates pass:
+ * reset → (find/sum) × 4 → write.
+ *
+ * `reload_forecast` is no longer the head of this chain: its successor is the
+ * `check_owned` gateway (#1082), whose out-edge is conditional, and every edge
+ * derived from this list is unconditional.
  */
 const OWNER_CHAIN = [
-  'reload_forecast',
   'reset_totals',
   ...BUCKETS.flatMap((b) => [b.find.id, b.sum.id]),
   'write_snapshot',
@@ -261,12 +317,30 @@ export const ForecastSnapshotFlow: Flow = {
               // Re-read rather than reuse the create output, so both paths
               // (row already existed / row just created) hand the rest of the
               // body ONE variable carrying the hook-derived period window.
+              //
+              // Scoped to OWNED_PERIOD_FILTER, not the gate's window (#1082):
+              // this read chooses the row that gets WRITTEN, and the sweep only
+              // ever owns its own. A miss binds `currentForecast` to null —
+              // `get_record` always binds — which is exactly what `check_owned`
+              // below is there to read.
               id: 'reload_forecast', type: 'get_record', label: 'Load Snapshot Row',
               config: {
                 objectName: 'crm_forecast',
-                filter: CURRENT_PERIOD_FILTER,
+                filter: OWNED_PERIOD_FILTER,
                 outputVariable: 'currentForecast',
               },
+            },
+            {
+              // Gateway only — the predicate lives on the out-edge (#650).
+              //
+              // The stand-down gate (#1082). The window is handled either way
+              // by the time we get here; this asks whether the row handling it
+              // is the sweep's. It is the same single-out-edge skip shape as
+              // `has_deals`: when the only conditional edge does not match, the
+              // iteration simply ends, and the engine records the unreached
+              // nodes as `skipped` with this node as `skippedBy` — so a
+              // stand-down is visible in the run log rather than silent.
+              id: 'check_owned', type: 'decision', label: 'Sweep Owns This Row?',
             },
             {
               // Accumulators live in the flow-wide variable map (a loop body
@@ -323,6 +397,14 @@ export const ForecastSnapshotFlow: Flow = {
             { id: 'b4', source: 'check_missing', target: 'create_forecast', type: 'conditional', condition: P`existingForecast == null`, label: 'Open new row' },
             { id: 'b5', source: 'check_missing', target: 'reload_forecast', type: 'conditional', condition: P`existingForecast != null`, label: 'Refresh existing row' },
             { id: 'b6', source: 'create_forecast', target: 'reload_forecast', type: 'default' },
+            { id: 'b7', source: 'reload_forecast', target: 'check_owned', type: 'default' },
+            // The stand-down (#1082). No complementary edge, on purpose: the
+            // false branch is "this window belongs to a manual/ai row", and the
+            // whole point is that the sweep then does NOTHING — no write, and
+            // no second row. A variable-root null test, so no `has()` guard is
+            // needed: `reload_forecast` is a `get_record` and binds
+            // `currentForecast` unconditionally, to `null` on a miss.
+            { id: 'b8', source: 'check_owned', target: 'reset_totals', type: 'conditional', condition: P`currentForecast != null`, label: 'Sweep owns the row' },
             ...OWNER_CHAIN.slice(0, -1).map((source, i) => ({
               id: `c${i}`,
               source,

--- a/test/forecast-manual-override.test.ts
+++ b/test/forecast-manual-override.test.ts
@@ -1,0 +1,325 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { makeFlowHarness, type Rec } from './helpers/flow-harness';
+import { ForecastSnapshotFlow } from '../src/flows/forecast-snapshot.flow';
+import forecastDerive from '../src/objects/forecast.hook';
+
+/**
+ * ═══ A manual forecast SUPPRESSES the nightly sweep for that period ════════
+ *
+ * `forecast_snapshot` used to identify "this owner's current-period row" purely
+ * by window containment, and then WRITE whatever that matched. A manager's
+ * hand-entered current-quarter row (`source: 'manual'`, one of the three
+ * documented origins, entered through the Snapshot block of the record form)
+ * satisfies that window exactly as the sweep's own row does — by construction
+ * since #1008/#1093 pinned both ends of the window to the calendar quarter. So
+ * at 03:00 the sweep adopted it: four amounts overwritten with its computed
+ * totals, `snapshot_date` restamped, `source` flipped `manual` → `scheduled`.
+ *
+ * Measured before the fix, on this exact fixture (#1082):
+ *
+ *   pipeline   4,242,000 → 130,000     snapshot_date  2026-01-02 → today
+ *   best case  3,100,000 →  30,000     source         manual → scheduled
+ *   commit     2,000,000 →  30,000     quota          1,500,000 (survives)
+ *   closed     1,000,000 →  70,000
+ *
+ * `quota` surviving is what made the loss *partial* and therefore easy to miss:
+ * attainment and coverage silently re-base onto the swept numbers and the row
+ * still looks plausible. Nothing recorded that the typed numbers ever existed.
+ *
+ * ### The contract this file pins
+ *
+ * The sweep asks two different questions and needs two different scopes:
+ *
+ *   | job                                          | scope                     |
+ *   | -------------------------------------------- | ------------------------- |
+ *   | gate — "has this period been handled?"       | ANY row in the window     |
+ *   | write target — "which row do I own?"         | `source: 'scheduled'` only|
+ *
+ * ⇒ three paths, one per `it` below:
+ *   1. a manual row exists  → the sweep STANDS DOWN: writes nothing, creates
+ *      nothing. The manager's numbers survive AND no second row appears.
+ *   2. a scheduled row exists → found, and refreshed in place. Unchanged.
+ *   3. nothing exists → the sweep opens its own, `source: 'scheduled'`.
+ *
+ * Path 1 must produce BOTH halves. Excluding non-`scheduled` rows from one
+ * shared filter delivers the first half and breaks the second: the gate stops
+ * finding the manual row, decides the period is unhandled, and opens a
+ * DUPLICATE in the same window — #702 again, and `this_quarter_forecasts` plus
+ * the Sales dashboard's quota-attainment widget both pin `period_start` by
+ * equality and would then match two rows. So every path asserts the row COUNT
+ * in the window, not just the surviving amounts.
+ *
+ * ### Why every case runs the real flow
+ *
+ * Inspecting the filter object would pass on a flow whose edges never reach the
+ * write, and fail on a correct one authored differently. These drive
+ * `forecast_snapshot` through the real `AutomationEngine` with the real
+ * `forecast_derive_period` hook installed, and read the store afterwards.
+ *
+ * Every case also carries a CONTROL owner with no forecast row of any kind.
+ * A stand-down and a flow that died on its first node look identical when you
+ * only look at the row that was supposed to survive; the control proves the
+ * sweep ran and did its ordinary work in the same pass.
+ */
+
+const pad = (n: number) => String(n).padStart(2, '0');
+const isoUtc = (d: Date) => `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+
+const nowUtc = new Date();
+const qStart = new Date(Date.UTC(nowUtc.getUTCFullYear(), Math.floor(nowUtc.getUTCMonth() / 3) * 3, 1));
+const qEnd = new Date(Date.UTC(qStart.getUTCFullYear(), qStart.getUTCMonth() + 3, 0));
+const inPeriod = isoUtc(qStart);
+const today = isoUtc(nowUtc);
+const quarterLabel = `Q${Math.floor(qStart.getUTCMonth() / 3) + 1} ${qStart.getUTCFullYear()}`;
+
+/** `rep_manual` owns the contested row; `rep_control` proves the sweep ran. */
+const users = (): Rec[] => [
+  { id: 'rep_manual', name: 'Managed Rep' },
+  { id: 'rep_control', name: 'Control Rep' },
+];
+
+/**
+ * Live pipeline for both owners. The totals the sweep would compute for
+ * `rep_manual` — 130k / 30k / 30k / 70k — are deliberately nothing like the
+ * numbers the manager typed, so "unchanged" cannot pass by coincidence.
+ */
+const opps = (): Rec[] => [
+  { id: 'o1', owner_id: 'rep_manual', stage: 'qualification', forecast_category: 'pipeline', amount: 100_000, close_date: inPeriod },
+  { id: 'o2', owner_id: 'rep_manual', stage: 'negotiation', forecast_category: 'commit', amount: 30_000, close_date: inPeriod },
+  { id: 'o3', owner_id: 'rep_manual', stage: 'closed_won', forecast_category: 'closed', amount: 70_000, close_date: inPeriod },
+  { id: 'o4', owner_id: 'rep_control', stage: 'proposal', forecast_category: 'commit', amount: 55_000, close_date: inPeriod },
+];
+
+/** What the sweep computes for `rep_manual` from the pipeline above. */
+const SWEPT = { pipeline: 130_000, bestCase: 30_000, commit: 30_000, closed: 70_000 };
+
+/** The manager's typed numbers — nothing here is a sum of anything above. */
+const TYPED = { pipeline: 4_242_000, bestCase: 3_100_000, commit: 2_000_000, closed: 1_000_000 };
+
+const forecastRow = (over: Rec): Rec => ({
+  owner_id: 'rep_manual',
+  period: 'quarter',
+  period_start: inPeriod,
+  period_end: isoUtc(qEnd),
+  period_label: quarterLabel,
+  // An old stamp, so a restamp to today is unmissable.
+  snapshot_date: '2026-01-02',
+  quota: 1_500_000,
+  ...over,
+});
+
+/** A current-quarter row a manager typed into the Snapshot block by hand. */
+const manualRow = (over: Rec = {}): Rec => forecastRow({
+  id: 'f_manual',
+  source: 'manual',
+  pipeline_amount: TYPED.pipeline,
+  best_case_amount: TYPED.bestCase,
+  commit_amount: TYPED.commit,
+  closed_amount: TYPED.closed,
+  ...over,
+});
+
+const harness = (forecasts: Rec[] = []) =>
+  makeFlowHarness(
+    { forecast_snapshot: ForecastSnapshotFlow },
+    { sys_user: users(), crm_opportunity: opps(), crm_forecast: forecasts },
+    { hooks: [forecastDerive] },
+  );
+
+const sweep = async (h: ReturnType<typeof harness>) => {
+  await h.run('forecast_snapshot', {}, { event: 'schedule' });
+  return h;
+};
+
+const run = async (forecasts: Rec[] = []) => sweep(harness(forecasts));
+
+/**
+ * The window as the CONSUMERS see it: `period_start` matched by equality, the
+ * way `this_quarter_forecasts` and `quota_attainment_by_rep` both do it. Asking
+ * the data engine rather than filtering the array in the test keeps the
+ * question identical to the one those surfaces ask.
+ */
+const currentQuarterRows = async (h: ReturnType<typeof harness>, owner: string) =>
+  h.data.find('crm_forecast', { where: { owner_id: owner, period_start: inPeriod } });
+
+/** The sweep did its ordinary work this pass — so a stand-down is a decision. */
+const expectControlSwept = async (h: ReturnType<typeof harness>) => {
+  const rows = await currentQuarterRows(h, 'rep_control');
+  expect(rows, 'the sweep never reached the control owner — it did not really run').toHaveLength(1);
+  expect(rows[0].source).toBe('scheduled');
+  expect(Number(rows[0].commit_amount)).toBe(55_000);
+};
+
+describe('path 1 — a manual current-quarter row stands the sweep down (#1082)', () => {
+  it('leaves the manager\'s four amounts, snapshot_date and source untouched', async () => {
+    const h = await run([manualRow()]);
+
+    const row = h.store.crm_forecast.find((f) => f.id === 'f_manual')!;
+    expect(Number(row.pipeline_amount), 'pipeline overwritten by the sweep').toBe(TYPED.pipeline);
+    expect(Number(row.best_case_amount), 'best case overwritten by the sweep').toBe(TYPED.bestCase);
+    expect(Number(row.commit_amount), 'commit overwritten by the sweep').toBe(TYPED.commit);
+    expect(Number(row.closed_amount), 'closed won overwritten by the sweep').toBe(TYPED.closed);
+    // The two tells that made the loss traceable in the first place.
+    expect(row.source, 'source was flipped manual → scheduled').toBe('manual');
+    expect(row.snapshot_date, 'snapshot_date was restamped').toBe('2026-01-02');
+    // And nothing about the row was rewritten at all — not even a field the
+    // sweep writes with an identical value.
+    expect(row).toEqual(manualRow());
+
+    await expectControlSwept(h);
+  });
+
+  it('opens no second row in the window — the #702 shape option 1 would have caused', async () => {
+    const h = await run([manualRow()]);
+
+    const rows = await currentQuarterRows(h, 'rep_manual');
+    expect(
+      rows.map((r) => `${r.id}:${r.source}`),
+      'the sweep opened a duplicate beside the manual row; `this_quarter_forecasts` '
+        + 'and quota_attainment_by_rep pin period_start by equality and now match two rows',
+    ).toEqual(['f_manual:manual']);
+  });
+
+  it('stands down again on every later run, not just the first', async () => {
+    // A stand-down that only holds once would restore the defect on night two.
+    const h = harness([manualRow()]);
+    await sweep(h);
+    await sweep(h);
+    await sweep(h);
+
+    expect(await currentQuarterRows(h, 'rep_manual')).toEqual([manualRow()]);
+  });
+
+  it('defers to an `ai` row for the same reason — the scope is "rows the sweep wrote"', async () => {
+    // `source: 'ai'` is the third documented origin. The write scope is
+    // `scheduled`, not "not manual", so an agent-written row is equally not the
+    // sweep's to overwrite. Pinned so the deference is a decision on record
+    // rather than a side effect of how the filter happened to be spelled.
+    //
+    // The seeded row and the expectation are built by SEPARATE calls on
+    // purpose: `makeFlowHarness` seeds the store by reference, so handing the
+    // same object to both sides compares the row the flow just mutated against
+    // itself and passes on the unfixed flow too. Measured — that spelling was
+    // green against `origin/main`.
+    const aiRow = () => manualRow({ id: 'f_ai', source: 'ai' });
+    const h = await run([aiRow()]);
+
+    expect(await currentQuarterRows(h, 'rep_manual')).toEqual([aiRow()]);
+    await expectControlSwept(h);
+  });
+});
+
+describe('path 2 — a scheduled row is still found and refreshed in place (#1082)', () => {
+  const scheduledRow = (over: Rec = {}) => forecastRow({
+    id: 'f_sched',
+    source: 'scheduled',
+    pipeline_amount: 9_999_999,
+    best_case_amount: 9_999_999,
+    commit_amount: 9_999_999,
+    closed_amount: 9_999_999,
+    ...over,
+  });
+
+  it('recomputes the amounts onto the same row', async () => {
+    const h = await run([scheduledRow()]);
+
+    const rows = await currentQuarterRows(h, 'rep_manual');
+    expect(rows, 'the sweep duplicated its own row').toHaveLength(1);
+    expect(rows[0].id, 'the existing row was replaced rather than refreshed').toBe('f_sched');
+    expect(Number(rows[0].pipeline_amount)).toBe(SWEPT.pipeline);
+    expect(Number(rows[0].best_case_amount)).toBe(SWEPT.bestCase);
+    expect(Number(rows[0].commit_amount)).toBe(SWEPT.commit);
+    expect(Number(rows[0].closed_amount)).toBe(SWEPT.closed);
+    expect(rows[0].snapshot_date).toBe(today);
+    expect(rows[0].source).toBe('scheduled');
+    // Still never writes quota — the hand-maintained attainment denominator.
+    expect(Number(rows[0].quota)).toBe(1_500_000);
+  });
+
+  it('targets its OWN row deterministically when a manual row sits beside it', async () => {
+    // A manager can add a manual row to a window the sweep already opened. Both
+    // orderings are exercised because the shared-window `findOne` the sweep used
+    // to reload with would return whichever row the driver ordered first — the
+    // scoped read makes the target the same either way.
+    for (const [label, seeded] of [
+      ['scheduled first', [scheduledRow(), manualRow()]],
+      ['manual first', [manualRow(), scheduledRow()]],
+    ] as const) {
+      const h = await run(seeded.map((r) => ({ ...r })));
+
+      const rows = await currentQuarterRows(h, 'rep_manual');
+      expect(rows, `${label}: the sweep opened a third row`).toHaveLength(2);
+
+      const manual = rows.find((r) => r.id === 'f_manual')!;
+      expect(manual, `${label}: the manual row was written`).toEqual(manualRow());
+
+      const scheduled = rows.find((r) => r.id === 'f_sched')!;
+      expect(Number(scheduled.pipeline_amount), `${label}: the sweep's own row went stale`)
+        .toBe(SWEPT.pipeline);
+      expect(scheduled.snapshot_date, `${label}: the sweep's own row went stale`).toBe(today);
+    }
+  });
+});
+
+describe('path 3 — an empty window is still the sweep\'s to open (#1082)', () => {
+  it('creates a scheduled row when the owner has none', async () => {
+    const h = await run();
+
+    const rows = await currentQuarterRows(h, 'rep_manual');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source).toBe('scheduled');
+    expect(rows[0].period_start).toBe(inPeriod);
+    expect(rows[0].period_end).toBe(isoUtc(qEnd));
+    expect(Number(rows[0].pipeline_amount)).toBe(SWEPT.pipeline);
+    expect(rows[0].snapshot_date).toBe(today);
+  });
+
+  it('THE WAY OUT: deleting the manual row restores automated snapshotting', async () => {
+    // An override the owner cannot lift is not an override, it is a dead end.
+    // Deleting the row is an ordinary edit, and the next sweep takes the window
+    // back — this is the whole reason no schema change was needed.
+    const h = harness([manualRow()]);
+    await sweep(h);
+    expect(await currentQuarterRows(h, 'rep_manual')).toEqual([manualRow()]);
+
+    await h.data.delete('crm_forecast', { where: { id: 'f_manual' } });
+    await sweep(h);
+
+    const rows = await currentQuarterRows(h, 'rep_manual');
+    expect(rows, 'the sweep never resumed after the override was lifted').toHaveLength(1);
+    expect(rows[0].source).toBe('scheduled');
+    expect(Number(rows[0].pipeline_amount)).toBe(SWEPT.pipeline);
+    expect(rows[0].snapshot_date).toBe(today);
+  });
+});
+
+describe('the two scopes are authored as two filters, and stay that way (#1082)', () => {
+  /** The loop body, flattened out of the `loop` container. */
+  const body = (ForecastSnapshotFlow.nodes as any[])
+    .find((n) => n.id === 'loop_owners').config.body;
+  const node = (id: string) => (body.nodes as any[]).find((n) => n.id === id);
+
+  it('the idempotency gate reads the window source-blind', () => {
+    // If `source` ever appears here, the gate stops seeing the manual row and
+    // path 1's second assertion (no duplicate) is what breaks — quietly, and
+    // only in the window a human happens to be using.
+    expect(node('find_forecast').config.filter).not.toHaveProperty('source');
+  });
+
+  it('the write target is scoped to the rows the sweep wrote', () => {
+    expect(node('reload_forecast').config.filter.source).toBe('scheduled');
+  });
+
+  it('the stand-down gate is a decision whose predicate lives on its out-edge (#650)', () => {
+    const gate = node('check_owned');
+    expect(gate.type).toBe('decision');
+    expect(gate.config?.condition, 'an inert singular condition — see #650').toBeUndefined();
+
+    const out = (body.edges as any[]).filter((e) => e.source === 'check_owned');
+    expect(out).toHaveLength(1);
+    expect(out[0].target).toBe('reset_totals');
+    expect(out[0].condition, 'the gate branches on nothing').toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #1082

Implements the PM ruling on that card: **a manual forecast for a period suppresses the automated snapshot for that period.**

## The premise, reproduced end-to-end first

The card was a read-only metadata probe and had never been driven through a real flow run, so that was step one: a manual current-quarter `crm_forecast` row for an owner who also owns live opportunities, then `forecast_snapshot` through the real `AutomationEngine` with the real `forecast_derive_period` hook. It reproduces exactly as described, against `origin/main` (920026d2):

```
BEFORE  pipeline 4242000  best_case 3100000  commit 2000000  closed 1000000
        snapshot_date 2026-01-02   source manual   quota 1500000
AFTER   pipeline  130000  best_case   30000  commit   30000  closed   70000
        snapshot_date 2026-08-12   source scheduled  quota 1500000
ROW COUNT: 1
```

All four typed amounts replaced, `snapshot_date` restamped, `source` flipped, `quota` surviving — the partial loss that makes the swept row still look plausible. `premise_still_valid: true`.

## What changed

The sweep used **one filter for two jobs**. It now uses two:

| job | filter | scope |
| --- | --- | --- |
| idempotency gate (`find_forecast`) — "has this period been handled?" | `CURRENT_PERIOD_FILTER` | **any** row in the window, manual included |
| write target (`reload_forecast` → `write_snapshot`) — "which row do I own?" | `OWNED_PERIOD_FILTER` | only `source: 'scheduled'` |

`OWNED_PERIOD_FILTER` is `{ ...CURRENT_PERIOD_FILTER, source: 'scheduled' }`, so the two cannot drift apart on the window itself.

The stand-down is one new `decision` node, `check_owned`, between `reload_forecast` and `reset_totals`, with a single conditional out-edge `currentForecast != null`. When it does not match, the iteration simply ends — the same single-out-edge skip shape `has_deals` already uses, so no loop-body restructuring was needed. `get_record` binds its output unconditionally (to `null` on a miss), so the predicate is a variable-root null test with no dot-walk and no `has()` guard. The engine records the unreached nodes as `skipped` with `skippedBy: check_owned`, so a stand-down is visible in the run log rather than silent.

The three required paths:

1. **manual row exists** → gate says handled, write target finds nothing → sweep writes nothing and creates nothing;
2. **scheduled row exists** → gate finds it, write targets it — unchanged;
3. **nothing exists** → sweep creates its own with `source: 'scheduled'` — unchanged.

Deleting the manual row restores automated snapshotting for the period, asserted as its own case.

Not done, per the ruling: no `source` added to the shared filter (option 1 — the gate would stop seeing the manual row and open a second row in the window, #702 again, and both `this_quarter_forecasts` and `quota_attainment_by_rep` pin `period_start` by equality); no schema change, no new object, no view-precedence rule (option 3).

## Two things worth a reviewer's eye

- **`ai` rows get the same deference.** The ruling defines the write scope as *"only rows the sweep wrote (`source: 'scheduled'`)"*, so the implementation is `source == 'scheduled'` rather than `source != 'manual'`, and an agent-written row is equally not the sweep's to overwrite. Pinned by a test so it is a decision on record rather than a spelling accident.
- **A mixed window is now deterministic.** A manager can add a manual row to a window the sweep already opened. The old shared-window `findOne` would reload whichever row the driver ordered first; the scoped read always targets the sweep's own. Both seed orderings are exercised: the manual row is untouched, the scheduled row stays current, and no third row appears.

## Prove it can fail

`test/forecast-manual-override.test.ts` drives the real flow in every case (a filter-object inspection would pass on a flow whose edges never reach the write). Every case also carries a control owner with no forecast row, because a stand-down and a flow that died on its first node look identical if you only inspect the row that was supposed to survive.

Run against `origin/main`'s flow with this PR's tests — **8 of 11 red**:

```
 x path 1 ... leaves the manager's four amounts, snapshot_date and source untouched
   -> pipeline overwritten by the sweep: expected 130000 to be 4242000
 x path 1 ... opens no second row in the window
   -> expected [ 'f_manual:scheduled' ] to deeply equal [ 'f_manual:manual' ]
 x path 1 ... stands down again on every later run, not just the first
 x path 1 ... defers to an `ai` row for the same reason
 v path 2 ... recomputes the amounts onto the same row
 x path 2 ... targets its OWN row deterministically when a manual row sits beside it
 v path 3 ... creates a scheduled row when the owner has none
 x path 3 ... THE WAY OUT: deleting the manual row restores automated snapshotting
 v ... the idempotency gate reads the window source-blind
 x ... the write target is scoped to the rows the sweep wrote
 x ... the stand-down gate is a decision whose predicate lives on its out-edge (#650)

 Test Files  1 failed (1)
      Tests  8 failed | 3 passed (11)
```

The three that stay green are exactly the paths the ruling says are unchanged (path 2's plain refresh, path 3's create, and the gate staying source-blind). With the fix:

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

That reverse run earned its keep beyond the pin: the first draft of the `ai` case handed the *same object* to the harness seed and to the expectation, and `makeFlowHarness` seeds the store by reference — so it compared the row the flow had just mutated against itself and was green on the unfixed flow. Caught only because the red direction was predicted and checked. The test now builds both sides from separate calls, and says why.

## Verification

```
pnpm validate    OK  Validation passed (1258ms)  — 87 pre-existing author-time warnings, none on flows
pnpm typecheck   OK  tsc --noEmit, clean
pnpm build       OK  Build complete — 26 Flows, dist/objectstack.json
pnpm hygiene     OK  source hygiene clean (no raw control bytes)
pnpm lint        OK  exit 0, no forecast_snapshot findings
vitest (full)    OK  Test Files 100 passed (100) / Tests 2451 passed | 1 skipped (2452)
```

`test/flow-filter-today-token.test.ts`'s `{TODAY()}` census for this flow is unchanged — the new filter key is a literal, so both reads still contribute exactly their two window bounds.

## Out of scope, filed separately

**#1131** — `content/docs/sales/forecasting.mdx` documents the three `source` values and the nightly sweep but not this suppression rule (and its line 56 "re-running it refreshes the same row" now reads as the removed behaviour). `content/docs/**` belongs to another card this round (#1113), so it is filed rather than edited here.


---
_Generated by [Claude Code](https://claude.ai/code/session_012caozke9UaxYdVLaudxJvv)_