### PR TITLE
chore(deps)!: upgrade @objectstack/* 17.0.0-rc.6 → 17.0.0 GA, absorb four behaviour changes, sweep the formula-filter refusal

### DIFF
--- a/.changeset/objectstack-17-ga-upgrade.md
+++ b/.changeset/objectstack-17-ga-upgrade.md
@@ -1,0 +1,54 @@
+---
+'hotcrm': minor
+---
+
+Move the platform line to ObjectStack **17.0.0 GA** (from `17.0.0-rc.6`) and absorb
+the four behaviour changes that arrive with it. All 12 `@objectstack/*` entries move
+together, and `objectstack.manifest.json` `specVersion` / `objectstack.config.ts`
+`engines.protocol` follow the pin.
+
+Three of the four are invisible in the release's conventional-commit markers — the
+delta carries no `feat!` / `fix!` / `refactor!` at all — and each was measured on the
+two builds side by side rather than read off a changelog.
+
+**1. A `where` on a `formula` field now throws.** `assertFilterIsMaterializable` is new
+in `@objectstack/objectql@17.0.0` (absent at rc.6, with `assertListComparandShapes`,
+`lowerWhereFilterArray` and `INVALID_FILTER` as unchanged positive controls). Every
+call site that reaches it — `find`, `findOne`, `count`, `aggregate`, `update`,
+`delete` — can newly raise `400 INVALID_FIELD` for input it used to accept with a
+`200` and a wrong answer. **HotCRM is unaffected**: all 19 `Field.formula` fields
+across 12 objects were checked against every predicate surface in the app
+(`where:` on `ctx.api`, `filter:` in flow node config, saved-view and page-component
+`filter:`, in all four spellings the engine lowers) and **no predicate names a formula
+field**. No query changed; nothing needed denormalising.
+
+**2. `exportOptions` is now the object form `{ formats: [...] }`** (spec #8010,
+maintainer ruling 2026-08-12). The bare array HotCRM authored is the legacy spelling
+and still parses, but it *lifts* at parse — so `z.input` accepts both while `z.output`
+only ever yields the object. The five list views now author the canonical form. This
+one was quietly dangerous: the `allowExport` coverage guard tested the legacy array's
+`.length`, read `undefined` on every surface, and reported 23 bulk-egress grants as
+gratuitous — an inverted security verdict, not a silent one. Grants and surfaces are
+unchanged; only the reader was wrong.
+
+**3. `PERMISSION_DENIED` now carries a localized end-user message.** The sentence
+naming the operation and object moved to `developerMessage`, the machine-readable
+facts to `details`, and `message` became a four-locale user-facing string from the new
+`BUILTIN_OPERATION_MESSAGES` table. Refusal assertions now read the ADR-0112 envelope
+(`code` + `status` + `details`) instead of message text.
+
+**4. `update()` on an id that matches no row rejects instead of resolving `null`**
+(`RECORD_NOT_FOUND` / 404; measured both ways with a live-id control). This one is a
+real behaviour fix, not just a test update: `mass_update_stage` iterates a selection,
+and an uncaught rejection on the first stale id left **every selected row behind it
+unattempted** — and because re-running aborted at the same row, the selection could
+never be covered from the UI at all. The body now records a miss per row and rejects
+once at the end, so live rows are written whatever their position in the selection and
+the error still names every id it could not update. The catch is deliberately
+cause-agnostic: a host rejection crosses the QuickJS boundary as `{ name, message }`
+only, so a body cannot test for `RECORD_NOT_FOUND` and must not sniff engine wording.
+
+Also verified clear on GA, by measurement rather than assumption: all 18 objects
+author `sharingModel` (the new `security-owd-unset` door publishes them all), and no
+`viewKind` / `defineViewItem` usage exists for the `views:`-container-only tighten to
+reject.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -72,7 +72,7 @@ pnpm verify
 | --- | --- |
 | Node.js | `>=22` |
 | pnpm | `>=10.0.0` |
-| ObjectStack packages | `17.0.0-rc.6` |
+| ObjectStack packages | `17.0.0` |
 | Local dev port | `4001` |
 
 Each row above is asserted against `package.json` (`engines`, the `@objectstack/*`

--- a/objectstack.config.ts
+++ b/objectstack.config.ts
@@ -45,7 +45,7 @@ export default defineStack({
     // pairing against `objectstack.manifest.json` instead of trusting this
     // comment, because two platform upgrades in a row (rc.2, then rc.3) moved
     // the manifest and left this line behind (#728).
-    engines: { protocol: '^17.0.0-rc.6' },
+    engines: { protocol: '^17.0.0' },
   },
 
   // ─── Platform capabilities this app needs ─────────────────────────

--- a/objectstack.manifest.json
+++ b/objectstack.manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://schemas.objectstack.dev/template-manifest.json",
   "name": "hotcrm",
-  "specVersion": "^17.0.0-rc.6",
+  "specVersion": "^17.0.0",
   "engines": {
-    "protocol": "^17.0.0-rc.6"
+    "protocol": "^17.0.0"
   },
   "manifestId": "app.objectstack.hotcrm",
   "displayName": "HotCRM",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
       "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/account": "17.0.0-rc.6",
-        "@objectstack/cli": "17.0.0-rc.6",
-        "@objectstack/driver-memory": "17.0.0-rc.6",
-        "@objectstack/driver-sql": "17.0.0-rc.6",
-        "@objectstack/driver-sqlite-wasm": "17.0.0-rc.6",
-        "@objectstack/metadata": "17.0.0-rc.6",
-        "@objectstack/objectql": "17.0.0-rc.6",
-        "@objectstack/runtime": "17.0.0-rc.6",
-        "@objectstack/service-analytics": "17.0.0-rc.6",
-        "@objectstack/service-automation": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/account": "17.0.0",
+        "@objectstack/cli": "17.0.0",
+        "@objectstack/driver-memory": "17.0.0",
+        "@objectstack/driver-sql": "17.0.0",
+        "@objectstack/driver-sqlite-wasm": "17.0.0",
+        "@objectstack/metadata": "17.0.0",
+        "@objectstack/objectql": "17.0.0",
+        "@objectstack/runtime": "17.0.0",
+        "@objectstack/service-analytics": "17.0.0",
+        "@objectstack/service-automation": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "devDependencies": {
         "@changesets/cli": "^2.31.1",
-        "@objectstack/formula": "17.0.0-rc.6",
+        "@objectstack/formula": "17.0.0",
         "@playwright/test": "^1.61.1",
         "@vitest/coverage-v8": "^4.1.10",
         "tsx": "^4.23.1",
@@ -964,9 +964,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
-      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -1282,72 +1282,72 @@
       }
     },
     "node_modules/@objectstack/account": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/account/-/account-17.0.0-rc.6.tgz",
-      "integrity": "sha512-+NZRswk/uoEfmZxl6yj9p/939x3Xc2bfde4NYEsvidQnFYLqixqsj6VliOSuNnG16udvSvLz1N1DrfN+pVxyCQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/account/-/account-17.0.0.tgz",
+      "integrity": "sha512-yYashMAACT2kOUB75xZ5sLOfpdfeaDqaHIQ3Mp3hTaBbsO8Xeq+g3ZrTq5IJmS1Yd2qlnaz4zWlQbOpvy9ijBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/cli": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/cli/-/cli-17.0.0-rc.6.tgz",
-      "integrity": "sha512-vNzIcf7seI/WOpmasQihxBJ2/6t7MOuA2y8JSjEXEEh0rwZr1EEBJcSi8Gcf+xBc5GKZ2qSRG500TriXUK9K+g==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/cli/-/cli-17.0.0.tgz",
+      "integrity": "sha512-HUhXiiLFU22jJMelE+yj86yddFUEFwb64/7dgk9jCBX/bBRGwcnFaYnBMkzATTty76Ndneffd08AblQYz81KHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/account": "17.0.0-rc.6",
-        "@objectstack/client": "17.0.0-rc.6",
-        "@objectstack/cloud-connection": "17.0.0-rc.6",
-        "@objectstack/console": "17.0.0-rc.6",
-        "@objectstack/core": "^17.0.0-rc.6",
-        "@objectstack/driver-memory": "^17.0.0-rc.6",
-        "@objectstack/driver-mongodb": "^17.0.0-rc.6",
-        "@objectstack/driver-sql": "^17.0.0-rc.6",
-        "@objectstack/driver-sqlite-wasm": "^17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/lint": "17.0.0-rc.6",
-        "@objectstack/mcp": "17.0.0-rc.6",
-        "@objectstack/metadata": "17.0.0-rc.6",
-        "@objectstack/metadata-protocol": "17.0.0-rc.6",
-        "@objectstack/objectql": "^17.0.0-rc.6",
-        "@objectstack/observability": "^17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/plugin-approvals": "17.0.0-rc.6",
-        "@objectstack/plugin-audit": "17.0.0-rc.6",
-        "@objectstack/plugin-auth": "17.0.0-rc.6",
-        "@objectstack/plugin-email": "17.0.0-rc.6",
-        "@objectstack/plugin-hono-server": "17.0.0-rc.6",
-        "@objectstack/plugin-pinyin-search": "17.0.0-rc.6",
-        "@objectstack/plugin-reports": "17.0.0-rc.6",
-        "@objectstack/plugin-security": "17.0.0-rc.6",
-        "@objectstack/plugin-sharing": "17.0.0-rc.6",
-        "@objectstack/plugin-webhooks": "17.0.0-rc.6",
-        "@objectstack/rest": "17.0.0-rc.6",
-        "@objectstack/runtime": "^17.0.0-rc.6",
-        "@objectstack/service-analytics": "17.0.0-rc.6",
-        "@objectstack/service-automation": "17.0.0-rc.6",
-        "@objectstack/service-cache": "17.0.0-rc.6",
-        "@objectstack/service-datasource": "17.0.0-rc.6",
-        "@objectstack/service-job": "17.0.0-rc.6",
-        "@objectstack/service-messaging": "17.0.0-rc.6",
-        "@objectstack/service-package": "17.0.0-rc.6",
-        "@objectstack/service-queue": "17.0.0-rc.6",
-        "@objectstack/service-realtime": "17.0.0-rc.6",
-        "@objectstack/service-settings": "17.0.0-rc.6",
-        "@objectstack/service-sms": "17.0.0-rc.6",
-        "@objectstack/service-storage": "17.0.0-rc.6",
-        "@objectstack/setup": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/trigger-api": "17.0.0-rc.6",
-        "@objectstack/trigger-record-change": "17.0.0-rc.6",
-        "@objectstack/trigger-schedule": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
-        "@objectstack/verify": "17.0.0-rc.6",
+        "@objectstack/account": "17.0.0",
+        "@objectstack/client": "17.0.0",
+        "@objectstack/cloud-connection": "17.0.0",
+        "@objectstack/console": "17.0.0",
+        "@objectstack/core": "^17.0.0",
+        "@objectstack/driver-memory": "^17.0.0",
+        "@objectstack/driver-mongodb": "^17.0.0",
+        "@objectstack/driver-sql": "^17.0.0",
+        "@objectstack/driver-sqlite-wasm": "^17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/lint": "17.0.0",
+        "@objectstack/mcp": "17.0.0",
+        "@objectstack/metadata": "17.0.0",
+        "@objectstack/metadata-protocol": "17.0.0",
+        "@objectstack/objectql": "^17.0.0",
+        "@objectstack/observability": "^17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/plugin-approvals": "17.0.0",
+        "@objectstack/plugin-audit": "17.0.0",
+        "@objectstack/plugin-auth": "17.0.0",
+        "@objectstack/plugin-email": "17.0.0",
+        "@objectstack/plugin-hono-server": "17.0.0",
+        "@objectstack/plugin-pinyin-search": "17.0.0",
+        "@objectstack/plugin-reports": "17.0.0",
+        "@objectstack/plugin-security": "17.0.0",
+        "@objectstack/plugin-sharing": "17.0.0",
+        "@objectstack/plugin-webhooks": "17.0.0",
+        "@objectstack/rest": "17.0.0",
+        "@objectstack/runtime": "^17.0.0",
+        "@objectstack/service-analytics": "17.0.0",
+        "@objectstack/service-automation": "17.0.0",
+        "@objectstack/service-cache": "17.0.0",
+        "@objectstack/service-datasource": "17.0.0",
+        "@objectstack/service-job": "17.0.0",
+        "@objectstack/service-messaging": "17.0.0",
+        "@objectstack/service-package": "17.0.0",
+        "@objectstack/service-queue": "17.0.0",
+        "@objectstack/service-realtime": "17.0.0",
+        "@objectstack/service-settings": "17.0.0",
+        "@objectstack/service-sms": "17.0.0",
+        "@objectstack/service-storage": "17.0.0",
+        "@objectstack/setup": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/trigger-api": "17.0.0",
+        "@objectstack/trigger-record-change": "17.0.0",
+        "@objectstack/trigger-schedule": "17.0.0",
+        "@objectstack/types": "17.0.0",
+        "@objectstack/verify": "17.0.0",
         "@oclif/core": "^4.13.2",
         "bundle-require": "^5.1.0",
         "chalk": "^6.0.0",
@@ -1370,7 +1370,7 @@
         "better-sqlite3": "^13.0.2"
       },
       "peerDependencies": {
-        "@objectstack/driver-turso": "^17.0.0-rc.6"
+        "@objectstack/driver-turso": "^17.0.0"
       },
       "peerDependenciesMeta": {
         "@objectstack/driver-turso": {
@@ -1392,46 +1392,46 @@
       }
     },
     "node_modules/@objectstack/client": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/client/-/client-17.0.0-rc.6.tgz",
-      "integrity": "sha512-gdHhcY3JTRRmjlosIUP2WE4wG0ciwfYWu+HqyvtjFHVnhuNOoDOuzsKy2M/CppeOaKDay21Bs/HNH9ljGRQOnQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/client/-/client-17.0.0.tgz",
+      "integrity": "sha512-pfapHGMXA0/nKohGNg6tXTZ9AuKa3lN7ZRrvb6N8h0+PEZsJLsGP13C2nb3Hc6T9NzCl4uO1nDMMSRYcLe++Ug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/cloud-connection": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/cloud-connection/-/cloud-connection-17.0.0-rc.6.tgz",
-      "integrity": "sha512-inSabJnaLUljnRK9yonQs8RDlZXButiaydZLpZB/14yL9s8GRTdNpI9Jwq47x6al47JiOvQNapvQYzPv4eYmRw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/cloud-connection/-/cloud-connection-17.0.0.tgz",
+      "integrity": "sha512-7u28YOLZcd+NXrrwCz+HkxDY6DrOP/aOWAyt3xX+890SQW74iBWPqcuR2uidqkuRUYsDCF6hNnFOAqjBDgOsig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/runtime": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/runtime": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/console": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/console/-/console-17.0.0-rc.6.tgz",
-      "integrity": "sha512-7FcGC55puZpKrkd8dvA7k2jlAIuACd+dsASW4Br+hUAfljCFFYCaWv4/AHIgEYVtG6fD2eXGZt0ja7gVfFJiyA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/console/-/console-17.0.0.tgz",
+      "integrity": "sha512-qSYeOosKg4UzqCshDBmeoR4WcaRU8uxNUKsitWhyCC7iol3T5CXG79EZNnm6NTNSR9fwfCKqrvnEVlAnHudcaw==",
       "license": "Apache-2.0"
     },
     "node_modules/@objectstack/core": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/core/-/core-17.0.0-rc.6.tgz",
-      "integrity": "sha512-78VndPhlxUXAupQVJ04YDdFbyIYcMJxw1I+Q7dlUuf+NGrlP7VzWwAQZm98dRH3q+M5wEvvV5t0myLhmVEpmKQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/core/-/core-17.0.0.tgz",
+      "integrity": "sha512-byJCvD92jvepzzcvydmQfSyjb5Qiu+r+RJEKn/qlRwYXFpMG9CbJovglBHyyCFRzbpWKc70z88FGrj5vlr25gQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/spec": "17.0.0-rc.6",
+        "@objectstack/spec": "17.0.0",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -1439,13 +1439,14 @@
       }
     },
     "node_modules/@objectstack/driver-memory": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/driver-memory/-/driver-memory-17.0.0-rc.6.tgz",
-      "integrity": "sha512-iVvYWRdve5QLJMKiK1XbhZjct6h3ZtQL5djuJAdK8/SXtlgdQgweNQaD8AgXIfgbbSpW4B2HOlkzAQ4SCsOqCA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/driver-memory/-/driver-memory-17.0.0.tgz",
+      "integrity": "sha512-OvMRopD8WBPg3s7O8Go0Lj+cbqBjkZQ1Btv2xsLJCLA1wgFr5SxAO2IXQasnEhPvqPkYeWWBmboVM8RHRql0tw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "mingo": "^7.2.2"
       },
       "engines": {
@@ -1453,14 +1454,14 @@
       }
     },
     "node_modules/@objectstack/driver-mongodb": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/driver-mongodb/-/driver-mongodb-17.0.0-rc.6.tgz",
-      "integrity": "sha512-gSdCMEwXIZkG5B+nw/ia4m2ZCeMFyHlcYBrPhy2lDTpip7ir6sAw/dUZKjCqJTL7lu97cIRZuVK62to7HsLidA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/driver-mongodb/-/driver-mongodb-17.0.0.tgz",
+      "integrity": "sha512-V+7Akwh5SrUdKHqmiaWTEEXd2G/ArhXuafc5Uwx+6qylAfgOvD54/5qdZlTKQeeADcK0WlfHQGZ1Co5vdVJnHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "mongodb": "^7.5.0",
         "nanoid": "^6.0.0"
       },
@@ -1469,15 +1470,15 @@
       }
     },
     "node_modules/@objectstack/driver-sql": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/driver-sql/-/driver-sql-17.0.0-rc.6.tgz",
-      "integrity": "sha512-hs8SD59KmIuNHjqc/8QunUNGr9g20H+kI5qWtr3C27+vKiPlwoxyE236+FVZ1b4aueYAHSP79B24zR4+Ah/pRA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/driver-sql/-/driver-sql-17.0.0.tgz",
+      "integrity": "sha512-Vh6o+dm0a+KyCtgfojrdlqY6LHJIVCDYAjEx+a3oaCOMQLpWi7/1TC4A3PMZeGFDJCa/u6BozTZym/1MAKZsWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/observability": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/observability": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "knex": "^3.3.0",
         "nanoid": "^6.0.0"
       },
@@ -1518,14 +1519,14 @@
       }
     },
     "node_modules/@objectstack/driver-sqlite-wasm": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/driver-sqlite-wasm/-/driver-sqlite-wasm-17.0.0-rc.6.tgz",
-      "integrity": "sha512-uuA+GhhHKdH2OkgACrUfAl3twUhf4WUY7grjpxT177aNylIZXx5+T4TMNGi4HlkxC7p37U+D2Meix3FjyIIZvQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/driver-sqlite-wasm/-/driver-sqlite-wasm-17.0.0.tgz",
+      "integrity": "sha512-lUHvPGx7I2JyCuVfy6m5Kg8z/GxD6BdBMLn1wvt/X31Q4Tk+eXpfIWHFEa+MVZR8syOISl/pr4o9jntU9O3e2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/driver-sql": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/driver-sql": "17.0.0",
+        "@objectstack/spec": "17.0.0",
         "knex": "^3.3.0",
         "nanoid": "^6.0.0",
         "sql.js": "^1.14.1"
@@ -1535,24 +1536,24 @@
       }
     },
     "node_modules/@objectstack/formula": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/formula/-/formula-17.0.0-rc.6.tgz",
-      "integrity": "sha512-7vK6WgjeaO4rijaI4qZucRLsYGOPnrO/vuSd6wJCr1MpsH9go1yWLVte8itF0mTU0PhqXcnwtPHYCsxYnu4Y1Q==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/formula/-/formula-17.0.0.tgz",
+      "integrity": "sha512-PhJcfhZBMZTmerGeFJfVuhntvhvPrZhXd8MxmBl8wJjOr0CpTsr25WsNxq86lwKlTkq9PRscSbIW8fxCiTRV9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@marcbachmann/cel-js": "^8.0.0",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/spec": "17.0.0"
       }
     },
     "node_modules/@objectstack/lint": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/lint/-/lint-17.0.0-rc.6.tgz",
-      "integrity": "sha512-xZsa8DB2h76M0b6R4pFNnVZ1IzwGPxRI2vZhsFa5qNMiEWOLTc+WGVB76X18syzh0hhSMf69BR0G1G40/nOa5Q==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/lint/-/lint-17.0.0.tgz",
+      "integrity": "sha512-U34gEiEK7VFF/By5RXRrbU69hhX0uekhfp9H5nhz+thr2zOcRjpL8FoAH+mwAZvv3bz/mWeVw0t40KiR5PIlww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/sdui-parser": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/sdui-parser": "17.0.0",
+        "@objectstack/spec": "17.0.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "sucrase": "^3.35.1",
@@ -1576,16 +1577,16 @@
       }
     },
     "node_modules/@objectstack/mcp": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/mcp/-/mcp-17.0.0-rc.6.tgz",
-      "integrity": "sha512-lbdbyxmBEAKZ80F9WF9R7HgDVAmzN0j5gSPEPf/2rUwTRBIgHAVJQFb3pEuN4xveuGiU1Rft0syW4TAE4Db9Ng==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/mcp/-/mcp-17.0.0.tgz",
+      "integrity": "sha512-kAauKJ6Pn3euERqAPFarLx/U4mHIEBK6gApQYoW5tXZNj2Fx7csaJw/iLETZGBvRt/tW1XHZl52NTjt8MLUznA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -1593,17 +1594,17 @@
       }
     },
     "node_modules/@objectstack/metadata": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/metadata/-/metadata-17.0.0-rc.6.tgz",
-      "integrity": "sha512-igsZx2R6Z/zJdDCvrs91IPwNSOv1RSPL4mu1dM4S4uPUWsOf/y6eft9bSpzsylgbxlSHkFTc3ZlzElnsquG4Mg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/metadata/-/metadata-17.0.0.tgz",
+      "integrity": "sha512-SwBiq9g2cUAHJNqsnIRZ1ZcXhhkOMh8+X69pUrCI5dCl7QjyiUDbZ29aASU3g9ypyodg3Vi9ynhX4XZf3dtNpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/metadata-core": "17.0.0-rc.6",
-        "@objectstack/metadata-fs": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/metadata-fs": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "chokidar": "^5.0.0",
         "glob": "^13.0.6",
         "js-yaml": "^5.2.2",
@@ -1614,12 +1615,12 @@
       }
     },
     "node_modules/@objectstack/metadata-core": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/metadata-core/-/metadata-core-17.0.0-rc.6.tgz",
-      "integrity": "sha512-/vn7Eg0KpsAsax+O7Rxo88+dJ+Zlby1FKhWyXwslPQ/ureqoREZ3D/gSgP+SYVd10QcrCgA+JmcUU8vvatjRQg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/metadata-core/-/metadata-core-17.0.0.tgz",
+      "integrity": "sha512-+vMgf/noj5rJ0iBFAkmxmqcgbItB1DuYvDuaU9lFgP1mCaHqcfdWWRnBT9ClwNRXLnKoT74zror71UzNAuWwWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/spec": "17.0.0-rc.6",
+        "@objectstack/spec": "17.0.0",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -1635,12 +1636,12 @@
       }
     },
     "node_modules/@objectstack/metadata-fs": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/metadata-fs/-/metadata-fs-17.0.0-rc.6.tgz",
-      "integrity": "sha512-dDofMr4joL5um5gxK/iR3yRC4pAzd90LZdMQTRbsQS40e12mWYX9HzScmrH5ZBDZ/daUo43Po3xgWElAH1BZNQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/metadata-fs/-/metadata-fs-17.0.0.tgz",
+      "integrity": "sha512-M0ljQnAAIK7lwjHGOwDjAFqGFoj8ryvZiA8bsmpM8f7QkIlRjswUF5SysHcILjvSMaWs8TK4NW8KQgF1lVyJ7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/metadata-core": "17.0.0-rc.6",
+        "@objectstack/metadata-core": "17.0.0",
         "chokidar": "^5.0.0"
       },
       "engines": {
@@ -1648,18 +1649,18 @@
       }
     },
     "node_modules/@objectstack/metadata-protocol": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/metadata-protocol/-/metadata-protocol-17.0.0-rc.6.tgz",
-      "integrity": "sha512-m2QkDfKXaULfCQAGBh6UL2EEV79APkoJh45C+PugUibtJT/VJlYqObFWa7HJT1rWW5fGiMVf75b7MszVr9WggQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/metadata-protocol/-/metadata-protocol-17.0.0.tgz",
+      "integrity": "sha512-h979Cq7s2cMZ2pM6W5oK1dztVZYlLgwszJIujHQx+n+3d77Z6OOhGAvGc/3SUlz0/BOrgks+9GeIZ60iT9g77Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/lint": "17.0.0-rc.6",
-        "@objectstack/metadata": "17.0.0-rc.6",
-        "@objectstack/metadata-core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/lint": "17.0.0",
+        "@objectstack/metadata": "17.0.0",
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "zod": "^4.4.3"
       },
       "engines": {
@@ -1689,18 +1690,18 @@
       }
     },
     "node_modules/@objectstack/objectql": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/objectql/-/objectql-17.0.0-rc.6.tgz",
-      "integrity": "sha512-c2XDE+44N7ouzXNgSeG5MU0NfgE5TkAklsPXoZ9wZsGJRS3XWYMTvShsU+25xWjg/kPhuKzPzg7LZj+Fpe+uMA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/objectql/-/objectql-17.0.0.tgz",
+      "integrity": "sha512-jmMuZygqTEhRVmNh23hSQweyrb9LJntvvYoc3jMi+Cwus45HiSz5YPEgCw03ovh68P9lRgnjalnMDGxa61KnwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/metadata": "17.0.0-rc.6",
-        "@objectstack/metadata-core": "17.0.0-rc.6",
-        "@objectstack/metadata-protocol": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/metadata": "17.0.0",
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/metadata-protocol": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "zod": "^4.4.3"
@@ -1710,63 +1711,63 @@
       }
     },
     "node_modules/@objectstack/observability": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/observability/-/observability-17.0.0-rc.6.tgz",
-      "integrity": "sha512-4oOPQWzp7esI/pDSy6ApxvhCDNW8BSPEyBdDxb7seHAnpyss+MBlpbz9QzH56QyyFnBHUjJaJbtuEYEo1DtCgQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/observability/-/observability-17.0.0.tgz",
+      "integrity": "sha512-fblPbKx/W3MIajmCGvvZyVc0BuezkHYDuMRf4xd+XLE2TqtN5/TXAKw1dsIp6U+M+1WQP0Zum10XU26Fzc02uQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/platform-objects": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/platform-objects/-/platform-objects-17.0.0-rc.6.tgz",
-      "integrity": "sha512-BvDvPIijd76qhPfKqWp1UhXyaycSEamL18tNsOEoSsvRPigH/raLeH1QpLlon4MTcajItOWIylp2Y4AzX2jL3g==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/platform-objects/-/platform-objects-17.0.0.tgz",
+      "integrity": "sha512-lnk6CQlpunaAzC2WnDl13Wic30T1sfrcdxCrxe9QlmfCEFyNqNF0bTUr4ldKUgdhXiFWMOHMvv//YmoUZh8Rdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/metadata-core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/plugin-approvals": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-approvals/-/plugin-approvals-17.0.0-rc.6.tgz",
-      "integrity": "sha512-KsJYLvLUVCD6OevMbYV+CYxhxukws3FJwyTxeQMrnTy7196QluVrcRU/Hw2vwD5TWGDsTHXgoRfiDbr8u+6ysw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-approvals/-/plugin-approvals-17.0.0.tgz",
+      "integrity": "sha512-4emOJ9vClz8S10Xl7PwuOFuZoCJPFrc9tplSbCGVj0bPqqOn9Az7iUXHPzv3etzhKwhamhCJVbAy37XG8ouk0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/metadata-core": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       }
     },
     "node_modules/@objectstack/plugin-audit": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-audit/-/plugin-audit-17.0.0-rc.6.tgz",
-      "integrity": "sha512-wtnMpc8VJARJCOogdrlnCQsFoaZR4Yb0HXbTwfMtlae2RO2Mvybx9Qaa7cmOEE+yW/60zC5BoENzxhiSzWH2IA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-audit/-/plugin-audit-17.0.0.tgz",
+      "integrity": "sha512-I0QdUDII6UlYUCeF2OJhmMGFTMTGHITVKT00JFwMV9VA+z6iSbdfq9APWB597rxBHuXrbVP/bbQm1djOyRK0iQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/objectql": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/objectql": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/plugin-auth": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-auth/-/plugin-auth-17.0.0-rc.6.tgz",
-      "integrity": "sha512-LxuyBq69/RDVodw+AbKHstJGk+I2dU/7B/vh1ZERQ9AXQJnB/RVpwQ+H7Cuihl2egbD4+9zWtQHkfabvKQHwKw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-auth/-/plugin-auth-17.0.0.tgz",
+      "integrity": "sha512-wZkdw0v9SUd7zlO6UNwXErHRwj+DqMlGj5BHH5wLOtyD6xjVtfgG8uZtJ6WHD8cYbnVanaiCmNkxsYmbVbQQhQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@better-auth/core": "1.7.0-rc.2",
@@ -1774,11 +1775,11 @@
         "@better-auth/scim": "1.7.0-rc.1",
         "@better-auth/sso": "1.7.0-rc.2",
         "@noble/hashes": "^2.2.0",
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/rest": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/rest": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "better-auth": "1.7.0-rc.2",
         "jose": "^6.2.5"
       },
@@ -1944,29 +1945,29 @@
       }
     },
     "node_modules/@objectstack/plugin-email": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-email/-/plugin-email-17.0.0-rc.6.tgz",
-      "integrity": "sha512-YbbJ+dXb3fhKRKwPt28QEXcPGp1SUyhgZCiB0Q+nhBbUQyDQgTWinUODbzRqHghdJgB+/PAAa81TsLfLD8ftmA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-email/-/plugin-email-17.0.0.tgz",
+      "integrity": "sha512-ALbpgE4NixE7BHH16iT81JK1uq+vev8a6SZ2DUajQBj/6vkP6zl3JqwlTELomsOtH/J1HKcMnI00qrcly7KKqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0",
         "nodemailer": "^9.0.3"
       }
     },
     "node_modules/@objectstack/plugin-hono-server": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-hono-server/-/plugin-hono-server-17.0.0-rc.6.tgz",
-      "integrity": "sha512-BN0fBxHMNR8eYesCtp+26tWjxc1l6v03FoWivU9NfP4v3nRLJpwSmYW1bRtHZGWvpGdeB5sjHYybnoVDo9vSvw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-hono-server/-/plugin-hono-server-17.0.0.tgz",
+      "integrity": "sha512-xY/RdR3hp3z9ezfnvmGeNbeNUE+Go8NqKytT7Q6UZEuYzc/2f0j9UvKcrkiYeHmnAWsRsBehNJdHC++3s0uR9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/observability": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/observability": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "hono": "^4.12.34"
       },
       "engines": {
@@ -1974,82 +1975,84 @@
       }
     },
     "node_modules/@objectstack/plugin-pinyin-search": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-pinyin-search/-/plugin-pinyin-search-17.0.0-rc.6.tgz",
-      "integrity": "sha512-JNbuqAmZWO4Se38/Gl+7Z3H16S9ZQitQRMljgwVEwbNDhYwWAkffofjidcAckxjFzLwtModXjURVr6EN26FgQA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-pinyin-search/-/plugin-pinyin-search-17.0.0.tgz",
+      "integrity": "sha512-iB+9uHuYpryWjD7pb6otCZudDXRCSUZMz7QKEwPiajL4a/olr0bGcrC7t9d+O203/gPV0XkmcPQKDzTaMCMLxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/objectql": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/objectql": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "pinyin-pro": "^3.28.2"
       }
     },
     "node_modules/@objectstack/plugin-reports": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-reports/-/plugin-reports-17.0.0-rc.6.tgz",
-      "integrity": "sha512-t0B3Yp/8/GU7zrx4NQ26Ee8VylDcGhcT+5eO75/7ouKIqz8eXDo3UZI0BGHEiQ0WlNBSdh1ijnSZL7r5twzcrw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-reports/-/plugin-reports-17.0.0.tgz",
+      "integrity": "sha512-Uiy7LDBSpantd0HzvWRIhsM3AvV+y3kshjYh9ZwQFblwwFKhk/k2sMpXeqJEoRhHDk9k+VA/VDyncrl1qHDyjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0",
         "croner": "^10.0.1"
       }
     },
     "node_modules/@objectstack/plugin-security": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-security/-/plugin-security-17.0.0-rc.6.tgz",
-      "integrity": "sha512-/i8nG3mmyD13es9mMsPXOdLZdi/2usPz5Kf2TmCQ/Oyfw12LpHbMIf9vNS8iWLvv4DXakzUmTiZCaP/r0YnHjQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-security/-/plugin-security-17.0.0.tgz",
+      "integrity": "sha512-fVSbXvoDsH2wO0+1Ws1zAiEGTIShz1oO1o9lTS5Mj2Ljo60CY3Cw7Z466BU+EcqljwpZXC+4yotOXra7R7zyWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/plugin-sharing": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-sharing/-/plugin-sharing-17.0.0-rc.6.tgz",
-      "integrity": "sha512-XsIT2yOZh/0lQnRLGOrmyliDzGafe8QTY5OFCTnnvW4j5CXRMkFM+7rt1TDo3BGq8avWCw0AkVfthYRtQNCtlA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-sharing/-/plugin-sharing-17.0.0.tgz",
+      "integrity": "sha512-gyO+4tDufS7GmPi3AiRwfJQ3QIbE41dS4xY/Wz6qbQJlRrMS64gGkEMOjhcpTtjtTXpydBv4ye1fh2m+Wcc/ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/objectql": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/objectql": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       }
     },
     "node_modules/@objectstack/plugin-webhooks": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/plugin-webhooks/-/plugin-webhooks-17.0.0-rc.6.tgz",
-      "integrity": "sha512-pCthYdliM9f4NANDPEXnSkMA5XQFf8q/+u5xnpzun6rsb/3dc1AaefrdTN7sS8sC9nFWGCWL0XhOfPRHTZpqpg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/plugin-webhooks/-/plugin-webhooks-17.0.0.tgz",
+      "integrity": "sha512-UgcWHT0boaweHLBe2Ws3CWyeqOb4tWMXfUJchOg1EgpjiNCFvF5+bwOe+fQxW6A9Z/D/KWDo7AnVVPcz6VN3Dw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/service-messaging": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/service-messaging": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       }
     },
     "node_modules/@objectstack/rest": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/rest/-/rest-17.0.0-rc.6.tgz",
-      "integrity": "sha512-NAXRW8RAT920yRaZiTNXfb49MTa5ty5Mv1v/4Gvf68i98+iQlcgy458M++yuennn4vwR6pWXfQQZwST8/lU3zA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/rest/-/rest-17.0.0.tgz",
+      "integrity": "sha512-Xl+A2qu2gDst/3XzGKwagL86G/Q5LPhSiOXFWbf0sB003igU2oD/OmVKbgKXlAyM51tcrcOuEm0VXGXn/jE33Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/metadata-core": "17.0.0-rc.6",
-        "@objectstack/observability": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/service-package": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/observability": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/service-package": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "exceljs": "^4.4.0",
         "zod": "^4.4.3"
       },
@@ -2058,29 +2061,29 @@
       }
     },
     "node_modules/@objectstack/runtime": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/runtime/-/runtime-17.0.0-rc.6.tgz",
-      "integrity": "sha512-5ZdN7fmLSBHduGLKMmYyJmdUTZ3eGhdOZuB3hzUx02vwzWSUZNlThgZLYFBd3gXy4KzAaNnQPWE935wON95+dg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/runtime/-/runtime-17.0.0.tgz",
+      "integrity": "sha512-BTSZnPhhkE+ZhrlOzGgd01vQhwiTE1ZpT5Oaj9J6jVU2T8OZeGejtgf+xKw7aJOBjySvFdVkiDawbJ5ZZKlvyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/driver-memory": "17.0.0-rc.6",
-        "@objectstack/driver-sql": "17.0.0-rc.6",
-        "@objectstack/driver-sqlite-wasm": "17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/metadata": "17.0.0-rc.6",
-        "@objectstack/metadata-core": "17.0.0-rc.6",
-        "@objectstack/metadata-protocol": "17.0.0-rc.6",
-        "@objectstack/objectql": "17.0.0-rc.6",
-        "@objectstack/observability": "17.0.0-rc.6",
-        "@objectstack/plugin-auth": "17.0.0-rc.6",
-        "@objectstack/plugin-security": "17.0.0-rc.6",
-        "@objectstack/rest": "17.0.0-rc.6",
-        "@objectstack/service-cluster": "17.0.0-rc.6",
-        "@objectstack/service-datasource": "17.0.0-rc.6",
-        "@objectstack/service-i18n": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/driver-memory": "17.0.0",
+        "@objectstack/driver-sql": "17.0.0",
+        "@objectstack/driver-sqlite-wasm": "17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/metadata": "17.0.0",
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/metadata-protocol": "17.0.0",
+        "@objectstack/objectql": "17.0.0",
+        "@objectstack/observability": "17.0.0",
+        "@objectstack/plugin-auth": "17.0.0",
+        "@objectstack/plugin-security": "17.0.0",
+        "@objectstack/rest": "17.0.0",
+        "@objectstack/service-cluster": "17.0.0",
+        "@objectstack/service-datasource": "17.0.0",
+        "@objectstack/service-i18n": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0",
         "quickjs-emscripten": "^0.32.0",
         "zod": "^4.4.3"
       },
@@ -2088,101 +2091,101 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@objectstack/driver-mongodb": "17.0.0-rc.6"
+        "@objectstack/driver-mongodb": "17.0.0"
       }
     },
     "node_modules/@objectstack/sdui-parser": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/sdui-parser/-/sdui-parser-17.0.0-rc.6.tgz",
-      "integrity": "sha512-bao+TMFCGwu73ilvoJCrXLHWBvXhzHo/um1IHFJPcLXSRyee0Mea8rDy6Q2Ks04/VhYOza4M9rG1npoLk5DqQA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/sdui-parser/-/sdui-parser-17.0.0.tgz",
+      "integrity": "sha512-hHcjBsHH9B+WFHoqwBF5qV75Su9W0LXVFeWoTMJ+1mkdNyD5pKSQH7cWx81pTAkJ8yFTKlKUk74sLBHZIIHwPg==",
       "license": "Apache-2.0"
     },
     "node_modules/@objectstack/service-analytics": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-analytics/-/service-analytics-17.0.0-rc.6.tgz",
-      "integrity": "sha512-UoXTMoL4V/xnXFURgz0aoUl5tFf9ag5RWMPI+i/NEaUNjEr7A8bBp/jsUck/aHS0Sn4ZRaKZt836mDfAoLtDng==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-analytics/-/service-analytics-17.0.0.tgz",
+      "integrity": "sha512-29fqPMNCYUeODMsmm1HhO/TMjE0eVWNVcCPdMGSRcLS0G0Lyf00l5Tzkc+MvPD5SplkKVVAl4dj13wTfabycRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-automation": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-automation/-/service-automation-17.0.0-rc.6.tgz",
-      "integrity": "sha512-IL7n9hIt/X6cSfvVOdfe1W46DymZKLcmdECe2dJQIr/yi3oHLJ9Cqe5w7XfsiCG7jlInexAhmK+Svk/1N+r9PA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-automation/-/service-automation-17.0.0.tgz",
+      "integrity": "sha512-HaOsNgo0cIhUDxY9WGPYOaACQu4V/ijiJcfuRsvXoDTOeBjOLK3xxPJze19nETzi+PI5KoUeGTbu19DF3uOqlA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/formula": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/formula": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-cache": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-cache/-/service-cache-17.0.0-rc.6.tgz",
-      "integrity": "sha512-O4+pAWrARZJDK3thWImnvPbwEoAXiPvpYAaKMnXQqaIye6I7mWUsTnTcwCAAZBQcm8tmBXd+AAEJJTR3weB58A==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-cache/-/service-cache-17.0.0.tgz",
+      "integrity": "sha512-R4pUKAZQzZzOecvoMso8vlV2tgFsgDS0nQYm0giJUTX8UlajqgFgmw6+7C7GXlACnJ3SHMRMn13s4v3l4G5K6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/observability": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/observability": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-cluster": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-cluster/-/service-cluster-17.0.0-rc.6.tgz",
-      "integrity": "sha512-18vwkK7H01leiJzDK2uz/+b/HKjPyRoFBKnJebmGYvW4lBEeandZYN2KNDFuHGpBVp/Rxx5OySAsyFyHhz8OHw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-cluster/-/service-cluster-17.0.0.tgz",
+      "integrity": "sha512-7H4nW5Q4SIZrqtd8sJLrmDC5M2ZpdqTw9j1WplQPr1BEziutVZF9s1kjpl0Ag0j0vj4E04kcRp1Lo5+82a6+/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       }
     },
     "node_modules/@objectstack/service-datasource": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-datasource/-/service-datasource-17.0.0-rc.6.tgz",
-      "integrity": "sha512-BxXwQ3oaXMhcxriuWPA3XUNEBIyAXJl6TLG+21nP+o6hGaHmGhbQK1BFQSxK5gjeFCxzFF11TcgojdQGYrfzYA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-datasource/-/service-datasource-17.0.0.tgz",
+      "integrity": "sha512-i2zEyEcaNbhXS+lGi1xaxjKdpe9gD/SCYsCrplTGsIppWU1DxRu2QtMl4fvfRCrk1lHvjDjy2HdkIMhinXTBvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       }
     },
     "node_modules/@objectstack/service-i18n": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-i18n/-/service-i18n-17.0.0-rc.6.tgz",
-      "integrity": "sha512-LRDb5FvE8yLXvSjXZf28ecTlbVvH3ksaqNWbp5aw8sfHOOJr0Rh0/Viiq4RgOSGtgujKVErbyFuNN7tmOT52EQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-i18n/-/service-i18n-17.0.0.tgz",
+      "integrity": "sha512-7x21pZbd0JnRL8YlzoddA5X9WZrvh5wmAqe3d4hWVwJyi4AbVHrBYu5O0PG5me3C8MTfVdC6yEODOM6JwHjk+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-job": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-job/-/service-job-17.0.0-rc.6.tgz",
-      "integrity": "sha512-jObj41mTIIAqnQj6eGfAHxHfIQidz04ZsDRrUARj4p+QcRPiHnKct6sXyPfGGp+HUaErAit+c/8z79qeN35Lvw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-job/-/service-job-17.0.0.tgz",
+      "integrity": "sha512-XUFbf/8SAgMHS1qj1DnTGjgZ+eoEeu+W5YujM+HH4DL7j836ZKd3Z0k3OpLC+Z0O1SXyi2t3tVYX5seCpeeYTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
+        "@objectstack/core": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0",
         "croner": "^10.0.1"
       },
       "engines": {
@@ -2190,100 +2193,100 @@
       }
     },
     "node_modules/@objectstack/service-messaging": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-messaging/-/service-messaging-17.0.0-rc.6.tgz",
-      "integrity": "sha512-moMyoBINxjATJj7HEPJoku8vIe3p+XjilinnhHxzFyrK6N5D9mxLSwiSYKq1SmnXz4Wz8GGqq7wxLyawvHVfPQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-messaging/-/service-messaging-17.0.0.tgz",
+      "integrity": "sha512-R+5F6E/5HN4VmyFwOoZOpb02uW/6+dAHYUf8usa+kziFZbKYFU26FCTgrCkRB0tCjNj+hovekd42hvrhr+zm8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-package": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-package/-/service-package-17.0.0-rc.6.tgz",
-      "integrity": "sha512-YrfMqSEycGBmMqatz/9jmiK0bRkaukSmLHVbNhIrUe+bPUqnBHbkdXTif3pVNxqce1RrblWsdmoEpWnszECFCw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-package/-/service-package-17.0.0.tgz",
+      "integrity": "sha512-GPztbqTrk9xDGHVGVSb8OPog0qJoIccXLdiK/dPi7VlpJabqpeS11DFMi7d6GlbFK7OQbGTAF7wEk9FWQL1t+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/metadata-core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/metadata-core": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-queue": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-queue/-/service-queue-17.0.0-rc.6.tgz",
-      "integrity": "sha512-jtcUR0TxZBOG1RDHSfyA3QtdJI2FU1/dbFOoPf5tS3SGG4aMRNnWN47X7MRihgD1699JdQnOn/MP2lH29dF9AA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-queue/-/service-queue-17.0.0.tgz",
+      "integrity": "sha512-MsDaxnc+V4/bW3fUioWHL9hPPU156sEAv2Ob3lOXkVbCO5oJvDg5dtbkgn+CoFchQpbJbQKfe/aaK3KKaZcJPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-realtime": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-realtime/-/service-realtime-17.0.0-rc.6.tgz",
-      "integrity": "sha512-njOGZRv+j1Vf58XvO+dcxBIoqJ8RA6SkxMeFQhZ342h7ahKonBb02gMdUYIPR2tXATAckro+d2myweidf9oFNw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-realtime/-/service-realtime-17.0.0.tgz",
+      "integrity": "sha512-ZLsfbMJnENlhaH5lCZcCoQv870v9OK2RNbO/t0Co2KqNQ/K0GNfAQ8iyQxqUE7TpPSPlyJubHtWm+VcrDOR4BQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-settings": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-settings/-/service-settings-17.0.0-rc.6.tgz",
-      "integrity": "sha512-H3deBuD5LDrgdziq5XVLV4AdnEmfeoFE9ekOdmOUe7caZWFGgBNRt9Q3RDjqOJqeTlvkVR/tYq5+MV0KHHIPEQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-settings/-/service-settings-17.0.0.tgz",
+      "integrity": "sha512-e7xq4RZIGvvdSL0TRn8YBsFPfuYLyk8ECdP8xHSjyjM/cty0i/PYAX+5szPpOG5ltwU5pOJelt00a/Qtz98QLw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/service-sms": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-sms/-/service-sms-17.0.0-rc.6.tgz",
-      "integrity": "sha512-Yys1fHeNP41x7N/A/dwUqHc2ki60BZQTCMiE7QSWhXHGdYKEom7MnX75T306o3VC8K+Sjn4aM+K6jTjP1p4//A==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-sms/-/service-sms-17.0.0.tgz",
+      "integrity": "sha512-Pi3JIWh+0dFsj18fVZCBwIXclqV1FcZtT6M4BKiyH/x7Yb5/CHMXwbPIdLM3k0Q3oY8sCwURTP66zDA5Negk7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/plugin-auth": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/plugin-auth": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       }
     },
     "node_modules/@objectstack/service-storage": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/service-storage/-/service-storage-17.0.0-rc.6.tgz",
-      "integrity": "sha512-A5b/4WzQSODBIv4o4ksVmM7wgmXxhWCpC5jVvJRBrlK+NrRWDAqWj820Q8WAs11rMK1oEc8MgyIt0U3PrD6ldQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/service-storage/-/service-storage-17.0.0.tgz",
+      "integrity": "sha512-6Xsvmu1NJLSV3UJ2NwT6gPG3k4Gn+dURZ6ZZD5kvRu6MlTpSyYNQ8Xnbu8jjkvuIhUBbDU/0pA9aAgKCaALIIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/observability": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/observability": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -2302,22 +2305,22 @@
       }
     },
     "node_modules/@objectstack/setup": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/setup/-/setup-17.0.0-rc.6.tgz",
-      "integrity": "sha512-yNr0Fc0Yr5v2WGa5zuUMkYX9yfARPZdV3TMytdxxDEsyIMFt+E1ztZIDuED1HLHFgq+2+nsdlxfn0BDceG+V7w==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/setup/-/setup-17.0.0.tgz",
+      "integrity": "sha512-pwYlhobA3ls3+VA1Okr231pW4i7irnLYEJaQlot+bSnXozSl1XfQSzX0ndfvOJe4lo2j1sZ7ulQ4JKHg6fQ+eQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/spec": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/spec/-/spec-17.0.0-rc.6.tgz",
-      "integrity": "sha512-xDdZVm7KtpcKZVyt0LSaGQ8OtAgaIZnPqug5zPkndySFGQKdjPtiANUfVVX4H/L25HdEXbzodFZwBbPYR37zFQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/spec/-/spec-17.0.0.tgz",
+      "integrity": "sha512-65rmDnj6WKnIATvEg9/coDYSVUgBTtym/FysEApaK2W/k4ub0DP7dQ9VUmLB4HEbJxo0ahzD1tFObkXYEIT7Fw==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2335,74 +2338,74 @@
       }
     },
     "node_modules/@objectstack/trigger-api": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/trigger-api/-/trigger-api-17.0.0-rc.6.tgz",
-      "integrity": "sha512-517QhWIKRCvL/7qzM/4reOTx7NK+8Q39bpsSu/YJ75K0OTh1GijYl97pV71JMFIPUHjbcXg3CpxXTC/BjbqnSA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/trigger-api/-/trigger-api-17.0.0.tgz",
+      "integrity": "sha512-BiNnuwJoGriIpLIyHaADkio0HxAoAdwE6oXk94c0JrmQO2Lo7pAAckYn/B85dZ8gD/455fmTpLjNl79kiM8Zyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       }
     },
     "node_modules/@objectstack/trigger-record-change": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/trigger-record-change/-/trigger-record-change-17.0.0-rc.6.tgz",
-      "integrity": "sha512-/BRQticzdE0NNH/YLJ9SW+jFFFALG6o66Fm4maJnWQy+lLvj8PMcndD5MUmw7UZmA/UMuGYPaSAviAZVZS6sww==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/trigger-record-change/-/trigger-record-change-17.0.0.tgz",
+      "integrity": "sha512-NwpvdmWNHBRFftIZf2ePN9Y9Mz7egGtYFbKh/f/w3b6oxXyPDYRj2tvgyAID/xAUKvcAyAYCuQpaDpyebwW0ZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/trigger-schedule": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/trigger-schedule/-/trigger-schedule-17.0.0-rc.6.tgz",
-      "integrity": "sha512-PpZwgwzzVgyVPeP9R6UixRZErfwMQMY6UVNkbwGyXNewfIvTMEKZj0VpvBughPs7IOhTtvo5jR7nDWQXAtR4tg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/trigger-schedule/-/trigger-schedule-17.0.0.tgz",
+      "integrity": "sha512-muiXL0xPkYV1Fyl7HFREhSzUYpzA3ABzgc5v2lqydnduVQxae5jGmmSsBcKX/VZhJ4y3p5IgVlzBGdItfcuhbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/types": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/types/-/types-17.0.0-rc.6.tgz",
-      "integrity": "sha512-Di0cD+ObLzdAdkuESMDiMFAtviO5Ro3XX3+FNzaGXLwOVvxwBgddT91xm72fiT2iWybOhf3RNjnwws/eYZD7SA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-t02V65dAK1vkvb/1Srl1Wxi1Tml0KUyheBPpgGQoRh58iyLjgKX4L0EXyfX7U+fZG2zAHen8d4OW7KE+YNnCaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/spec": "17.0.0-rc.6"
+        "@objectstack/spec": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@objectstack/verify": {
-      "version": "17.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/@objectstack/verify/-/verify-17.0.0-rc.6.tgz",
-      "integrity": "sha512-g4Ro6VsW9v+w5sUVw5Ue370E6o6uZQ0PNw3jLY8QW7Gsp3zThuPMcu6/9eVUnttK+VxKJfngv16vVa6zPzV2WA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@objectstack/verify/-/verify-17.0.0.tgz",
+      "integrity": "sha512-t0nAuzxJdd/kEBg4Qtmv4F7HxjyaWvjZHaBd2XC/7D0HFadYR1y8Lhmfqz4ItUuif6nBvQfW/69oBQj1TPDvtw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@objectstack/core": "17.0.0-rc.6",
-        "@objectstack/objectql": "17.0.0-rc.6",
-        "@objectstack/platform-objects": "17.0.0-rc.6",
-        "@objectstack/plugin-auth": "17.0.0-rc.6",
-        "@objectstack/plugin-hono-server": "17.0.0-rc.6",
-        "@objectstack/plugin-security": "17.0.0-rc.6",
-        "@objectstack/plugin-sharing": "17.0.0-rc.6",
-        "@objectstack/rest": "17.0.0-rc.6",
-        "@objectstack/runtime": "17.0.0-rc.6",
-        "@objectstack/service-analytics": "17.0.0-rc.6",
-        "@objectstack/service-automation": "17.0.0-rc.6",
-        "@objectstack/service-datasource": "17.0.0-rc.6",
-        "@objectstack/service-settings": "17.0.0-rc.6",
-        "@objectstack/spec": "17.0.0-rc.6",
-        "@objectstack/types": "17.0.0-rc.6"
+        "@objectstack/core": "17.0.0",
+        "@objectstack/objectql": "17.0.0",
+        "@objectstack/platform-objects": "17.0.0",
+        "@objectstack/plugin-auth": "17.0.0",
+        "@objectstack/plugin-hono-server": "17.0.0",
+        "@objectstack/plugin-security": "17.0.0",
+        "@objectstack/plugin-sharing": "17.0.0",
+        "@objectstack/rest": "17.0.0",
+        "@objectstack/runtime": "17.0.0",
+        "@objectstack/service-analytics": "17.0.0",
+        "@objectstack/service-automation": "17.0.0",
+        "@objectstack/service-datasource": "17.0.0",
+        "@objectstack/service-settings": "17.0.0",
+        "@objectstack/spec": "17.0.0",
+        "@objectstack/types": "17.0.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -2447,9 +2450,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
       "devOptional": true,
       "license": "MIT",
       "funding": {
@@ -2473,9 +2476,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
-      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
       "cpu": [
         "arm64"
       ],
@@ -2490,9 +2493,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
       "cpu": [
         "arm64"
       ],
@@ -2507,9 +2510,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
       "cpu": [
         "x64"
       ],
@@ -2524,9 +2527,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
-      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
       "cpu": [
         "x64"
       ],
@@ -2541,9 +2544,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
-      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
       "cpu": [
         "arm"
       ],
@@ -2558,9 +2561,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
       "cpu": [
         "arm64"
       ],
@@ -2575,9 +2578,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
-      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
       "cpu": [
         "arm64"
       ],
@@ -2592,9 +2595,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
-      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2609,9 +2612,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
-      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
       "cpu": [
         "s390x"
       ],
@@ -2626,9 +2629,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
-      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
       "cpu": [
         "x64"
       ],
@@ -2643,9 +2646,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
-      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
       "cpu": [
         "x64"
       ],
@@ -2660,9 +2663,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
-      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
       "cpu": [
         "arm64"
       ],
@@ -2677,9 +2680,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
-      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
       "cpu": [
         "arm64"
       ],
@@ -2694,9 +2697,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
-      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
       "cpu": [
         "x64"
       ],
@@ -3280,9 +3283,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.14.tgz",
+      "integrity": "sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3732,9 +3735,9 @@
       }
     },
     "node_modules/body-parser/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3770,9 +3773,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
-      "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.2.tgz",
+      "integrity": "sha512-1w0ra+ho1cuE+w8jzwgzTFIimFtCfZeCoOsvIPQg6uyFCsp8M29U7bNNf5GrFh88TXbYg1g3TyKUGpd6O7q6zA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.19.0"
@@ -4722,9 +4725,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
-      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
       "funding": [
         {
           "type": "github",
@@ -5108,9 +5111,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6472,9 +6475,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
-      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -6792,9 +6795,9 @@
       }
     },
     "node_modules/pinyin-pro": {
-      "version": "3.28.2",
-      "resolved": "https://registry.npmjs.org/pinyin-pro/-/pinyin-pro-3.28.2.tgz",
-      "integrity": "sha512-jV38yxXHLfidirMC4hrXasLDozLCSq/4DfX88GnHcSEJ2+GpSedG6I9VOiEXJu6iQ5dbJC/RjmzyMuS5h/wH5A==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/pinyin-pro/-/pinyin-pro-3.29.1.tgz",
+      "integrity": "sha512-GkdTguAt9JDAO7Xw71gyx3mtzgFXpmeigesM3XkcTcQdudg2v5k1ZFzWM30Oo4UkwZ9U8pE1pcLKKu8cx8icPg==",
       "license": "MIT"
     },
     "node_modules/pirates": {
@@ -7329,13 +7332,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
-      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.143.0",
+        "@oxc-project/types": "=0.144.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -7345,20 +7348,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.3",
-        "@rolldown/binding-darwin-arm64": "1.2.3",
-        "@rolldown/binding-darwin-x64": "1.2.3",
-        "@rolldown/binding-freebsd-x64": "1.2.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
-        "@rolldown/binding-linux-arm64-musl": "1.2.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-gnu": "1.2.3",
-        "@rolldown/binding-linux-x64-musl": "1.2.3",
-        "@rolldown/binding-openharmony-arm64": "1.2.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
-        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
       }
     },
     "node_modules/rou3": {
@@ -8214,9 +8217,9 @@
       }
     },
     "node_modules/type-is/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -35,24 +35,24 @@
   },
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
-    "@objectstack/account": "17.0.0-rc.6",
-    "@objectstack/cli": "17.0.0-rc.6",
-    "@objectstack/driver-memory": "17.0.0-rc.6",
-    "@objectstack/driver-sql": "17.0.0-rc.6",
-    "@objectstack/driver-sqlite-wasm": "17.0.0-rc.6",
-    "@objectstack/metadata": "17.0.0-rc.6",
-    "@objectstack/objectql": "17.0.0-rc.6",
-    "@objectstack/runtime": "17.0.0-rc.6",
-    "@objectstack/service-analytics": "17.0.0-rc.6",
-    "@objectstack/service-automation": "17.0.0-rc.6",
-    "@objectstack/spec": "17.0.0-rc.6"
+    "@objectstack/account": "17.0.0",
+    "@objectstack/cli": "17.0.0",
+    "@objectstack/driver-memory": "17.0.0",
+    "@objectstack/driver-sql": "17.0.0",
+    "@objectstack/driver-sqlite-wasm": "17.0.0",
+    "@objectstack/metadata": "17.0.0",
+    "@objectstack/objectql": "17.0.0",
+    "@objectstack/runtime": "17.0.0",
+    "@objectstack/service-analytics": "17.0.0",
+    "@objectstack/service-automation": "17.0.0",
+    "@objectstack/spec": "17.0.0"
   },
   "optionalDependencies": {
     "better-sqlite3": "^12.11.1"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
-    "@objectstack/formula": "17.0.0-rc.6",
+    "@objectstack/formula": "17.0.0",
     "@playwright/test": "^1.61.1",
     "@vitest/coverage-v8": "^4.1.10",
     "tsx": "^4.23.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,45 +9,45 @@ importers:
   .:
     dependencies:
       '@objectstack/account':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6(vitest@4.1.10)
+        specifier: 17.0.0
+        version: 17.0.0(vitest@4.1.10)
       '@objectstack/cli':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+        specifier: 17.0.0
+        version: 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
       '@objectstack/driver-memory':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6
+        specifier: 17.0.0
+        version: 17.0.0
       '@objectstack/driver-sql':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6
+        specifier: 17.0.0
+        version: 17.0.0
       '@objectstack/driver-sqlite-wasm':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6(better-sqlite3@12.11.1)
+        specifier: 17.0.0
+        version: 17.0.0(better-sqlite3@12.11.1)
       '@objectstack/metadata':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6(vitest@4.1.10)
+        specifier: 17.0.0
+        version: 17.0.0(vitest@4.1.10)
       '@objectstack/objectql':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6(vitest@4.1.10)
+        specifier: 17.0.0
+        version: 17.0.0(vitest@4.1.10)
       '@objectstack/runtime':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+        specifier: 17.0.0
+        version: 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
       '@objectstack/service-analytics':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6
+        specifier: 17.0.0
+        version: 17.0.0
       '@objectstack/service-automation':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6
+        specifier: 17.0.0
+        version: 17.0.0
       '@objectstack/spec':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6
+        specifier: 17.0.0
+        version: 17.0.0
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.1
         version: 2.31.1
       '@objectstack/formula':
-        specifier: 17.0.0-rc.6
-        version: 17.0.0-rc.6
+        specifier: 17.0.0
+        version: 17.0.0
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.62.0
@@ -526,45 +526,45 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@objectstack/account@17.0.0-rc.6':
-    resolution: {integrity: sha512-+NZRswk/uoEfmZxl6yj9p/939x3Xc2bfde4NYEsvidQnFYLqixqsj6VliOSuNnG16udvSvLz1N1DrfN+pVxyCQ==}
+  '@objectstack/account@17.0.0':
+    resolution: {integrity: sha512-yYashMAACT2kOUB75xZ5sLOfpdfeaDqaHIQ3Mp3hTaBbsO8Xeq+g3ZrTq5IJmS1Yd2qlnaz4zWlQbOpvy9ijBg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/cli@17.0.0-rc.6':
-    resolution: {integrity: sha512-vNzIcf7seI/WOpmasQihxBJ2/6t7MOuA2y8JSjEXEEh0rwZr1EEBJcSi8Gcf+xBc5GKZ2qSRG500TriXUK9K+g==}
+  '@objectstack/cli@17.0.0':
+    resolution: {integrity: sha512-HUhXiiLFU22jJMelE+yj86yddFUEFwb64/7dgk9jCBX/bBRGwcnFaYnBMkzATTty76Ndneffd08AblQYz81KHA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@objectstack/driver-turso': ^17.0.0-rc.6
+      '@objectstack/driver-turso': ^17.0.0
     peerDependenciesMeta:
       '@objectstack/driver-turso':
         optional: true
 
-  '@objectstack/client@17.0.0-rc.6':
-    resolution: {integrity: sha512-gdHhcY3JTRRmjlosIUP2WE4wG0ciwfYWu+HqyvtjFHVnhuNOoDOuzsKy2M/CppeOaKDay21Bs/HNH9ljGRQOnQ==}
+  '@objectstack/client@17.0.0':
+    resolution: {integrity: sha512-pfapHGMXA0/nKohGNg6tXTZ9AuKa3lN7ZRrvb6N8h0+PEZsJLsGP13C2nb3Hc6T9NzCl4uO1nDMMSRYcLe++Ug==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/cloud-connection@17.0.0-rc.6':
-    resolution: {integrity: sha512-inSabJnaLUljnRK9yonQs8RDlZXButiaydZLpZB/14yL9s8GRTdNpI9Jwq47x6al47JiOvQNapvQYzPv4eYmRw==}
+  '@objectstack/cloud-connection@17.0.0':
+    resolution: {integrity: sha512-7u28YOLZcd+NXrrwCz+HkxDY6DrOP/aOWAyt3xX+890SQW74iBWPqcuR2uidqkuRUYsDCF6hNnFOAqjBDgOsig==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/console@17.0.0-rc.6':
-    resolution: {integrity: sha512-7FcGC55puZpKrkd8dvA7k2jlAIuACd+dsASW4Br+hUAfljCFFYCaWv4/AHIgEYVtG6fD2eXGZt0ja7gVfFJiyA==}
+  '@objectstack/console@17.0.0':
+    resolution: {integrity: sha512-qSYeOosKg4UzqCshDBmeoR4WcaRU8uxNUKsitWhyCC7iol3T5CXG79EZNnm6NTNSR9fwfCKqrvnEVlAnHudcaw==}
 
-  '@objectstack/core@17.0.0-rc.6':
-    resolution: {integrity: sha512-78VndPhlxUXAupQVJ04YDdFbyIYcMJxw1I+Q7dlUuf+NGrlP7VzWwAQZm98dRH3q+M5wEvvV5t0myLhmVEpmKQ==}
+  '@objectstack/core@17.0.0':
+    resolution: {integrity: sha512-byJCvD92jvepzzcvydmQfSyjb5Qiu+r+RJEKn/qlRwYXFpMG9CbJovglBHyyCFRzbpWKc70z88FGrj5vlr25gQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/driver-memory@17.0.0-rc.6':
-    resolution: {integrity: sha512-iVvYWRdve5QLJMKiK1XbhZjct6h3ZtQL5djuJAdK8/SXtlgdQgweNQaD8AgXIfgbbSpW4B2HOlkzAQ4SCsOqCA==}
+  '@objectstack/driver-memory@17.0.0':
+    resolution: {integrity: sha512-OvMRopD8WBPg3s7O8Go0Lj+cbqBjkZQ1Btv2xsLJCLA1wgFr5SxAO2IXQasnEhPvqPkYeWWBmboVM8RHRql0tw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/driver-mongodb@17.0.0-rc.6':
-    resolution: {integrity: sha512-gSdCMEwXIZkG5B+nw/ia4m2ZCeMFyHlcYBrPhy2lDTpip7ir6sAw/dUZKjCqJTL7lu97cIRZuVK62to7HsLidA==}
+  '@objectstack/driver-mongodb@17.0.0':
+    resolution: {integrity: sha512-V+7Akwh5SrUdKHqmiaWTEEXd2G/ArhXuafc5Uwx+6qylAfgOvD54/5qdZlTKQeeADcK0WlfHQGZ1Co5vdVJnHg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/driver-sql@17.0.0-rc.6':
-    resolution: {integrity: sha512-hs8SD59KmIuNHjqc/8QunUNGr9g20H+kI5qWtr3C27+vKiPlwoxyE236+FVZ1b4aueYAHSP79B24zR4+Ah/pRA==}
+  '@objectstack/driver-sql@17.0.0':
+    resolution: {integrity: sha512-Vh6o+dm0a+KyCtgfojrdlqY6LHJIVCDYAjEx+a3oaCOMQLpWi7/1TC4A3PMZeGFDJCa/u6BozTZym/1MAKZsWw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       mysql2: ^3.0.0
@@ -578,23 +578,23 @@ packages:
       tedious:
         optional: true
 
-  '@objectstack/driver-sqlite-wasm@17.0.0-rc.6':
-    resolution: {integrity: sha512-uuA+GhhHKdH2OkgACrUfAl3twUhf4WUY7grjpxT177aNylIZXx5+T4TMNGi4HlkxC7p37U+D2Meix3FjyIIZvQ==}
+  '@objectstack/driver-sqlite-wasm@17.0.0':
+    resolution: {integrity: sha512-lUHvPGx7I2JyCuVfy6m5Kg8z/GxD6BdBMLn1wvt/X31Q4Tk+eXpfIWHFEa+MVZR8syOISl/pr4o9jntU9O3e2w==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/formula@17.0.0-rc.6':
-    resolution: {integrity: sha512-7vK6WgjeaO4rijaI4qZucRLsYGOPnrO/vuSd6wJCr1MpsH9go1yWLVte8itF0mTU0PhqXcnwtPHYCsxYnu4Y1Q==}
+  '@objectstack/formula@17.0.0':
+    resolution: {integrity: sha512-PhJcfhZBMZTmerGeFJfVuhntvhvPrZhXd8MxmBl8wJjOr0CpTsr25WsNxq86lwKlTkq9PRscSbIW8fxCiTRV9g==}
 
-  '@objectstack/lint@17.0.0-rc.6':
-    resolution: {integrity: sha512-xZsa8DB2h76M0b6R4pFNnVZ1IzwGPxRI2vZhsFa5qNMiEWOLTc+WGVB76X18syzh0hhSMf69BR0G1G40/nOa5Q==}
+  '@objectstack/lint@17.0.0':
+    resolution: {integrity: sha512-U34gEiEK7VFF/By5RXRrbU69hhX0uekhfp9H5nhz+thr2zOcRjpL8FoAH+mwAZvv3bz/mWeVw0t40KiR5PIlww==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/mcp@17.0.0-rc.6':
-    resolution: {integrity: sha512-lbdbyxmBEAKZ80F9WF9R7HgDVAmzN0j5gSPEPf/2rUwTRBIgHAVJQFb3pEuN4xveuGiU1Rft0syW4TAE4Db9Ng==}
+  '@objectstack/mcp@17.0.0':
+    resolution: {integrity: sha512-kAauKJ6Pn3euERqAPFarLx/U4mHIEBK6gApQYoW5tXZNj2Fx7csaJw/iLETZGBvRt/tW1XHZl52NTjt8MLUznA==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/metadata-core@17.0.0-rc.6':
-    resolution: {integrity: sha512-/vn7Eg0KpsAsax+O7Rxo88+dJ+Zlby1FKhWyXwslPQ/ureqoREZ3D/gSgP+SYVd10QcrCgA+JmcUU8vvatjRQg==}
+  '@objectstack/metadata-core@17.0.0':
+    resolution: {integrity: sha512-+vMgf/noj5rJ0iBFAkmxmqcgbItB1DuYvDuaU9lFgP1mCaHqcfdWWRnBT9ClwNRXLnKoT74zror71UzNAuWwWg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       vitest: ^4.0.0
@@ -602,126 +602,126 @@ packages:
       vitest:
         optional: true
 
-  '@objectstack/metadata-fs@17.0.0-rc.6':
-    resolution: {integrity: sha512-dDofMr4joL5um5gxK/iR3yRC4pAzd90LZdMQTRbsQS40e12mWYX9HzScmrH5ZBDZ/daUo43Po3xgWElAH1BZNQ==}
+  '@objectstack/metadata-fs@17.0.0':
+    resolution: {integrity: sha512-M0ljQnAAIK7lwjHGOwDjAFqGFoj8ryvZiA8bsmpM8f7QkIlRjswUF5SysHcILjvSMaWs8TK4NW8KQgF1lVyJ7A==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/metadata-protocol@17.0.0-rc.6':
-    resolution: {integrity: sha512-m2QkDfKXaULfCQAGBh6UL2EEV79APkoJh45C+PugUibtJT/VJlYqObFWa7HJT1rWW5fGiMVf75b7MszVr9WggQ==}
+  '@objectstack/metadata-protocol@17.0.0':
+    resolution: {integrity: sha512-h979Cq7s2cMZ2pM6W5oK1dztVZYlLgwszJIujHQx+n+3d77Z6OOhGAvGc/3SUlz0/BOrgks+9GeIZ60iT9g77Q==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/metadata@17.0.0-rc.6':
-    resolution: {integrity: sha512-igsZx2R6Z/zJdDCvrs91IPwNSOv1RSPL4mu1dM4S4uPUWsOf/y6eft9bSpzsylgbxlSHkFTc3ZlzElnsquG4Mg==}
+  '@objectstack/metadata@17.0.0':
+    resolution: {integrity: sha512-SwBiq9g2cUAHJNqsnIRZ1ZcXhhkOMh8+X69pUrCI5dCl7QjyiUDbZ29aASU3g9ypyodg3Vi9ynhX4XZf3dtNpw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/objectql@17.0.0-rc.6':
-    resolution: {integrity: sha512-c2XDE+44N7ouzXNgSeG5MU0NfgE5TkAklsPXoZ9wZsGJRS3XWYMTvShsU+25xWjg/kPhuKzPzg7LZj+Fpe+uMA==}
+  '@objectstack/objectql@17.0.0':
+    resolution: {integrity: sha512-jmMuZygqTEhRVmNh23hSQweyrb9LJntvvYoc3jMi+Cwus45HiSz5YPEgCw03ovh68P9lRgnjalnMDGxa61KnwQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/observability@17.0.0-rc.6':
-    resolution: {integrity: sha512-4oOPQWzp7esI/pDSy6ApxvhCDNW8BSPEyBdDxb7seHAnpyss+MBlpbz9QzH56QyyFnBHUjJaJbtuEYEo1DtCgQ==}
+  '@objectstack/observability@17.0.0':
+    resolution: {integrity: sha512-fblPbKx/W3MIajmCGvvZyVc0BuezkHYDuMRf4xd+XLE2TqtN5/TXAKw1dsIp6U+M+1WQP0Zum10XU26Fzc02uQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/platform-objects@17.0.0-rc.6':
-    resolution: {integrity: sha512-BvDvPIijd76qhPfKqWp1UhXyaycSEamL18tNsOEoSsvRPigH/raLeH1QpLlon4MTcajItOWIylp2Y4AzX2jL3g==}
+  '@objectstack/platform-objects@17.0.0':
+    resolution: {integrity: sha512-lnk6CQlpunaAzC2WnDl13Wic30T1sfrcdxCrxe9QlmfCEFyNqNF0bTUr4ldKUgdhXiFWMOHMvv//YmoUZh8Rdg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-approvals@17.0.0-rc.6':
-    resolution: {integrity: sha512-KsJYLvLUVCD6OevMbYV+CYxhxukws3FJwyTxeQMrnTy7196QluVrcRU/Hw2vwD5TWGDsTHXgoRfiDbr8u+6ysw==}
+  '@objectstack/plugin-approvals@17.0.0':
+    resolution: {integrity: sha512-4emOJ9vClz8S10Xl7PwuOFuZoCJPFrc9tplSbCGVj0bPqqOn9Az7iUXHPzv3etzhKwhamhCJVbAy37XG8ouk0A==}
 
-  '@objectstack/plugin-audit@17.0.0-rc.6':
-    resolution: {integrity: sha512-wtnMpc8VJARJCOogdrlnCQsFoaZR4Yb0HXbTwfMtlae2RO2Mvybx9Qaa7cmOEE+yW/60zC5BoENzxhiSzWH2IA==}
+  '@objectstack/plugin-audit@17.0.0':
+    resolution: {integrity: sha512-I0QdUDII6UlYUCeF2OJhmMGFTMTGHITVKT00JFwMV9VA+z6iSbdfq9APWB597rxBHuXrbVP/bbQm1djOyRK0iQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-auth@17.0.0-rc.6':
-    resolution: {integrity: sha512-LxuyBq69/RDVodw+AbKHstJGk+I2dU/7B/vh1ZERQ9AXQJnB/RVpwQ+H7Cuihl2egbD4+9zWtQHkfabvKQHwKw==}
+  '@objectstack/plugin-auth@17.0.0':
+    resolution: {integrity: sha512-wZkdw0v9SUd7zlO6UNwXErHRwj+DqMlGj5BHH5wLOtyD6xjVtfgG8uZtJ6WHD8cYbnVanaiCmNkxsYmbVbQQhQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-email@17.0.0-rc.6':
-    resolution: {integrity: sha512-YbbJ+dXb3fhKRKwPt28QEXcPGp1SUyhgZCiB0Q+nhBbUQyDQgTWinUODbzRqHghdJgB+/PAAa81TsLfLD8ftmA==}
+  '@objectstack/plugin-email@17.0.0':
+    resolution: {integrity: sha512-ALbpgE4NixE7BHH16iT81JK1uq+vev8a6SZ2DUajQBj/6vkP6zl3JqwlTELomsOtH/J1HKcMnI00qrcly7KKqw==}
 
-  '@objectstack/plugin-hono-server@17.0.0-rc.6':
-    resolution: {integrity: sha512-BN0fBxHMNR8eYesCtp+26tWjxc1l6v03FoWivU9NfP4v3nRLJpwSmYW1bRtHZGWvpGdeB5sjHYybnoVDo9vSvw==}
+  '@objectstack/plugin-hono-server@17.0.0':
+    resolution: {integrity: sha512-xY/RdR3hp3z9ezfnvmGeNbeNUE+Go8NqKytT7Q6UZEuYzc/2f0j9UvKcrkiYeHmnAWsRsBehNJdHC++3s0uR9w==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-pinyin-search@17.0.0-rc.6':
-    resolution: {integrity: sha512-JNbuqAmZWO4Se38/Gl+7Z3H16S9ZQitQRMljgwVEwbNDhYwWAkffofjidcAckxjFzLwtModXjURVr6EN26FgQA==}
+  '@objectstack/plugin-pinyin-search@17.0.0':
+    resolution: {integrity: sha512-iB+9uHuYpryWjD7pb6otCZudDXRCSUZMz7QKEwPiajL4a/olr0bGcrC7t9d+O203/gPV0XkmcPQKDzTaMCMLxA==}
 
-  '@objectstack/plugin-reports@17.0.0-rc.6':
-    resolution: {integrity: sha512-t0B3Yp/8/GU7zrx4NQ26Ee8VylDcGhcT+5eO75/7ouKIqz8eXDo3UZI0BGHEiQ0WlNBSdh1ijnSZL7r5twzcrw==}
+  '@objectstack/plugin-reports@17.0.0':
+    resolution: {integrity: sha512-Uiy7LDBSpantd0HzvWRIhsM3AvV+y3kshjYh9ZwQFblwwFKhk/k2sMpXeqJEoRhHDk9k+VA/VDyncrl1qHDyjA==}
 
-  '@objectstack/plugin-security@17.0.0-rc.6':
-    resolution: {integrity: sha512-/i8nG3mmyD13es9mMsPXOdLZdi/2usPz5Kf2TmCQ/Oyfw12LpHbMIf9vNS8iWLvv4DXakzUmTiZCaP/r0YnHjQ==}
+  '@objectstack/plugin-security@17.0.0':
+    resolution: {integrity: sha512-fVSbXvoDsH2wO0+1Ws1zAiEGTIShz1oO1o9lTS5Mj2Ljo60CY3Cw7Z466BU+EcqljwpZXC+4yotOXra7R7zyWQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/plugin-sharing@17.0.0-rc.6':
-    resolution: {integrity: sha512-XsIT2yOZh/0lQnRLGOrmyliDzGafe8QTY5OFCTnnvW4j5CXRMkFM+7rt1TDo3BGq8avWCw0AkVfthYRtQNCtlA==}
+  '@objectstack/plugin-sharing@17.0.0':
+    resolution: {integrity: sha512-gyO+4tDufS7GmPi3AiRwfJQ3QIbE41dS4xY/Wz6qbQJlRrMS64gGkEMOjhcpTtjtTXpydBv4ye1fh2m+Wcc/ew==}
 
-  '@objectstack/plugin-webhooks@17.0.0-rc.6':
-    resolution: {integrity: sha512-pCthYdliM9f4NANDPEXnSkMA5XQFf8q/+u5xnpzun6rsb/3dc1AaefrdTN7sS8sC9nFWGCWL0XhOfPRHTZpqpg==}
+  '@objectstack/plugin-webhooks@17.0.0':
+    resolution: {integrity: sha512-UgcWHT0boaweHLBe2Ws3CWyeqOb4tWMXfUJchOg1EgpjiNCFvF5+bwOe+fQxW6A9Z/D/KWDo7AnVVPcz6VN3Dw==}
 
-  '@objectstack/rest@17.0.0-rc.6':
-    resolution: {integrity: sha512-NAXRW8RAT920yRaZiTNXfb49MTa5ty5Mv1v/4Gvf68i98+iQlcgy458M++yuennn4vwR6pWXfQQZwST8/lU3zA==}
+  '@objectstack/rest@17.0.0':
+    resolution: {integrity: sha512-Xl+A2qu2gDst/3XzGKwagL86G/Q5LPhSiOXFWbf0sB003igU2oD/OmVKbgKXlAyM51tcrcOuEm0VXGXn/jE33Q==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/runtime@17.0.0-rc.6':
-    resolution: {integrity: sha512-5ZdN7fmLSBHduGLKMmYyJmdUTZ3eGhdOZuB3hzUx02vwzWSUZNlThgZLYFBd3gXy4KzAaNnQPWE935wON95+dg==}
+  '@objectstack/runtime@17.0.0':
+    resolution: {integrity: sha512-BTSZnPhhkE+ZhrlOzGgd01vQhwiTE1ZpT5Oaj9J6jVU2T8OZeGejtgf+xKw7aJOBjySvFdVkiDawbJ5ZZKlvyg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/sdui-parser@17.0.0-rc.6':
-    resolution: {integrity: sha512-bao+TMFCGwu73ilvoJCrXLHWBvXhzHo/um1IHFJPcLXSRyee0Mea8rDy6Q2Ks04/VhYOza4M9rG1npoLk5DqQA==}
+  '@objectstack/sdui-parser@17.0.0':
+    resolution: {integrity: sha512-hHcjBsHH9B+WFHoqwBF5qV75Su9W0LXVFeWoTMJ+1mkdNyD5pKSQH7cWx81pTAkJ8yFTKlKUk74sLBHZIIHwPg==}
 
-  '@objectstack/service-analytics@17.0.0-rc.6':
-    resolution: {integrity: sha512-UoXTMoL4V/xnXFURgz0aoUl5tFf9ag5RWMPI+i/NEaUNjEr7A8bBp/jsUck/aHS0Sn4ZRaKZt836mDfAoLtDng==}
+  '@objectstack/service-analytics@17.0.0':
+    resolution: {integrity: sha512-29fqPMNCYUeODMsmm1HhO/TMjE0eVWNVcCPdMGSRcLS0G0Lyf00l5Tzkc+MvPD5SplkKVVAl4dj13wTfabycRA==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-automation@17.0.0-rc.6':
-    resolution: {integrity: sha512-IL7n9hIt/X6cSfvVOdfe1W46DymZKLcmdECe2dJQIr/yi3oHLJ9Cqe5w7XfsiCG7jlInexAhmK+Svk/1N+r9PA==}
+  '@objectstack/service-automation@17.0.0':
+    resolution: {integrity: sha512-HaOsNgo0cIhUDxY9WGPYOaACQu4V/ijiJcfuRsvXoDTOeBjOLK3xxPJze19nETzi+PI5KoUeGTbu19DF3uOqlA==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-cache@17.0.0-rc.6':
-    resolution: {integrity: sha512-O4+pAWrARZJDK3thWImnvPbwEoAXiPvpYAaKMnXQqaIye6I7mWUsTnTcwCAAZBQcm8tmBXd+AAEJJTR3weB58A==}
+  '@objectstack/service-cache@17.0.0':
+    resolution: {integrity: sha512-R4pUKAZQzZzOecvoMso8vlV2tgFsgDS0nQYm0giJUTX8UlajqgFgmw6+7C7GXlACnJ3SHMRMn13s4v3l4G5K6g==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-cluster@17.0.0-rc.6':
-    resolution: {integrity: sha512-18vwkK7H01leiJzDK2uz/+b/HKjPyRoFBKnJebmGYvW4lBEeandZYN2KNDFuHGpBVp/Rxx5OySAsyFyHhz8OHw==}
+  '@objectstack/service-cluster@17.0.0':
+    resolution: {integrity: sha512-7H4nW5Q4SIZrqtd8sJLrmDC5M2ZpdqTw9j1WplQPr1BEziutVZF9s1kjpl0Ag0j0vj4E04kcRp1Lo5+82a6+/Q==}
 
-  '@objectstack/service-datasource@17.0.0-rc.6':
-    resolution: {integrity: sha512-BxXwQ3oaXMhcxriuWPA3XUNEBIyAXJl6TLG+21nP+o6hGaHmGhbQK1BFQSxK5gjeFCxzFF11TcgojdQGYrfzYA==}
+  '@objectstack/service-datasource@17.0.0':
+    resolution: {integrity: sha512-i2zEyEcaNbhXS+lGi1xaxjKdpe9gD/SCYsCrplTGsIppWU1DxRu2QtMl4fvfRCrk1lHvjDjy2HdkIMhinXTBvA==}
 
-  '@objectstack/service-i18n@17.0.0-rc.6':
-    resolution: {integrity: sha512-LRDb5FvE8yLXvSjXZf28ecTlbVvH3ksaqNWbp5aw8sfHOOJr0Rh0/Viiq4RgOSGtgujKVErbyFuNN7tmOT52EQ==}
+  '@objectstack/service-i18n@17.0.0':
+    resolution: {integrity: sha512-7x21pZbd0JnRL8YlzoddA5X9WZrvh5wmAqe3d4hWVwJyi4AbVHrBYu5O0PG5me3C8MTfVdC6yEODOM6JwHjk+w==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-job@17.0.0-rc.6':
-    resolution: {integrity: sha512-jObj41mTIIAqnQj6eGfAHxHfIQidz04ZsDRrUARj4p+QcRPiHnKct6sXyPfGGp+HUaErAit+c/8z79qeN35Lvw==}
+  '@objectstack/service-job@17.0.0':
+    resolution: {integrity: sha512-XUFbf/8SAgMHS1qj1DnTGjgZ+eoEeu+W5YujM+HH4DL7j836ZKd3Z0k3OpLC+Z0O1SXyi2t3tVYX5seCpeeYTw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-messaging@17.0.0-rc.6':
-    resolution: {integrity: sha512-moMyoBINxjATJj7HEPJoku8vIe3p+XjilinnhHxzFyrK6N5D9mxLSwiSYKq1SmnXz4Wz8GGqq7wxLyawvHVfPQ==}
+  '@objectstack/service-messaging@17.0.0':
+    resolution: {integrity: sha512-R+5F6E/5HN4VmyFwOoZOpb02uW/6+dAHYUf8usa+kziFZbKYFU26FCTgrCkRB0tCjNj+hovekd42hvrhr+zm8A==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-package@17.0.0-rc.6':
-    resolution: {integrity: sha512-YrfMqSEycGBmMqatz/9jmiK0bRkaukSmLHVbNhIrUe+bPUqnBHbkdXTif3pVNxqce1RrblWsdmoEpWnszECFCw==}
+  '@objectstack/service-package@17.0.0':
+    resolution: {integrity: sha512-GPztbqTrk9xDGHVGVSb8OPog0qJoIccXLdiK/dPi7VlpJabqpeS11DFMi7d6GlbFK7OQbGTAF7wEk9FWQL1t+Q==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-queue@17.0.0-rc.6':
-    resolution: {integrity: sha512-jtcUR0TxZBOG1RDHSfyA3QtdJI2FU1/dbFOoPf5tS3SGG4aMRNnWN47X7MRihgD1699JdQnOn/MP2lH29dF9AA==}
+  '@objectstack/service-queue@17.0.0':
+    resolution: {integrity: sha512-MsDaxnc+V4/bW3fUioWHL9hPPU156sEAv2Ob3lOXkVbCO5oJvDg5dtbkgn+CoFchQpbJbQKfe/aaK3KKaZcJPg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-realtime@17.0.0-rc.6':
-    resolution: {integrity: sha512-njOGZRv+j1Vf58XvO+dcxBIoqJ8RA6SkxMeFQhZ342h7ahKonBb02gMdUYIPR2tXATAckro+d2myweidf9oFNw==}
+  '@objectstack/service-realtime@17.0.0':
+    resolution: {integrity: sha512-ZLsfbMJnENlhaH5lCZcCoQv870v9OK2RNbO/t0Co2KqNQ/K0GNfAQ8iyQxqUE7TpPSPlyJubHtWm+VcrDOR4BQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-settings@17.0.0-rc.6':
-    resolution: {integrity: sha512-H3deBuD5LDrgdziq5XVLV4AdnEmfeoFE9ekOdmOUe7caZWFGgBNRt9Q3RDjqOJqeTlvkVR/tYq5+MV0KHHIPEQ==}
+  '@objectstack/service-settings@17.0.0':
+    resolution: {integrity: sha512-e7xq4RZIGvvdSL0TRn8YBsFPfuYLyk8ECdP8xHSjyjM/cty0i/PYAX+5szPpOG5ltwU5pOJelt00a/Qtz98QLw==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/service-sms@17.0.0-rc.6':
-    resolution: {integrity: sha512-Yys1fHeNP41x7N/A/dwUqHc2ki60BZQTCMiE7QSWhXHGdYKEom7MnX75T306o3VC8K+Sjn4aM+K6jTjP1p4//A==}
+  '@objectstack/service-sms@17.0.0':
+    resolution: {integrity: sha512-Pi3JIWh+0dFsj18fVZCBwIXclqV1FcZtT6M4BKiyH/x7Yb5/CHMXwbPIdLM3k0Q3oY8sCwURTP66zDA5Negk7A==}
 
-  '@objectstack/service-storage@17.0.0-rc.6':
-    resolution: {integrity: sha512-A5b/4WzQSODBIv4o4ksVmM7wgmXxhWCpC5jVvJRBrlK+NrRWDAqWj820Q8WAs11rMK1oEc8MgyIt0U3PrD6ldQ==}
+  '@objectstack/service-storage@17.0.0':
+    resolution: {integrity: sha512-6Xsvmu1NJLSV3UJ2NwT6gPG3k4Gn+dURZ6ZZD5kvRu6MlTpSyYNQ8Xnbu8jjkvuIhUBbDU/0pA9aAgKCaALIIg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@aws-sdk/client-s3': ^3.0.0
@@ -732,12 +732,12 @@ packages:
       '@aws-sdk/s3-request-presigner':
         optional: true
 
-  '@objectstack/setup@17.0.0-rc.6':
-    resolution: {integrity: sha512-yNr0Fc0Yr5v2WGa5zuUMkYX9yfARPZdV3TMytdxxDEsyIMFt+E1ztZIDuED1HLHFgq+2+nsdlxfn0BDceG+V7w==}
+  '@objectstack/setup@17.0.0':
+    resolution: {integrity: sha512-pwYlhobA3ls3+VA1Okr231pW4i7irnLYEJaQlot+bSnXozSl1XfQSzX0ndfvOJe4lo2j1sZ7ulQ4JKHg6fQ+eQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/spec@17.0.0-rc.6':
-    resolution: {integrity: sha512-xDdZVm7KtpcKZVyt0LSaGQ8OtAgaIZnPqug5zPkndySFGQKdjPtiANUfVVX4H/L25HdEXbzodFZwBbPYR37zFQ==}
+  '@objectstack/spec@17.0.0':
+    resolution: {integrity: sha512-65rmDnj6WKnIATvEg9/coDYSVUgBTtym/FysEApaK2W/k4ub0DP7dQ9VUmLB4HEbJxo0ahzD1tFObkXYEIT7Fw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       ai: ^7.0.0
@@ -745,23 +745,23 @@ packages:
       ai:
         optional: true
 
-  '@objectstack/trigger-api@17.0.0-rc.6':
-    resolution: {integrity: sha512-517QhWIKRCvL/7qzM/4reOTx7NK+8Q39bpsSu/YJ75K0OTh1GijYl97pV71JMFIPUHjbcXg3CpxXTC/BjbqnSA==}
+  '@objectstack/trigger-api@17.0.0':
+    resolution: {integrity: sha512-BiNnuwJoGriIpLIyHaADkio0HxAoAdwE6oXk94c0JrmQO2Lo7pAAckYn/B85dZ8gD/455fmTpLjNl79kiM8Zyg==}
 
-  '@objectstack/trigger-record-change@17.0.0-rc.6':
-    resolution: {integrity: sha512-/BRQticzdE0NNH/YLJ9SW+jFFFALG6o66Fm4maJnWQy+lLvj8PMcndD5MUmw7UZmA/UMuGYPaSAviAZVZS6sww==}
+  '@objectstack/trigger-record-change@17.0.0':
+    resolution: {integrity: sha512-NwpvdmWNHBRFftIZf2ePN9Y9Mz7egGtYFbKh/f/w3b6oxXyPDYRj2tvgyAID/xAUKvcAyAYCuQpaDpyebwW0ZA==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/trigger-schedule@17.0.0-rc.6':
-    resolution: {integrity: sha512-PpZwgwzzVgyVPeP9R6UixRZErfwMQMY6UVNkbwGyXNewfIvTMEKZj0VpvBughPs7IOhTtvo5jR7nDWQXAtR4tg==}
+  '@objectstack/trigger-schedule@17.0.0':
+    resolution: {integrity: sha512-muiXL0xPkYV1Fyl7HFREhSzUYpzA3ABzgc5v2lqydnduVQxae5jGmmSsBcKX/VZhJ4y3p5IgVlzBGdItfcuhbA==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/types@17.0.0-rc.6':
-    resolution: {integrity: sha512-Di0cD+ObLzdAdkuESMDiMFAtviO5Ro3XX3+FNzaGXLwOVvxwBgddT91xm72fiT2iWybOhf3RNjnwws/eYZD7SA==}
+  '@objectstack/types@17.0.0':
+    resolution: {integrity: sha512-t02V65dAK1vkvb/1Srl1Wxi1Tml0KUyheBPpgGQoRh58iyLjgKX4L0EXyfX7U+fZG2zAHen8d4OW7KE+YNnCaA==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/verify@17.0.0-rc.6':
-    resolution: {integrity: sha512-g4Ro6VsW9v+w5sUVw5Ue370E6o6uZQ0PNw3jLY8QW7Gsp3zThuPMcu6/9eVUnttK+VxKJfngv16vVa6zPzV2WA==}
+  '@objectstack/verify@17.0.0':
+    resolution: {integrity: sha512-t0nAuzxJdd/kEBg4Qtmv4F7HxjyaWvjZHaBd2XC/7D0HFadYR1y8Lhmfqz4ItUuif6nBvQfW/69oBQj1TPDvtw==}
     engines: {node: '>=22.0.0'}
 
   '@oclif/core@4.13.2':
@@ -1073,6 +1073,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -3398,64 +3399,64 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@objectstack/account@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/account@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/cli@17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/cli@17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/account': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/client': 17.0.0-rc.6
-      '@objectstack/cloud-connection': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/console': 17.0.0-rc.6
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/driver-memory': 17.0.0-rc.6
-      '@objectstack/driver-mongodb': 17.0.0-rc.6
-      '@objectstack/driver-sql': 17.0.0-rc.6
-      '@objectstack/driver-sqlite-wasm': 17.0.0-rc.6(better-sqlite3@13.0.2)
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/lint': 17.0.0-rc.6
-      '@objectstack/mcp': 17.0.0-rc.6
-      '@objectstack/metadata': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/metadata-protocol': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/objectql': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/observability': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-approvals': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-audit': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-auth': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/plugin-email': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-hono-server': 17.0.0-rc.6
-      '@objectstack/plugin-pinyin-search': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-reports': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-security': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-sharing': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-webhooks': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/runtime': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/service-analytics': 17.0.0-rc.6
-      '@objectstack/service-automation': 17.0.0-rc.6
-      '@objectstack/service-cache': 17.0.0-rc.6
-      '@objectstack/service-datasource': 17.0.0-rc.6
-      '@objectstack/service-job': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/service-messaging': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/service-package': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/service-queue': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/service-realtime': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/service-settings': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/service-sms': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/service-storage': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/setup': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/trigger-api': 17.0.0-rc.6
-      '@objectstack/trigger-record-change': 17.0.0-rc.6
-      '@objectstack/trigger-schedule': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
-      '@objectstack/verify': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/account': 17.0.0(vitest@4.1.10)
+      '@objectstack/client': 17.0.0
+      '@objectstack/cloud-connection': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/console': 17.0.0
+      '@objectstack/core': 17.0.0
+      '@objectstack/driver-memory': 17.0.0
+      '@objectstack/driver-mongodb': 17.0.0
+      '@objectstack/driver-sql': 17.0.0
+      '@objectstack/driver-sqlite-wasm': 17.0.0(better-sqlite3@13.0.2)
+      '@objectstack/formula': 17.0.0
+      '@objectstack/lint': 17.0.0
+      '@objectstack/mcp': 17.0.0
+      '@objectstack/metadata': 17.0.0(vitest@4.1.10)
+      '@objectstack/metadata-protocol': 17.0.0(vitest@4.1.10)
+      '@objectstack/objectql': 17.0.0(vitest@4.1.10)
+      '@objectstack/observability': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-approvals': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-audit': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-auth': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/plugin-email': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-hono-server': 17.0.0
+      '@objectstack/plugin-pinyin-search': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-reports': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-security': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-sharing': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-webhooks': 17.0.0(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0(vitest@4.1.10)
+      '@objectstack/runtime': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/service-analytics': 17.0.0
+      '@objectstack/service-automation': 17.0.0
+      '@objectstack/service-cache': 17.0.0
+      '@objectstack/service-datasource': 17.0.0
+      '@objectstack/service-job': 17.0.0(vitest@4.1.10)
+      '@objectstack/service-messaging': 17.0.0(vitest@4.1.10)
+      '@objectstack/service-package': 17.0.0(vitest@4.1.10)
+      '@objectstack/service-queue': 17.0.0(vitest@4.1.10)
+      '@objectstack/service-realtime': 17.0.0(vitest@4.1.10)
+      '@objectstack/service-settings': 17.0.0(vitest@4.1.10)
+      '@objectstack/service-sms': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/service-storage': 17.0.0(vitest@4.1.10)
+      '@objectstack/setup': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/trigger-api': 17.0.0
+      '@objectstack/trigger-record-change': 17.0.0
+      '@objectstack/trigger-schedule': 17.0.0
+      '@objectstack/types': 17.0.0
+      '@objectstack/verify': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
       '@oclif/core': 4.13.2
       bundle-require: 5.1.0(esbuild@0.28.1)
       chalk: 6.0.0
@@ -3513,19 +3514,19 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/client@17.0.0-rc.6':
+  '@objectstack/client@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/cloud-connection@17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/cloud-connection@17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/runtime': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/runtime': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -3569,28 +3570,29 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/console@17.0.0-rc.6': {}
+  '@objectstack/console@17.0.0': {}
 
-  '@objectstack/core@17.0.0-rc.6':
+  '@objectstack/core@17.0.0':
     dependencies:
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/spec': 17.0.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-memory@17.0.0-rc.6':
+  '@objectstack/driver-memory@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       mingo: 7.2.2
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-mongodb@17.0.0-rc.6':
+  '@objectstack/driver-mongodb@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       mongodb: 7.5.0
       nanoid: 6.0.0
     transitivePeerDependencies:
@@ -3603,12 +3605,12 @@ snapshots:
       - snappy
       - socks
 
-  '@objectstack/driver-sql@17.0.0-rc.6':
+  '@objectstack/driver-sql@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/observability': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/observability': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       knex: 3.3.0(better-sqlite3@13.0.2)
       nanoid: 6.0.0
     optionalDependencies:
@@ -3622,11 +3624,11 @@ snapshots:
       - sqlite3
       - supports-color
 
-  '@objectstack/driver-sqlite-wasm@17.0.0-rc.6(better-sqlite3@12.11.1)':
+  '@objectstack/driver-sqlite-wasm@17.0.0(better-sqlite3@12.11.1)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/driver-sql': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/driver-sql': 17.0.0
+      '@objectstack/spec': 17.0.0
       knex: 3.3.0(better-sqlite3@12.11.1)
       nanoid: 6.0.0
       sql.js: 1.14.1
@@ -3643,11 +3645,11 @@ snapshots:
       - supports-color
       - tedious
 
-  '@objectstack/driver-sqlite-wasm@17.0.0-rc.6(better-sqlite3@13.0.2)':
+  '@objectstack/driver-sqlite-wasm@17.0.0(better-sqlite3@13.0.2)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/driver-sql': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/driver-sql': 17.0.0
+      '@objectstack/spec': 17.0.0
       knex: 3.3.0(better-sqlite3@13.0.2)
       nanoid: 6.0.0
       sql.js: 1.14.1
@@ -3664,18 +3666,18 @@ snapshots:
       - supports-color
       - tedious
 
-  '@objectstack/formula@17.0.0-rc.6':
+  '@objectstack/formula@17.0.0':
     dependencies:
       '@marcbachmann/cel-js': 8.0.0
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/lint@17.0.0-rc.6':
+  '@objectstack/lint@17.0.0':
     dependencies:
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/sdui-parser': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/formula': 17.0.0
+      '@objectstack/sdui-parser': 17.0.0
+      '@objectstack/spec': 17.0.0
       ajv: 8.20.0
       ajv-formats: 3.0.1
       sucrase: 3.35.1
@@ -3683,58 +3685,58 @@ snapshots:
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/mcp@17.0.0-rc.6':
+  '@objectstack/mcp@17.0.0':
     dependencies:
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/formula': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - ai
       - supports-color
 
-  '@objectstack/metadata-core@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/metadata-core@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/spec': 17.0.0
       zod: 4.4.3
     optionalDependencies:
       vitest: 4.1.10(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-fs@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/metadata-fs@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
       chokidar: 5.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/metadata-protocol@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/metadata-protocol@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/lint': 17.0.0-rc.6
-      '@objectstack/metadata': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/formula': 17.0.0
+      '@objectstack/lint': 17.0.0
+      '@objectstack/metadata': 17.0.0(vitest@4.1.10)
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/metadata@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/metadata@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/metadata-fs': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/metadata-fs': 17.0.0(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       chokidar: 5.0.0
       glob: 13.0.6
       js-yaml: 5.2.2
@@ -3743,15 +3745,15 @@ snapshots:
       - ai
       - vitest
 
-  '@objectstack/objectql@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/objectql@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/metadata': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/metadata-protocol': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/formula': 17.0.0
+      '@objectstack/metadata': 17.0.0(vitest@4.1.10)
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/metadata-protocol': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       ajv: 8.20.0
       ajv-formats: 3.0.1
       zod: 4.4.3
@@ -3759,54 +3761,54 @@ snapshots:
       - ai
       - vitest
 
-  '@objectstack/observability@17.0.0-rc.6':
+  '@objectstack/observability@17.0.0':
     dependencies:
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/platform-objects@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/platform-objects@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/plugin-approvals@17.0.0-rc.6(vitest@4.1.10)':
-    dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-audit@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/plugin-approvals@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/objectql': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/formula': 17.0.0
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-auth@17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/plugin-audit@17.0.0(vitest@4.1.10)':
+    dependencies:
+      '@objectstack/core': 17.0.0
+      '@objectstack/objectql': 17.0.0(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/plugin-auth@17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
       '@better-auth/core': 1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2)
       '@better-auth/oauth-provider': 1.7.0-rc.2(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.2(better-sqlite3@12.11.1)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/scim': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(better-auth@1.7.0-rc.2(better-sqlite3@12.11.1)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/sso': 1.7.0-rc.2(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.2(better-sqlite3@12.11.1)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@noble/hashes': 2.2.0
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       better-auth: 1.7.0-rc.2(better-sqlite3@12.11.1)(mongodb@7.5.0)(vitest@4.1.10)
       jose: 6.2.5
     transitivePeerDependencies:
@@ -3838,18 +3840,18 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/plugin-auth@17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/plugin-auth@17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
       '@better-auth/core': 1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2)
       '@better-auth/oauth-provider': 1.7.0-rc.2(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.2(better-sqlite3@13.0.2)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/scim': 1.7.0-rc.1(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(better-auth@1.7.0-rc.2(better-sqlite3@13.0.2)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@better-auth/sso': 1.7.0-rc.2(@better-auth/core@1.7.0-rc.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.0-rc.2(better-sqlite3@13.0.2)(mongodb@7.5.0)(vitest@4.1.10))(better-call@1.3.7(zod@4.4.3))
       '@noble/hashes': 2.2.0
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       better-auth: 1.7.0-rc.2(better-sqlite3@13.0.2)(mongodb@7.5.0)(vitest@4.1.10)
       jose: 6.2.5
     transitivePeerDependencies:
@@ -3881,118 +3883,120 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/plugin-email@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/plugin-email@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/formula': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
       nodemailer: 9.0.4
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-hono-server@17.0.0-rc.6':
+  '@objectstack/plugin-hono-server@17.0.0':
     dependencies:
       '@hono/node-server': 2.0.12(hono@4.13.0)
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/observability': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/observability': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       hono: 4.13.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-pinyin-search@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/plugin-pinyin-search@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/objectql': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/objectql': 17.0.0(vitest@4.1.10)
+      '@objectstack/types': 17.0.0
       pinyin-pro: 3.28.2
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-reports@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/plugin-reports@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
       croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-security@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/plugin-security@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/formula': 17.0.0
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-sharing@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/plugin-sharing@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/objectql': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/formula': 17.0.0
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/objectql': 17.0.0(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-webhooks@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/plugin-webhooks@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/service-messaging': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/service-messaging': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/rest@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/rest@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/observability': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/service-package': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/observability': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/service-package': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       exceljs: 4.4.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/runtime@17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/runtime@17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/driver-memory': 17.0.0-rc.6
-      '@objectstack/driver-sql': 17.0.0-rc.6
-      '@objectstack/driver-sqlite-wasm': 17.0.0-rc.6(better-sqlite3@12.11.1)
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/metadata': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/metadata-protocol': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/objectql': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/observability': 17.0.0-rc.6
-      '@objectstack/plugin-auth': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/plugin-security': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/service-cluster': 17.0.0-rc.6
-      '@objectstack/service-datasource': 17.0.0-rc.6
-      '@objectstack/service-i18n': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/driver-memory': 17.0.0
+      '@objectstack/driver-sql': 17.0.0
+      '@objectstack/driver-sqlite-wasm': 17.0.0(better-sqlite3@12.11.1)
+      '@objectstack/formula': 17.0.0
+      '@objectstack/metadata': 17.0.0(vitest@4.1.10)
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/metadata-protocol': 17.0.0(vitest@4.1.10)
+      '@objectstack/objectql': 17.0.0(vitest@4.1.10)
+      '@objectstack/observability': 17.0.0
+      '@objectstack/plugin-auth': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@12.11.1)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/plugin-security': 17.0.0(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0(vitest@4.1.10)
+      '@objectstack/service-cluster': 17.0.0
+      '@objectstack/service-datasource': 17.0.0
+      '@objectstack/service-i18n': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       quickjs-emscripten: 0.32.0
       zod: 4.4.3
     optionalDependencies:
-      '@objectstack/driver-mongodb': 17.0.0-rc.6
+      '@objectstack/driver-mongodb': 17.0.0
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -4036,30 +4040,30 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/runtime@17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/runtime@17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/driver-memory': 17.0.0-rc.6
-      '@objectstack/driver-sql': 17.0.0-rc.6
-      '@objectstack/driver-sqlite-wasm': 17.0.0-rc.6(better-sqlite3@13.0.2)
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/metadata': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/metadata-protocol': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/objectql': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/observability': 17.0.0-rc.6
-      '@objectstack/plugin-auth': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/plugin-security': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/service-cluster': 17.0.0-rc.6
-      '@objectstack/service-datasource': 17.0.0-rc.6
-      '@objectstack/service-i18n': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/driver-memory': 17.0.0
+      '@objectstack/driver-sql': 17.0.0
+      '@objectstack/driver-sqlite-wasm': 17.0.0(better-sqlite3@13.0.2)
+      '@objectstack/formula': 17.0.0
+      '@objectstack/metadata': 17.0.0(vitest@4.1.10)
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/metadata-protocol': 17.0.0(vitest@4.1.10)
+      '@objectstack/objectql': 17.0.0(vitest@4.1.10)
+      '@objectstack/observability': 17.0.0
+      '@objectstack/plugin-auth': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/plugin-security': 17.0.0(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0(vitest@4.1.10)
+      '@objectstack/service-cluster': 17.0.0
+      '@objectstack/service-datasource': 17.0.0
+      '@objectstack/service-i18n': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
       quickjs-emscripten: 0.32.0
       zod: 4.4.3
     optionalDependencies:
-      '@objectstack/driver-mongodb': 17.0.0-rc.6
+      '@objectstack/driver-mongodb': 17.0.0
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -4103,118 +4107,118 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/sdui-parser@17.0.0-rc.6': {}
+  '@objectstack/sdui-parser@17.0.0': {}
 
-  '@objectstack/service-analytics@17.0.0-rc.6':
+  '@objectstack/service-analytics@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-automation@17.0.0-rc.6':
+  '@objectstack/service-automation@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/formula': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/formula': 17.0.0
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cache@17.0.0-rc.6':
+  '@objectstack/service-cache@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/observability': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/observability': 17.0.0
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cluster@17.0.0-rc.6':
+  '@objectstack/service-cluster@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-datasource@17.0.0-rc.6':
+  '@objectstack/service-datasource@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-i18n@17.0.0-rc.6':
+  '@objectstack/service-i18n@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-job@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/service-job@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
       croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-messaging@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/service-messaging@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-package@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/service-package@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/metadata-core': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/metadata-core': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-queue@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/service-queue@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-realtime@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/service-realtime@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-settings@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/service-settings@17.0.0(vitest@4.1.10)':
     dependencies:
       '@noble/ciphers': 2.2.0
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-sms@17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/service-sms@17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/plugin-auth': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/plugin-auth': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - '@better-auth/utils'
       - '@better-fetch/fetch'
@@ -4244,73 +4248,73 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/service-storage@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/service-storage@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/observability': 17.0.0-rc.6
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/observability': 17.0.0
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/setup@17.0.0-rc.6(vitest@4.1.10)':
+  '@objectstack/setup@17.0.0(vitest@4.1.10)':
     dependencies:
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/spec@17.0.0-rc.6':
+  '@objectstack/spec@17.0.0':
     dependencies:
       zod: 4.4.3
 
-  '@objectstack/trigger-api@17.0.0-rc.6':
+  '@objectstack/trigger-api@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/trigger-record-change@17.0.0-rc.6':
+  '@objectstack/trigger-record-change@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/trigger-schedule@17.0.0-rc.6':
+  '@objectstack/trigger-schedule@17.0.0':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/types@17.0.0-rc.6':
+  '@objectstack/types@17.0.0':
     dependencies:
-      '@objectstack/spec': 17.0.0-rc.6
+      '@objectstack/spec': 17.0.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/verify@17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
+  '@objectstack/verify@17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)':
     dependencies:
-      '@objectstack/core': 17.0.0-rc.6
-      '@objectstack/objectql': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/platform-objects': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-auth': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/plugin-hono-server': 17.0.0-rc.6
-      '@objectstack/plugin-security': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/plugin-sharing': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/rest': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/runtime': 17.0.0-rc.6(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
-      '@objectstack/service-analytics': 17.0.0-rc.6
-      '@objectstack/service-automation': 17.0.0-rc.6
-      '@objectstack/service-datasource': 17.0.0-rc.6
-      '@objectstack/service-settings': 17.0.0-rc.6(vitest@4.1.10)
-      '@objectstack/spec': 17.0.0-rc.6
-      '@objectstack/types': 17.0.0-rc.6
+      '@objectstack/core': 17.0.0
+      '@objectstack/objectql': 17.0.0(vitest@4.1.10)
+      '@objectstack/platform-objects': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-auth': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/plugin-hono-server': 17.0.0
+      '@objectstack/plugin-security': 17.0.0(vitest@4.1.10)
+      '@objectstack/plugin-sharing': 17.0.0(vitest@4.1.10)
+      '@objectstack/rest': 17.0.0(vitest@4.1.10)
+      '@objectstack/runtime': 17.0.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(better-sqlite3@13.0.2)(kysely@0.29.4)(mongodb@7.5.0)(nanostores@1.4.2)(vitest@4.1.10)
+      '@objectstack/service-analytics': 17.0.0
+      '@objectstack/service-automation': 17.0.0
+      '@objectstack/service-datasource': 17.0.0
+      '@objectstack/service-settings': 17.0.0(vitest@4.1.10)
+      '@objectstack/spec': 17.0.0
+      '@objectstack/types': 17.0.0
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'

--- a/src/actions/opportunity.actions.ts
+++ b/src/actions/opportunity.actions.ts
@@ -118,21 +118,46 @@ export const MassUpdateStageAction: Action = {
       const ids = selected.length ? selected : (ctx.recordId ? [ctx.recordId] : []);
       if (!ids.length) throw new Error('mass_update_stage: no opportunity selected');
       const missed = [];
+      let firstCause = '';
       let updated = 0;
       for (const id of ids) {
         // \`update(data, options)\` — \`ctx.api\` is the engine repo facade, whose
         // update takes a DOCUMENT, not an id. \`updateById(id, data)\` exists on
         // ObjectRepository but NOT on the facade the runtime builds when it has
         // no scoped context, so this spelling is the only one live on both.
-        const row = await ctx.api.object('crm_opportunity').update(
-          { id: id, stage: newStage },
-          { where: { id: id } },
-        );
-        // An id that matched no row resolves to null — the engine does NOT
-        // throw for it. Counting the attempt instead of the returned row is how
-        // a stale or invisible id turns into a success toast for a write that
-        // never happened, which is the exact silent-success failure #588 pulled
-        // this button for. Count only what came back.
+        //
+        // An id that matches no row is a MISS, not an abort, and the engine has
+        // answered it both ways: through @objectstack/* 17.0.0-rc.6 \`update\`
+        // RESOLVED WITH NULL, and from 17.0.0 it REJECTS (RECORD_NOT_FOUND /
+        // 404). Both are handled here, and neither may end the loop — an
+        // uncaught rejection on the first stale id would leave every id after
+        // it unattempted, so re-running the action over the same selection
+        // would fail at the same row forever and the live rows behind it could
+        // never be covered. That is strictly worse than the silent-success
+        // failure #588 pulled this button for, because it is unrecoverable
+        // from the UI. Collect the miss, keep going, reject once at the end.
+        //
+        // The catch is deliberately cause-AGNOSTIC. A host rejection crosses
+        // the QuickJS boundary as \`{ name, message }\` only — \`code\`, \`status\`
+        // and \`details\` are dropped by the bridge (runtime \`vm.newError\`) — so
+        // a body physically cannot test for RECORD_NOT_FOUND, and sniffing the
+        // message text would pin engine wording that is not contract. Every
+        // per-row failure is therefore reported as what the aggregate error
+        // already claims — this id was not updated — with the first cause
+        // carried along so the reason is not lost.
+        let row = null;
+        try {
+          row = await ctx.api.object('crm_opportunity').update(
+            { id: id, stage: newStage },
+            { where: { id: id } },
+          );
+        } catch (err) {
+          row = null;
+          if (!firstCause) firstCause = (err && err.message) ? String(err.message) : String(err);
+        }
+        // Count only what came back: counting the ATTEMPT is how a stale or
+        // invisible id turns into a success toast for a write that never
+        // happened (#588).
         if (row) { updated++; } else { missed.push(id); }
       }
       // Aggregate dispatch is all-or-nothing (objectui#3139): a handler that
@@ -146,6 +171,7 @@ export const MassUpdateStageAction: Action = {
           'mass_update_stage: ' + missed.length + ' of ' + ids.length
           + ' selected opportunities could not be updated (' + missed.join(', ')
           + '). Re-run the action on the selection to retry.'
+          + (firstCause ? ' First cause: ' + firstCause : '')
         );
       }
       return { stage: newStage, updated };

--- a/src/profiles/index.ts
+++ b/src/profiles/index.ts
@@ -25,6 +25,18 @@
  * same route. So the gate is object-wide and reachable with `curl`, which is
  * exactly why it has to be enforced server-side rather than by hiding a button.
  *
+ * SHAPE (@objectstack/spec 17.0.0, #8010, maintainer ruling 2026-08-12): the
+ * declaration is the OBJECT form `exportOptions: { formats: ['csv', 'xlsx'] }`.
+ * The bare array this app used through 17.0.0-rc.6 is the legacy spelling; it
+ * still parses and LIFTS to `{ formats: [...] }`, so `z.input` accepts both
+ * while `z.output` — everything that reads loaded metadata, this app's own
+ * guards included — only ever sees the object. That asymmetry is why the bump
+ * to 17.0.0 blinded the guard below rather than failing it: the views still
+ * declared their surfaces, and a reader testing the legacy array's `.length`
+ * silently measured `undefined` on every one of them. Read `.formats`.
+ * `'pdf'` left the format enum in the same change (#1301 NOT_PLANNED); this
+ * app never declared it.
+ *
  * `ReportService.assertExportAllowed` is a genuinely separate gate, but it
  * belongs to the `reports` capability (saved reports + emailed digests over
  * `sys_saved_report`), which this app does not require — `/api/v1/reports`

--- a/src/views/account.view.ts
+++ b/src/views/account.view.ts
@@ -28,7 +28,7 @@ export const AccountViews = defineView({
     rowColor: { field: 'is_active', colors: { true: '#16a34a', false: '#94a3b8' } },
     selection: { type: 'multiple' },
     pagination: { pageSize: 50, pageSizeOptions: [25, 50, 100] },
-    exportOptions: ['csv', 'xlsx'],
+    exportOptions: { formats: ['csv', 'xlsx'] },
     compactToolbar: true,
     bulkActionDefs: [
       {

--- a/src/views/case.view.ts
+++ b/src/views/case.view.ts
@@ -49,7 +49,7 @@ export const CaseViews = defineView({
     // profile without the grant gets 403 whether it clicks the button or
     // curls the route. Measured in #798/#816; before this the grant was live
     // but reachable only by `curl`.
-    exportOptions: ['csv', 'xlsx'],
+    exportOptions: { formats: ['csv', 'xlsx'] },
     appearance: {
       showDescription: true,
       allowedVisualizations: ['grid', 'kanban', 'calendar', 'timeline'],

--- a/src/views/contact.view.ts
+++ b/src/views/contact.view.ts
@@ -35,7 +35,7 @@ export const ContactViews = defineView({
     // `locations: ['list_item']` and are auto-injected into the row menu.
     bulkActions: ['add_contact_to_campaign'],
     pagination: { pageSize: 50, pageSizeOptions: [25, 50, 100] },
-    exportOptions: ['csv', 'xlsx'],
+    exportOptions: { formats: ['csv', 'xlsx'] },
     appearance: {
       showDescription: true,
       allowedVisualizations: ['grid', 'gallery'],

--- a/src/views/lead.view.ts
+++ b/src/views/lead.view.ts
@@ -180,7 +180,7 @@ export const LeadViews = defineView({
     // Features
     pagination: { pageSize: 25, pageSizeOptions: [10, 25, 50, 100] },
     rowHeight: 'medium',
-    exportOptions: ['csv', 'xlsx'],
+    exportOptions: { formats: ['csv', 'xlsx'] },
     
     // Empty State
     emptyState: {

--- a/src/views/opportunity.view.ts
+++ b/src/views/opportunity.view.ts
@@ -58,7 +58,7 @@ export const OpportunityViews = defineView({
     pagination: { pageSize: 25, pageSizeOptions: [25, 50, 100] },
     selection: { type: 'multiple' },
     showRecordCount: true,
-    exportOptions: ['csv', 'xlsx'],
+    exportOptions: { formats: ['csv', 'xlsx'] },
     appearance: {
       showDescription: true,
       allowedVisualizations: ['grid', 'kanban', 'calendar', 'timeline', 'gallery'],

--- a/test/action-sandbox.test.ts
+++ b/test/action-sandbox.test.ts
@@ -430,11 +430,21 @@ describe('every script action body executes under QuickJS', () => {
       // retry, so a handler that covers only part of the selection must reject
       // rather than return a success the bar will toast.
       //
-      // The trap this pins is specific and silent: an id matching no row does
-      // NOT make the engine throw — `update` RESOLVES WITH NULL. A body that
-      // counted iterations instead of returned rows would answer `updated: 2`
-      // for one write, which is exactly the "success toast, nothing written"
-      // failure #588 pulled this button off the list for.
+      // The trap this pins is specific and silent: a body that counted
+      // iterations instead of returned rows would answer `updated: 2` for one
+      // write, which is exactly the "success toast, nothing written" failure
+      // #588 pulled this button off the list for.
+      //
+      // How the engine reports the stale id changed under us, and the body
+      // handles both — measured on this harness with a live-id control:
+      //
+      //   ≤ 17.0.0-rc.6   update() RESOLVES WITH NULL
+      //   ≥ 17.0.0        update() REJECTS — RECORD_NOT_FOUND / 404
+      //
+      // Either way the aggregate message below is what the rep must see, so
+      // the body catches per row rather than letting the first miss abort the
+      // run. `covers_live_rows_after_a_stale_id` next door pins the half that
+      // an uncaught rejection would silently cost.
       const api = ql.createContext({ isSystem: true });
       const live = await api.object('crm_opportunity').insert({ name: 'Deal C', stage: 'prospecting' });
       const stale = 'opp_deleted_between_select_and_submit';
@@ -453,6 +463,30 @@ describe('every script action body executes under QuickJS', () => {
       // because setting a stage is idempotent.
       const stored = await api.object('crm_opportunity').findOne({ where: { id: live.id } });
       expect(stored?.stage).toBe('negotiation');
+    });
+
+    it('covers_live_rows_after_a_stale_id — a miss does not abandon the rest of the selection', async () => {
+      // The stale id goes FIRST, which is the ordering the previous leg cannot
+      // see: with `update` rejecting on a miss (17.0.0), a body that let the
+      // rejection escape the loop would never attempt `live` at all, and the
+      // rep's retry would abort at the same row every time — the selection
+      // could never be covered from the UI. Before 17.0.0 the same body passed
+      // this by accident, because a miss resolved null instead of throwing.
+      const api = ql.createContext({ isSystem: true });
+      const stale = 'opp_deleted_before_the_live_row';
+      const live = await api.object('crm_opportunity').insert({ name: 'Deal D', stage: 'prospecting' });
+
+      await expect(
+        runActionBody(action(MASS_UPDATE), {
+          objectName: 'crm_opportunity',
+          input: { stage: 'negotiation', _selectedIds: [stale, live.id] },
+          engine: asBodyEngine(ql),
+        }),
+      ).rejects.toThrow(/1 of 2 selected opportunities could not be updated/);
+
+      // The point of the leg: the row BEHIND the stale id was still written.
+      const stored = await api.object('crm_opportunity').findOne({ where: { id: live.id } });
+      expect(stored?.stage, 'the live row behind a stale id was never attempted').toBe('negotiation');
     });
   });
 

--- a/test/authorization-coverage.test.ts
+++ b/test/authorization-coverage.test.ts
@@ -628,7 +628,22 @@ describe('allowExport tracks the app’s real export surfaces', () => {
   for (const v of views) {
     const defaultObject = v.list?.data?.object;
     for (const list of [v.list, ...Object.values(v.listViews ?? {})].filter(Boolean) as AnyRec[]) {
-      if (!(list.exportOptions ?? []).length) continue;
+      // `.formats`, not the value itself. `exportOptions` is the OBJECT form
+      // `{ formats: [...] }` at @objectstack/spec 17.0.0 (#8010, maintainer
+      // ruling 2026-08-12); the bare array this app authored through
+      // 17.0.0-rc.6 is the legacy `z.input` spelling and LIFTS to the object
+      // at parse, so `z.output` — which is what `stack.views` hands us here —
+      // is the object on both spellings.
+      //
+      // Reading the old way is not a stale assertion, it is a BLIND one, and
+      // silently: `({ formats: [...] }).length` is `undefined`, `??` never
+      // fires because the object is not nullish, and every surface in the app
+      // fell out of this set at once. Both guards below invert on an empty
+      // set — "no surface" makes every `allowExport` grant look gratuitous —
+      // so the 17.0.0 bump turned a bulk-egress guard into 23 false accusals
+      // rather than into silence. Only the `not.toEqual([])` canary above
+      // separates the two, which is exactly why it is written.
+      if (!(list.exportOptions?.formats ?? []).length) continue;
       const objectName = list.data?.object ?? defaultObject;
       if (typeof objectName === 'string') exportSurfaces.add(objectName);
     }

--- a/test/contract-write-depth.test.ts
+++ b/test/contract-write-depth.test.ts
@@ -105,6 +105,13 @@ const attempt = async (object: string, doc: AnyRec, ctx: AnyRec) => {
       message: String(e?.message ?? ''),
       code: e?.code,
       status: e?.status ?? e?.statusCode,
+      // @objectstack/spec 17.0.0 split the refusal in two: `message` is now a
+      // localized END-USER sentence rendered from `BUILTIN_OPERATION_MESSAGES`
+      // (`errors.permission_denied`, four locales), while the operator-facing
+      // sentence naming the operation, object and positions moved to
+      // `developerMessage` and the machine-readable facts to `details`.
+      details: e?.details,
+      developerMessage: e?.developerMessage,
     };
   }
 };
@@ -386,7 +393,21 @@ describe('what the grant deliberately does NOT convey, on any edition', () => {
     // `statusCode` rather than a `status`.
     const r = await attempt('crm_contract', { id: id.repContract, contract_value: 9999 }, repCtx);
     expect(r.ok).toBe(false);
+    // The ENVELOPE is the contract (ADR-0112): code + status, then the
+    // structured facts. This used to read the refusal out of `message`, which
+    // stopped naming the object at @objectstack/spec 17.0.0 — `message` is now
+    // the localized end-user sentence and says nothing about `crm_contract`.
+    // Asserting `details` instead is strictly stronger than the old substring:
+    // it pins WHICH verb was refused on WHICH object as data, so a refusal
+    // arriving for the wrong object can no longer pass by wording alone.
     expect(r.code).toBe('PERMISSION_DENIED');
-    expect(r.message).toContain("operation 'update' on object 'crm_contract' is not permitted");
+    expect(r.status).toBe(403);
+    expect(r.details).toMatchObject({ operation: 'update', object: 'crm_contract' });
+    // The operator-facing sentence survives, one field over — kept in the
+    // assertion so a future release that drops `developerMessage` is loud here
+    // rather than quietly leaving the logs with nothing to grep.
+    expect(String(r.developerMessage)).toContain(
+      "operation 'update' on object 'crm_contract' is not permitted",
+    );
   });
 });


### PR DESCRIPTION
Fixes #1146

## Description

Moves the platform line to **ObjectStack 17.0.0 GA** (from `17.0.0-rc.6`) and absorbs the
behaviour changes that arrive with it. All 12 `@objectstack/*` entries move together, with
`objectstack.manifest.json` `specVersion`, `objectstack.config.ts` `engines.protocol` and
**both** lockfiles following the pin.

The card was filed around one expected break (a `where` on a `formula` field now throws).
That break turned out **not to touch this app at all** — and the bump carried **three other
behaviour changes that did**, none of which appears in the delta's conventional-commit
markers. Each was measured on the two builds side by side rather than read off a changelog.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — absorbed from upstream; no HotCRM-authored contract changes
- [x] Documentation update
- [x] CI/CD update — dependency line

## Related Issues

Fixes #1146
Related to #1104, #1141, #1148 (re-measured or filed; none is addressed here)

## Changes Made

- Bump all 12 `@objectstack/*` entries to `17.0.0`; regenerate **both** `pnpm-lock.yaml` and
  `package-lock.json`; align `specVersion` / `engines.protocol`.
- Migrate the five list views' `exportOptions` to the canonical object form and teach the
  `allowExport` guard to read `.formats`.
- Assert the ADR-0112 envelope (`code` + `status` + `details`) on the contract-permission
  refusal instead of message text.
- Make `mass_update_stage` record a per-row miss instead of letting the first stale id
  abort the run, and pin the restored behaviour with a new test leg.
- `docs/STATUS.md` runtime row follows `package.json`.
- Changeset: `.changeset/objectstack-17-ga-upgrade.md`.

---

## 1. The expected break: `where` on a `formula` field — HotCRM is clear

`assertFilterIsMaterializable` is genuinely new in this bump. Measured on the built
artifacts actually installed, with three unchanged symbols as positive controls:

| symbol in `@objectstack/objectql/dist/core.js` | rc.6 | 17.0.0 |
|---|---|---|
| `assertFilterIsMaterializable` | 0 | **3** |
| `isVirtualSearchField` | 0 | **1** |
| `collectFilterFieldNames` | 0 | **4** |
| `assertListComparandShapes` (control) | 5 | 5 |
| `lowerWhereFilterArray` (control) | 8 | 8 |
| `INVALID_FILTER` (control) | 1 | 1 |

**Inventory — 19 `Field.formula` fields across 12 objects**, read out of the sources rather
than from the card's starting hint:

| object | formula fields |
|---|---|
| `crm_account` | `display_title` |
| `crm_campaign` | `display_title`, `response_rate`, `roi` |
| `crm_case` | `display_title` |
| `crm_contact` | `full_name` |
| `crm_forecast` | `display_title`, `expected_amount`, `attainment_pct`, `coverage_ratio` |
| `crm_knowledge_article` | `display_title` |
| `crm_lead` | `full_name`, `display_title` |
| `crm_opportunity` | `days_in_stage` |
| `crm_opportunity_line_item` | `total_price` |
| `crm_product` | `display_title` |
| `crm_quote` | `display_title` |
| `crm_quote_line_item` | `subtotal`, `total_price` |

**Per-surface verdicts — every predicate surface, all four spellings the engine lowers:**

| surface | predicate spelling | regions scanned | formula-field predicates |
|---|---|---|---|
| `src/objects/**` (hooks, `_*.ts`) | `where:` (71) | all | **none** |
| `src/actions/*.actions.ts` | `where:` (10) | all | **none** |
| `src/views/*.view.ts` | `filter:` (33) | all | **none** |
| `src/flows/*.flow.ts` | `filter:` (48) + `filters:` (1) | all | **none** |
| `src/pages/*.page.ts` | `filter:` (10) + `filters:` (2) | all | **none** |
| `src/datasets` / `src/dashboards` | `filter:` (7 / 52) | all | **none** |
| `src/data`, `scripts/`, `test/`, `e2e/` | `where:` / `filter:` | all | **none** |

The scanner reproduces the engine's own `collectFilterFieldNames` semantics (top-level keys,
recursing `$and`/`$or`/`$not`, skipping dotted paths) and understands all four shapes this
repo uses — `{ field: op }`, `{ field: 'x', operator, value }`, `['x', 'op', v]`, and nested
logical arms. It was **positive-controlled** on a synthetic file carrying one of each shape
plus a non-formula decoy: 4 hits, decoy correctly ignored. Also checked and clear:
`searchableFields` names no formula field on any of the 11 objects that declare it, and
GA refuses only `where`, not `sort` (`isVirtualSearchField` has exactly one call site).

**Live confirmation on the running GA server** — the mechanism is active, so the sweep's
zero is a real zero and not a dormant check:

```
GET /api/v1/data/crm_lead?filter={"full_name":"Ada Lovelace"}
→ 400 {"code":"INVALID_FIELD","field":"full_name","object":"crm_lead"}

GET /api/v1/data/crm_opportunity?filter={"days_in_stage":{"$gt":14}}
→ 400 {"code":"INVALID_FIELD","field":"days_in_stage","object":"crm_opportunity"}

GET /api/v1/data/crm_lead?filter={"status":"new"}      ← same route, same user, stored field
→ 403 PERMISSION_DENIED                                   (refusal is field-specific, not blanket)
```

**No denormalisation was needed, and none was invented.** No predicate was deleted or
weakened — there was nothing to fix.

## 2. `exportOptions` became an object — and inverted a security guard

Spec #8010 (maintainer ruling 2026-08-12) makes `{ formats: [...] }` the contract. The bare
array still parses but **lifts** at parse, so `z.input` accepts both while `z.output` yields
only the object.

That asymmetry is the dangerous part. The `allowExport` coverage guard tested the legacy
array's `.length`; against `{ formats: [...] }` that is `undefined`, `??` never fires, and
every export surface fell out of the set at once — so the guard did not go quiet, it
**inverted**, reporting 23 legitimate bulk-egress grants as gratuitous. Grants and surfaces
were never wrong; only the reader was.

The five views now author the canonical form and the guard reads `.formats`.

## 3. `PERMISSION_DENIED` split into user-facing and operator-facing halves

New `BUILTIN_OPERATION_MESSAGES` (4 locales) makes `message` an end-user sentence; the text
naming the operation and object moved to `developerMessage`, and the machine-readable facts
to `details`. The refusal assertion now reads the envelope — `code` + `status` +
`details.operation` / `details.object` — which is strictly stronger than the old substring,
since a refusal for the wrong object can no longer pass on wording alone.

## 4. `update()` on a missing id now rejects — a real functional regression, fixed

Measured both ways, with a live-id positive control:

| ref | `update` on an id matching no row |
|---|---|
| `17.0.0-rc.6` | resolves `null` |
| `17.0.0` | throws `RECORD_NOT_FOUND` / 404 |

`mass_update_stage` iterates a selection. With the rejection uncaught, the first stale id
aborted the loop, leaving **every selected row behind it unattempted** — and since a retry
aborts at the same row, the selection could never be covered from the UI at all. That is
strictly worse than the silent-success failure the button was originally pulled for,
because it is unrecoverable by the user.

The body now records a miss per row and rejects once at the end, so live rows are written
whatever their position and the error still names every id it could not update. The catch
is deliberately **cause-agnostic**: a host rejection crosses the QuickJS boundary as
`{ name, message }` only (runtime `vm.newError`), so a body physically cannot test for
`RECORD_NOT_FOUND`, and sniffing engine wording would pin text that is not contract. The
first cause is carried into the aggregate message so the reason is not lost.

New test leg `covers_live_rows_after_a_stale_id` puts the stale id **first** — the ordering
the existing leg cannot see, and the one that was silently broken.

**Reverse-verified** (direction predicted before running): reverting the action body turns
both aggregate legs red; reverting the guard line turns the two export legs red. Both files
restored byte-identically from the commit afterwards.

## 5. This repo has TWO lockfiles — the bump's file surface was one file wider than the card named

Caught by CI at `7efb08be`, fixed in `3240c600`. `pnpm-lock.yaml` is the development
lockfile; `package-lock.json` exists so the StackBlitz demo boots without a full npm
re-resolve, and it is enforced by `scripts/check-stackblitz-lock.mjs` — a gate that runs in
the `Build and Test` job but is **not** part of `pnpm verify`, which is exactly why a green
local `verify` did not catch it.

Regenerated with the gate's own printed command. Worth knowing for the next bump: the npm
lockfile pins the whole **resolved transitive family**, not just the direct dependencies —

| | packages pinned |
|---|---|
| `package.json` | 12 |
| `package-lock.json` | **54** |

All 54 verified at `17.0.0` (`console`, `core`, `lint`, `mcp`, `metadata-core`,
`platform-objects`, every `plugin-*` / `service-*` / `trigger-*`, …), and the gate now
reports `package-lock.json is in sync with package.json (v3)`.

Swept for the same class of miss afterwards and found nothing else: every `scripts/check-*.mjs`
gate passes, and no other tracked file pins the platform version — `.stackblitzrc` carries
none, there is no devcontainer, and the README has no version badge.

## Testing

- [x] Unit tests pass — `pnpm test`
- [x] Linting passes — `pnpm lint`, `pnpm lint:i18n-gate`
- [x] Build succeeds — `pnpm build`
- [x] Manual testing completed — dev-server boot + live REST probes
- [x] New tests added

All re-run at final head **`3240c600`** (not inherited from the pre-lockfile head):

```
pnpm verify   → EXIT 0
  ✓ Validation passed (1112ms)
  83 warning(s), 10 suggestion(s)        ← pre-existing advisories, unchanged from main
  ✓ i18n lint gate: 0 `i18n/missing-*` issues
  ✓ source hygiene clean
  ✓ Build complete — 18 Objects, 347 Fields, 14 Views, 26 Flows
  Test Files  103 passed (103)
  Tests  2538 passed | 1 skipped (2539)

pnpm test:e2e → EXIT 0
  16 passed (47.6s)

node scripts/check-stackblitz-lock.mjs  → EXIT 0
node scripts/check-source-hygiene.mjs   → EXIT 0
node scripts/check-lint-i18n-gate.mjs   → EXIT 0
```

**Boot smoke check** (`pnpm demo:reset`, then `pnpm dev` on an empty DB):

```
✓ Server is ready          — 38 plugins loaded
health → {"success":true,"data":{"status":"ok",...}}
422 / metadata refusals: 0
ERROR lines in boot log:  0
```

Two notes on the verification, both self-inflicted rather than product findings:

- Playwright's bundled revision (`chromium_headless_shell-1234`) is not what this container
  ships (`chromium-1194`), so 2 of 16 specs failed to launch a browser. Resolved with the
  config's own escape hatch, `PLAYWRIGHT_CHROMIUM_EXECUTABLE` — **not** by running
  `playwright install`. Worth knowing for CI images.
- An intermediate e2e run went red with 403s on `crm_account`. Cause: the live REST probe
  above created its user on a freshly reset DB and took the first-user org-admin slot, so
  the e2e admin came up a plain member. Wiping `.objectstack/data` and re-running gave
  16/16. No product defect — recorded so the next reader does not chase it.

## Upstream mirror cards re-probed

The card named 8; the live `label:upstream:objectstack is:open` set read at start is **30**.
Verdicts for the 8 tracked plus what the probes could reach:

| card | verdict on GA |
|---|---|
| #1141 | **CHANGED — half fixed.** A bogus top-level stack key is still dropped, but no longer silently: `defineStack` names it and offers a did-you-mean. Commented. |
| #1122 | Unchanged — `FieldSchema` still rejects `indexed` by name (`unrecognized_keys`). Console-side card, untouched by the bump. |
| #1104 | **CHANGED — blocker lifted.** `publicSharing.eligibility` goes 0 → 12 consumption sites in `plugin-sharing`; it now compiles, evaluates and fails closed. Commented; ready for re-triage. |
| #1004 | Unchanged — no new translation surface for page-component strings. |
| #986 | Unchanged — `record:reference_rail` is still absent from `ComponentPropsMap`, so the shape remains undeclared. |
| #788 | **Still open** — `readonly: true` is still not enforced on insert (probe wrote `published_at` straight through). |
| #779 | **Inconclusive, reported as such** — the probe's hook never fired (registration shape unconfirmed), so this is a failed probe, not a verdict. Needs a real harness. |
| #520 | Partially clear — a datetime window filter returns 1/1 expected rows on `driver-memory`. The card is about the dashboard/SQLite path, so this is a signal, not a clearance. |

The other 22 open cards were **not** probed. Calling that out rather than implying coverage.

## Checklist

- [x] **I have added a changeset** — `.changeset/objectstack-17-ga-upgrade.md`
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings — warning count unchanged from `main` (83)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — the whole `17.0.0` family is on npm (verified all 12 direct, 54 resolved)

## Additional Notes

- `content/docs/releases/` is untouched, and no Dependabot PR was merged or rebased.
- Historical `17.0.0-rc.6` mentions in code comments are **dated measurement records**
  ("measured on X"), deliberately left as written — rewriting them would falsify when the
  measurement was taken.
- The `hierarchy-security` capability advisory and the 83 author-time warnings are
  pre-existing on `main` and out of scope here.
- #1148 was filed from this work: the same `update()`-now-throws change leaves ~20
  race-shaped call sites where a parent deleted between read and write-back used to no-op
  and now fails the triggering child write. Dormant, unexercised, and wants one design
  decision — so it is recorded for triage, not fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTaZzijZHFx8iiPfikoibn)_