### PR TITLE
feat(sharing): let service agents see the unowned cases they triage (#1096)

### DIFF
--- a/.changeset/unassigned-case-triage-sharing.md
+++ b/.changeset/unassigned-case-triage-sharing.md
@@ -1,0 +1,36 @@
+---
+'hotcrm': minor
+---
+
+Service agents can now see the unassigned cases they are supposed to triage
+(#1096).
+
+The **Unassigned — triage** tab shipped pinned in every Cases list, including
+the agent's — and returned nothing to the one persona it was built for. Service
+agents hold Cases with own-record scope, and a case that arrives with no owner
+is owned by nobody, so it matched no agent's scope. Administrators and sales
+managers could see the intake backlog; the service team could not. That is the
+normal state on a new org rather than an edge case: automatic round-robin
+assignment stands down whenever nobody yet holds the Service Agent position, and
+it stands down on the anonymous web-to-case path, so those submissions land
+ownerless by design.
+
+A new built-in sharing rule — **Unassigned Cases — Triage** — grants every
+holder of the Service Agent position edit access to open cases with no owner.
+The grant is self-limiting: it applies only while a case is unowned, so the
+moment the case has an owner it falls back to ordinary own-record scope and the
+share is withdrawn. No persona gains sight of a case that already belongs to
+someone else, and a closed case with no owner stays out of triage — that is
+history, not backlog.
+
+⚠️ **Claiming a case from triage is not yet possible, and this release does not
+change that.** Case ownership is system-managed: reassigning it requires a
+transfer permission that the Service Agent profile deliberately does not carry,
+and the platform applies that rule even when an agent assigns an unowned case to
+themselves. Agents can now open, work, annotate and prioritise the backlog they
+could not previously see; moving a case into their own name still needs an
+administrator, or a manager who holds the transfer grant. The remaining half is
+tracked on #1096.
+
+Administrators: the new rule appears in **Setup → Sharing Rules** alongside the
+existing ones, and is documented in *Administration → Sharing & Security*.

--- a/content/docs/administration/sharing-and-security.mdx
+++ b/content/docs/administration/sharing-and-security.mdx
@@ -94,6 +94,7 @@ Criteria-based rules are the enforced flavour: matching records materialise real
 | Large Open Deals — Executive | Opportunity | Read | `executive` — the same deals, one rung up |
 | Escalated Cases Sharing | Case | Edit | `service_manager` — open critical cases |
 | Escalated Cases — Service Director | Case | Read | `service_director` — the same cases, one rung up |
+| Unassigned Cases — Triage | Case | Edit | `service_agent` — open cases with no owner |
 | Live Campaigns — Marketing Manager | Campaign | Edit | `marketing_manager` — planning / in-progress campaigns |
 | Live Campaigns — Marketing Director | Campaign | Edit | `marketing_director` — the same campaigns |
 

--- a/objectstack.config.ts
+++ b/objectstack.config.ts
@@ -20,7 +20,7 @@ import { CrmSeedData } from './src/data/index.js';
 import {
   AccountTeamSharingRule, TerritorySharingRules,
   OpportunitySalesSharingRule, OpportunityExecutiveSharingRule,
-  CaseEscalationSharingRule, CaseDirectorSharingRule,
+  CaseEscalationSharingRule, CaseDirectorSharingRule, CaseUnassignedTriageSharingRule,
   CampaignLeadershipSharingRules,
   CrmPositions,
 } from './src/sharing/index.js';
@@ -155,6 +155,7 @@ export default defineStack({
     OpportunityExecutiveSharingRule,
     CaseEscalationSharingRule,
     CaseDirectorSharingRule,
+    CaseUnassignedTriageSharingRule,
     ...TerritorySharingRules,
     ...CampaignLeadershipSharingRules,
   ],

--- a/src/sharing/case.sharing.ts
+++ b/src/sharing/case.sharing.ts
@@ -32,3 +32,65 @@ export const CaseDirectorSharingRule = {
   accessLevel: 'read' as const,
   sharedWith: { type: 'position' as const, value: 'service_director' },
 };
+
+/**
+ * The intake queue's read side: an OPEN case that nobody owns is visible to
+ * every service agent, so they can pull it out of triage (#1096).
+ *
+ * ### What was broken
+ *
+ * #596 shipped round-robin intake plus a pinned `Unassigned — triage` tab, and
+ * `case_auto_assign` is a deliberate NO-OP whenever the `service_agent` pool is
+ * empty or unreadable (the anonymous web-to-case path cannot read
+ * `sys_user_position` at all). Those cases land ownerless — and `service_agent`
+ * holds `crm_case` with `readScope: 'own'`, so an unowned row matched nobody's
+ * own-scope. The tab was pinned in every Cases list including the agent's, and
+ * it returned zero rows for the one persona it exists for.
+ *
+ * ### Why THIS shape (the ruling on #1096, option A)
+ *
+ * The grant is **self-limiting**: it holds only while `owner_id` is empty, so
+ * the instant an agent claims the case the criteria stops matching, the share
+ * is revoked on the next reconcile, and ordinary own-scope resumes. There is no
+ * accumulating permission surface — the rule's own condition destroys it. That
+ * is what makes it narrower than the two rejected alternatives: `viewAllRecords`
+ * on the profile (option C) hands every agent every customer's entire case
+ * history to solve a null-owner problem, and unpinning the tab (option B) is not
+ * expressible — `ViewTabSchema` has no per-profile scoping — so it means
+ * removing the tab for everyone.
+ *
+ * `edit`, not `read`: triage is a pull queue. An agent who can see the row but
+ * not write it cannot claim it, and claiming is the whole point.
+ *
+ * ### ⚠️ Why there is no `has()` guard here, and why adding one would break it
+ *
+ * A sharing condition is NOT an interpreted CEL predicate. `plugin-sharing`
+ * compiles it to a pushdown filter with `compileCelToFilter`, which rejects the
+ * whole function-call class — so a `has(record.owner_id)` guard makes this rule
+ * *untranslatable*, and the seeder then refuses it outright (never degrading it
+ * to match-all). The rule would be declared, documented and silently unseeded:
+ * exactly the #621 defect. The house totality rule (AGENTS.md #630) governs the
+ * two INTERPRETED surfaces — object `validations[]` / field predicates, and
+ * record-change flow conditions — and does not reach this one.
+ *
+ * Totality is still answered, one layer down: `record.owner_id == null` lowers
+ * to `{ owner_id: { $null: true } }`, and `$null` is the operator form that
+ * treats an ABSENT key and a NULL column alike. That matters because the two
+ * shapes are both real — `driver-memory` stores only the columns a row was
+ * written with, SQL stores every column — and a marketplace app does not choose
+ * its host's datasource. Both are MEASURED, end to end, in
+ * `test/unassigned-case-triage-reach.test.ts`; the compiler's own verdict on
+ * `has()` is pinned in `test/sharing-seeding.test.ts`.
+ *
+ * A closed unowned case stays hidden on purpose: it is history, not backlog,
+ * and the tab's row count has to keep meaning "work waiting for a human".
+ */
+export const CaseUnassignedTriageSharingRule = {
+  name: 'case_unassigned_triage_sharing',
+  label: 'Unassigned Cases — Triage',
+  object: 'crm_case',
+  type: 'criteria' as const,
+  condition: P`record.owner_id == null && record.is_closed == false`,
+  accessLevel: 'edit' as const,
+  sharedWith: { type: 'position' as const, value: 'service_agent' },
+};

--- a/src/sharing/index.ts
+++ b/src/sharing/index.ts
@@ -5,6 +5,10 @@
  */
 export { AccountTeamSharingRule, TerritorySharingRules } from './account.sharing';
 export { CampaignLeadershipSharingRules } from './campaign.sharing';
-export { CaseDirectorSharingRule, CaseEscalationSharingRule } from './case.sharing';
+export {
+  CaseDirectorSharingRule,
+  CaseEscalationSharingRule,
+  CaseUnassignedTriageSharingRule,
+} from './case.sharing';
 export { OpportunityExecutiveSharingRule, OpportunitySalesSharingRule } from './opportunity.sharing';
 export { CrmPositions } from './positions';

--- a/test/authorization-coverage.test.ts
+++ b/test/authorization-coverage.test.ts
@@ -431,6 +431,80 @@ describe('sharing rules and positions line up', () => {
     expect(bad, `inert sharing rules:\n  ${bad.join('\n  ')}`).toEqual([]);
   });
 
+  /**
+   * The triage grant is AUTHORED, not implied (#1096).
+   *
+   * `service_agent` holds `crm_case` with `readScope: 'own'`, and an unowned row
+   * matches nobody's own-scope — so the `Unassigned — triage` view #596 pinned
+   * in every Cases list returned zero rows for the persona it was built for.
+   * `case_unassigned_triage_sharing` is the ruled fix, and this block is the
+   * reason the widening cannot be lost silently: a permission grant nobody
+   * asserts is a grant nobody notices losing.
+   *
+   * What is pinned here is the DECLARED shape — the object, the criteria, the
+   * access level and the recipient. What it delivers on a running engine, on
+   * both the sparse (absent-key) and column-complete (NULL) row shapes, is
+   * measured in `test/unassigned-case-triage-reach.test.ts`; that it survives
+   * `plugin-sharing`'s CEL→filter compiler at all is pinned in
+   * `test/sharing-seeding.test.ts`.
+   */
+  describe('#1096: unowned open cases reach the agents who triage them', () => {
+    const rule = () => sharingRules.find((r) => r.name === 'case_unassigned_triage_sharing');
+
+    it('the rule exists, on crm_case, granting edit to the service_agent position', () => {
+      const r = rule();
+      expect(
+        r,
+        'case_unassigned_triage_sharing is gone — the Unassigned — triage tab is empty again ' +
+          'for the only persona it is pinned for (#1096)',
+      ).toBeDefined();
+      expect(r!.object).toBe('crm_case');
+      expect(r!.type).toBe('criteria');
+      // `edit`, not `read`: triage is a pull queue, and an agent who cannot
+      // write the row cannot work it.
+      expect(r!.accessLevel).toBe('edit');
+      expect(r!.sharedWith).toEqual({ type: 'position', value: 'service_agent' });
+    });
+
+    it('its criteria is exactly "unowned AND open" — both halves, and nothing wider', () => {
+      // Asserted verbatim, because every token is load-bearing and each fails
+      // differently: drop `owner_id == null` and the rule shares the whole case
+      // table with every agent (option C by accident); drop
+      // `is_closed == false` and closed history joins the backlog, so the tab's
+      // row count stops meaning "work waiting for a human"; and `!= null` in
+      // place of `== null` inverts the grant into precisely the leak
+      // acceptance #2 forbids.
+      expect(String(rule()!.condition?.source ?? '')).toBe(
+        'record.owner_id == null && record.is_closed == false',
+      );
+    });
+
+    it('carries NO has() guard — one would make it untranslatable and silently unseeded', () => {
+      // ⚠️ The inverse of the house rule, and deliberate. AGENTS.md's totality
+      // rule (#630) governs the INTERPRETED CEL surfaces; a sharing condition is
+      // compiled to a pushdown filter instead, and `compileCelToFilter` rejects
+      // the whole function-call class — so a guard here would make the rule
+      // undeployable rather than safe (#621's defect, reintroduced). Totality is
+      // answered by the operator: `== null` lowers to `{ $null: true }`, which
+      // reads an absent key and a NULL column alike.
+      expect(String(rule()!.condition?.source ?? '')).not.toMatch(/\bhas\s*\(/);
+    });
+
+    it('the widening is a SHARING rule — the profile stays own-scoped', () => {
+      // The other half of "authored, not implied": option C (`viewAllRecords`
+      // on the profile) was rejected on sight and stays rejected, so if it ever
+      // arrives this fails rather than passing quietly alongside the rule.
+      const perm = (setByName.get('service_agent')?.objects ?? {}).crm_case ?? {};
+      expect(perm.readScope, 'service_agent.crm_case stopped being own-scoped').toBe('own');
+      expect(
+        perm.viewAllRecords,
+        'service_agent gained viewAllRecords on crm_case — that is #1096 option C, which hands ' +
+          "every agent every customer's entire case history to solve a null-owner problem",
+      ).toBe(false);
+      expect(perm.modifyAllRecords).toBe(false);
+    });
+  });
+
   it('every position is referenced by a sharing rule or a permission set', () => {
     const referenced = new Set<string>();
     for (const rule of sharingRules) {

--- a/test/sharing-coverage.test.ts
+++ b/test/sharing-coverage.test.ts
@@ -222,6 +222,69 @@ describe('what a shared account carries into its related lists', () => {
   });
 });
 
+/**
+ * `crm_case`'s three grants, named — including the triage widening (#1096).
+ *
+ * The ledger above answers `crm_case: 'partial'`, and 'partial' says only "some
+ * rule widens some records". That was true before #1096 and is true after it,
+ * so the ledger alone cannot notice a grant arriving or leaving — and the one
+ * that arrived is the app's only grant over records with **no owner at all**.
+ *
+ * So the roster is pinned by name. `service_agent` is the entry that matters:
+ * unlike the manager and director rungs, an agent's reach here is not "the same
+ * cases, one rung up" — it is a set of rows that had no reader whatsoever, and
+ * it is the one grant whose criteria matches on the ABSENCE of a value.
+ *
+ * Declared shape only. What it delivers on a running engine — on both the
+ * sparse (absent-key) and column-complete (NULL) row shapes — is measured in
+ * `test/unassigned-case-triage-reach.test.ts`.
+ */
+describe('who can read a case they do not own', () => {
+  const caseRules = () => rulesOn('crm_case');
+
+  it('exactly three rules widen crm_case, and each names its position', () => {
+    const roster = caseRules()
+      .map((r) => `${r.name}→${r.sharedWith?.value}:${r.accessLevel ?? 'read'}`)
+      .sort();
+    expect(
+      roster,
+      'the crm_case sharing roster changed. Adding a rule widens who reads customer case ' +
+        'history; removing one takes a persona back to own-only — both are decisions, and ' +
+        'both belong in a PR that also updates the admin docs and this list.',
+    ).toEqual([
+      'case_director_sharing→service_director:read',
+      'case_escalation_sharing→service_manager:edit',
+      'case_unassigned_triage_sharing→service_agent:edit',
+    ]);
+  });
+
+  it('the triage rule is the ONLY one that matches on the absence of an owner', () => {
+    // A second rule keying off `owner_id == null` would be a second, unreviewed
+    // answer to "who sees unowned work" — the shape that later has to be
+    // converged by deleting one of them. Across the WHOLE stack, not just
+    // crm_case: nothing else in this app shares records by ownerlessness.
+    const ownerless = sharingRules
+      .filter((r) => /record\.owner_id\s*==\s*null/.test(r.condition?.source ?? ''))
+      .map((r) => r.name as string);
+    expect(ownerless, 'more than one rule now grants sight of unowned records').toEqual([
+      'case_unassigned_triage_sharing',
+    ]);
+  });
+
+  it('no rule hands an agent a case that HAS an owner — acceptance #2, at the metadata layer', () => {
+    // The runtime proof is in the reach test; this is the authoring-time
+    // counterpart, and it is the cheaper of the two to keep honest. Any
+    // `service_agent`-targeted rule on crm_case must carry the ownerless
+    // condition — a second one that did not would grant owned rows, which is
+    // exactly what #1096 rejected option C for.
+    const bad = caseRules()
+      .filter((r) => r.sharedWith?.type === 'position' && r.sharedWith?.value === 'service_agent')
+      .filter((r) => !/record\.owner_id\s*==\s*null/.test(r.condition?.source ?? ''))
+      .map((r) => `${r.name}: grants agents cases without requiring the case to be unowned`);
+    expect(bad, `agent-targeted case rules that reach owned records:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+});
+
 describe('the admin docs describe the sharing the app actually ships', () => {
   const doc = DOC(SHARING_DOC);
 

--- a/test/unassigned-case-triage-reach.test.ts
+++ b/test/unassigned-case-triage-reach.test.ts
@@ -1,0 +1,452 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { DefaultDatasourcePlugin, AppPlugin } from '@objectstack/runtime';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { MetadataPlugin } from '@objectstack/metadata';
+import {
+  SecurityPlugin,
+  appDefaultPermissionSetName,
+  buildContextForUser,
+} from '@objectstack/plugin-security';
+import { SharingServicePlugin } from '@objectstack/plugin-sharing';
+import { SysUser, SysMember, SysOrganization } from '@objectstack/platform-objects/identity';
+import stack from '../objectstack.config';
+
+/**
+ * Who really sees the `Unassigned — triage` tab's rows (#1096) — measured
+ * against the real enforcement stack, on BOTH row shapes.
+ *
+ * ### What this file answers
+ *
+ * #596 shipped the queue substitute: a round-robin intake hook plus a pinned
+ * `Unassigned — triage` view. `case_auto_assign` is a deliberate no-op whenever
+ * the `service_agent` pool is empty or unreadable, so cases land ownerless — and
+ * `service_agent` holds `crm_case` with `readScope: 'own'`, which an unowned row
+ * matches for nobody. The tab was pinned in every Cases list *including the
+ * agent's* and returned zero rows for the persona it exists for.
+ *
+ * `case_unassigned_triage_sharing` (`src/sharing/case.sharing.ts`) is the ruled
+ * fix. Every other test in this repo reads METADATA; none can answer whether the
+ * engine turns that declaration into rows on an agent's screen. So this one boots
+ * the shipped stack — ObjectQL + `plugin-security` + `plugin-sharing`, the same
+ * plugins `objectstack serve` mounts — over the app's own `objectstack.config.ts`
+ * and asks the engine, as a real `service_agent`, what comes back.
+ *
+ * ### ⚠️ The hazard is the ROW SHAPE, and the two shapes are different inputs
+ *
+ * "No owner" is not one thing in storage:
+ *
+ *   - `driver-memory` (and `driver-mongodb`) store only the columns a row was
+ *     actually written with, so an ownerless case has **no `owner_id` key at
+ *     all**;
+ *   - a SQL driver materialises every declared column, so the same case has
+ *     `owner_id` **present and NULL**.
+ *
+ * A marketplace app does not choose its host's datasource, so a predicate that
+ * answers on one and not the other is a rule that works on half its installs.
+ * The whole matrix below therefore runs TWICE, once per driver, off one shared
+ * fixture builder — and `the two drivers really do store different shapes`
+ * asserts the difference is real, so the two runs cannot be the same measurement
+ * twice.
+ *
+ * ### ⚠️ Why the rule carries NO `has()` guard
+ *
+ * A sharing condition is not interpreted per record. `plugin-sharing` lowers it
+ * to a pushdown filter through `compileCelToFilter`, which rejects the entire
+ * function-call class — `has(record.owner_id)` makes the rule *untranslatable*,
+ * and the seeder then drops it rather than degrading it to match-all. The rule
+ * would be declared, documented and silently unseeded: the #621 defect, exactly.
+ * AGENTS.md's totality rule (#630) governs the two INTERPRETED CEL surfaces
+ * (object `validations[]` / field predicates, and record-change flow
+ * conditions); it does not reach this one, and applying it here is actively
+ * harmful. `test/sharing-seeding.test.ts` pins the compiler's verdict on
+ * `has()`; what THIS file pins is that the unguarded form nevertheless answers
+ * correctly on the absent-key shape, which is the reason the guard is not
+ * needed: `record.owner_id == null` lowers to `{ owner_id: { $null: true } }`,
+ * and `$null` reads an absent key and a NULL column alike.
+ *
+ * ### How to read a failure here
+ *
+ * A red `an agent sees every unowned OPEN case` means the queue-pull story is
+ * broken again — the tab is back to being empty for the persona it is pinned
+ * for. A red `an agent sees no case owned by someone else` is the opposite and
+ * far worse: the grant stopped being self-limiting and agents are reading other
+ * people's customer cases. Every visibility case carries a positive control (a
+ * row that MUST come back), so none of them can pass by returning nothing.
+ */
+
+type AnyRec = Record<string, any>;
+
+// The object registry announces every registered object on stdout at `info`.
+process.env.OS_REGISTRY_LOG ??= 'silent';
+
+const SYS = { isSystem: true } as AnyRec;
+
+/** The rule under test. */
+const RULE = 'case_unassigned_triage_sharing';
+
+interface Fixture {
+  kernel: AnyRec;
+  ql: AnyRec;
+  /** ids by fixture label. */
+  id: Record<string, string>;
+  /** The `service_agent` execution context under test. */
+  agentCtx: AnyRec;
+  /** What `agent` can see of `object`, as sorted fixture labels. */
+  sees: (object: string) => Promise<string[]>;
+  /** Attempt an agent-context update; returns a stable outcome label. */
+  writes: (object: string, rowId: string, patch: AnyRec) => Promise<string>;
+  /** The stored row as the driver hands it back, under a system context. */
+  raw: (object: string, rowId: string) => Promise<AnyRec>;
+}
+
+/**
+ * Boot the shipped stack on `driver` and populate the triage fixture.
+ *
+ * ⚠️ ORDER IS LOad-BEARING: the ownerless cases are inserted BEFORE anyone holds
+ * the `service_agent` position, because `case_auto_assign` would otherwise
+ * round-robin them onto an agent and there would be nothing ownerless left to
+ * measure. That is not a trick — it is the exact first-install state #596
+ * describes, where an empty pool is the norm rather than an edge case.
+ */
+async function boot(driver: string, config: AnyRec): Promise<Fixture> {
+  const kernel: AnyRec = new ObjectKernel({ logger: { level: 'silent' } } as never);
+  await kernel.use(new DefaultDatasourcePlugin({ driver, config } as never));
+  await kernel.use(
+    new MetadataPlugin({ watch: false, artifactWatch: false, environmentId: 'proj_test' } as never),
+  );
+  await kernel.use(new ObjectQLPlugin({ environmentId: 'proj_test' } as never));
+  await kernel.use(new AppPlugin(stack as never, undefined as never, { skipSeedData: true } as never));
+  await kernel.use(
+    new SecurityPlugin({
+      fallbackPermissionSet: appDefaultPermissionSetName((stack as AnyRec).permissions),
+    } as never),
+  );
+  await kernel.use(new SharingServicePlugin());
+  await kernel.bootstrap();
+  const ql: AnyRec = kernel.getService('objectql');
+
+  // The identity objects are the platform's, not this app's, so nothing in this
+  // boot declares them and a SQL driver has no DDL to create their tables from
+  // (the in-memory driver creates one lazily on first write, which is exactly
+  // why this gap is invisible until a SQL host runs the same code). Their real
+  // schemas are imported rather than hand-mirrored — guessing the column set
+  // would pin this repo's reading of the platform instead of the platform.
+  const engine: AnyRec = kernel.getService('data');
+  const driverName: string | undefined = engine?.getDefaultDriverName?.();
+  const dataDriver: AnyRec | undefined = driverName ? engine?.getDriverByName?.(driverName) : undefined;
+  await dataDriver?.initObjects?.([SysUser, SysMember, SysOrganization] as never);
+
+  const id: Record<string, string> = {};
+  const insert = async (object: string, doc: AnyRec): Promise<string> => {
+    const row = await ql.insert(object, doc, { context: SYS });
+    return String(row?.id ?? row?.record?.id);
+  };
+
+  // ── principals ────────────────────────────────────────────────────────
+  // The FIRST human user is auto-promoted to platform admin at boot, and a
+  // platform admin bypasses every filter this file measures. Burn that
+  // promotion on a throwaway so the agent under test is an ordinary user.
+  await insert('sys_user', { name: 'Platform Admin', email: 'admin@triage-reach.test' });
+  id.agent = await insert('sys_user', { name: 'Triage Agent', email: 'agent@triage-reach.test' });
+  id.other = await insert('sys_user', { name: 'Other Agent', email: 'other@triage-reach.test' });
+
+  // ── the ownerless population, inserted while the pool is EMPTY ─────────
+  const caseDoc = (subject: string, extra: AnyRec = {}) => ({
+    subject,
+    description: 'Inbound web-to-case with nobody on the rota.',
+    status: 'new',
+    priority: 'medium',
+    ...extra,
+  });
+  id.unowned_open = await insert('crm_case', caseDoc('Unowned, open'));
+  id.unowned_critical = await insert('crm_case', caseDoc('Unowned, critical', { priority: 'critical' }));
+  // The deliberate exclusion: an ownerless case that is already CLOSED is
+  // history, not backlog. `is_closed` is readonly and DERIVED from `status` by
+  // `case_sla_defaults`, so it is closed the way the product closes one — by
+  // moving the status — and NOT by writing the flag.
+  //
+  // ⚠️ It is closed on a second call rather than at insert, and that is
+  // measured, not stylistic: `case_sla_defaults` treats a write with neither a
+  // previous row nor a user id as a guest (web-to-case) submission, and the
+  // guest branch strips `is_closed` without recomputing it. A userless insert
+  // carrying `status: 'closed'` therefore stores `is_closed: false` — status
+  // and flag contradicting each other — which would have put this row in the
+  // triage set for a reason that has nothing to do with the rule under test.
+  // On the update there IS a previous row, so the derivation runs.
+  id.unowned_closed = await insert('crm_case', caseDoc('Unowned, closed'));
+  await ql.update(
+    'crm_case',
+    { id: id.unowned_closed, status: 'closed', resolution: 'Duplicate of an earlier report.' },
+    { context: SYS },
+  );
+
+  // ── the pool, staffed only now ────────────────────────────────────────
+  // `sys_user_position.position` holds the position NAME (that is what
+  // `expandPositionUsers` filters on) — an id here expands to nobody.
+  for (const user of [id.agent, id.other]) {
+    await insert('sys_user_position', { user_id: user, position: 'service_agent' });
+  }
+  const sets = await ql.find('sys_permission_set', { where: {} }, { context: SYS });
+  const agentSet = (sets as AnyRec[]).find((s) => s.name === 'service_agent');
+  for (const user of [id.agent, id.other]) {
+    // `permission_set_id` ONLY. `sys_user_permission_set` declares no bare
+    // `permission_set` column, and writing both keys — which a schemaless
+    // in-memory driver accepts silently — is rejected outright by SQL:
+    // "table sys_user_permission_set has no column named permission_set".
+    await insert('sys_user_permission_set', { user_id: user, permission_set_id: agentSet?.id });
+  }
+
+  // ── the owned population ──────────────────────────────────────────────
+  // `case_auto_assign` returns early when `owner_id` is already set, so these
+  // land exactly where they are put.
+  id.own_case = await insert('crm_case', caseDoc('Mine', { owner_id: id.agent }));
+  id.other_case = await insert('crm_case', caseDoc("Somebody else's", { owner_id: id.other }));
+  id.other_critical = await insert(
+    'crm_case',
+    caseDoc("Somebody else's, critical", { owner_id: id.other, priority: 'critical' }),
+  );
+
+  // Materialise the declared rules against the population just inserted (the
+  // boot backfill ran on an empty database).
+  const rules: AnyRec = kernel.getService('sharingRules');
+  for (const rule of [RULE, 'case_escalation_sharing', 'case_director_sharing']) {
+    // Reconciling a rule the stack does not declare is tolerated HERE and
+    // nowhere else, so that deleting the rule under test produces the
+    // INFORMATIVE red — "the agent sees zero unowned cases" — instead of a
+    // harness crash in `beforeAll` that skips every assertion and proves
+    // nothing. That is the reverse-verification lap this file is written to
+    // support, and the tolerance costs no coverage: whether the rule really
+    // seeded is asserted directly, per driver, by `the rule materialised share
+    // rows`, which fails loudly on an empty share set.
+    await rules.evaluateRule(rule, SYS).catch(() => undefined);
+  }
+
+  const agentCtx = await buildContextForUser(ql, id.agent);
+  const byId = new Map(Object.entries(id).map(([label, value]) => [value, label]));
+
+  return {
+    kernel,
+    ql,
+    id,
+    agentCtx,
+    sees: async (object: string) => {
+      const rows = await ql.find(object, { where: {} }, { context: agentCtx });
+      return (Array.isArray(rows) ? rows : [])
+        .map((r: AnyRec) => byId.get(String(r.id)) ?? String(r.id))
+        .sort();
+    },
+    writes: async (object: string, rowId: string, patch: AnyRec) => {
+      try {
+        await ql.update(object, { id: rowId, ...patch }, { context: agentCtx });
+        return 'allowed';
+      } catch (error: unknown) {
+        return `denied: ${(error as AnyRec)?.name}`;
+      }
+    },
+    raw: async (object: string, rowId: string) => {
+      const rows = await ql.find(object, { where: { id: rowId } }, { context: SYS });
+      return (Array.isArray(rows) ? rows : [])[0] ?? {};
+    },
+  };
+}
+
+/**
+ * The two row shapes, as two real datasources.
+ *
+ * `memory` is the sparse one — the shape `driver-mongodb` also produces, and the
+ * only place in the stack that exercises "the key is absent". `sqlite-wasm` is
+ * the column-complete one, standing in for every SQL host: it goes through
+ * `@objectstack/driver-sql`'s knex path, so the filter is lowered to real SQL
+ * rather than evaluated in JS.
+ */
+const DRIVERS: Array<{ label: string; driver: string; config: AnyRec }> = [
+  { label: 'driver-memory (sparse rows — the key is ABSENT)', driver: 'memory', config: {} },
+  {
+    label: 'sqlite-wasm (column-complete rows — the column is NULL)',
+    driver: 'sqlite-wasm',
+    config: { filename: ':memory:' },
+  },
+];
+
+const fixtures = new Map<string, Fixture>();
+
+beforeAll(async () => {
+  for (const { driver, config } of DRIVERS) {
+    fixtures.set(driver, await boot(driver, config));
+  }
+}, 240_000);
+
+afterAll(async () => {
+  for (const fixture of fixtures.values()) await fixture.kernel?.shutdown?.();
+});
+
+describe('the two drivers really do store different shapes', () => {
+  it('memory omits the owner_id key; SQL materialises it as NULL', async () => {
+    // Anti-vacuum for the whole file: if both drivers stored the same shape,
+    // running the matrix twice would be one measurement repeated, and the
+    // "totality" question this card turns on would go unasked.
+    const sparse = await fixtures.get('memory')!.raw('crm_case', fixtures.get('memory')!.id.unowned_open);
+    const complete = await fixtures
+      .get('sqlite-wasm')!
+      .raw('crm_case', fixtures.get('sqlite-wasm')!.id.unowned_open);
+
+    expect(Object.keys(sparse), 'the memory fixture stored no ownerless case at all').toContain('subject');
+    expect(
+      'owner_id' in sparse,
+      'driver-memory started materialising absent columns — the sparse shape this file ' +
+        'exists to cover is no longer being exercised anywhere in the suite',
+    ).toBe(false);
+
+    expect(Object.keys(complete)).toContain('subject');
+    expect(
+      'owner_id' in complete,
+      'the SQL fixture did not materialise owner_id — it is no longer the column-complete shape',
+    ).toBe(true);
+    expect(complete.owner_id ?? null).toBeNull();
+  });
+});
+
+for (const { label, driver } of DRIVERS) {
+  describe(`#1096 on ${label}`, () => {
+    const F = () => fixtures.get(driver)!;
+
+    it('the harness enforces — the agent is an ordinary service_agent', () => {
+      const ctx = F().agentCtx;
+      expect(ctx.permissions, 'the agent must carry its app profile').toContain('service_agent');
+      expect(ctx.permissions).not.toContain('admin_full_access');
+      expect(ctx.hasPlatformAdminGrant).toBe(false);
+      expect(ctx.positions).toContain('service_agent');
+    });
+
+    it('the rule materialised share rows, and ONLY for the unowned open cases', async () => {
+      const { ql, id } = F();
+      const shares = await ql.find(
+        'sys_record_share',
+        { where: { object_name: 'crm_case', recipient_id: id.agent } },
+        { context: SYS },
+      );
+      const byId = new Map(Object.entries(id).map(([k, v]) => [v, k]));
+      const got = (shares as AnyRec[])
+        .map((s) => `${byId.get(String(s.record_id)) ?? s.record_id}:${s.access_level}`)
+        .sort();
+      expect(
+        got,
+        'the triage rule seeded no share row, or seeded the wrong records — a declared rule ' +
+          'that plugin-sharing could not compile is dropped silently (see test/sharing-seeding.test.ts)',
+      ).toEqual(['unowned_critical:edit', 'unowned_open:edit']);
+    });
+
+    it('an agent sees every unowned OPEN case — acceptance #1', async () => {
+      // The defect this card reports, stated positively. `own_case` is the
+      // positive control: without it, a run where crm_case were denied outright
+      // would look the same as a run where the grant works.
+      expect(
+        await F().sees('crm_case'),
+        'the Unassigned — triage tab is empty for the persona it is pinned for again',
+      ).toEqual(['own_case', 'unowned_critical', 'unowned_open']);
+    });
+
+    it('an agent sees NO case owned by someone else — acceptance #2', async () => {
+      // The property that makes the grant safe, asserted as its own case rather
+      // than left implicit in the list above: two of the three cases the other
+      // agent owns are exactly the ones a wider grant would leak, and one of
+      // them is `critical`, which the manager/director rules DO widen — to
+      // positions this agent does not hold.
+      const seen = await F().sees('crm_case');
+      for (const hidden of ['other_case', 'other_critical']) {
+        expect(seen, `${hidden} became visible to an agent who does not own it`).not.toContain(hidden);
+      }
+    });
+
+    it('a CLOSED unowned case stays hidden — the deliberate exclusion', async () => {
+      // `is_closed == false` is part of the predicate on purpose: an ownerless
+      // case that is already closed is history, not backlog, and counting it
+      // would stop the tab's row count meaning "work waiting for a human".
+      expect(await F().sees('crm_case')).not.toContain('unowned_closed');
+    });
+
+    it('the share carries real EDIT — an agent can work the case they can now see', async () => {
+      // `accessLevel: 'edit'` is not decoration: triage means setting a
+      // priority, linking the account, leaving a note. The positive half of the
+      // write side, and the control for the denial pinned below — without it,
+      // "the agent cannot write owner_id" would be indistinguishable from "the
+      // share grants no write at all".
+      expect(
+        await F().writes('crm_case', F().id.unowned_open, { internal_notes: 'Triaging — customer called back.' }),
+        'the triage share stopped granting edit, so an agent can see the backlog and touch none of it',
+      ).toBe('allowed');
+    });
+
+    it('⚠️ taking ownership is DENIED by the transfer gate — acceptance #1’s write half is OPEN', async () => {
+      // MEASURED, and it is the finding this card turns on. The dispatch
+      // presumed the sharing rule alone would deliver "sees them and can take
+      // ownership". The read half it does deliver. The write half it cannot:
+      // `owner_id` is system-managed, and the platform's #3004 transfer gate
+      // refuses ANY ownership change on update without `allowTransfer` or
+      // `modifyAllRecords` — it does not exempt assigning to YOURSELF, and it
+      // does not exempt a record that currently has NO owner:
+      //
+      //   [Security] Access denied: 'owner_id' on 'crm_case' is system-managed
+      //   — changing record ownership on update requires the transfer grant
+      //   (allowTransfer or modifyAllRecords)
+      //
+      // `service_agent` holds `allowTransfer` on `crm_task` ONLY, deliberately
+      // (`src/profiles/service-agent.profile.ts`): granting it on `crm_case`
+      // would let an agent reassign any case they can edit, which is a
+      // permission-model widening the #1096 ruling did not take. So this is
+      // pinned as the measured status quo rather than "fixed" here.
+      //
+      // 🔴 WHEN THIS GOES RED, that is the queue-pull story being completed —
+      // by a claim seam or by a transfer grant. Do not relax it: take it back
+      // to #1096, which is where the seam gets decided.
+      const { id, writes } = F();
+      expect(
+        await writes('crm_case', id.unowned_open, { owner_id: id.agent }),
+        'claiming an unowned case became possible — #1096’s open half has been answered ' +
+          'somewhere; update the card and this pin together',
+      ).toBe('denied: PermissionDeniedError');
+      expect(
+        await writes('crm_case', id.other_case, { owner_id: id.agent }),
+        'an agent grabbed a case owned by somebody else — the transfer gate is not holding',
+      ).toBe('denied: PermissionDeniedError');
+    });
+
+    it('the grant is SELF-LIMITING — it evaporates the moment the case has an owner', async () => {
+      // The property the whole option-A argument rests on: the rule cannot
+      // accumulate a permission surface, because its own condition destroys it.
+      // The claim is performed by the SYSTEM here, not by the agent, only
+      // because the agent cannot yet perform it (see the pin above) — what is
+      // under test is the rule's reaction to a case acquiring an owner, not who
+      // performed the write.
+      const { id, ql, kernel, sees, raw } = F();
+      await ql.update('crm_case', { id: id.unowned_critical, owner_id: id.agent }, { context: SYS });
+      expect(String((await raw('crm_case', id.unowned_critical)).owner_id)).toBe(id.agent);
+
+      await kernel.getService('sharingRules').evaluateRule(RULE, SYS);
+      const shares = await ql.find(
+        'sys_record_share',
+        { where: { object_name: 'crm_case', record_id: id.unowned_critical, recipient_id: id.agent } },
+        { context: SYS },
+      );
+      expect(
+        (shares as AnyRec[]).length,
+        'the share survived the case acquiring an owner — the grant is no longer self-limiting, ' +
+          'and a case that passed through triage stays reachable through the rule forever',
+      ).toBe(0);
+
+      // …and the OTHER agent, who never owned it, loses sight of it entirely —
+      // the same reconcile, from the side that proves the revocation is real
+      // rather than the row merely being re-reached by its new owner.
+      const otherShares = await ql.find(
+        'sys_record_share',
+        { where: { object_name: 'crm_case', record_id: id.unowned_critical, recipient_id: id.other } },
+        { context: SYS },
+      );
+      expect((otherShares as AnyRec[]).length).toBe(0);
+      expect(await sees('crm_case')).toContain('unowned_critical'); // now theirs, by own-scope
+    });
+  });
+}


### PR DESCRIPTION
Part of #1096

`Part of`, not `Fixes`, and that is the headline: the card's acceptance #1 has two halves — "sees them **and can take ownership**" — and only the first is deliverable by a sharing rule. The second is blocked by the platform's transfer gate, measured below. #1096 stays open on that half.

Implements the ruling's **option A**. Option C (`viewAllRecords` on `service_agent`) stays rejected, and is now pinned as rejected in `test/authorization-coverage.test.ts` so it cannot arrive quietly later.

## What lands

One criteria sharing rule, a sibling of the two already in `src/sharing/case.sharing.ts`:

```ts
export const CaseUnassignedTriageSharingRule = {
  name: 'case_unassigned_triage_sharing',
  label: 'Unassigned Cases — Triage',
  object: 'crm_case',
  type: 'criteria' as const,
  condition: P`record.owner_id == null && record.is_closed == false`,
  accessLevel: 'edit' as const,
  sharedWith: { type: 'position' as const, value: 'service_agent' },
};
```

Self-limiting by construction: the condition holds only while the case is unowned, so the grant destroys itself the moment the case has an owner. That is asserted, not asserted-about — the reach test hands the case an owner, reconciles, and checks the `sys_record_share` row is gone for **both** agents.

## Finding 1 — the `has()` guard the dispatch required would have broken this rule

The dispatch's mechanism assumption was that the predicate needs the `has()` totality guard, on AGENTS.md #630's rule. **Measured, it is the opposite: a guard here makes the rule undeployable.**

A sharing condition is not interpreted per record. `plugin-sharing`'s `bootstrapDeclaredSharingRules` lowers it to an ObjectQL pushdown filter through `compileCelToFilter`, and that compiler rejects the entire function-call class. Measured against the shipped compiler:

```
record.owner_id == null && record.is_closed == false
  → {"ok":true,"filter":{"$and":[{"owner_id":{"$null":true}},{"is_closed":false}]}}

!has(record.owner_id) && record.is_closed == false
  → {"ok":false,"reason":"unsupported","detail":"unsupported operator \"call\""}
```

A rule the compiler cannot translate is **not** degraded to match-all — it is dropped, with one WARN in the boot stream. The rule would have been declared, documented, pinned by every metadata-shape test in this PR, and seeded nowhere: exactly the #621 defect, whose scar tissue is `test/sharing-seeding.test.ts` ("`sharing conditions cannot use has()`", written for #633 so this could not be relanded).

Totality is still answered, one layer down instead of at the predicate: `== null` lowers to `{ $null: true }`, the operator form that reads an **absent key** and a **NULL column** alike. Which is the hazard the dispatch was actually pointing at, so it is measured rather than argued — see below.

## Finding 2 — taking ownership is DENIED, so acceptance #1's write half stays open

The share grants `edit`, and edit works: an agent can now open, annotate, prioritise and work the backlog. What they still cannot do is claim it.

```
WRITE claim-self-unowned   denied PermissionDeniedError
  [Security] Access denied: 'owner_id' on 'crm_case' is system-managed —
  changing record ownership on update requires the transfer grant
  (allowTransfer or modifyAllRecords)
WRITE edit-nonowner-field-unowned   allowed
WRITE claim-self-theirs    denied PermissionDeniedError
```

The gate exempts neither "assign to **yourself**" nor "the record has **no owner**". `service_agent` holds `allowTransfer` on `crm_task` only, deliberately — `src/profiles/service-agent.profile.ts` reserves the `crm_case` decision in as many words, because the grant would let an agent reassign any case they can edit. So this PR does not take it. The denial is **pinned as the measured status quo**, with a comment saying that a red there means the open half was answered somewhere and the card needs updating — not that the pin should be relaxed.

Three ways forward are priced in the report on #1096; the narrowest is a claim seam on the `beforeUpdate` hook, which `src/objects/_case-assignment.ts` has already measured to be invisible to this gate — but that is hook code on the seam #1070 also writes, and it is not this card's file surface.

To be explicit about what this means for the tab: an agent's **Unassigned — triage** now has rows, and those rows are workable. Moving one into their own name still needs an admin or a manager holding the transfer grant.

## The predicate evaluates on BOTH row shapes — measured, not assumed

`test/unassigned-case-triage-reach.test.ts` boots the shipped stack (ObjectQL + `plugin-security` + `plugin-sharing` over this app's own `objectstack.config.ts`) and runs the whole matrix **twice**, once per datasource, because "no owner" is not one thing in storage:

| driver | the ownerless row | result |
| --- | --- | --- |
| `driver-memory` (also `driver-mongodb`'s shape) | `owner_id` key **absent** | rule matches, share materialises, agent sees it |
| `sqlite-wasm` (real SQL, knex path) | `owner_id` column present, **NULL** | identical |

The two shapes being genuinely different is itself asserted — `the two drivers really do store different shapes` fails if the memory driver ever starts materialising absent columns, so the second run can never quietly become the first one repeated. A marketplace app does not choose its host's datasource, which is why one green driver would not have been an answer.

## Reverse verification — verbatim RED

Predicted direction: with the rule unregistered the agent sees **zero** unowned cases while still seeing their own (the positive control), the share set is empty, and the edit is refused. Taken out with `git checkout origin/main -- objectstack.config.ts`, measured on this tree, `8 failed | 9 passed`, identically on both drivers:

```
FAIL … > #1096 on driver-memory (sparse rows — the key is ABSENT) > an agent sees every unowned OPEN case — acceptance #1
FAIL … > #1096 on sqlite-wasm (column-complete rows — the column is NULL) > an agent sees every unowned OPEN case — acceptance #1
AssertionError: the Unassigned — triage tab is empty for the persona it is pinned for again: expected [ 'own_case' ] to deeply equal [ Array(3) ]
- Expected
+ Received
  [
    "own_case",
-   "unowned_critical",
-   "unowned_open",
  ]

FAIL … > the rule materialised share rows, and ONLY for the unowned open cases
- [
-   "unowned_critical:edit",
-   "unowned_open:edit",
- ]
+ []

FAIL … > the share carries real EDIT — an agent can work the case they can now see
AssertionError: the triage share stopped granting edit, so an agent can see the backlog and touch none of it: expected 'denied: Error' to be 'allowed'
```

Restored, `17 passed`.

## Acceptance, line by line

1. **An agent opening `Unassigned — triage` sees unowned open cases** — driven, both drivers. **Can take ownership** — measured DENIED, finding 2, card stays open.
2. **No persona gains sight of a case owned by someone else** — its own negative case, and the two rows it checks include a `critical` one, which the manager/director rules *do* widen, to positions this agent does not hold.
3. **Pinned alongside the existing grants** — `test/authorization-coverage.test.ts` gets a `#1096` block (rule shape, criteria verbatim, no-`has()`, and the profile still own-scoped with `viewAllRecords: false`); `test/sharing-coverage.test.ts` gets the named three-rule `crm_case` roster plus "only one rule in the whole stack matches on the absence of an owner".

Deliberately unchanged: a closed unowned case stays hidden (`is_closed == false` is part of the predicate — history, not backlog), and `src/profiles/service-agent.profile.ts` is untouched, the ruling's assumption having held.

## Local gates

`pnpm typecheck` clean · `pnpm validate` exit 0 (87 pre-existing author-time warnings, none from this change) · `pnpm build` exit 0 · `pnpm hygiene` clean · `npx vitest run` **100 files, 2463 passed | 1 skipped**.

## Docs, and one deliberate omission

`content/docs/administration/sharing-and-security.mdx` gains the rule's row — forced, not optional: `sharing-coverage` asserts the built-in-rules table lists *exactly* the shipped rules. The two Chinese pages carry the same table and are **not** touched: they are not covered by that guard, and `sharing-and-security.zh-Hant.mdx` is being edited three lines below that table by the open PR #1124 (#1113 sub-class 3). Those two rows want a follow-up once #1124 lands; noted in the report rather than fixed into a conflict.

## Out of scope, filed

**#1133** — the guest-submission sanitisation in `case.hook.ts` never reaches storage: `delete input.x` is a no-op while an assignment on the same object in the same branch lands. Found building the fixture (a userless insert with `status: 'closed'` stores `is_closed: false`), and it touches this rule's blast radius — such a case reads as open backlog to both the triage view and this grant. The same construct guards web-to-lead. Filed unassigned, not fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012caozke9UaxYdVLaudxJvv)_