### PR TITLE
feat(service): let an agent claim an unowned case out of triage (#1096)

### DIFF
--- a/.changeset/case-triage-self-claim.md
+++ b/.changeset/case-triage-self-claim.md
@@ -1,0 +1,9 @@
+---
+'hotcrm': minor
+---
+
+Service agents can now take a case out of the **Unassigned — triage** tab, completing the queue-pull story #1134 opened.
+
+Moving an unowned, open case into a worked status (**In Progress**, **Waiting on Customer**, **Waiting on Support**) now makes the person who moved it its owner. The case leaves the triage tab, the triage share that made it visible evaporates, and it appears in **My Cases** — no admin hand-off in between.
+
+The claim is deliberately narrow. It fires only on a case that currently has no owner and is not closed, and the owner written is always the caller: assigning a case to somebody else, or taking one that already has an owner, remains refused as before and needs the transfer grant that service agents do not hold. Escalation is unaffected — that transition still routes the case to the service-manager pool. Automated and system writes never claim, so an ownerless case stays in triage until a person picks it up.

--- a/src/objects/_case-assignment.ts
+++ b/src/objects/_case-assignment.ts
@@ -117,6 +117,41 @@ import type { HookApi } from './_hook-api';
  * moves the guard, reading A flips and that test goes red — the signal is to
  * grant `allowTransfer` deliberately or to stop assigning in a hook, NOT to
  * widen the permission model to make a red test green.
+ *
+ * # The ORDER of the gate and the hook phase (#1096) — reading D
+ *
+ * Readings A–C answer "can the gate SEE a hook's stamp". #1096's claim seam
+ * turns on the sharper question underneath: WHEN does the gate run relative to
+ * the hook phase — because if a hook ran first it could sanitise a payload the
+ * gate would otherwise refuse, and an agent could then spell a claim as
+ * `{ owner_id: <self> }` after all.
+ *
+ * It cannot. Measured 2026-08-12 on `@objectstack/*` 17.0.0-rc.6, against the
+ * FULL shipped stack (ObjectQL + `plugin-security` + `plugin-sharing` over this
+ * app's own `objectstack.config.ts`) as a real `service_agent` holding the
+ * `case_unassigned_triage_sharing` share, three readings:
+ *
+ *   D1. `update(unowned_open, { owner_id: <self> })` → denied,
+ *       `PermissionDeniedError`, "'owner_id' on 'crm_case' is system-managed".
+ *       So does `{ owner_id: <other> }`, and so does the same write against a
+ *       case owned by somebody else. `{ internal_notes: … }` on the very same
+ *       row is ALLOWED, which is the control that says the denial is about the
+ *       ownership column and not about reach.
+ *   D2. THE DECISIVE ONE. With a `beforeUpdate` hook installed that DELETES
+ *       `input.owner_id`, the same claim write is still denied — and the hook
+ *       never fired at all (its recorder logged nothing). The gate rejects
+ *       inside the middleware, upstream of the hook phase, so no hook can
+ *       rescue, launder or adjudicate a payload that carries `owner_id`.
+ *   D3. A `beforeUpdate` hook stamping `owner_id` onto a payload that did NOT
+ *       carry the key — `{ status: 'in_progress' }` — is ALLOWED, and the
+ *       stored row comes back owned by the hook's pick. Reading A, re-measured
+ *       through the real security plugin rather than a bare ObjectQL.
+ *
+ * ⇒ "An agent may set `owner_id` to themselves" is not implementable as an
+ * adjudicated write, because the agent's payload may not contain the key at
+ * all. It IS implementable one level up, as a GESTURE the hook interprets:
+ * {@link createCaseSelfClaim}. That is a strictly stronger safety property —
+ * see its own header.
  */
 
 /** The position whose holders form the case intake pool (`sys_user_position`). */
@@ -142,6 +177,36 @@ export const CLOSED_CASE_STATUSES = ['resolved', 'closed'] as const;
 
 /** Cap on the pool read — the same bound `lead_auto_assign` uses. */
 export const POOL_QUERY_LIMIT = 1000;
+
+/**
+ * The statuses that mean "a human has picked this case up and it is not
+ * finished" — the gesture {@link createCaseSelfClaim} reads as a claim (#1096).
+ *
+ * One concept, not three arbitrary picks: each of these says a person is
+ * engaged with the case and the work is still live. The four statuses NOT here
+ * are excluded for a stated reason apiece:
+ *
+ *   - `new` — the state a triage row is already IN. Not a move, so not a claim.
+ *   - `escalated` — {@link createCaseEscalationReassign} owns that transition
+ *     and routes the case to the `service_manager` pool. Two hooks answering
+ *     "who owns this case" for one status change is the "one operation, two
+ *     implementations" shape this whole module exists to prevent.
+ *   - `resolved` / `closed` — finishing a case is not picking it up. An agent
+ *     may still resolve an unowned case straight out of triage (the share
+ *     grants edit); doing so records them in `updated_by` and leaves the
+ *     ownership column honest about the fact that nobody ever took the work.
+ *
+ * ⚠️ Declared here for the doc, the tests and future readers — the handler body
+ * spells the same three strings INLINE, because the L2 sandbox gives it no
+ * module scope (see this file's header).
+ * `test/unassigned-case-triage-reach.test.ts` drives every one of them through
+ * the real engine, so the two copies cannot drift apart quietly.
+ */
+export const CLAIMABLE_TARGET_STATUSES = [
+  'in_progress',
+  'waiting_customer',
+  'waiting_support',
+] as const;
 
 /**
  * Round-robin assignment for ownerless new cases.
@@ -390,6 +455,165 @@ export function createCaseEscalationReassign(hookName = 'case_escalation_reassig
         // `sys_user_position` read leaves the case where it is, escalated.
         // (No `console` here — the L2 hook sandbox does not define one.)
       }
+    },
+  };
+}
+
+/**
+ * Let an agent CLAIM an unowned case out of triage (#1096, acceptance #1's
+ * write half).
+ *
+ * `case_unassigned_triage_sharing` (#1134) gave `service_agent` sight of, and
+ * `edit` on, every unowned open case — so the pinned `Unassigned — triage` tab
+ * finally has rows for the persona it was built for. It could not give them the
+ * other half of the sentence: *"and can take ownership"*. This hook is that
+ * half.
+ *
+ * ## The contract, and why it is STRUCTURAL rather than adjudicated
+ *
+ * The ruled contract is: **an agent may set `owner_id` to THEMSELVES, only
+ * while it is currently null, only on a case that is not closed.**
+ *
+ * The obvious implementation — let the agent write `{ owner_id: <self> }` and
+ * have a hook approve or refuse it — is not available, and that is measured,
+ * not assumed: reading D2 in this file's header shows the #3004 gate rejecting
+ * such a payload INSIDE the middleware, upstream of the hook phase, with the
+ * hook never firing at all. A hook cannot approve a write it never sees.
+ *
+ * So the claim is not a value the agent supplies; it is a GESTURE the hook
+ * reads. The agent moves an unowned open case into a status that means they
+ * have picked it up ({@link CLAIMABLE_TARGET_STATUSES}) and this hook stamps
+ * the ownership column — with `ctx.user.id`, the only user id it has.
+ *
+ * That inverts the usual safety burden, and it is the reason this shape is
+ * preferable to `crm_case.allowTransfer` even setting the blast radius aside:
+ *
+ *   - **"claim it for somebody else" has no spelling.** The hook writes the
+ *     caller's own id and reads no target from the payload; a payload that
+ *     names a third party is refused one layer up by the gate, before this code
+ *     runs, and a payload that carries `owner_id` at all makes this hook stand
+ *     down. There is no lenient branch to find, because there is no input to be
+ *     lenient about.
+ *   - **"claim a case that already has an owner" has no spelling either.** The
+ *     hook is inert unless the STORED row is ownerless.
+ *   - A transfer grant, by contrast, is a general capability being installed to
+ *     obtain a specific one: it would let an agent reassign any case they can
+ *     edit, to anyone, and it cannot express "to yourself only".
+ *
+ * `src/profiles/service-agent.profile.ts` is therefore UNCHANGED by this card —
+ * no new grant of any kind — which is the same standing the intake round-robin
+ * and the escalation hand-off already have.
+ *
+ * ## The four boundaries
+ *
+ * | write, as a `service_agent`                       | outcome |
+ * | --- | --- |
+ * | `{ status: 'in_progress' }` on an unowned OPEN case | claimed — owner becomes the caller |
+ * | the same on a case owned by SOMEBODY ELSE           | refused: no reach, and the ownership guard below |
+ * | `{ owner_id: <anyone> }`, unowned or not            | refused by the transfer gate, upstream |
+ * | the same on an unowned CLOSED case                  | refused: not shared, and the closed guard below |
+ *
+ * Each guard is doubled on purpose. The sharing rule already hides a closed
+ * unowned case and a case owned by someone else, so an agent's write is refused
+ * before reaching here — but the hook must not depend on that, because the hook
+ * also runs for callers the sharing rule does not constrain (an admin, a
+ * manager holding the escalation share). `is_closed == false` in the predicate
+ * and `previous.status !== 'closed'` here are the SAME rule stated at two
+ * layers, and the reach test drives both layers separately so neither can pass
+ * on the other's behalf.
+ *
+ * ## Re-entrancy — reasoned, not assumed
+ *
+ * This file's neighbourhood has been bitten twice (the `closed_date` write, and
+ * the `is_escalated` re-fire loop that wedged a first-boot seed on 2026-07-06),
+ * and both accidents were EXTRA WRITES. Four properties keep this hook off that
+ * surface, in descending order of how much work they do:
+ *
+ *   1. **It performs no operation.** It mutates the payload of the update
+ *      already in flight — no second write, no second `record-after-update`
+ *      event, nothing for `case_escalation`, `case_sla_monitor` or
+ *      `case_status_side_effects` to re-fire on. Same disposal as
+ *      {@link createCaseEscalationReassign}, and it is a disposal rather than a
+ *      guard: there is no loop to break.
+ *   2. **The predicate is a TRANSITION, not a state** (`input.status` present
+ *      AND different from `previous.status`), so it is false on a replay of the
+ *      very update it fired on. The 2026-07-06 loop read a boolean STATE and
+ *      met SQLite's `1 != true`; this one compares two status strings, a
+ *      column with no boolean round-trip to get wrong. The closed guard reads
+ *      `previous.status` first for the same reason, and accepts `is_closed`
+ *      as either `true` or `1` rather than trusting the driver's spelling.
+ *   3. **It is idempotent by construction.** After a successful claim the
+ *      stored row HAS an owner, so guard 3 stops every subsequent run — the
+ *      claim cannot be re-applied, and cannot move a case a second time.
+ *   4. **It cannot collide with the escalation hand-off.** The two hooks are
+ *      disjoint by target status (`escalated` is deliberately not claimable),
+ *      and doubly so by order: at priority 260 this runs AFTER
+ *      `case_escalation_reassign` (250), and stands down entirely the moment
+ *      `owner_id` is already in the payload — so whichever of them speaks
+ *      first, the other is silent.
+ *
+ * ## Who this runs for
+ *
+ * A claim is something a PERSON does, so a write with no user (a seed, a
+ * system-context migration, the anonymous web-to-case path) never claims —
+ * ownerless intake stays ownerless and stays in the tab, which is the whole
+ * point of #596's no-op. A write carrying a real user id claims for that user,
+ * whoever they are: an admin or a service manager who moves an unowned case
+ * into progress has picked it up in exactly the sense an agent has, and both
+ * can hand it on afterwards because both hold the transfer grant an agent does
+ * not.
+ *
+ * @param hookName registry name for the hook (metadata only — never read by
+ *   the body, which the sandbox would not let it be).
+ */
+export function createCaseSelfClaim(hookName = 'case_self_claim'): Hook {
+  return {
+    name: hookName,
+    object: 'crm_case',
+    events: ['beforeUpdate'],
+    priority: 260,
+    description: 'Let a user claim an unowned open case by picking it up; the owner written is always the caller.',
+    handler: async (ctx: HookContext) => {
+      const { input } = ctx;
+      const previous = ctx.previous;
+      if (!previous) return;
+
+      // 1. A claim is something a PERSON does. A system or seed write leaves
+      //    the case ownerless for the triage tab to keep showing.
+      const claimant = ctx.user?.id;
+      if (typeof claimant !== 'string' || !claimant) return;
+      if (ctx.session?.isSystem) return;
+
+      // 2. An explicit `owner_id` in the payload WINS and is never touched.
+      //    For an agent this branch is unreachable — the transfer gate refuses
+      //    that payload upstream (reading D2) — so in practice it means: a
+      //    caller who legitimately holds `allowTransfer` and named an owner
+      //    gets the owner they named, not this hook's opinion.
+      if ('owner_id' in input) return;
+
+      // 3. Only an UNOWNED case can be claimed. Covers both storage shapes of
+      //    "no owner": the key ABSENT (memory/mongo) and the column NULL (SQL).
+      if (typeof previous.owner_id === 'string' && previous.owner_id) return;
+
+      // 4. …and only one that is not CLOSED — the same line the sharing rule
+      //    draws with `is_closed == false`. `status` is read first because it
+      //    is a string on every driver; `is_closed` is accepted as `true` or
+      //    `1` because SQLite hands booleans back as integers.
+      if (previous.status === 'closed') return;
+      if (previous.is_closed === true || previous.is_closed === 1) return;
+
+      // 5. The gesture: the status MOVES to one that means a human has picked
+      //    the case up. These three literals are CLAIMABLE_TARGET_STATUSES;
+      //    the sandbox forbids reading the constant from here, and the parity
+      //    assertion in `test/unassigned-case-triage-reach.test.ts` is what
+      //    keeps the two in step. `escalated` is absent on purpose — that
+      //    transition belongs to `case_escalation_reassign`.
+      const next = input.status;
+      if (typeof next !== 'string' || next === previous.status) return;
+      if (next !== 'in_progress' && next !== 'waiting_customer' && next !== 'waiting_support') return;
+
+      // The only user id this hook has, and the only one it can write.
+      input.owner_id = claimant;
     },
   };
 }

--- a/src/objects/case.hook.ts
+++ b/src/objects/case.hook.ts
@@ -2,7 +2,11 @@
 
 import type { Hook, HookContext } from '@objectstack/spec/data';
 import type { HookApi } from './_hook-api';
-import { createCaseRoundRobinAssign, createCaseEscalationReassign } from './_case-assignment';
+import {
+  createCaseRoundRobinAssign,
+  createCaseEscalationReassign,
+  createCaseSelfClaim,
+} from './_case-assignment';
 
 /**
  * Case SLA & escalation hook.
@@ -18,9 +22,10 @@ import { createCaseRoundRobinAssign, createCaseEscalationReassign } from './_cas
  * - On `resolved`: stamps `closed_date` (proxy for the resolution time — there is
  *   no resolved_date field) and bumps account `last_activity_date`.
  *
- * Ownership assignment is NOT here: both answers to "who should own this case"
- * live in `_case-assignment.ts` — the ownerless-intake round-robin (#596) and
- * the escalation hand-off to the `service_manager` pool (#1070). One module, so
+ * Ownership assignment is NOT here: all three answers to "who should own this
+ * case" live in `_case-assignment.ts` — the ownerless-intake round-robin
+ * (#596), the escalation hand-off to the `service_manager` pool (#1070), and
+ * the triage self-claim (#1096). One module, so
  * the app never grows two independently-authored ownership paths on `crm_case`;
  * its hooks are composed into this module's default export below, so the
  * registry still sees one `crm_case` hook set. In particular the escalation
@@ -278,6 +283,19 @@ const caseAutoAssign: Hook = createCaseRoundRobinAssign();
 const caseEscalationReassign: Hook = createCaseEscalationReassign();
 
 /**
+ * Triage self-claim (#1096), composed from `_case-assignment.ts`.
+ *
+ * The write half of the queue-pull story #1134 opened the read half of: an
+ * agent who moves an unowned open case into a worked status becomes its owner.
+ * Priority 260 puts it AFTER the escalation hand-off (250), and it stands down
+ * whenever `owner_id` is already in the payload — so the two ownership writers
+ * on this seam cannot both speak. Like the hand-off it issues no operation of
+ * its own; unlike either sibling it reads no pool, because the only user id it
+ * can write is the caller's own.
+ */
+const caseSelfClaim: Hook = createCaseSelfClaim();
+
+/**
  * Normalise a BLANK `resolved_by_article` to NULL (#601).
  *
  * Additive and deliberately independent of everything above: it touches no
@@ -341,6 +359,7 @@ export default [
   caseValidation,
   caseAutoAssign,
   caseEscalationReassign,
+  caseSelfClaim,
   caseResolutionArticleNormalize,
   caseSideEffects,
 ];

--- a/test/runtime-coverage.test.ts
+++ b/test/runtime-coverage.test.ts
@@ -67,6 +67,14 @@ const RUNTIME_TEST_FILES = [
   // measures through the real analytics executor on both drivers.
   'knowledge-feedback.test.ts',
   'knowledge-deflection.test.ts',
+  // #1096 — the triage claim seam. Same precedent as the lines above, and a
+  // stronger case for it than most: `case_self_claim` cannot be exercised by a
+  // hook harness at all, because the behaviour under test is what the PLATFORM
+  // does either side of the hook (the transfer gate refusing a hand-written
+  // `owner_id` upstream of the hook phase, and accepting the hook's own stamp).
+  // Only a boot of the real stack can ask that, so the hook's runtime evidence
+  // lives beside the sharing rule it completes.
+  'unassigned-case-triage-reach.test.ts',
 ];
 
 /**

--- a/test/unassigned-case-triage-reach.test.ts
+++ b/test/unassigned-case-triage-reach.test.ts
@@ -13,6 +13,8 @@ import {
 import { SharingServicePlugin } from '@objectstack/plugin-sharing';
 import { SysUser, SysMember, SysOrganization } from '@objectstack/platform-objects/identity';
 import stack from '../objectstack.config';
+import caseHooks from '../src/objects/case.hook';
+import { CLAIMABLE_TARGET_STATUSES } from '../src/objects/_case-assignment';
 
 /**
  * Who really sees the `Unassigned — triage` tab's rows (#1096) — measured
@@ -75,6 +77,24 @@ import stack from '../objectstack.config';
  * far worse: the grant stopped being self-limiting and agents are reading other
  * people's customer cases. Every visibility case carries a positive control (a
  * row that MUST come back), so none of them can pass by returning nothing.
+ *
+ * ### The write half (#1096, second pass)
+ *
+ * #1134 shipped the sight and left the card open on *"and can take ownership"*.
+ * The final block per driver — `the write half — taking ownership` — is that
+ * half, driven the same way: real writes, real contexts, both row shapes.
+ *
+ * The seam is `case_self_claim` (`src/objects/_case-assignment.ts`), and the
+ * one thing to understand before reading those cases is WHY it is a gesture
+ * rather than an adjudicated value. Measured, the #3004 transfer gate refuses a
+ * payload carrying `owner_id` inside the middleware, UPSTREAM of the hook phase
+ * — a hook that would sanitise the key never fires. So "an agent may set
+ * `owner_id` to themselves" is unimplementable as written, and is implemented
+ * one level up instead: the agent moves an unowned open case into a worked
+ * status, and the hook stamps the only user id it has, the caller's own.
+ *
+ * That is why `writing owner_id BY HAND is still denied` is still here and
+ * still green. It is no longer the card's open half; it is the safety half.
  */
 
 type AnyRec = Record<string, any>;
@@ -94,12 +114,26 @@ interface Fixture {
   id: Record<string, string>;
   /** The `service_agent` execution context under test. */
   agentCtx: AnyRec;
+  /** The platform-admin context — the actor that can reach what the rule hides. */
+  adminCtx: AnyRec;
   /** What `agent` can see of `object`, as sorted fixture labels. */
   sees: (object: string) => Promise<string[]>;
   /** Attempt an agent-context update; returns a stable outcome label. */
   writes: (object: string, rowId: string, patch: AnyRec) => Promise<string>;
+  /** The same, under any context — the admin, or the system. */
+  writesAs: (context: AnyRec, object: string, rowId: string, patch: AnyRec) => Promise<string>;
   /** The stored row as the driver hands it back, under a system context. */
   raw: (object: string, rowId: string) => Promise<AnyRec>;
+  /**
+   * The stored `owner_id` as a PRIMITIVE, read fresh from the driver.
+   *
+   * ⚠️ Deliberately not "the row before" and "the row after". The in-memory
+   * driver can hand back the very object it stores, so a "before" ROW captured
+   * into a variable is the same reference the write then mutates — comparing it
+   * afterwards compares a row against itself and passes on unfixed code. A
+   * string (or null) copied out at read time cannot do that.
+   */
+  ownerOf: (rowId: string) => Promise<string | null>;
 }
 
 /**
@@ -149,7 +183,13 @@ async function boot(driver: string, config: AnyRec): Promise<Fixture> {
   // The FIRST human user is auto-promoted to platform admin at boot, and a
   // platform admin bypasses every filter this file measures. Burn that
   // promotion on a throwaway so the agent under test is an ordinary user.
-  await insert('sys_user', { name: 'Platform Admin', email: 'admin@triage-reach.test' });
+  //
+  // #1096 then gives that throwaway a second job: it is the actor that can
+  // REACH a case the sharing rule hides, which is the only way to ask
+  // `case_self_claim`'s own guards a question the record-level denial has not
+  // already answered. See `the closed guard is the SEAM's, not just the
+  // sharing rule's` below.
+  id.admin = await insert('sys_user', { name: 'Platform Admin', email: 'admin@triage-reach.test' });
   id.agent = await insert('sys_user', { name: 'Triage Agent', email: 'agent@triage-reach.test' });
   id.other = await insert('sys_user', { name: 'Other Agent', email: 'other@triage-reach.test' });
 
@@ -182,6 +222,28 @@ async function boot(driver: string, config: AnyRec): Promise<Fixture> {
     { id: id.unowned_closed, status: 'closed', resolution: 'Duplicate of an earlier report.' },
     { context: SYS },
   );
+
+  // ── the claim population (#1096's write half) ─────────────────────────
+  // One row per boundary, because every claim case CONSUMES its row: a
+  // successful claim gives the case an owner, and a second test reusing it
+  // would be measuring an owned case. They are inserted HERE, inside the
+  // empty-pool window, for the same reason as the three above — a row created
+  // after the pool is staffed is round-robined onto an agent by
+  // `case_auto_assign` and is not ownerless at all. That is also what gives
+  // them the driver's genuine ownerless SHAPE (key absent on memory, column
+  // NULL on SQL), which is the input `case_self_claim`'s guard 3 has to answer.
+  id.claim_pickup = await insert('crm_case', caseDoc('Claimable — picked up'));
+  id.claim_waiting = await insert('crm_case', caseDoc('Claimable — answered'));
+  // Seeded already `waiting_customer` (an import/migration shape): the status
+  // machine does not allow `new → waiting_support`, so the only realistic way
+  // to reach that gesture is from a case that is already mid-conversation.
+  id.claim_support = await insert('crm_case', caseDoc('Claimable — waiting on support', { status: 'waiting_customer' }));
+  id.claim_escalate = await insert('crm_case', caseDoc('Escalated, not claimed'));
+  // Likewise seeded `in_progress`: `new → resolved` is not a declared
+  // transition, and resolving is the gesture being excluded, not tested.
+  id.claim_resolve = await insert('crm_case', caseDoc('Resolved, not claimed', { status: 'in_progress' }));
+  id.claim_system = await insert('crm_case', caseDoc('Touched by automation, not claimed'));
+  id.claim_admin = await insert('crm_case', caseDoc('Picked up by an admin'));
 
   // ── the pool, staffed only now ────────────────────────────────────────
   // `sys_user_position.position` holds the position NAME (that is what
@@ -225,30 +287,40 @@ async function boot(driver: string, config: AnyRec): Promise<Fixture> {
   }
 
   const agentCtx = await buildContextForUser(ql, id.agent);
+  const adminCtx = await buildContextForUser(ql, id.admin);
   const byId = new Map(Object.entries(id).map(([label, value]) => [value, label]));
+
+  const rawRow = async (object: string, rowId: string): Promise<AnyRec> => {
+    const rows = await ql.find(object, { where: { id: rowId } }, { context: SYS });
+    return (Array.isArray(rows) ? rows : [])[0] ?? {};
+  };
+  const writesAs = async (context: AnyRec, object: string, rowId: string, patch: AnyRec): Promise<string> => {
+    try {
+      await ql.update(object, { id: rowId, ...patch }, { context });
+      return 'allowed';
+    } catch (error: unknown) {
+      return `denied: ${(error as AnyRec)?.name}`;
+    }
+  };
 
   return {
     kernel,
     ql,
     id,
     agentCtx,
+    adminCtx,
     sees: async (object: string) => {
       const rows = await ql.find(object, { where: {} }, { context: agentCtx });
       return (Array.isArray(rows) ? rows : [])
         .map((r: AnyRec) => byId.get(String(r.id)) ?? String(r.id))
         .sort();
     },
-    writes: async (object: string, rowId: string, patch: AnyRec) => {
-      try {
-        await ql.update(object, { id: rowId, ...patch }, { context: agentCtx });
-        return 'allowed';
-      } catch (error: unknown) {
-        return `denied: ${(error as AnyRec)?.name}`;
-      }
-    },
-    raw: async (object: string, rowId: string) => {
-      const rows = await ql.find(object, { where: { id: rowId } }, { context: SYS });
-      return (Array.isArray(rows) ? rows : [])[0] ?? {};
+    writes: (object: string, rowId: string, patch: AnyRec) => writesAs(agentCtx, object, rowId, patch),
+    writesAs,
+    raw: rawRow,
+    ownerOf: async (rowId: string) => {
+      const stored = (await rawRow('crm_case', rowId)).owner_id;
+      return typeof stored === 'string' && stored ? stored : null;
     },
   };
 }
@@ -336,7 +408,21 @@ for (const { label, driver } of DRIVERS) {
         got,
         'the triage rule seeded no share row, or seeded the wrong records — a declared rule ' +
           'that plugin-sharing could not compile is dropped silently (see test/sharing-seeding.test.ts)',
-      ).toEqual(['unowned_critical:edit', 'unowned_open:edit']);
+      ).toEqual([
+        // The seven `claim_*` rows are #1096's write-half fixtures, one per
+        // boundary. They are ordinary unowned open cases and the rule reaches
+        // them for exactly that reason — which is itself worth seeing here,
+        // because a claim is only interesting on a case the agent can reach.
+        'claim_admin:edit',
+        'claim_escalate:edit',
+        'claim_pickup:edit',
+        'claim_resolve:edit',
+        'claim_support:edit',
+        'claim_system:edit',
+        'claim_waiting:edit',
+        'unowned_critical:edit',
+        'unowned_open:edit',
+      ]);
     });
 
     it('an agent sees every unowned OPEN case — acceptance #1', async () => {
@@ -346,7 +432,18 @@ for (const { label, driver } of DRIVERS) {
       expect(
         await F().sees('crm_case'),
         'the Unassigned — triage tab is empty for the persona it is pinned for again',
-      ).toEqual(['own_case', 'unowned_critical', 'unowned_open']);
+      ).toEqual([
+        'claim_admin',
+        'claim_escalate',
+        'claim_pickup',
+        'claim_resolve',
+        'claim_support',
+        'claim_system',
+        'claim_waiting',
+        'own_case',
+        'unowned_critical',
+        'unowned_open',
+      ]);
     });
 
     it('an agent sees NO case owned by someone else — acceptance #2', async () => {
@@ -380,38 +477,56 @@ for (const { label, driver } of DRIVERS) {
       ).toBe('allowed');
     });
 
-    it('⚠️ taking ownership is DENIED by the transfer gate — acceptance #1’s write half is OPEN', async () => {
-      // MEASURED, and it is the finding this card turns on. The dispatch
-      // presumed the sharing rule alone would deliver "sees them and can take
-      // ownership". The read half it does deliver. The write half it cannot:
-      // `owner_id` is system-managed, and the platform's #3004 transfer gate
-      // refuses ANY ownership change on update without `allowTransfer` or
-      // `modifyAllRecords` — it does not exempt assigning to YOURSELF, and it
-      // does not exempt a record that currently has NO owner:
+    it('writing owner_id BY HAND is still denied — to self, to a third party, on any case', async () => {
+      // ═══ #1096, second pass: this pin used to be the card's open half ═════
       //
-      //   [Security] Access denied: 'owner_id' on 'crm_case' is system-managed
-      //   — changing record ownership on update requires the transfer grant
-      //   (allowTransfer or modifyAllRecords)
+      // It shipped in #1134 reading "⚠️ taking ownership is DENIED by the
+      // transfer gate — acceptance #1's write half is OPEN", and it carried
+      // this instruction:
       //
-      // `service_agent` holds `allowTransfer` on `crm_task` ONLY, deliberately
-      // (`src/profiles/service-agent.profile.ts`): granting it on `crm_case`
-      // would let an agent reassign any case they can edit, which is a
-      // permission-model widening the #1096 ruling did not take. So this is
-      // pinned as the measured status quo rather than "fixed" here.
+      //   🔴 WHEN THIS GOES RED, that is the queue-pull story being completed
+      //   — by a claim seam or by a transfer grant. Do not relax it: take it
+      //   back to #1096, which is where the seam gets decided.
       //
-      // 🔴 WHEN THIS GOES RED, that is the queue-pull story being completed —
-      // by a claim seam or by a transfer grant. Do not relax it: take it back
-      // to #1096, which is where the seam gets decided.
-      const { id, writes } = F();
+      // The seam landed (`case_self_claim`) and this pin did NOT go red, which
+      // is the whole shape of the answer rather than an oversight. MEASURED
+      // 2026-08-12 on the full stack (reading D2 in `_case-assignment.ts`): the
+      // #3004 gate rejects a payload carrying `owner_id` INSIDE the middleware,
+      // upstream of the hook phase — a `beforeUpdate` hook that deletes the key
+      // does not fire at all, and the write is still denied. No hook can
+      // approve a write it never sees.
+      //
+      // So the claim is not a VALUE an agent supplies and something adjudicates.
+      // It is a GESTURE the hook reads, and the hook's only possible output is
+      // the caller's own id. This test is now the safety half of that: the hand
+      // route stays shut in every direction, including the one a looser design
+      // would have opened — naming a THIRD PARTY on a case nobody owns.
+      //
+      // 🔴 If any of these goes green, an ownership grant has appeared on
+      // `service_agent` (or the gate moved). That is a permission-model change
+      // and belongs on its own card — do not absorb it here.
+      const { id, writes, ownerOf } = F();
       expect(
         await writes('crm_case', id.unowned_open, { owner_id: id.agent }),
-        'claiming an unowned case became possible — #1096’s open half has been answered ' +
-          'somewhere; update the card and this pin together',
+        'the hand-written ownership route opened up — an agent can now name an owner directly',
+      ).toBe('denied: PermissionDeniedError');
+      expect(
+        await writes('crm_case', id.unowned_open, { owner_id: id.other }),
+        'an agent assigned an unowned case to SOMEBODY ELSE — the claim seam is supposed to make ' +
+          'that unspellable, and the gate is supposed to refuse it',
       ).toBe('denied: PermissionDeniedError');
       expect(
         await writes('crm_case', id.other_case, { owner_id: id.agent }),
         'an agent grabbed a case owned by somebody else — the transfer gate is not holding',
       ).toBe('denied: PermissionDeniedError');
+      // Nor can the value ride along with the gesture that IS allowed.
+      expect(
+        await writes('crm_case', id.unowned_open, { status: 'in_progress', owner_id: id.agent }),
+        'owner_id smuggled alongside a claim gesture was accepted',
+      ).toBe('denied: PermissionDeniedError');
+      // A denied claim leaves nothing behind: the case is still unowned, so no
+      // half of the refused write landed.
+      expect(await ownerOf(id.unowned_open), 'a denied ownership write partially applied').toBeNull();
     });
 
     it('the grant is SELF-LIMITING — it evaporates the moment the case has an owner', async () => {
@@ -448,5 +563,211 @@ for (const { label, driver } of DRIVERS) {
       expect((otherShares as AnyRec[]).length).toBe(0);
       expect(await sees('crm_case')).toContain('unowned_critical'); // now theirs, by own-scope
     });
+
+    // ══════════ #1096, write half — claiming a case out of triage ══════════
+    //
+    // Everything above is about SIGHT. These are about TAKING, and they run
+    // last because every one of them consumes its fixture: a claimed case has
+    // an owner, and re-using it would be measuring a different question.
+    //
+    // ⚠️ How the "before" state is read matters here. `ownerOf()` copies a
+    // STRING (or null) out of a fresh read, never a row object: the in-memory
+    // driver can hand back the object it stores, so a row captured into a
+    // variable and re-inspected after the write is the same reference the write
+    // mutated — a comparison against itself, green on unfixed code (#1132).
+    describe('the write half — taking ownership', () => {
+      it('an agent CLAIMS an unowned open case by picking it up — acceptance #1', async () => {
+        const { id, writes, ownerOf, raw, sees } = F();
+
+        // The input shape this driver actually presents to the seam's guard 3.
+        // Asserted per driver, so a claim on the sparse (key-absent) shape and
+        // a claim on the column-complete (NULL) shape are two measurements and
+        // never one repeated — the same reason the whole matrix runs twice.
+        const stored = await raw('crm_case', id.claim_pickup);
+        expect(
+          'owner_id' in stored,
+          driver === 'memory'
+            ? 'the memory fixture materialised owner_id — the absent-key shape is no longer covered'
+            : 'the SQL fixture did not materialise owner_id — the NULL-column shape is no longer covered',
+        ).toBe(driver !== 'memory');
+        expect(await ownerOf(id.claim_pickup), 'the fixture was not ownerless to begin with').toBeNull();
+
+        expect(
+          await writes('crm_case', id.claim_pickup, { status: 'in_progress' }),
+          'an agent could not pick up a case from their own triage tab',
+        ).toBe('allowed');
+
+        expect(
+          await ownerOf(id.claim_pickup),
+          'the case was not claimed — #1096 acceptance #1 is back to half-delivered: the tab has ' +
+            'rows and nobody can take one',
+        ).toBe(id.agent);
+        expect((await raw('crm_case', id.claim_pickup)).status, 'the gesture itself did not land').toBe('in_progress');
+        // …and it is still theirs to work, now by ordinary own-scope rather
+        // than by the triage grant.
+        expect(await sees('crm_case')).toContain('claim_pickup');
+      });
+
+      it('the claim gesture is exactly CLAIMABLE_TARGET_STATUSES — every member, driven', async () => {
+        // The parity pin. The handler spells these three strings INLINE (the L2
+        // sandbox gives it no module scope), so the exported constant and the
+        // body can only be kept in step behaviourally: every member is driven
+        // through a real write here, and the two exclusions below are driven too.
+        const { id, writes, ownerOf } = F();
+        expect([...CLAIMABLE_TARGET_STATUSES].sort()).toEqual(['in_progress', 'waiting_customer', 'waiting_support']);
+
+        expect(await writes('crm_case', id.claim_waiting, { status: 'waiting_customer' })).toBe('allowed');
+        expect(
+          await ownerOf(id.claim_waiting),
+          'answering the customer on an unowned case did not claim it, so it stays in the triage ' +
+            'tab while an agent is already handling it',
+        ).toBe(id.agent);
+
+        expect(await writes('crm_case', id.claim_support, { status: 'waiting_support' })).toBe('allowed');
+        expect(await ownerOf(id.claim_support)).toBe(id.agent);
+      });
+
+      it('ESCALATING is not claiming — that transition belongs to the hand-off', async () => {
+        // `case_escalation_reassign` (#1070) owns `→ escalated` and routes the
+        // case to the `service_manager` pool. Two hooks answering "who owns
+        // this case" for one status change is the shape `_case-assignment.ts`
+        // exists to prevent, so `escalated` is deliberately not claimable. The
+        // manager pool is unstaffed in this fixture — the first-install norm —
+        // so the hand-off is a no-op and the case stays ownerless, which is
+        // exactly what makes this a clean reading of OUR hook standing down.
+        const { id, writes, ownerOf, raw } = F();
+        expect(await writes('crm_case', id.claim_escalate, { status: 'escalated' })).toBe('allowed');
+        expect((await raw('crm_case', id.claim_escalate)).status).toBe('escalated');
+        expect(
+          await ownerOf(id.claim_escalate),
+          'escalating an unowned case claimed it for the escalating agent — the escalation ' +
+            'hand-off and the claim seam are both writing owner_id on the same transition',
+        ).toBeNull();
+      });
+
+      it('RESOLVING is not claiming — finishing a case is not picking it up', async () => {
+        const { id, writes, ownerOf } = F();
+        expect(await writes('crm_case', id.claim_resolve, { status: 'resolved' })).toBe('allowed');
+        expect(
+          await ownerOf(id.claim_resolve),
+          'resolving an unowned case claimed it — the ownership column should stay honest about ' +
+            'the fact that nobody ever took the work',
+        ).toBeNull();
+      });
+
+      it('an unowned CLOSED case cannot be claimed — the record-level half', async () => {
+        // Layer one: the sharing rule's `is_closed == false` never grants the
+        // agent the row, so the write is refused before any hook runs. This is
+        // a record-level FORBIDDEN, not the transfer gate's PermissionDenied —
+        // a different refusal from the one pinned above, which is why it is
+        // matched loosely and asserted on the stored row as well.
+        const { id, writes, ownerOf } = F();
+        expect(
+          await writes('crm_case', id.unowned_closed, { status: 'in_progress' }),
+          'a closed unowned case became writable by an agent — the triage grant is leaking ' +
+            'past its own predicate',
+        ).toMatch(/^denied/);
+        expect(await ownerOf(id.unowned_closed)).toBeNull();
+      });
+
+      it('the closed guard is the SEAM’s too, not only the sharing rule’s', async () => {
+        // Layer two, and the reason it needs its own case: the denial above
+        // proves the agent cannot REACH the row, which would look identical if
+        // `case_self_claim` had no closed guard at all. So the same question is
+        // asked by an actor that CAN reach it, with a control that differs in
+        // one property only — whether the case is closed.
+        const { id, adminCtx, writesAs, ownerOf } = F();
+        expect(adminCtx.hasPlatformAdminGrant, 'the admin cannot reach the row either — this case proves nothing').toBe(true);
+
+        expect(await writesAs(adminCtx, 'crm_case', id.unowned_closed, { status: 'in_progress' })).toBe('allowed');
+        expect(
+          await ownerOf(id.unowned_closed),
+          'the seam claimed a CLOSED case for whoever touched it — history is not backlog, and ' +
+            'the guard that says so has gone',
+        ).toBeNull();
+
+        // The control: same actor, same payload, an OPEN case. It claims — so
+        // the refusal above is about closedness and not about the caller.
+        expect(await writesAs(adminCtx, 'crm_case', id.claim_admin, { status: 'in_progress' })).toBe('allowed');
+        expect(
+          await ownerOf(id.claim_admin),
+          'the control did not claim either, so the closed case proves nothing about the guard',
+        ).toBe(id.admin);
+      });
+
+      it('a write with no user never claims — automation leaves the backlog alone', async () => {
+        // #596's no-op is load-bearing: an ownerless case must STAY ownerless
+        // and stay in the tab when nothing human has picked it up. A seam that
+        // claimed on any write would hand the whole backlog to whichever
+        // scheduled sweep touched it first.
+        const { id, ql, ownerOf } = F();
+        await ql.update('crm_case', { id: id.claim_system, status: 'in_progress' }, { context: SYS });
+        expect(
+          await ownerOf(id.claim_system),
+          'a system write claimed the case — automation is now taking ownership of the triage backlog',
+        ).toBeNull();
+      });
+
+      it('claiming is idempotent, and it makes the triage grant evaporate', async () => {
+        // Two properties on the case claimed in the first test above.
+        //
+        // (1) Idempotence: the seam cannot move a case a second time, because
+        //     its own success gives the row an owner and guard 3 then stops it.
+        //     That is what keeps it off the re-entrancy surface this file's
+        //     neighbourhood has been bitten on twice.
+        // (2) The claim closes the loop with the read half: the grant that let
+        //     the agent see the case destroys itself the moment they take it.
+        const { id, ql, kernel, writes, ownerOf } = F();
+        expect(await ownerOf(id.claim_pickup), 'the earlier claim did not stick').toBe(id.agent);
+
+        expect(await writes('crm_case', id.claim_pickup, { status: 'waiting_customer' })).toBe('allowed');
+        expect(
+          await ownerOf(id.claim_pickup),
+          'a second worked-status move re-ran the claim — on a case with an owner, the seam must be inert',
+        ).toBe(id.agent);
+
+        await kernel.getService('sharingRules').evaluateRule(RULE, SYS);
+        const shares = await ql.find(
+          'sys_record_share',
+          { where: { object_name: 'crm_case', record_id: id.claim_pickup } },
+          { context: SYS },
+        );
+        expect(
+          (shares as AnyRec[]).length,
+          'the triage share outlived the claim — a claimed case stays reachable by every other ' +
+            'agent through the rule',
+        ).toBe(0);
+      });
+    });
   });
 }
+
+/**
+ * The seam's registered shape (#1096).
+ *
+ * Metadata rather than behaviour, and here rather than in a shape-only suite
+ * because both halves of the priority argument are measured in this file: 260
+ * puts `case_self_claim` AFTER `case_escalation_reassign` (250), and the
+ * escalation case above is what proves the two do not both write.
+ */
+describe('case_self_claim is registered on the seam it was measured on', () => {
+  const claim = (caseHooks as AnyRec[]).find((h) => h.name === 'case_self_claim');
+
+  it('exists, on beforeUpdate, after the escalation hand-off', () => {
+    expect(claim, 'the claim hook is not registered on crm_case at all').toBeTruthy();
+    expect(claim!.object).toBe('crm_case');
+    expect(
+      claim!.events,
+      'the claim seam moved off beforeUpdate — every other phase is VISIBLE to the #3004 transfer ' +
+        'gate (readings C and D in _case-assignment.ts), so the claim would start needing ' +
+        'crm_case.allowTransfer on service_agent',
+    ).toEqual(['beforeUpdate']);
+
+    const escalation = (caseHooks as AnyRec[]).find((h) => h.name === 'case_escalation_reassign');
+    expect(
+      claim!.priority,
+      'the claim hook must run after the escalation hand-off, so an escalation that has already ' +
+        'chosen an owner is never second-guessed',
+    ).toBeGreaterThan(escalation!.priority as number);
+  });
+});


### PR DESCRIPTION
Fixes #1096

The write half. #1134 shipped acceptance #1's *"sees them"* and left the card open on *"and can take ownership"*. An agent can now take a case out of **Unassigned — triage**, and `service_agent` gains no new grant of any kind — `src/profiles/service-agent.profile.ts` is untouched.

## ⚠️ Read this first: the contract is enforced STRUCTURALLY, not adjudicated

The dispatch's contract was *"an agent may set `owner_id` to themselves, only when it is currently null, only on a non-closed case"*, with the expectation that the pinned denial in `test/unassigned-case-triage-reach.test.ts` would go red.

**That pin did not go red, and it should not.** Measured on the full stack, the #3004 transfer gate refuses a payload carrying `owner_id` **inside the middleware, upstream of the hook phase** — a `beforeUpdate` hook that would sanitise the key never fires at all. Three readings, all on `@objectstack/*` 17.0.0-rc.6 through ObjectQL + `plugin-security` + `plugin-sharing` over this app's own `objectstack.config.ts`, as a real `service_agent` holding the triage share:

```
D1  update(unowned_open, { owner_id: self })     denied  PermissionDeniedError
      [Security] Access denied: 'owner_id' on 'crm_case' is system-managed —
      changing record ownership on update requires the transfer grant
      (allowTransfer or modifyAllRecords)
    update(unowned_open, { owner_id: other })    denied  PermissionDeniedError
    update(other_case,   { owner_id: self })     denied  PermissionDeniedError
    update(unowned_open, { internal_notes: … })  allowed          ← the control

D2  the same claim write, with a beforeUpdate hook installed that DELETES
    input.owner_id                               denied  PermissionDeniedError
      hook fired? []                             ← it never ran

D3  a beforeUpdate hook stamping owner_id onto a payload that did NOT carry
    the key — { status: 'in_progress' }          allowed
      stored owner_id: the agent      stored status: in_progress
```

**D2 is the decisive one.** No hook can approve, launder or adjudicate a write it never sees, so *"an agent may set `owner_id` to themselves"* is not implementable as a permitted value. It is implementable one level up, as a **gesture**: the agent moves an unowned open case into a worked status, and the hook stamps the only user id it has — the caller's own.

That is strictly stronger than the shape the card imagined, and it is why this is the right answer rather than a workaround for a blocked one:

- **"claim it for somebody else" has no spelling.** The hook reads no target from the payload; it writes `ctx.user.id`. A payload naming a third party is refused by the gate one layer up, before this code runs. There is no lenient branch to find because there is no input to be lenient about.
- **"claim a case that already has an owner" has no spelling either** — the hook is inert unless the stored row is ownerless.
- `crm_case.allowTransfer`, by contrast, would install a general capability to obtain a specific one: reassign any case you can edit, to anyone, with no way to express *"to yourself only"*. Not taken, as ruled.

## What lands

`case_self_claim` — a third factory in `src/objects/_case-assignment.ts`, the module that exists so *"who should own this case"* has one home:

```ts
name: 'case_self_claim', object: 'crm_case', events: ['beforeUpdate'], priority: 260
```

Five guards, in order: a real user (never a system or seed write) · no `owner_id` already in the payload · the stored row is **unowned** · the stored row is **not closed** · the status **moves** to one of `CLAIMABLE_TARGET_STATUSES` = `in_progress` / `waiting_customer` / `waiting_support`. Then, and only then, `input.owner_id = ctx.user.id`.

`escalated` is deliberately **not** claimable: that transition belongs to `case_escalation_reassign` (#1070), which routes the case to the `service_manager` pool. `resolved` / `closed` are not claimable either — finishing a case is not picking it up.

### Re-entrancy, reasoned rather than assumed

This file's neighbourhood has been bitten twice (the `closed_date` write; the `is_escalated` re-fire loop that wedged a first-boot seed on 2026-07-06) and **both accidents were extra writes**. Four properties, in descending order of how much work they do:

1. **It performs no operation.** It mutates the payload of the update already in flight — no second write, no second `record-after-update`, nothing for `case_escalation`, `case_sla_monitor` or `case_status_side_effects` to re-fire on. A disposal, not a guard: there is no loop to break.
2. **The predicate is a transition, not a state** (`input.status` present AND different from `previous.status`), so it is false on a replay of the very update it fired on. The 2026-07-06 loop read a boolean STATE and met SQLite's `1 != true`; this compares two status strings. The closed guard reads `previous.status` first for the same reason and accepts `is_closed` as `true` **or** `1`.
3. **Idempotent by construction** — a successful claim gives the row an owner, so guard 3 stops every later run. Driven.
4. **It cannot collide with the escalation hand-off**: disjoint by target status, and doubly so by order — 260 runs after 250, and it stands down the moment `owner_id` is already in the payload, so whichever speaks first, the other is silent. Driven.

## The four boundaries, each its own case, each a real write

Run twice, once per driver, inside the existing per-driver matrix:

| write, as a `service_agent` | outcome | refused by |
| --- | --- | --- |
| `{ status: 'in_progress' }` on an unowned OPEN case | **claimed** — owner becomes the caller | — |
| `{ status: 'in_progress' }` on a case owned by someone else | refused | no reach, plus the ownership guard |
| `{ owner_id: … }` to self **or to a third party**, unowned or not | refused | the transfer gate, upstream |
| `{ status: 'in_progress' }` on an unowned CLOSED case | refused | not shared, plus the closed guard |

The third row is the one a loose implementation gets wrong, so it is asserted in three spellings including `{ status: 'in_progress', owner_id: self }` — the value cannot ride along with the gesture — and the stored row is checked afterwards to prove no half of a refused write landed.

**The closed boundary gets a second case on purpose.** The agent's denial there is *record-level* — the sharing rule never grants the row — which would look identical if the seam had no closed guard at all. So the same question is put to an actor that CAN reach the row (the platform admin) with a control that differs in one property only: closed → no claim, open → claimed. Layer one and layer two are measured separately, so neither passes on the other's behalf.

## Both driver row shapes — asserted, not assumed

"No owner" is not one thing in storage, and the claim's guard 3 is entirely about it. The claim fixtures are inserted inside the empty-pool window (a row created after the pool is staffed is round-robined onto an agent and is not ownerless at all), so they carry the driver's genuine ownerless shape, and the first claim case asserts which shape it just ran against:

| driver | the ownerless row | claim |
| --- | --- | --- |
| `driver-memory` (also `driver-mongodb`'s shape) | `owner_id` key **absent** | claimed |
| `sqlite-wasm` (real SQL, knex path) | `owner_id` column present, **NULL** | claimed |

`the two drivers really do store different shapes` still guards the pair, so the second run can never quietly become the first repeated.

## The by-reference trap (#1132)

Every ownership read goes through `ownerOf()`, which copies a **string or null** out of a fresh `find` under a system context. Deliberately never "the row before" and "the row after": the in-memory driver can hand back the object it stores, so a row captured into a variable and re-inspected after the write is the same reference the write mutated — a comparison against itself, green on unfixed code. Seed and expectation come from separate calls throughout: the expected id is a fixture id captured at boot from a different insert, and the observed value is read from storage after the write.

## Reverse verification — verbatim RED, direction predicted first

Predicted before running: with `case_self_claim` unregistered, the claim cases fail and every denial case still passes; the three *exclusion* cases (escalating / resolving / a system write do not claim) stay green **vacuously**, which is exactly why each is paired with a positive control. Measured on this tree, identically on both drivers — `9 failed | 25 passed`:

```
× an agent CLAIMS an unowned open case by picking it up — acceptance #1
  AssertionError: the case was not claimed — #1096 acceptance #1 is back to
  half-delivered: the tab has rows and nobody can take one:
  expected null to be 'sys_user-1786523373431-2'

× the claim gesture is exactly CLAIMABLE_TARGET_STATUSES — every member, driven
  AssertionError: answering the customer on an unowned case did not claim it,
  so it stays in the triage tab while an agent is already handling it:
  expected null to be 'sys_user-1786523373431-2'

× the closed guard is the SEAM's too, not only the sharing rule's
  AssertionError: the control did not claim either, so the closed case proves
  nothing about the guard: expected null to be 'sys_user-1786523373397-1'

× claiming is idempotent, and it makes the triage grant evaporate
  AssertionError: the earlier claim did not stick:
  expected null to be 'sys_user-1786523373431-2'

× case_self_claim is registered on the seam it was measured on
  AssertionError: the claim hook is not registered on crm_case at all:
  expected undefined to be truthy
```

Still green under the same removal, as predicted: `writing owner_id BY HAND is still denied`, `an unowned CLOSED case cannot be claimed — the record-level half`, all three exclusion cases, and every one of #1134's read-half cases. Restored: `34 passed`.

## The pin #1134 left, and what happened to it

The card's instruction was that the denial pin would go red and must not be relaxed. Its comment read, verbatim:

> 🔴 WHEN THIS GOES RED, that is the queue-pull story being completed —
> by a claim seam or by a transfer grant. Do not relax it: take it back
> to #1096, which is where the seam gets decided.

It has not been relaxed and it has not gone red. It is **kept, widened and re-documented**: `writing owner_id BY HAND is still denied — to self, to a third party, on any case`. It is no longer the card's open half; it is the safety half of the answer, and its new comment records D2 as the reason a red was never available here. It now also carries the third-party and the smuggled-value spellings, and a new instruction: if any of them goes green, an ownership grant has appeared on `service_agent` — that is a permission-model change and belongs on its own card.

## Two behaviours worth confirming rather than discovering

- **Anyone who picks a case up owns it, not only a `service_agent`.** An admin or a service manager who moves an unowned case into progress is claiming it in exactly the sense an agent is, and both can hand it on afterwards because both hold the transfer grant an agent does not. This is asserted (it is the control in the closed-guard case), not incidental. Restricting the seam to `service_agent` position holders would also lock out the manager/director personas that `case_escalation_sharing` puts in front of unowned critical cases.
- **The gesture is a status move, not a button.** No new field, no new action, no new view button — none of that is this card's file surface, and a dedicated **Claim** action would in any case have to trigger this very hook, because a screen flow's `update_record` runs as the caller and hits the same gate. The button is purely additive UI on top of what lands here; filed as a follow-up rather than smuggled in.

## Local gates

`pnpm typecheck` clean · `pnpm validate` exit 0 · `pnpm build` exit 0 · `pnpm hygiene` clean (including the control-byte scan) · `pnpm lint` exit 0 · `pnpm lint:i18n-gate` 0 issues · `npx vitest run` **102 files, 2526 passed | 1 skipped**.

`validate` reports 88 author-time warnings, and that number is **measured rather than asserted to be pre-existing**: unregistering the new hook and re-running gives 88 as well, so this change contributes none. All 88 are page / view / flow / capability categories and none names the hook.

## File surface

`src/objects/_case-assignment.ts` and `src/objects/case.hook.ts` (the ruled seam), `test/unassigned-case-triage-reach.test.ts`, a changeset — plus one line and its comment in `test/runtime-coverage.test.ts`, which is forced rather than chosen: that guard fails any registered hook not named in a runtime test file, and `case_self_claim` cannot be exercised by a hook harness at all, because the behaviour under test is what the platform does either side of the hook. `src/sharing/case.sharing.ts` and `content/docs/**` untouched, as instructed — the docs row is a follow-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_012caozke9UaxYdVLaudxJvv)_